### PR TITLE
fix: add --tools default to all Claude CLI -p spawns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ client/dist/
 data/
 
 # specrails installer (one-time setup tool, not part of the project)
-specrails/
+# Leading slash limits match to root level — without it, the pattern also
+# matches .claude/commands/specrails/ which must be tracked.
+/specrails/
 .claude/worktrees/
 coverage/

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "cli/dist",
     "server/dist",
     "client/dist",
-    "docs"
+    "docs",
+    ".claude/commands/specrails"
   ],
   "scripts": {
     "dev": "concurrently \"npm run dev:server\" \"npm run dev:client\"",

--- a/server/chat-manager.ts
+++ b/server/chat-manager.ts
@@ -220,6 +220,7 @@ export class ChatManager {
       args = [
         '--model', conversation.model,
         '--dangerously-skip-permissions',
+        '--tools', 'default',
         '--output-format', 'stream-json',
         '--verbose',
         '--system-prompt', systemPrompt,

--- a/server/command-resolver.ts
+++ b/server/command-resolver.ts
@@ -1,10 +1,41 @@
 import { readFileSync, existsSync } from 'fs'
-import { join } from 'path'
+import { join, resolve } from 'path'
+
+/**
+ * Locate the hub repository root (the directory containing .claude/commands/).
+ * Works in both dev mode (tsx: __dirname = <hub>/server/) and
+ * compiled mode (tsc: __dirname = <hub>/server/dist/).
+ */
+function findHubRoot(): string | null {
+  let dir = resolve(__dirname, '..')
+  if (existsSync(join(dir, '.claude', 'commands'))) return dir
+  dir = resolve(__dirname, '../..')
+  if (existsSync(join(dir, '.claude', 'commands'))) return dir
+  return null
+}
+
+const HUB_ROOT = findHubRoot()
+
+/**
+ * Try to find a command/skill .md file for the given command path parts
+ * within the given base directory. Returns the resolved path or null.
+ */
+function findCommandFile(baseDir: string, parts: string[]): string | null {
+  const filePath = join(baseDir, '.claude', 'commands', ...parts) + '.md'
+  if (existsSync(filePath)) return filePath
+  const skillPath = join(baseDir, '.claude', 'skills', ...parts) + '.md'
+  if (existsSync(skillPath)) return skillPath
+  return null
+}
 
 /**
  * Resolves a slash command string to its full prompt content.
  * Reads the command file from .claude/commands/ or .claude/skills/,
  * strips YAML frontmatter, and substitutes $ARGUMENTS.
+ *
+ * Searches the project directory first, then falls back to the hub's
+ * own .claude/commands/ directory (for hub-namespaced commands like
+ * /specrails:implement that aren't installed in the target project).
  *
  * Falls back to returning the command string as-is if the file is not found.
  */
@@ -14,11 +45,15 @@ export function resolveCommand(command: string, cwd: string): string {
 
   const commandPath = match[1]
   const commandArgs = match[2].trim()
+  const parts = commandPath.split(':')
 
-  const filePath = join(cwd, '.claude', 'commands', ...commandPath.split(':')) + '.md'
-  const skillPath = join(cwd, '.claude', 'skills', ...commandPath.split(':')) + '.md'
+  // 1. Check the project directory
+  let resolvedPath = findCommandFile(cwd, parts)
 
-  const resolvedPath = existsSync(filePath) ? filePath : existsSync(skillPath) ? skillPath : null
+  // 2. Fallback: check the hub's own directory
+  if (!resolvedPath && HUB_ROOT && resolve(cwd) !== resolve(HUB_ROOT)) {
+    resolvedPath = findCommandFile(HUB_ROOT, parts)
+  }
 
   if (!resolvedPath) return command
 

--- a/server/project-router.ts
+++ b/server/project-router.ts
@@ -1187,6 +1187,7 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
       binary = 'claude'
       args = [
         '--dangerously-skip-permissions',
+        '--tools', 'default',
         '--output-format', 'stream-json',
         '--verbose',
         '--max-turns', '1',
@@ -1450,6 +1451,7 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
       binary = 'claude'
       args = [
         '--dangerously-skip-permissions',
+        '--tools', 'default',
         '--output-format', 'stream-json',
         '--verbose',
         '--max-turns', '4',

--- a/server/proposal-manager.ts
+++ b/server/proposal-manager.ts
@@ -50,6 +50,7 @@ export class ProposalManager {
 
     const args = [
       '--dangerously-skip-permissions',
+      '--tools', 'default',
       '--output-format', 'stream-json',
       '--verbose',
       '-p', prompt,
@@ -90,6 +91,7 @@ export class ProposalManager {
 
     const args = [
       '--dangerously-skip-permissions',
+      '--tools', 'default',
       '--output-format', 'stream-json',
       '--verbose',
       '--resume', proposal.session_id,
@@ -135,6 +137,7 @@ export class ProposalManager {
 
     const args = [
       '--dangerously-skip-permissions',
+      '--tools', 'default',
       '--output-format', 'stream-json',
       '--verbose',
       '--resume', proposal.session_id,

--- a/server/queue-manager.ts
+++ b/server/queue-manager.ts
@@ -420,6 +420,7 @@ export class QueueManager {
       binary = 'claude'
       args = [
         '--dangerously-skip-permissions',
+        '--tools', 'default',
         '--output-format', 'stream-json',
         '--verbose',
         '-p',

--- a/server/setup-manager.ts
+++ b/server/setup-manager.ts
@@ -620,6 +620,7 @@ export class SetupManager {
     const args = [
       '-p', enrichCmd,
       '--dangerously-skip-permissions',
+      '--tools', 'default',
       '--output-format', 'stream-json',
       '--verbose',
     ]
@@ -674,6 +675,7 @@ export class SetupManager {
     const args = [
       '--resume', sessionId,
       '--dangerously-skip-permissions',
+      '--tools', 'default',
       '--output-format', 'stream-json',
       '--verbose',
       '-p', userMessage,

--- a/server/spec-launcher-manager.ts
+++ b/server/spec-launcher-manager.ts
@@ -33,6 +33,7 @@ export class SpecLauncherManager {
 
     const args = [
       '--dangerously-skip-permissions',
+      '--tools', 'default',
       '--output-format', 'stream-json',
       '--verbose',
       '-p', prompt,


### PR DESCRIPTION
## Summary

- **Root cause**: Recent Claude CLI versions disabled tools by default in `-p` (print) mode. Without `--tools default`, Claude responds conversationally instead of executing pipelines — it cannot use Bash, Read, Write, Agent, etc.
- Added `--tools default` to all 9 Claude CLI spawn sites: queue-manager, chat-manager, setup-manager, spec-launcher-manager, proposal-manager, and project-router
- Improved command-resolver with hub root fallback for resolving hub-namespaced commands (`specrails:*`) when not found in the target project
- Fixed `.gitignore` pattern `specrails/` → `/specrails/` that accidentally excluded `.claude/commands/specrails/`

## Test plan

- [x] All existing tests pass (1139/1139)
- [x] TypeScript compiles clean
- [x] Verified `claude --dangerously-skip-permissions --tools default -p "Use the Bash tool to run: echo hello"` executes tools correctly
- [ ] Launch a rail from the hub dashboard and verify the implementation pipeline runs (not just a greeting)
- [ ] Verify chat, proposals, and setup wizard also work with tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)