### PR TITLE
fix: spec list refresh + local-tickets instruction for rails

### DIFF
--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -75,7 +75,7 @@ function saveRails(projectId: string | null, rails: RailState[]) {
 
 export default function DashboardPage() {
   const { activeProjectId } = useHub()
-  const { tickets, isLoading, updateTicket, deleteTicket, createTicket } = useTickets()
+  const { tickets, isLoading, updateTicket, deleteTicket, createTicket, refetch } = useTickets()
   const { registerHandler, unregisterHandler, connectionStatus } = useSharedWebSocket()
   const [detailTicket, setDetailTicket] = useState<LocalTicket | null>(null)
   const [createTicketOpen, setCreateTicketOpen] = useState(false)
@@ -514,7 +514,7 @@ export default function DashboardPage() {
       <div className="flex h-full overflow-hidden">
         {/* Left panel: Specs board */}
         <div className="flex-1 min-w-0 border-r border-border/40 flex flex-col overflow-hidden">
-          <SpecsBoard tickets={specTickets} allTickets={tickets} doneTickets={doneSpecTickets} isLoading={isLoading} onTicketClick={setDetailTicket} onTicketCreated={setDetailTicket} />
+          <SpecsBoard tickets={specTickets} allTickets={tickets} doneTickets={doneSpecTickets} isLoading={isLoading} onTicketClick={setDetailTicket} onTicketCreated={(ticket) => { setDetailTicket(ticket); refetch() }} />
         </div>
 
         {/* Right panel: Rails board */}

--- a/server/project-router.test.ts
+++ b/server/project-router.test.ts
@@ -120,6 +120,7 @@ function makeContext(db: DbInstance, overrides: Partial<ProjectContext> = {}): P
     setupManager: makeSetupManager() as any,
     proposalManager: makeProposalManager() as any,
     specLauncherManager: makeSpecLauncherManager() as any,
+    ticketWatcher: { notifyHubWrite: vi.fn(), start: vi.fn(), close: vi.fn() } as any,
     broadcast: vi.fn(),
     ...overrides,
   }

--- a/server/project-router.ts
+++ b/server/project-router.ts
@@ -1154,7 +1154,7 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
       res.status(400).json({ error: 'idea is required' }); return
     }
 
-    const { project, broadcast } = ctx(req)
+    const { project, broadcast, ticketWatcher } = ctx(req)
     const provider = project.provider ?? 'claude'
     const requestId = uuidv4()
     const projectId = project.id
@@ -1256,7 +1256,7 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
         try {
           const now = new Date().toISOString()
           let created: import('./ticket-store').Ticket | undefined
-          mutateStore(filePath, (s) => {
+          const store = mutateStore(filePath, (s) => {
             const id = s.next_id++
             const ticket: import('./ticket-store').Ticket = {
               id,
@@ -1277,6 +1277,7 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
             s.tickets[String(id)] = ticket
             created = ticket
           })
+          ticketWatcher.notifyHubWrite(store.revision)
 
           const ticketMsg: TicketCreatedMessage = {
             type: 'ticket_created', ticket: created! as unknown as LocalTicket,
@@ -1345,7 +1346,8 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
         s.tickets[String(id)] = ticket
         created = ticket
       })
-      const { broadcast } = ctx(req)
+      const { broadcast, ticketWatcher } = ctx(req)
+      ticketWatcher.notifyHubWrite(store.revision)
       const msg: TicketCreatedMessage = { type: 'ticket_created', ticket: created! as unknown as LocalTicket, projectId: ctx(req).project.id, timestamp: new Date().toISOString() }
       broadcast(msg)
       res.status(201).json({ ticket: created!, revision: store.revision })
@@ -1393,7 +1395,8 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
       if (!updated) {
         res.status(404).json({ error: 'Ticket not found' }); return
       }
-      const { broadcast } = ctx(req)
+      const { broadcast, ticketWatcher } = ctx(req)
+      ticketWatcher.notifyHubWrite(store.revision)
       const msg: TicketUpdatedMessage = { type: 'ticket_updated', ticket: updated as unknown as LocalTicket, projectId: ctx(req).project.id, timestamp: new Date().toISOString() }
       broadcast(msg)
       res.json({ ticket: updated, revision: store.revision })
@@ -1553,7 +1556,8 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
       if (!found) {
         res.status(404).json({ error: 'Ticket not found' }); return
       }
-      const { broadcast } = ctx(req)
+      const { broadcast, ticketWatcher } = ctx(req)
+      ticketWatcher.notifyHubWrite(store.revision)
       const msg: TicketDeletedMessage = { type: 'ticket_deleted', ticketId: Number(ticketId), projectId: ctx(req).project.id, timestamp: new Date().toISOString() }
       broadcast(msg)
       res.json({ ok: true, revision: store.revision })

--- a/server/queue-manager.ts
+++ b/server/queue-manager.ts
@@ -415,6 +415,14 @@ export class QueueManager {
       systemAppend += '\n\nIMPORTANT: This command is running in headless/unattended mode (--yes flag). Do NOT wait for user confirmation at any step. Auto-proceed with "yes" for all confirmation prompts. Skip any "Wait for user confirmation" instructions.'
     }
 
+    // Local ticket store: implement/batch-implement jobs must read specs from
+    // .specrails/local-tickets.json — never from external trackers like Jira/Linear.
+    if (/\/(specrails|sr):(implement|batch-implement)\b/.test(commandToRun)) {
+      systemAppend += '\n\nIMPORTANT: The ticket/spec data for this project is stored locally in .specrails/local-tickets.json. ' +
+        'You MUST read specs from this file. Do NOT attempt to fetch tickets from Jira, Linear, GitHub Issues, or any other external tracker. ' +
+        'The #<id> references in the command correspond to ticket IDs inside .specrails/local-tickets.json.'
+    }
+
     let binary: string
     let args: string[]
     if (this._provider === 'codex') {

--- a/server/ticket-integration.test.ts
+++ b/server/ticket-integration.test.ts
@@ -82,6 +82,7 @@ function makeContext(db: DbInstance, projectPath: string): ProjectContext & { br
     setupManager: makeSetupManager() as any,
     proposalManager: makeProposalManager() as any,
     specLauncherManager: makeSpecLauncherManager() as any,
+    ticketWatcher: { notifyHubWrite: vi.fn(), start: vi.fn(), close: vi.fn() } as any,
     broadcast,
   } as any
 }

--- a/server/ticket-store.test.ts
+++ b/server/ticket-store.test.ts
@@ -76,6 +76,7 @@ function makeContext(db: DbInstance, projectPath: string): ProjectContext {
     setupManager: makeSetupManager() as any,
     proposalManager: makeProposalManager() as any,
     specLauncherManager: makeSpecLauncherManager() as any,
+    ticketWatcher: { notifyHubWrite: vi.fn(), start: vi.fn(), close: vi.fn() } as any,
     broadcast: vi.fn(),
   } as any
 }


### PR DESCRIPTION
## Summary

- **Spec list refresh**: When creating a spec via Add Spec modal, the newly created spec wasn't appearing in the list until page refresh. Now explicitly calls `refetch()` on ticket creation alongside opening the detail view.
- **TicketWatcher echo suppression**: Added missing `notifyHubWrite()` calls after all ticket mutations (create, update, delete, generate-spec) so the file watcher doesn't treat hub-originated writes as external changes.
- **Local tickets instruction for rails**: When running `implement` or `batch-implement` rails, appends a system prompt instruction forcing Claude to read specs from `.specrails/local-tickets.json` instead of external trackers (Jira, Linear, etc.).

## Test plan

- [ ] Create a spec via Add Spec modal → verify it appears in the specs list immediately after the modal closes (no page refresh needed)
- [ ] Run an implement rail → verify Claude reads the spec from `local-tickets.json`, not from Jira/external tracker
- [ ] Update/delete a ticket via the UI → verify no duplicate loading flash from TicketWatcher echo

🤖 Generated with [Claude Code](https://claude.com/claude-code)