### PR TITLE
feat: zombie timeout 30min default + per-project config

### DIFF
--- a/server/project-registry.ts
+++ b/server/project-registry.ts
@@ -137,9 +137,20 @@ export class ProjectRegistry {
       }
     }
 
+    // Per-project zombie timeout (stored in queue_state)
+    let projectZombieTimeout: number | undefined
+    try {
+      const row = db.prepare(`SELECT value FROM queue_state WHERE key = 'config.zombie_timeout_ms'`).get() as { value: string } | undefined
+      if (row) {
+        const parsed = parseInt(row.value, 10)
+        if (!isNaN(parsed) && parsed > 0) projectZombieTimeout = parsed
+      }
+    } catch { /* queue_state table may not exist yet */ }
+
     const webhookManager = this._webhookManager
     const railJobs = new Map<string, { railIndex: number; mode: string; ticketIds: number[] }>()
     const queueManager = new QueueManager(boundBroadcast, db, undefined, project.path, {
+      zombieTimeoutMs: projectZombieTimeout,
       provider: project.provider ?? 'claude',
       getCostAlertThreshold: () => {
         const val = getHubSetting(this._hubDb, 'cost_alert_threshold_usd')

--- a/server/project-router.ts
+++ b/server/project-router.ts
@@ -13,7 +13,7 @@ import {
   createTemplate, listTemplates, getTemplate, updateTemplate, deleteTemplate,
 } from './db'
 import { getProjectSetupSession } from './hub-db'
-import { ClaudeNotFoundError, JobNotFoundError, JobAlreadyTerminalError } from './queue-manager'
+import { ClaudeNotFoundError, JobNotFoundError, JobAlreadyTerminalError, DEFAULT_ZOMBIE_TIMEOUT_MS } from './queue-manager'
 import type { JobPriority } from './types'
 import { VALID_PRIORITIES } from './types'
 import { resolveCommand } from './command-resolver'
@@ -504,7 +504,9 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
       const config = getConfig(project.path, db, project.name)
       const dailyBudgetRaw = (db.prepare(`SELECT value FROM queue_state WHERE key = 'config.daily_budget_usd'`).get() as { value: string } | undefined)?.value
       const dailyBudgetUsd = dailyBudgetRaw != null ? parseFloat(dailyBudgetRaw) : null
-      res.json({ ...config, dailyBudgetUsd })
+      const zombieTimeoutRaw = (db.prepare(`SELECT value FROM queue_state WHERE key = 'config.zombie_timeout_ms'`).get() as { value: string } | undefined)?.value
+      const zombieTimeoutMs = zombieTimeoutRaw != null ? parseInt(zombieTimeoutRaw, 10) : null
+      res.json({ ...config, dailyBudgetUsd, zombieTimeoutMs })
     } catch (err) {
       console.error('[project-router] config error:', err)
       res.status(500).json({ error: 'Failed to read config' })
@@ -512,8 +514,8 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
   })
 
   router.post('/:projectId/config', (req: Request, res: Response) => {
-    const { active, labelFilter, dailyBudgetUsd } = req.body ?? {}
-    const { db } = ctx(req)
+    const { active, labelFilter, dailyBudgetUsd, zombieTimeoutMs } = req.body ?? {}
+    const { db, queueManager } = ctx(req)
     try {
       if (active !== undefined) {
         db.prepare(`INSERT OR REPLACE INTO queue_state (key, value) VALUES ('config.active_tracker', ?)`).run(active ?? '')
@@ -527,6 +529,14 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
         } else if (typeof dailyBudgetUsd === 'number' && dailyBudgetUsd > 0) {
           db.prepare(`INSERT OR REPLACE INTO queue_state (key, value) VALUES ('config.daily_budget_usd', ?)`).run(String(dailyBudgetUsd))
         }
+      }
+      if (zombieTimeoutMs !== undefined) {
+        if (zombieTimeoutMs === null) {
+          db.prepare(`DELETE FROM queue_state WHERE key = 'config.zombie_timeout_ms'`).run()
+        } else if (typeof zombieTimeoutMs === 'number' && zombieTimeoutMs > 0) {
+          db.prepare(`INSERT OR REPLACE INTO queue_state (key, value) VALUES ('config.zombie_timeout_ms', ?)`).run(String(zombieTimeoutMs))
+        }
+        queueManager.setZombieTimeout(typeof zombieTimeoutMs === 'number' && zombieTimeoutMs > 0 ? zombieTimeoutMs : DEFAULT_ZOMBIE_TIMEOUT_MS)
       }
       res.json({ ok: true })
     } catch (err) {

--- a/server/queue-manager.ts
+++ b/server/queue-manager.ts
@@ -12,7 +12,7 @@ import type { CommandInfo } from './config'
 
 const LOG_BUFFER_MAX = 5000
 const LOG_BUFFER_DROP = 1000
-const DEFAULT_ZOMBIE_TIMEOUT_MS = 300_000 // 5 minutes
+export const DEFAULT_ZOMBIE_TIMEOUT_MS = 1_800_000 // 30 minutes
 
 // ─── Error classes ────────────────────────────────────────────────────────────
 
@@ -161,6 +161,14 @@ export class QueueManager {
 
   setCommands(commands: CommandInfo[]): void {
     this._commands = commands
+  }
+
+  setZombieTimeout(ms: number): void {
+    this._zombieTimeoutMs = ms
+    // If a job is currently running, reset the timer with the new value
+    if (this._activeJobId) {
+      this._resetZombieTimer()
+    }
   }
 
   // ─── Public API ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Increased default zombie timeout from 5 minutes to 30 minutes — prevents premature termination of long-running pipeline jobs where subagents in worktrees go silent during internal processing
- Made zombie timeout configurable per project via `POST /config` with `zombieTimeoutMs` field, persisted in `queue_state`
- Added `setZombieTimeout()` method to `QueueManager` for hot-reload when config changes

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] 227 tests pass in `queue-manager.test.ts` + `project-router.test.ts`
- [ ] Verify `GET /api/projects/:id/config` returns `zombieTimeoutMs` (null when using default)
- [ ] Verify `POST /api/projects/:id/config` with `{"zombieTimeoutMs": 3600000}` persists and applies immediately
- [ ] Verify `POST /api/projects/:id/config` with `{"zombieTimeoutMs": null}` resets to 30min default
- [ ] Verify `WM_ZOMBIE_TIMEOUT_MS` env var still works as global fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)