### PR TITLE
fix: refresh job metrics on completion while viewing job detail

### DIFF
--- a/client/src/pages/JobDetailPage.tsx
+++ b/client/src/pages/JobDetailPage.tsx
@@ -128,7 +128,14 @@ export default function JobDetailPage() {
       const jobs = msg.jobs as Array<{ id: string; status: string }> | undefined
       const matchingJob = jobs?.find((j) => j.id === id)
       if (matchingJob) {
-        setJob((prev) => prev ? { ...prev, status: matchingJob.status as JobSummary['status'] } : prev)
+        const newStatus = matchingJob.status as JobSummary['status']
+        setJob((prev) => prev ? { ...prev, status: newStatus } : prev)
+        if (newStatus === 'completed' || newStatus === 'failed' || newStatus === 'canceled') {
+          fetch(`${getApiBase()}/jobs/${id}`)
+            .then((r) => r.json())
+            .then((data: { job: JobSummary }) => setJob(data.job))
+            .catch(() => {})
+        }
       }
     }
   }, [id, flushEvents])

--- a/client/src/pages/__tests__/JobDetailPage.test.tsx
+++ b/client/src/pages/__tests__/JobDetailPage.test.tsx
@@ -218,6 +218,28 @@ describe('JobDetailPage', () => {
     })
   })
 
+  it('re-fetches job when queue message transitions job to completed', async () => {
+    const runningJob = { ...mockJob, status: 'running' as const, duration_ms: null, total_cost_usd: null }
+    const completedJob = { ...mockJob, status: 'completed' as const, duration_ms: 30000, total_cost_usd: 0.05 }
+
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ job: runningJob, events: [] }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ job: completedJob, events: mockEvents }) })
+
+    render(<JobDetailPage />)
+    await waitFor(() => {
+      expect(mockRegisterHandler).toHaveBeenCalled()
+    })
+
+    const handler = mockRegisterHandler.mock.calls[0][1]
+    handler({ type: 'queue', projectId: 'proj-1', jobs: [{ id: 'job-abc123', status: 'completed' }] })
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(2)
+      expect(global.fetch).toHaveBeenLastCalledWith('/api/jobs/job-abc123')
+    })
+  })
+
   it('renders log viewer section', async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,


### PR DESCRIPTION
## Summary

- When a job finishes (completed/failed/canceled), `JobDetailPage` now re-fetches the full job from the API via the existing WS `queue` message handler
- Fixes DURATION, COST, TURNS, TOKENS columns not updating live when you're already on the job detail page at the moment of completion

## Root cause

The WS `queue` broadcast only carries the in-memory `Job` type (no metrics fields). The handler was only updating `status`, leaving the stale initial fetch values for all metrics.

## Fix

On status transition to a terminal state, fire a lightweight re-fetch of `/jobs/:id` → `setJob(data.job)` to hydrate metrics from the DB.

## Test plan

- [x] Added test: queue WS message with `completed` status triggers a second `fetch` call to `/jobs/:id`
- [x] All 18 existing `JobDetailPage` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)