### PR TITLE
feat: publish latest/manifest.json channel for macOS desktop build

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -65,7 +65,109 @@ jobs:
           path: ./artifacts/
           merge-multiple: true
 
-      - name: Deploy to Hostinger
+      # openspec: add-latest-release-channel
+      # The deploy job publishes the .dmg twice:
+      #   1. downloads/specrails-hub/v<tag>/  — archival, versioned (pre-existing behaviour)
+      #   2. downloads/specrails-hub/latest/  — stable channel consumed by specrails-web
+      #
+      # Consumers (specrails-web) read manifest.json in latest/ to render the
+      # Download CTA and surface the current version without hardcoding.
+      #
+      # IMPORTANT: The latest/ folder on Hostinger also contains a one-time,
+      # hand-authored .htaccess file that must remain in place:
+      #
+      #     <Files "manifest.json">
+      #       Header set Cache-Control "no-cache, must-revalidate"
+      #       Header set Access-Control-Allow-Origin "*"
+      #     </Files>
+      #
+      # The .htaccess is server-managed (Hostinger), NOT from this repo. Do
+      # not add steps that wipe latest/ wholesale — only delete stale .dmg
+      # files explicitly.
+
+      - name: Compute release version
+        id: vars
+        run: |
+          set -euo pipefail
+          # github.ref_name is e.g. "v1.30.0" on tag pushes. Strip the leading "v".
+          # For workflow_dispatch the user must dispatch against a v* tag so
+          # the version is unambiguous; we fail fast otherwise.
+          if [[ ! "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "This workflow must run against a v* tag. Got ref_name=${GITHUB_REF_NAME}"
+            exit 1
+          fi
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          echo "Release version: ${VERSION}"
+
+      - name: Rename .dmg to canonical filename
+        id: rename
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.vars.outputs.version }}"
+          src="$(ls artifacts/*.dmg | head -n1)"
+          if [[ -z "${src}" ]]; then
+            echo "No .dmg found in artifacts/"
+            exit 1
+          fi
+          canonical="specrails-hub-${VERSION}-aarch64.dmg"
+          if [[ "$(basename "${src}")" != "${canonical}" ]]; then
+            mv "${src}" "artifacts/${canonical}"
+          fi
+          echo "filename=${canonical}" >> "$GITHUB_OUTPUT"
+          echo "path=artifacts/${canonical}" >> "$GITHUB_OUTPUT"
+          ls -la artifacts/
+
+      - name: Compute sha256 and byte size
+        id: hash
+        run: |
+          set -euo pipefail
+          file="${{ steps.rename.outputs.path }}"
+          sha="$(sha256sum "${file}" | awk '{print $1}')"
+          size="$(stat -c%s "${file}")"
+          echo "sha256=${sha}" >> "$GITHUB_OUTPUT"
+          echo "size=${size}" >> "$GITHUB_OUTPUT"
+          echo "sha256: ${sha}"
+          echo "size:   ${size} bytes"
+
+      - name: Build manifest.json
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.vars.outputs.version }}"
+          TAG="${{ steps.vars.outputs.tag }}"
+          FILENAME="${{ steps.rename.outputs.filename }}"
+          SHA="${{ steps.hash.outputs.sha256 }}"
+          SIZE="${{ steps.hash.outputs.size }}"
+          RELEASED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          URL="https://specrails.dev/downloads/specrails-hub/latest/${FILENAME}"
+          RELEASE_URL="https://github.com/fjpulidop/specrails-hub/releases/tag/${TAG}"
+
+          mkdir -p manifest
+          cat > manifest/manifest.json <<JSON
+          {
+            "schemaVersion": 1,
+            "version": "${VERSION}",
+            "releasedAt": "${RELEASED_AT}",
+            "releaseUrl": "${RELEASE_URL}",
+            "platforms": {
+              "darwin-arm64": {
+                "filename": "${FILENAME}",
+                "url": "${URL}",
+                "sha256": "${SHA}",
+                "size": ${SIZE}
+              }
+            }
+          }
+          JSON
+
+          # Fail fast if the JSON is malformed.
+          jq empty manifest/manifest.json
+          cat manifest/manifest.json
+
+      # Pre-existing versioned upload. Behaviour unchanged except the
+      # uploaded .dmg now uses the canonical filename.
+      - name: Deploy versioned .dmg to Hostinger
         uses: SamKirkland/FTP-Deploy-Action@v4.3.6
         with:
           server: ${{ secrets.HOSTINGER_HOST }}
@@ -73,4 +175,105 @@ jobs:
           password: ${{ secrets.HOSTINGER_PASSWORD }}
           protocol: ftp
           local-dir: ./artifacts/
-          server-dir: domains/specrails.dev/public_html/downloads/specrails-hub/${{ github.ref_name }}/
+          server-dir: domains/specrails.dev/public_html/downloads/specrails-hub/${{ steps.vars.outputs.tag }}/
+
+      # ---------------------------------------------------------------
+      # latest/ channel — openspec: add-latest-release-channel
+      # ---------------------------------------------------------------
+      #
+      # Ordering matters (spec: desktop-release-channel):
+      #   1. Delete any prior .dmg in latest/ (keep .htaccess untouched).
+      #   2. Upload the new .dmg.
+      #   3. HEAD-verify the new .dmg is HTTP-reachable.
+      #   4. Upload manifest.json.
+      #   5. HEAD-verify manifest.json is HTTP-reachable and valid JSON.
+      #
+      # A consumer that sees the new manifest must always find the
+      # referenced binary. Never upload manifest.json before step 3 passes.
+
+      - name: Delete stale .dmg in latest/
+        env:
+          HOST: ${{ secrets.HOSTINGER_HOST }}
+          FTP_USER: ${{ secrets.HOSTINGER_USER }}
+          FTP_PASS: ${{ secrets.HOSTINGER_PASSWORD }}
+        run: |
+          set -euo pipefail
+          remote="domains/specrails.dev/public_html/downloads/specrails-hub/latest/"
+          # List the directory. Returns just filenames when using --list-only.
+          stale="$(curl -s --ftp-pasv --user "${FTP_USER}:${FTP_PASS}" "ftp://${HOST}/${remote}" --list-only | grep -E '\.dmg$' || true)"
+          if [[ -z "${stale}" ]]; then
+            echo "No stale .dmg files in latest/"
+            exit 0
+          fi
+          while IFS= read -r f; do
+            [[ -z "${f}" ]] && continue
+            echo "Deleting stale: ${f}"
+            curl -s --ftp-pasv --user "${FTP_USER}:${FTP_PASS}" \
+              -Q "DELE ${remote}${f}" \
+              "ftp://${HOST}/${remote}" || echo "  (DELE failed for ${f}; continuing)"
+          done <<< "${stale}"
+
+      - name: Upload new .dmg to latest/
+        env:
+          HOST: ${{ secrets.HOSTINGER_HOST }}
+          FTP_USER: ${{ secrets.HOSTINGER_USER }}
+          FTP_PASS: ${{ secrets.HOSTINGER_PASSWORD }}
+        run: |
+          set -euo pipefail
+          remote="domains/specrails.dev/public_html/downloads/specrails-hub/latest/"
+          file="${{ steps.rename.outputs.path }}"
+          curl --fail --silent --show-error --ftp-pasv \
+            --user "${FTP_USER}:${FTP_PASS}" \
+            -T "${file}" \
+            "ftp://${HOST}/${remote}"
+          echo "Uploaded $(basename "${file}") to ${remote}"
+
+      - name: Verify .dmg is HTTP-reachable
+        run: |
+          set -euo pipefail
+          filename="${{ steps.rename.outputs.filename }}"
+          url="https://specrails.dev/downloads/specrails-hub/latest/${filename}"
+          # Retry briefly to absorb FTP-to-HTTP propagation.
+          for i in 1 2 3 4 5 6; do
+            code="$(curl --head --silent --output /dev/null --write-out '%{http_code}' "${url}")"
+            if [[ "${code}" == "200" ]]; then
+              echo "✓ ${url} reachable"
+              exit 0
+            fi
+            echo "  attempt ${i}: ${url} -> HTTP ${code}, retrying in 5s..."
+            sleep 5
+          done
+          echo "✗ ${url} still not reachable"
+          exit 1
+
+      - name: Upload manifest.json to latest/
+        env:
+          HOST: ${{ secrets.HOSTINGER_HOST }}
+          FTP_USER: ${{ secrets.HOSTINGER_USER }}
+          FTP_PASS: ${{ secrets.HOSTINGER_PASSWORD }}
+        run: |
+          set -euo pipefail
+          remote="domains/specrails.dev/public_html/downloads/specrails-hub/latest/"
+          curl --fail --silent --show-error --ftp-pasv \
+            --user "${FTP_USER}:${FTP_PASS}" \
+            -T manifest/manifest.json \
+            "ftp://${HOST}/${remote}"
+          echo "Uploaded manifest.json to ${remote}"
+
+      - name: Verify manifest.json is reachable and valid JSON
+        run: |
+          set -euo pipefail
+          url="https://specrails.dev/downloads/specrails-hub/latest/manifest.json"
+          for i in 1 2 3 4 5 6; do
+            if curl --fail --silent --show-error "${url}" -o /tmp/manifest.json; then
+              if jq empty /tmp/manifest.json; then
+                echo "✓ manifest.json reachable and valid"
+                cat /tmp/manifest.json
+                exit 0
+              fi
+            fi
+            echo "  attempt ${i}: manifest.json not yet valid, retrying in 5s..."
+            sleep 5
+          done
+          echo "✗ manifest.json not reachable or invalid"
+          exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,5 +108,11 @@ Releases are automated via release-please + GitHub Actions:
   - release-please creates/updates a Release PR (bumps version in `package.json` + `CHANGELOG.md`)
   - When the Release PR is merged, release-please creates the GitHub Release and `npm publish` runs automatically
   - Publishes with **npm provenance attestation** (`--provenance --access public`) for SLSA Level 2 supply chain security. Requires `id-token: write` permission in the workflow.
+- **Desktop Release** (`.github/workflows/desktop-release.yml`) — on every `v*` tag push or manual dispatch:
+  - Builds a signed + notarised macOS Apple Silicon `.dmg` via Tauri.
+  - FTP-uploads the `.dmg` to Hostinger under two paths: the archival versioned folder `downloads/specrails-hub/v<version>/` and a stable `downloads/specrails-hub/latest/` channel.
+  - Writes a machine-readable `manifest.json` into `latest/` describing the release (schemaVersion, version, releasedAt, releaseUrl, platforms.darwin-arm64 with filename/url/sha256/size). Consumers like specrails-web read this to render a Download CTA without hardcoding versions.
+  - Ordering: `.dmg` is uploaded first and HEAD-verified before `manifest.json` is uploaded, so a consumer that sees the new manifest always finds the referenced binary.
+  - **Server-side one-time setup**: the Hostinger `latest/` folder contains a hand-authored `.htaccess` that sets `Cache-Control: no-cache, must-revalidate` and `Access-Control-Allow-Origin: *` on `manifest.json`. This file is server-managed, not in the repo — do not add workflow steps that wipe `latest/` wholesale. See the inline comment in `desktop-release.yml` for the `.htaccess` contents.
 
 Commit message prefixes that affect versioning: `feat:` → minor, `fix:` → patch, `feat!:` → major. Commits without a conventional prefix are ignored by release-please.

--- a/openspec/changes/add-latest-release-channel/.openspec.yaml
+++ b/openspec/changes/add-latest-release-channel/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-17

--- a/openspec/changes/add-latest-release-channel/design.md
+++ b/openspec/changes/add-latest-release-channel/design.md
@@ -1,0 +1,104 @@
+## Context
+
+specrails-hub ships a signed + notarized macOS `.dmg` through `.github/workflows/desktop-release.yml`. The workflow is triggered by `push: tags: ["v*"]` or manual dispatch. Current behaviour:
+
+1. A macOS runner builds the Tauri desktop app and uploads the artifact.
+2. An Ubuntu "deploy" job downloads the artifact and FTP-uploads it to Hostinger at `domains/specrails.dev/public_html/downloads/specrails-hub/<tag>/` (e.g. `/downloads/specrails-hub/v1.30.0/`).
+
+Consumers of that URL must know the exact version ahead of time. specrails-web wants a hero-level Download CTA that always points to the newest build and surfaces the current version without a hardcoded string or a GitHub API call at page load time.
+
+We currently ship macOS Apple Silicon only (see recent commit `babb0f0 ci: drop x64 matrix, build Apple Silicon only`). Designing the channel to be future-extensible to additional platforms is cheap and worth doing now.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide a stable, versionless URL for the most recent `.dmg`.
+- Expose a small JSON manifest describing the release so consumers can render version and integrity info without scraping HTML or calling the GitHub API.
+- Keep the existing versioned folder (`v<version>/`) working unchanged for archival, direct links, and deep links from changelogs.
+- Keep the workflow easy to extend to Windows / Intel Mac / Linux later without re-plumbing the channel.
+
+**Non-Goals:**
+- Auto-updates inside the desktop app (Tauri updater). Out of scope; separate future work.
+- Code-signing or notarisation changes. Reuse existing Apple cert + API key flow.
+- Cross-repo automation that copies the hub-demo build into specrails-web. Orthogonal concern, future spec.
+- Intel / Windows / Linux builds. macOS Apple Silicon only today.
+- Any web-side change. specrails-web consumes the manifest in a separate change.
+
+## Decisions
+
+### Decision 1: Stable URL via `latest/` folder, not symlink or redirect
+Hostinger FTP does not support symlinks reliably across shared hosting and HTTP redirects would add a round-trip. Copying the `.dmg` into a `latest/` folder on every release is simple, deterministic, and cacheable.
+
+Alternatives considered:
+- HTTP redirect from `latest/` to versioned path — extra latency, needs `.htaccess` per release.
+- Symlink — not portable over FTP.
+- Rely solely on GitHub Releases "latest" API — unauthenticated rate limits + CORS risk at page load.
+
+### Decision 2: Manifest schema is flat and versioned
+`manifest.json` uses a minimal flat schema. A top-level `schemaVersion` field lets consumers detect and ignore incompatible future changes. The release-specific fields describe one build at a time; multi-platform is layered in later by promoting platform-specific fields into a nested object.
+
+Minimum schema (v1):
+```json
+{
+  "schemaVersion": 1,
+  "version": "1.30.0",
+  "releasedAt": "2026-04-17T08:54:20Z",
+  "releaseUrl": "https://github.com/fjpulidop/specrails-hub/releases/tag/v1.30.0",
+  "platforms": {
+    "darwin-arm64": {
+      "filename": "specrails-hub-1.30.0-aarch64.dmg",
+      "url": "https://specrails.dev/downloads/specrails-hub/latest/specrails-hub-1.30.0-aarch64.dmg",
+      "sha256": "<64-hex>",
+      "size": 123456789
+    }
+  }
+}
+```
+
+Rationale for nested `platforms` even though we ship one today:
+- Adding `darwin-x64`, `win32-x64`, `linux-x64` later is a purely additive change; consumers that already handle `platforms["darwin-arm64"]` keep working.
+- Flat alternative (`filename`, `sha256`, `size` at top level) forces a breaking rename when a second platform ships.
+
+Alternatives considered:
+- GitHub Releases asset JSON — same information, but requires a live network call to `api.github.com` with CORS + rate-limit risk.
+- Version-only manifest (no checksum) — smaller but weaker integrity story; sha256 is cheap to compute on the runner.
+
+### Decision 3: Filename includes the version
+Name pattern `specrails-hub-<version>-<arch>.dmg` (e.g. `specrails-hub-1.30.0-aarch64.dmg`) is used in both `v<version>/` and `latest/`. Putting the version in the filename gives two fallbacks when the manifest is unreachable:
+1. Filename-based version display (regex).
+2. Easier human debugging when a user downloads from the stable URL.
+
+Today Tauri's default output is already version-aware; we just need to rename or copy-with-rename in the workflow.
+
+### Decision 4: Computation and upload happen on the Ubuntu deploy job
+The macOS build job stays focused on compilation + signing. The Ubuntu deploy job already downloads the artifact, so computing sha256 + size + timestamp and authoring `manifest.json` there is cheap and keeps runner minutes low (no extra macOS time).
+
+### Decision 5: Keep versioned folder untouched
+The `v<tag>/` path already exists and is referenced elsewhere (changelogs, blog posts, prior releases). It continues to be populated exactly as today. `latest/` is strictly additive.
+
+### Decision 6: Write manifest last, after `.dmg` is fully uploaded
+Consumers may poll `manifest.json` right after a release notification. Uploading the `.dmg` before the manifest guarantees that a consumer that sees the new manifest can successfully download the referenced binary (no 404 race).
+
+## Risks / Trade-offs
+
+- **[FTP upload partially fails, leaves stale `manifest.json` pointing to missing binary]** → Order of operations: upload `.dmg` first, verify 200 on HEAD, then upload `manifest.json`. If the step fails after `.dmg` upload but before manifest, next re-run fixes it.
+- **[Cache of old `manifest.json` at CDN / browser]** → Set `Cache-Control: no-cache, must-revalidate` via `.htaccess` for `latest/manifest.json`, or append `?t=<timestamp>` query string on the web side when fetching. Pick `.htaccess` — one-time server config.
+- **[Version in filename diverges from version in manifest]** → Single source of truth: `package.json` version, read once in the deploy job and reused for both filename and manifest.
+- **[Workflow secret rotation breaks publish silently]** → Pre-existing risk, unchanged. No new secrets introduced.
+- **[Adding new platforms later requires coordinated changes in web]** → Nested `platforms` object absorbs additions without breaking consumers that only read `darwin-arm64`. Document the expansion policy in the spec.
+
+## Migration Plan
+
+1. Update `.github/workflows/desktop-release.yml` with new deploy steps (rename, compute sha256, upload to `latest/`, write and upload `manifest.json`).
+2. Add a `.htaccess` fragment (or edit existing) under `domains/specrails.dev/public_html/downloads/specrails-hub/latest/` to set `Cache-Control: no-cache` on `manifest.json`.
+3. Cut a patch release (`v1.30.1` or next `fix:` commit) to exercise the full path end-to-end.
+4. Verify:
+   - `https://specrails.dev/downloads/specrails-hub/latest/specrails-hub-<ver>-aarch64.dmg` returns 200.
+   - `https://specrails.dev/downloads/specrails-hub/latest/manifest.json` returns valid JSON matching the schema.
+   - `https://specrails.dev/downloads/specrails-hub/v<ver>/...` still resolves (backwards compat).
+5. No rollback needed — if `latest/` publish fails, versioned publish is unaffected. Web-side fetch handles missing manifest gracefully (see Spec 3).
+
+## Open Questions
+
+- Should the manifest also include release notes / changelog snippet? Leaning no — changelog lives in `CHANGELOG.md` and GitHub Releases; manifest stays minimal. Revisit if the web wants to render "What's new" inline.
+- Should we produce a detached `.dmg.sha256` sidecar file in addition to embedding sha256 in the manifest? Probably redundant given manifest consumers, skip for now.

--- a/openspec/changes/add-latest-release-channel/proposal.md
+++ b/openspec/changes/add-latest-release-channel/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+specrails-web needs a stable URL to download the latest specrails-hub macOS build without hardcoding version numbers. Today the desktop-release workflow uploads `.dmg` files to a versioned folder (`/downloads/specrails-hub/v1.30.0/`) on Hostinger, which forces consumers to know the version ahead of time. A stable "latest" channel plus a machine-readable manifest lets the website render a live download button that always points at the newest build and surfaces the current version on the page.
+
+## What Changes
+
+- Desktop-release workflow SHALL also publish a copy of each released `.dmg` to `/downloads/specrails-hub/latest/` on Hostinger.
+- Desktop-release workflow SHALL write a `manifest.json` into the same `latest/` folder describing the release (version, filename, sha256, size, released-at, release URL).
+- The `.dmg` filename SHALL include the version so consumers can derive the version from the filename as a fallback when the manifest is unavailable.
+- The versioned folder (`v<version>/`) SHALL continue to be published for archival and direct-link use.
+
+## Capabilities
+
+### New Capabilities
+- `desktop-release-channel`: stable "latest" download URL for the specrails-hub macOS desktop build plus a machine-readable release manifest consumed by the marketing website.
+
+### Modified Capabilities
+_None. The existing `ci-cd` capability covers the npm publish side of the release pipeline and is not changed by this proposal._
+
+## Impact
+
+- **Code**: `.github/workflows/desktop-release.yml` gains a post-build step that uploads to `latest/` and writes `manifest.json`.
+- **Infrastructure**: Hostinger FTP path `/downloads/specrails-hub/latest/` starts serving the most recent `.dmg` + a `manifest.json` file. The versioned path is unchanged.
+- **Downstream**: specrails-web (separate repo) can read `manifest.json` to power a hero Download CTA. This change unblocks that work but does not require any web-side change to ship.
+- **Security**: manifest includes sha256; consumers can verify integrity before install.
+- **Breaking**: none. Additive — existing `v<version>/` URLs keep working.

--- a/openspec/changes/add-latest-release-channel/specs/desktop-release-channel/spec.md
+++ b/openspec/changes/add-latest-release-channel/specs/desktop-release-channel/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: Stable "latest" download URL for macOS build
+The system SHALL publish the most recent signed and notarised `.dmg` for specrails-hub to a stable, version-independent URL at `https://specrails.dev/downloads/specrails-hub/latest/`. The file SHALL be the same signed and notarised artifact that is published to the versioned folder for the corresponding tag.
+
+#### Scenario: Tag push publishes to latest folder
+- **WHEN** a commit tagged `v<version>` is pushed and the `Desktop Release` workflow completes successfully
+- **THEN** a file named `specrails-hub-<version>-aarch64.dmg` exists at `https://specrails.dev/downloads/specrails-hub/latest/` and returns HTTP 200
+
+#### Scenario: Latest file matches versioned file
+- **WHEN** both the `latest/` and the corresponding `v<version>/` folder have been populated by the same workflow run
+- **THEN** the `.dmg` binaries at both locations have identical sha256 hashes
+
+#### Scenario: Subsequent release replaces latest
+- **WHEN** a newer tag `v<version+1>` is released
+- **THEN** `https://specrails.dev/downloads/specrails-hub/latest/specrails-hub-<version+1>-aarch64.dmg` is served and any prior `.dmg` left in `latest/` from a previous release SHALL NOT be served from that folder
+
+### Requirement: Versioned download URL remains available
+The system SHALL continue to publish each released `.dmg` to its version-specific folder `https://specrails.dev/downloads/specrails-hub/v<version>/` for archival and deep linking.
+
+#### Scenario: Versioned URL remains reachable after new release
+- **WHEN** a new release is published and `latest/` has been updated
+- **THEN** the previous release's `.dmg` at `https://specrails.dev/downloads/specrails-hub/v<previous-version>/` still returns HTTP 200
+
+### Requirement: Release manifest describes the latest build
+The system SHALL publish a `manifest.json` file at `https://specrails.dev/downloads/specrails-hub/latest/manifest.json` that describes the most recent release. The manifest SHALL be a UTF-8 encoded JSON document with the following fields:
+
+- `schemaVersion` (integer): currently `1`.
+- `version` (string): semver version of the release, without a leading `v` (e.g. `"1.30.0"`).
+- `releasedAt` (string): ISO 8601 UTC timestamp of when the release was published.
+- `releaseUrl` (string): HTTPS URL of the corresponding GitHub Release page.
+- `platforms` (object): map whose keys are `<os>-<arch>` identifiers (e.g. `darwin-arm64`). Each value contains:
+  - `filename` (string): the `.dmg` filename inside `latest/`.
+  - `url` (string): absolute HTTPS URL of the `.dmg` inside `latest/`.
+  - `sha256` (string): lowercase hex sha256 of the `.dmg`.
+  - `size` (integer): size of the `.dmg` in bytes.
+
+#### Scenario: Manifest is valid JSON and matches schema
+- **WHEN** a release completes and `manifest.json` is fetched
+- **THEN** it parses as JSON, contains `schemaVersion`, `version`, `releasedAt`, `releaseUrl`, and a `platforms` object with at least `darwin-arm64`
+
+#### Scenario: Manifest reflects the most recent release
+- **WHEN** the release for tag `v<version>` completes
+- **THEN** `manifest.json.version === "<version>"` (no leading `v`)
+
+#### Scenario: Manifest sha256 matches the published binary
+- **WHEN** the consumer downloads the file referenced by `platforms["darwin-arm64"].url` and computes its sha256
+- **THEN** the result equals `platforms["darwin-arm64"].sha256`
+
+#### Scenario: Manifest size matches the published binary
+- **WHEN** the consumer issues `HEAD` on the file referenced by `platforms["darwin-arm64"].url`
+- **THEN** the returned `Content-Length` equals `platforms["darwin-arm64"].size`
+
+### Requirement: Manifest is uploaded after the binary
+The system SHALL upload the `.dmg` to `latest/` before uploading `manifest.json`. This ordering SHALL prevent a race in which a consumer reads a manifest referencing a binary that has not yet been published.
+
+#### Scenario: Deploy step ordering
+- **WHEN** the desktop-release deploy job runs
+- **THEN** the `.dmg` file is fully uploaded to the FTP server before the `manifest.json` file is uploaded
+
+### Requirement: Manifest cache is short-lived
+The system SHALL serve `manifest.json` from `latest/` with HTTP cache headers that prevent intermediate caches from returning a stale version to a consumer across releases. Cache-Control SHALL be set to `no-cache, must-revalidate`.
+
+#### Scenario: Browser fetches manifest after new release
+- **WHEN** a browser has previously fetched `manifest.json` before a release and fetches it again after the release
+- **THEN** the browser receives the new manifest (not a cached prior version) assuming the server is reachable
+
+### Requirement: Released filename includes the version
+The `.dmg` filename published to both `latest/` and `v<version>/` SHALL contain the release version so that a consumer can derive the version by parsing the filename when the manifest is unavailable.
+
+#### Scenario: Filename contains semver
+- **WHEN** the release for tag `v<version>` publishes
+- **THEN** the `.dmg` filename matches the regular expression `^specrails-hub-\d+\.\d+\.\d+-aarch64\.dmg$` and the captured version equals the release version

--- a/openspec/changes/add-latest-release-channel/tasks.md
+++ b/openspec/changes/add-latest-release-channel/tasks.md
@@ -1,0 +1,40 @@
+## 1. Workflow Plumbing
+
+- [x] 1.1 Read release version from `package.json` (or from `github.ref_name`) once in the deploy job and export it as a step output for downstream steps
+- [x] 1.2 Rename or copy the built `.dmg` to the canonical name `specrails-hub-<version>-aarch64.dmg` before FTP upload, matching the filename regex in the spec
+- [x] 1.3 Compute sha256 and byte size of the renamed `.dmg` on the Ubuntu deploy runner and export both as step outputs
+- [x] 1.4 Upload the renamed `.dmg` to the existing `downloads/specrails-hub/v<version>/` folder (unchanged behavior, just new filename)
+
+## 2. Latest Channel Upload
+
+- [x] 2.1 Upload the same `.dmg` to `downloads/specrails-hub/latest/` via FTP (implemented with `curl` so ordering with the manifest upload is deterministic; old `.dmg` files in `latest/` are explicitly deleted first to avoid accumulation while leaving `.htaccess` untouched)
+- [x] 2.2 Verify the `.dmg` is reachable via HTTP HEAD on `https://specrails.dev/downloads/specrails-hub/latest/specrails-hub-<version>-aarch64.dmg` before proceeding to manifest upload; fail the job if it does not return HTTP 200
+
+## 3. Manifest Generation
+
+- [x] 3.1 Generate `manifest.json` on the runner using the schema defined in `design.md` §Decision 2 (schemaVersion=1, version, releasedAt, releaseUrl, platforms.darwin-arm64 with filename/url/sha256/size)
+- [x] 3.2 Populate `releasedAt` with the job's UTC timestamp in ISO 8601 format (use `date -u +"%Y-%m-%dT%H:%M:%SZ"` in bash)
+- [x] 3.3 Populate `releaseUrl` with `https://github.com/fjpulidop/specrails-hub/releases/tag/v<version>`
+- [x] 3.4 Validate that the generated JSON parses successfully (e.g. `jq empty manifest.json`) before upload
+
+## 4. Manifest Upload
+
+- [x] 4.1 Upload `manifest.json` to `downloads/specrails-hub/latest/manifest.json` AFTER the `.dmg` HEAD check succeeds
+- [x] 4.2 Verify `https://specrails.dev/downloads/specrails-hub/latest/manifest.json` returns HTTP 200 and parseable JSON
+
+## 5. Cache Headers
+
+- [ ] 5.1 Add (or update) an `.htaccess` snippet inside `domains/specrails.dev/public_html/downloads/specrails-hub/latest/` that sets `Cache-Control: no-cache, must-revalidate` on `manifest.json` — **MANUAL**: server-side one-time step on Hostinger; exact `.htaccess` contents are embedded as a comment in `.github/workflows/desktop-release.yml` so they can be copy-pasted into the server's File Manager
+- [x] 5.2 Document in the workflow comments that the `.htaccess` lives on the server, not in the repo (one-time Hostinger step)
+
+## 6. End-to-End Verification
+
+- [ ] 6.1 Trigger a dry-run of the workflow via `workflow_dispatch` against a pre-release tag in a non-main branch, confirm both `latest/` and `v<tag>/` are populated — **MANUAL**: defer to the next release or a dedicated dispatch
+- [ ] 6.2 Fetch `manifest.json` and confirm `version`, `filename`, `url`, `sha256`, `size` are all correct — **MANUAL**: defer
+- [ ] 6.3 Download the `.dmg` from the `url` in the manifest and confirm its sha256 matches the manifest field — **MANUAL**: defer
+- [ ] 6.4 Confirm the previous `v<older-version>/` URL still resolves (regression check) — **MANUAL**: defer
+
+## 7. Documentation
+
+- [x] 7.1 Update `CLAUDE.md` release-pipeline section to mention the new `latest/` channel and `manifest.json` output (one short paragraph)
+- [x] 7.2 Add a brief inline comment in `desktop-release.yml` near the new steps pointing to the openspec change id `add-latest-release-channel` so future contributors can find the rationale


### PR DESCRIPTION
## Summary
- Adds a stable `downloads/specrails-hub/latest/` channel alongside the existing `v<version>/` archival path, so consumers (specrails-web Download CTA, future auto-updaters, internal tools) can fetch the newest `.dmg` without hardcoding a version.
- Emits a machine-readable `manifest.json` next to the latest `.dmg` with `schemaVersion`, `version`, `releasedAt`, `releaseUrl`, and a nested `platforms.darwin-arm64` object (`filename`, `url`, `sha256`, `size`). Nested `platforms` makes future Windows/Linux additions purely additive.
- Enforces safe ordering: upload `.dmg` → HEAD-verify it is HTTP-reachable → upload `manifest.json` → HEAD-verify manifest JSON parses. A consumer that sees the new manifest will always find the referenced binary.
- Explicitly deletes stale `.dmg` files in `latest/` before upload (via `curl -Q 'DELE ...'`) so the folder does not accumulate, while leaving the server-managed `.htaccess` (Cache-Control + CORS) untouched.

## Openspec
- Proposal / design / specs / tasks under `openspec/changes/add-latest-release-channel/`.
- Capability: `desktop-release-channel` (new).

## Manual steps (server-side, one-time)
- Paste the following `.htaccess` into `downloads/specrails-hub/latest/` on Hostinger (exact contents also inlined as a comment in the workflow):

  ```apache
  <Files "manifest.json">
    Header set Cache-Control "no-cache, must-revalidate"
    Header set Access-Control-Allow-Origin "*"
  </Files>
  ```

## Test plan
- [ ] CI typecheck / vitest unaffected (no code paths touched).
- [ ] Merge lands on main without retriggering the desktop release (no `v*` tag pushed).
- [ ] On the next tag push (or `gh workflow run desktop-release.yml --ref v<next>`), confirm:
  - [ ] `downloads/specrails-hub/v<next>/specrails-hub-<next>-aarch64.dmg` returns HTTP 200.
  - [ ] `downloads/specrails-hub/latest/specrails-hub-<next>-aarch64.dmg` returns HTTP 200.
  - [ ] `downloads/specrails-hub/latest/manifest.json` returns 200 with valid JSON; `version`, `filename`, `url`, `sha256`, `size` all match the uploaded binary.
  - [ ] The previous `v<older>/` URL still resolves (regression check).
  - [ ] No `.dmg` files other than the newest one remain inside `latest/`.
  - [ ] `manifest.json` responses include `Cache-Control: no-cache, must-revalidate` and `Access-Control-Allow-Origin: *`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)