### PR TITLE
fix: auto-create latest/ folder on first desktop-release run

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -222,7 +222,8 @@ jobs:
           set -euo pipefail
           remote="domains/specrails.dev/public_html/downloads/specrails-hub/latest/"
           file="${{ steps.rename.outputs.path }}"
-          curl --fail --silent --show-error --ftp-pasv \
+          # --ftp-create-dirs auto-creates the latest/ folder on first run.
+          curl --fail --silent --show-error --ftp-pasv --ftp-create-dirs \
             --user "${FTP_USER}:${FTP_PASS}" \
             -T "${file}" \
             "ftp://${HOST}/${remote}"
@@ -254,7 +255,9 @@ jobs:
         run: |
           set -euo pipefail
           remote="domains/specrails.dev/public_html/downloads/specrails-hub/latest/"
-          curl --fail --silent --show-error --ftp-pasv \
+          # --ftp-create-dirs is defensive; latest/ should already exist from
+          # the previous step but we keep the flag for idempotency.
+          curl --fail --silent --show-error --ftp-pasv --ftp-create-dirs \
             --user "${FTP_USER}:${FTP_PASS}" \
             -T manifest/manifest.json \
             "ftp://${HOST}/${remote}"


### PR DESCRIPTION
## Summary
The initial run of the new latest/ channel fails with `curl: (9) Server denied you to change to the given directory` because the Hostinger path does not exist yet. Adding `--ftp-create-dirs` tells curl to issue `MKD` for any missing path components on upload. Idempotent after the first run.

Failed run: https://github.com/fjpulidop/specrails-hub/actions/runs/24569073432

## Test plan
- [ ] Merge.
- [ ] Re-run the failed workflow: `gh run rerun 24569073432 --failed`
- [ ] Confirm `downloads/specrails-hub/latest/specrails-hub-1.31.0-aarch64.dmg` returns 200
- [ ] Confirm `downloads/specrails-hub/latest/manifest.json` returns 200 with valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)