### PR TITLE
fix(desktop): exclude node-gyp build/ dir from .app to unblock notarization

### DIFF
--- a/scripts/build-sidecar.mjs
+++ b/scripts/build-sidecar.mjs
@@ -300,6 +300,13 @@ async function main() {
   const nodePtySrc = path.join(ROOT, 'node_modules', 'node-pty')
   const nodePtyDest = path.join(BINARIES_DIR, 'node-pty')
   copyDirSync(nodePtySrc, nodePtyDest)
+  // Purge node-gyp intermediate outputs — they contain unsigned duplicates of
+  // pty.node + spawn-helper under build/Release/ that Apple notarization
+  // rejects with "binary is not signed with a valid Developer ID certificate"
+  // and "signature does not include a secure timestamp". The signed copies
+  // live under prebuilds/<platform>-<arch>/ and are what node-pty actually
+  // resolves at runtime via node-gyp-build.
+  fs.rmSync(path.join(nodePtyDest, 'build'), { recursive: true, force: true })
   // node-pty's prebuilds occasionally lose the +x bit during extraction — restore it
   // for spawn-helper so posix_spawnp succeeds at runtime.
   ensureSpawnHelperExecutable(nodePtyDest)


### PR DESCRIPTION
## Summary

The v1.34.0 desktop release failed Apple notarization because the
node-gyp rebuild step left intermediate artifacts at
\`node_modules/node-pty/build/Release/{pty.node,spawn-helper}\`, and
\`build-sidecar.mjs\` copied the entire \`node-pty\` directory into the
\`.app\`. Notarization rejected those unsigned duplicates with
\"binary is not signed with a valid Developer ID certificate\",
\"signature does not include a secure timestamp\", and
\"executable does not have the hardened runtime enabled\".

The signed copies live under \`prebuilds/<platform>-<arch>/\` (where
node-pty's \`node-gyp-build\` resolves them at runtime); the \`build/\`
dir is just an intermediate.

Fix: \`rm -rf\` the \`build/\` directory inside \`src-tauri/binaries/node-pty/\`
immediately after the copy, before Tauri bundles.

## Test plan

- [x] \`npm run build:sidecar\` locally — verified no \`build/\` in
  \`src-tauri/binaries/node-pty/\`; \`prebuilds/darwin-arm64/\` still has
  \`pty.node\` + \`spawn-helper\`.
- [ ] CI Desktop Release workflow on the v1.34.1 tag succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)