### PR TITLE
fix(settings): orchestrator model UX polish + generic descriptions + two-column budget

### DIFF
--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -32,6 +32,7 @@ export default function SettingsPage() {
   const [telemetryEnabled, setTelemetryEnabled] = useState(false)
   const [isSavingTelemetry, setIsSavingTelemetry] = useState(false)
   const [orchestratorModel, setOrchestratorModel] = useState('sonnet')
+  const [pendingOrchestratorModel, setPendingOrchestratorModel] = useState('sonnet')
   const [isSavingOrchestratorModel, setIsSavingOrchestratorModel] = useState(false)
   const [agentModels, setAgentModels] = useState<AgentModel[]>([])
   const [pendingModels, setPendingModels] = useState<Record<string, string>>({})
@@ -95,7 +96,9 @@ export default function SettingsPage() {
         if (!res.ok) return
         const data = await res.json() as ProjectSettings
         setTelemetryEnabled(data.pipelineTelemetryEnabled ?? false)
-        setOrchestratorModel(data.orchestratorModel ?? 'sonnet')
+        const m = data.orchestratorModel ?? 'sonnet'
+        setOrchestratorModel(m)
+        setPendingOrchestratorModel(m)
       } catch {
         // ignore
       }
@@ -192,20 +195,18 @@ export default function SettingsPage() {
     }
   }
 
-  async function saveOrchestratorModel(model: string) {
+  async function saveOrchestratorModel() {
     setIsSavingOrchestratorModel(true)
-    const prev = orchestratorModel
-    setOrchestratorModel(model)
     try {
       const res = await fetch(`${getApiBase()}/settings`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ orchestratorModel: model }),
+        body: JSON.stringify({ orchestratorModel: pendingOrchestratorModel }),
       })
       if (!res.ok) throw new Error('Failed to save')
-      toast.success(`Orchestrator model set to ${model}`)
+      setOrchestratorModel(pendingOrchestratorModel)
+      toast.success(`Orchestrator model set to ${pendingOrchestratorModel}`)
     } catch (err) {
-      setOrchestratorModel(prev)
       toast.error('Failed to save orchestrator model', { description: (err as Error).message })
     } finally {
       setIsSavingOrchestratorModel(false)
@@ -254,132 +255,33 @@ export default function SettingsPage() {
         )}
       </div>
 
-      {/* Budget Section */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Budget</CardTitle>
-          <CardDescription>
-            Set a daily spend cap for this project. The queue auto-pauses when the limit is hit.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="space-y-1.5">
-            <label className="text-xs font-medium">Daily budget (USD)</label>
-            <div className="flex gap-2 max-w-xs">
-              <Input
-                type="number"
-                min="0"
-                step="0.01"
-                value={dailyBudget}
-                onChange={(e) => setDailyBudget(e.target.value)}
-                placeholder="e.g. 5.00"
-                className="h-8 text-xs font-mono"
-              />
-              <Button
-                size="sm"
-                variant="secondary"
-                className="h-8 text-xs shrink-0"
-                disabled={isSavingBudget}
-                onClick={saveDailyBudget}
-              >
-                {isSavingBudget ? 'Saving...' : 'Save'}
-              </Button>
-            </div>
-            <p className="text-[10px] text-muted-foreground">
-              Leave blank to disable. Spend is calculated over the last 24 hours.
-            </p>
-          </div>
-
-          <Separator />
-
-          <div className="space-y-1.5">
-            <label className="text-xs font-medium">Per-job cost alert (USD)</label>
-            <div className="flex gap-2 max-w-xs">
-              <Input
-                type="number"
-                min="0"
-                step="0.01"
-                value={jobCostThreshold}
-                onChange={(e) => setJobCostThreshold(e.target.value)}
-                placeholder="e.g. 0.50"
-                className="h-8 text-xs font-mono"
-              />
-              <Button
-                size="sm"
-                variant="secondary"
-                className="h-8 text-xs shrink-0"
-                disabled={isSavingJobThreshold}
-                onClick={saveJobCostThreshold}
-              >
-                {isSavingJobThreshold ? 'Saving...' : 'Save'}
-              </Button>
-            </div>
-            <p className="text-[10px] text-muted-foreground">
-              Alert when a single job in this project exceeds this amount.
-            </p>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Pipeline Telemetry Section — hub mode only */}
-      {isHubMode && (
-        <Card>
-          <CardHeader>
-            <CardTitle>Pipeline Telemetry</CardTitle>
-            <CardDescription>
-              Capture token usage, phase durations, and subagent activity for diagnostic export. Off by default.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="flex items-center justify-between">
-              <div className="space-y-0.5">
-                <p className="text-xs font-medium">Enable pipeline telemetry</p>
-                <p className="text-[10px] text-muted-foreground">
-                  When on, OTEL data from pipeline jobs is captured locally. Use the{' '}
-                  <span className="font-mono">Export diagnostic</span> button on any job card to download.
-                </p>
-              </div>
-              <button
-                type="button"
-                role="switch"
-                aria-label="Enable pipeline telemetry"
-                aria-checked={telemetryEnabled}
-                disabled={isSavingTelemetry}
-                onClick={() => saveTelemetryToggle(!telemetryEnabled)}
-                className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 ${
-                  telemetryEnabled ? 'bg-primary' : 'bg-input'
-                }`}
-              >
-                <span
-                  className={`inline-block h-3.5 w-3.5 rounded-full bg-background shadow-sm transition-transform ${
-                    telemetryEnabled ? 'translate-x-4' : 'translate-x-0.5'
-                  }`}
-                />
-              </button>
-            </div>
-          </CardContent>
-        </Card>
-      )}
-
       {/* Orchestrator Model Section — hub mode only */}
       {isHubMode && (
         <Card>
           <CardHeader>
             <CardTitle>Orchestrator Model</CardTitle>
             <CardDescription>
-              Claude model used by the pipeline orchestrator (the Claude CLI process that runs each job). Defaults to Sonnet.
+              Model used by the pipeline orchestrator (the CLI process that runs each job). Defaults to Sonnet.
             </CardDescription>
           </CardHeader>
-          <CardContent>
-            <div className="flex items-center gap-3">
+          <CardContent className="space-y-3">
+            <div className="flex justify-end">
               <ModelCombobox
-                value={orchestratorModel}
-                onChange={saveOrchestratorModel}
+                value={pendingOrchestratorModel}
+                onChange={setPendingOrchestratorModel}
                 disabled={isSavingOrchestratorModel}
               />
-              {isSavingOrchestratorModel && (
-                <span className="text-[11px] text-muted-foreground">Saving...</span>
-              )}
+            </div>
+            <div className="flex justify-end">
+              <Button
+                size="sm"
+                variant="secondary"
+                className="h-7 text-xs"
+                disabled={isSavingOrchestratorModel || pendingOrchestratorModel === orchestratorModel}
+                onClick={saveOrchestratorModel}
+              >
+                {isSavingOrchestratorModel ? 'Saving...' : 'Save'}
+              </Button>
             </div>
           </CardContent>
         </Card>
@@ -391,7 +293,7 @@ export default function SettingsPage() {
           <CardHeader>
             <CardTitle>Agent Models</CardTitle>
             <CardDescription>
-              Configure the Claude model for each installed agent.
+              Configure the model for each installed agent.
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-3">
@@ -457,6 +359,118 @@ export default function SettingsPage() {
           </CardContent>
         </Card>
       )}
+
+      {/* Pipeline Telemetry Section — hub mode only */}
+      {isHubMode && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Pipeline Telemetry</CardTitle>
+            <CardDescription>
+              Capture token usage, phase durations, and subagent activity for diagnostic export. Off by default.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <p className="text-xs font-medium">Enable pipeline telemetry</p>
+                <p className="text-[10px] text-muted-foreground">
+                  When on, OTEL data from pipeline jobs is captured locally. Use the{' '}
+                  <span className="font-mono">Export diagnostic</span> button on any job card to download.
+                </p>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-label="Enable pipeline telemetry"
+                aria-checked={telemetryEnabled}
+                disabled={isSavingTelemetry}
+                onClick={() => saveTelemetryToggle(!telemetryEnabled)}
+                className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 ${
+                  telemetryEnabled ? 'bg-primary' : 'bg-input'
+                }`}
+              >
+                <span
+                  className={`inline-block h-3.5 w-3.5 rounded-full bg-background shadow-sm transition-transform ${
+                    telemetryEnabled ? 'translate-x-4' : 'translate-x-0.5'
+                  }`}
+                />
+              </button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Budget Section */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Budget</CardTitle>
+          <CardDescription>
+            Set a daily spend cap for this project. The queue auto-pauses when the limit is hit.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 gap-6">
+            <div className="space-y-2">
+              <div>
+                <label className="text-xs font-medium">Daily budget (USD)</label>
+                <p className="text-xs text-muted-foreground">
+                  Leave blank to disable. Spend is calculated over the last 24 hours.
+                </p>
+              </div>
+              <Input
+                type="number"
+                min="0"
+                step="0.01"
+                value={dailyBudget}
+                onChange={(e) => setDailyBudget(e.target.value)}
+                placeholder="e.g. 5.00"
+                className="h-8 text-xs font-mono"
+              />
+              <div className="flex justify-end">
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  className="h-7 text-xs"
+                  disabled={isSavingBudget}
+                  onClick={saveDailyBudget}
+                >
+                  {isSavingBudget ? 'Saving...' : 'Save'}
+                </Button>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <div>
+                <label className="text-xs font-medium">Per-job cost alert (USD)</label>
+                <p className="text-xs text-muted-foreground">
+                  Alert when a single job in this project exceeds this amount.
+                </p>
+              </div>
+              <Input
+                type="number"
+                min="0"
+                step="0.01"
+                value={jobCostThreshold}
+                onChange={(e) => setJobCostThreshold(e.target.value)}
+                placeholder="e.g. 0.50"
+                className="h-8 text-xs font-mono"
+              />
+              <div className="flex justify-end">
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  className="h-7 text-xs"
+                  disabled={isSavingJobThreshold}
+                  onClick={saveJobCostThreshold}
+                >
+                  {isSavingJobThreshold ? 'Saving...' : 'Save'}
+                </Button>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
 
     </div>
   )

--- a/client/src/pages/__tests__/SettingsPageExtended.test.tsx
+++ b/client/src/pages/__tests__/SettingsPageExtended.test.tsx
@@ -131,9 +131,10 @@ describe('SettingsPage - extended coverage', () => {
     })
     const budgetInput = screen.getByPlaceholderText(/e\.g\. 5\.00/i) as HTMLInputElement
     await user.type(budgetInput, '5.00')
+    // First enabled Save button is the daily budget Save (Orchestrator Save is disabled)
     const saveBtn = screen.getAllByRole('button', { name: /^save$/i }).find(
-      (btn) => (btn as HTMLButtonElement).closest('div')?.querySelector('input[placeholder*="5.00"]')
-    ) ?? screen.getAllByRole('button', { name: /^save$/i })[0]
+      (btn) => !(btn as HTMLButtonElement).disabled
+    )!
     await user.click(saveBtn)
     await waitFor(() => {
       expect(toast.success).toHaveBeenCalledWith('Daily budget set to $5')
@@ -150,7 +151,10 @@ describe('SettingsPage - extended coverage', () => {
     })
     const budgetInput = screen.getByPlaceholderText(/e\.g\. 5\.00/i) as HTMLInputElement
     await user.type(budgetInput, '-1')
-    await user.click(screen.getAllByRole('button', { name: /^save$/i })[0])
+    const saveBtn = screen.getAllByRole('button', { name: /^save$/i }).find(
+      (btn) => !(btn as HTMLButtonElement).disabled
+    )!
+    await user.click(saveBtn)
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Enter a positive number or leave blank to disable')
     })
@@ -171,7 +175,10 @@ describe('SettingsPage - extended coverage', () => {
     })
     const budgetInput = screen.getByPlaceholderText(/e\.g\. 5\.00/i) as HTMLInputElement
     await user.clear(budgetInput)
-    await user.click(screen.getAllByRole('button', { name: /^save$/i })[0])
+    const saveBtn = screen.getAllByRole('button', { name: /^save$/i }).find(
+      (btn) => !(btn as HTMLButtonElement).disabled
+    )!
+    await user.click(saveBtn)
     await waitFor(() => {
       expect(toast.success).toHaveBeenCalledWith('Daily budget removed')
     })


### PR DESCRIPTION
## Summary

Follow-up polish to #235:

- **Orchestrator model Save UX**: Save button now disabled until the selection differs from the persisted value (`pendingOrchestratorModel` state tracks the in-flight change)
- **Generic descriptions**: removed "Claude" brand references from Orchestrator Model and Agent Models card descriptions — forward-compatible with other CLI providers
- **Budget layout**: two-column grid (Daily budget + Per-job cost alert side by side in one row instead of two stacked rows)
- **Test fixes**: `SettingsPageExtended` save-button selectors now find the first *enabled* Save button instead of using `[0]` (which would click the disabled Orchestrator Save)

## Test plan

- [ ] All client tests pass (`npx vitest run` from `client/`)
- [ ] Orchestrator Model Save button is disabled when no change, enabled after selecting a different model
- [ ] Budget section renders as two columns on the Settings page
- [ ] Card descriptions contain no "Claude" references

🤖 Generated with [Claude Code](https://claude.com/claude-code)