### PR TITLE
fix(setup): force fresh registry lookup when installing specrails-core

### DIFF
--- a/server/setup-manager.test.ts
+++ b/server/setup-manager.test.ts
@@ -157,7 +157,7 @@ describe('SetupManager', () => {
 
       expect(mockSpawn).toHaveBeenCalledWith(
         'npx',
-        ['specrails-core@latest', 'init', '--yes', '--root-dir', '/path/to/project'],
+        ['--yes', '--prefer-online', 'specrails-core@latest', 'init', '--yes', '--root-dir', '/path/to/project'],
         expect.objectContaining({ cwd: '/path/to/project' })
       )
     })
@@ -171,7 +171,7 @@ describe('SetupManager', () => {
 
       expect(mockSpawn).toHaveBeenCalledWith(
         'npx',
-        ['specrails-core@latest', 'init', '--yes', '--from-config', '/path/to/project/.specrails/install-config.yaml'],
+        ['--yes', '--prefer-online', 'specrails-core@latest', 'init', '--yes', '--from-config', '/path/to/project/.specrails/install-config.yaml'],
         expect.objectContaining({ cwd: '/path/to/project' })
       )
     })

--- a/server/setup-manager.ts
+++ b/server/setup-manager.ts
@@ -28,7 +28,7 @@ function getCoreCommand(): { bin: string; pkg: string } {
 
 function spawnCoreInit(args: string[], cwd: string): ChildProcess {
   const { bin, pkg } = getCoreCommand()
-  const fullArgs = pkg ? [pkg, 'init', ...args] : ['init', ...args]
+  const fullArgs = pkg ? ['--yes', '--prefer-online', pkg, 'init', ...args] : ['init', ...args]
   return spawn(bin, fullArgs, {
     cwd,
     env: process.env,


### PR DESCRIPTION
## Summary

- Adds `--prefer-online` flag to `npx` when spawning `specrails-core@latest init`
- Bypasses local npx cache so users always get the latest published version (fixes installs picking up stale versions like 4.0.5 instead of 4.0.7)
- Transparent to users — same wizard output, npx just verifies against registry first

## Test plan

- [ ] Existing `startInstall` spawn arg tests updated and passing (88/88)
- [ ] Verify setup wizard installs latest specrails-core version after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)