### PR TITLE
feat: inject ticket attachments + pre-prompt into implement spawns

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -37,7 +37,7 @@ import { useOsNotifications } from './hooks/useOsNotifications'
 import { WS_URL } from './lib/ws-url'
 import { API_ORIGIN } from './lib/origin'
 import { TerminalsProvider, useTerminals } from './context/TerminalsContext'
-import { FEATURE_TERMINAL_PANEL } from './lib/feature-flags'
+import { FEATURE_AGENTS_SECTION, FEATURE_TERMINAL_PANEL } from './lib/feature-flags'
 
 // ─── Hub mode detection ───────────────────────────────────────────────────────
 
@@ -161,7 +161,9 @@ function HubApp() {
 
   // Keyboard shortcuts
   const { cheatsheetOpen, setCheatsheetOpen, openCheatsheet } = useCheatsheetState()
-  const PROJECT_PAGES = ['/', '/jobs', '/analytics', '/settings']
+  const PROJECT_PAGES = FEATURE_AGENTS_SECTION
+    ? ['/', '/jobs', '/analytics', '/agents', '/settings']
+    : ['/', '/jobs', '/analytics', '/settings']
   useKeyboardShortcuts({
     onOpenCheatsheet: openCheatsheet,
     onToggleLeftSidebar: () => setLeftPinned((p) => !p),

--- a/client/src/components/AttachmentChip.tsx
+++ b/client/src/components/AttachmentChip.tsx
@@ -22,7 +22,7 @@ function iconForMime(mime: string): string {
   if (mime === 'application/pdf') return '📄'
   if (mime === 'text/csv' || mime.includes('spreadsheetml') || mime === 'application/vnd.ms-excel') return '📊'
   if (mime === 'application/json') return '{ }'
-  if (mime === 'text/plain') return '📝'
+  if (mime === 'text/plain' || mime.includes('sql')) return '📝'
   return '📎'
 }
 

--- a/client/src/components/AttachmentsSection.tsx
+++ b/client/src/components/AttachmentsSection.tsx
@@ -33,7 +33,7 @@ function iconForMime(mime: string): string {
   if (mime === 'application/pdf') return '📄'
   if (mime === 'text/csv' || mime.includes('spreadsheetml') || mime === 'application/vnd.ms-excel') return '📊'
   if (mime === 'application/json') return '{ }'
-  if (mime === 'text/plain') return '📝'
+  if (mime === 'text/plain' || mime.includes('sql')) return '📝'
   return '📎'
 }
 

--- a/client/src/components/BatchImplementWizard.tsx
+++ b/client/src/components/BatchImplementWizard.tsx
@@ -192,7 +192,7 @@ export function BatchImplementWizard({ open, onClose }: BatchImplementWizardProp
                           {availableProfiles.map((p) => (
                             <option key={p.name} value={p.name}>{p.name}</option>
                           ))}
-                          <option value="__legacy__">legacy</option>
+                          <option value="__legacy__">No profile</option>
                         </select>
                         {!isInherited && (
                           <button

--- a/client/src/components/ImplementWizard.tsx
+++ b/client/src/components/ImplementWizard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useReducer, useRef } from 'react'
+import { useReducer } from 'react'
 import { toast } from 'sonner'
 import { getApiBase } from '../lib/api'
 import type { IssueItem } from '../types'
@@ -14,7 +14,6 @@ import { IssuePickerStep, FreeFormStep } from './IssuePickerStep'
 import { cn } from '../lib/utils'
 import {
   ProfilePicker,
-  type ProfileSelection,
   selectionToSpawnPayload,
   useDefaultProfileSelection,
 } from './agents/ProfilePicker'
@@ -65,13 +64,6 @@ export function ImplementWizard({ open, onClose }: ImplementWizardProps) {
     freeFormDescription: '',
   })
   const [profileSelection, setProfileSelection] = useDefaultProfileSelection()
-  const initialProfileRef = useRef<ProfileSelection | null>(null)
-  // Capture the resolved default once so we know when the user changed it
-  useEffect(() => {
-    if (initialProfileRef.current === null) {
-      initialProfileRef.current = profileSelection
-    }
-  }, [profileSelection])
 
   function handleClose() {
     dispatch({ type: 'RESET' })
@@ -109,18 +101,6 @@ export function ImplementWizard({ open, onClose }: ImplementWizardProps) {
       })
       const data = await res.json() as { jobId?: string; error?: string }
       if (!res.ok) throw new Error(data.error ?? 'Failed to queue job')
-
-      // Persist per-developer preference when the user explicitly picked a
-      // non-default profile in this launch (fire-and-forget).
-      const initial = initialProfileRef.current
-      if (profileSelection.kind === 'profile' &&
-          (!initial || initial.kind !== 'profile' || initial.name !== profileSelection.name)) {
-        void fetch(`${getApiBase()}/profiles/active`, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ profile: profileSelection.name }),
-        }).catch(() => { /* non-fatal */ })
-      }
       const toastDesc = state.path === 'from-issues'
         ? state.selectedIssues.length === 1
           ? `#${state.selectedIssues[0].number}: ${state.selectedIssues[0].title}`

--- a/client/src/components/RichAttachmentEditor.tsx
+++ b/client/src/components/RichAttachmentEditor.tsx
@@ -12,12 +12,11 @@ import {
 import type { Attachment } from '../types'
 import {
   ATTACHMENT_ACCEPT_MIME,
+  isSupportedAttachmentFile,
   uploadAttachment,
 } from '../lib/attachments'
 import { cn } from '../lib/utils'
 import { AttachmentChip } from './AttachmentChip'
-
-const SUPPORTED = new Set(ATTACHMENT_ACCEPT_MIME.split(','))
 
 export interface RichAttachmentEditorHandle {
   getPlainText: () => string
@@ -247,7 +246,7 @@ export const RichAttachmentEditor = forwardRef<RichAttachmentEditorHandle, RichA
 
     const uploadFile = useCallback(
       async (file: File) => {
-        if (!SUPPORTED.has(file.type)) {
+        if (!isSupportedAttachmentFile(file)) {
           onUnsupportedFile?.(file)
           return
         }

--- a/client/src/components/__tests__/AttachmentChip.test.tsx
+++ b/client/src/components/__tests__/AttachmentChip.test.tsx
@@ -103,6 +103,11 @@ describe('AttachmentChip', () => {
     expect(container.textContent).toContain('📝')
   })
 
+  it('shows text icon for sql mime types', () => {
+    const { container } = render(<AttachmentChip attachment={makeAttachment({ mimeType: 'application/sql', filename: 'schema.sql' })} />)
+    expect(container.textContent).toContain('📝')
+  })
+
   it('shows fallback icon for unknown mime type', () => {
     const { container } = render(<AttachmentChip attachment={makeAttachment({ mimeType: 'application/octet-stream', filename: 'file.bin' })} />)
     expect(container.textContent).toContain('📎')

--- a/client/src/components/__tests__/KeyboardShortcutsCheatsheet.test.tsx
+++ b/client/src/components/__tests__/KeyboardShortcutsCheatsheet.test.tsx
@@ -33,6 +33,9 @@ describe('KeyboardShortcutsCheatsheet', () => {
     render(
       <KeyboardShortcutsCheatsheet open={true} onOpenChange={vi.fn()} />,
     )
+    expect(
+      screen.getByText('Navigate to project page (Dashboard/Jobs/Analytics/Agents/Settings)'),
+    ).toBeInTheDocument()
     expect(screen.getByText('Go to Dashboard')).toBeInTheDocument()
     expect(screen.getByText('Go to Analytics')).toBeInTheDocument()
     expect(screen.getByText('Go to Settings')).toBeInTheDocument()

--- a/client/src/components/agents/ProfileAnalyticsCard.tsx
+++ b/client/src/components/agents/ProfileAnalyticsCard.tsx
@@ -47,7 +47,40 @@ export function ProfileAnalyticsCard() {
   }, [windowDays])
 
   if (loading && !data) return null
-  if (!data || data.rows.length === 0) return null
+  if (!data || data.rows.length === 0) {
+    return (
+      <div className="mx-6 my-4 rounded-md border border-border bg-muted/20">
+        <div className="flex items-center justify-between px-4 py-2 border-b border-border">
+          <div>
+            <div className="text-xs font-medium text-foreground">Profile usage</div>
+            <div className="text-[11px] text-muted-foreground">
+              Jobs launched per profile in the selected window.
+            </div>
+          </div>
+          <div className="flex gap-0.5">
+            {WINDOW_OPTIONS.map((opt) => (
+              <button
+                key={opt.days}
+                type="button"
+                onClick={() => setWindowDays(opt.days)}
+                className={
+                  'text-[10px] px-2 py-1 rounded transition-colors ' +
+                  (windowDays === opt.days
+                    ? 'bg-accent text-foreground'
+                    : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground')
+                }
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="px-4 py-8 text-xs text-muted-foreground">
+          No profile-scoped jobs yet.
+        </div>
+      </div>
+    )
+  }
 
   const maxJobs = Math.max(...data.rows.map((r) => r.jobs), 1)
 

--- a/client/src/components/agents/ProfileEditor.tsx
+++ b/client/src/components/agents/ProfileEditor.tsx
@@ -32,6 +32,8 @@ import {
   type RoutingTagRule,
 } from './types'
 
+const ROUTING_TAG_PATTERN = /^[a-z0-9][a-z0-9-]*$/
+
 interface CatalogAgent {
   id: string
   kind: 'upstream' | 'custom'
@@ -42,17 +44,17 @@ export function ProfileEditor({
   onChange,
   footer,
   onValidityChange,
+  onSoftWarningsChange,
 }: {
   profile: Profile
   onChange: (p: Profile) => void
   footer?: ReactNode
   onValidityChange?: (issues: string[]) => void
+  onSoftWarningsChange?: (warnings: { agentsMissingRouting: string[] }) => void
 }) {
-  // The shipped `default` profile keeps the strict baseline/pin constraints —
-  // removing architect or moving merge-resolver would break the pipeline the
-  // hub ships. Custom profiles get max flexibility: every agent is removable
-  // and every routing rule is deletable, including the default catch-all.
-  const isDefaultProfile = profile.name === 'default' || profile.name === 'project-default'
+  // Baseline agents (architect / developer / reviewer / merge-resolver) are
+  // required and pinned in every profile — default and custom alike — because
+  // the pipeline relies on all four. Routing rules stay fully flexible.
   const [catalog, setCatalog] = useState<CatalogAgent[]>([])
   const [pickingAgent, setPickingAgent] = useState(false)
   const [addRoutingPrompt, setAddRoutingPrompt] = useState(false)
@@ -84,16 +86,10 @@ export function ProfileEditor({
   // ── Live validation (structural checks beyond the JSON schema) ─────────────
   const validationIssues: string[] = useMemo(() => {
     const issues: string[] = []
-    // At least one agent is always required (schema minItems: 1).
-    if (profile.agents.length === 0) {
-      issues.push('Agent chain is empty — add at least one agent before saving')
-    }
-    // Baseline requirement only binds the shipped default profile.
-    if (isDefaultProfile) {
-      for (const baseline of BASELINE_REQUIRED_AGENTS) {
-        if (!profile.agents.some((a) => a.id === baseline)) {
-          issues.push(`Missing required baseline agent: ${baseline}`)
-        }
+    // Baseline is required on every profile — default and custom alike.
+    for (const baseline of BASELINE_REQUIRED_AGENTS) {
+      if (!profile.agents.some((a) => a.id === baseline)) {
+        issues.push(`Missing required baseline agent: ${baseline}`)
       }
     }
     // Routing: at most one default rule, last if present.
@@ -111,40 +107,62 @@ export function ProfileEditor({
       if (!profile.agents.some((a) => a.id === rule.agent)) {
         issues.push(`Routing references agent not in the chain: ${rule.agent}`)
       }
+      if ('tags' in rule) {
+        const invalidTags = rule.tags.filter((tag) => !ROUTING_TAG_PATTERN.test(tag))
+        if (invalidTags.length > 0) {
+          issues.push(
+            `Routing rule ${rule.agent} has invalid tags: ${invalidTags.join(', ')} (use lowercase kebab-case)`,
+          )
+        }
+      }
     }
     return issues
-  }, [profile, isDefaultProfile])
+  }, [profile])
+
+  // ── Soft warnings (non-blocking, surfaced at save-time) ─────────────────────
+  // Only surface this when explicit routing exists. If routing is empty the
+  // runtime falls back to the first developer-shaped agent in the chain.
+  const agentsMissingRouting: string[] = useMemo(() => {
+    if (profile.routing.length === 0) return []
+    const routedIds = new Set(profile.routing.map((r) => r.agent))
+    return profile.agents
+      .filter((a) => !BASELINE_REQUIRED_AGENTS.has(a.id) && !routedIds.has(a.id))
+      .map((a) => a.id)
+  }, [profile])
+
+  const hasDefaultRoutingRule = useMemo(
+    () => profile.routing.some((r) => 'default' in r && r.default === true),
+    [profile.routing],
+  )
 
   useEffect(() => {
     if (onValidityChange) onValidityChange(validationIssues)
   }, [validationIssues, onValidityChange])
 
+  useEffect(() => {
+    if (onSoftWarningsChange) onSoftWarningsChange({ agentsMissingRouting })
+  }, [agentsMissingRouting, onSoftWarningsChange])
+
   const addAgent = (id: string) => {
     update((d) => {
-      // On the default profile, insert before sr-merge-resolver so the merge
-      // row stays pinned last without a manual move. Custom profiles just
-      // append — user reorders freely.
+      // Insert before sr-merge-resolver if present so the merge row stays
+      // pinned last without a manual reorder after every add.
       const row: ProfileAgent = { id, model: 'sonnet' }
-      if (isDefaultProfile) {
-        const mergeIdx = d.agents.findIndex((a) => a.id === 'sr-merge-resolver')
-        if (mergeIdx >= 0) {
-          d.agents.splice(mergeIdx, 0, row)
-          setPickingAgent(false)
-          return
-        }
+      const mergeIdx = d.agents.findIndex((a) => a.id === 'sr-merge-resolver')
+      if (mergeIdx >= 0) {
+        d.agents.splice(mergeIdx, 0, row)
+      } else {
+        d.agents.push(row)
       }
-      d.agents.push(row)
     })
     setPickingAgent(false)
   }
 
   const removeAgent = (idx: number) => {
     const agent = profile.agents[idx]
-    // Baseline agents can only be removed in custom profiles; the default
-    // profile keeps them locked.
-    if (isDefaultProfile && BASELINE_REQUIRED_AGENTS.has(agent.id)) return
-    // Custom profiles must still hold at least one agent (schema minItems: 1).
-    if (profile.agents.length <= 1) return
+    // Baseline agents (architect/developer/reviewer/merge-resolver) can't be
+    // removed from any profile — the pipeline depends on all four.
+    if (BASELINE_REQUIRED_AGENTS.has(agent.id)) return
     update((d) => {
       d.agents.splice(idx, 1)
       // Cascade: drop routing rules that target the removed agent.
@@ -158,18 +176,16 @@ export function ProfileEditor({
     const newIndex = profile.agents.findIndex((a) => a.id === overId)
     if (oldIndex < 0 || newIndex < 0) return
     const reordered = arrayMove(profile.agents, oldIndex, newIndex)
-    // Pins only apply to the default profile. Custom profiles get free reorder.
-    if (isDefaultProfile) {
-      const archIdx = reordered.findIndex((a) => a.id === 'sr-architect')
-      if (archIdx > 0) {
-        const [arch] = reordered.splice(archIdx, 1)
-        reordered.unshift(arch)
-      }
-      const mergeIdx = reordered.findIndex((a) => a.id === 'sr-merge-resolver')
-      if (mergeIdx >= 0 && mergeIdx !== reordered.length - 1) {
-        const [merge] = reordered.splice(mergeIdx, 1)
-        reordered.push(merge)
-      }
+    // Pins apply to every profile: architect starts the pipeline, merge runs last.
+    const archIdx = reordered.findIndex((a) => a.id === 'sr-architect')
+    if (archIdx > 0) {
+      const [arch] = reordered.splice(archIdx, 1)
+      reordered.unshift(arch)
+    }
+    const mergeIdx = reordered.findIndex((a) => a.id === 'sr-merge-resolver')
+    if (mergeIdx >= 0 && mergeIdx !== reordered.length - 1) {
+      const [merge] = reordered.splice(mergeIdx, 1)
+      reordered.push(merge)
     }
     update((d) => {
       d.agents = reordered
@@ -195,19 +211,38 @@ export function ProfileEditor({
 
   const addRoutingRule = (tags: string[], agent: string) => {
     update((d) => {
-      const defaultRule = d.routing.pop() as RoutingDefaultRule
       const newRule: RoutingTagRule = { tags, agent }
-      d.routing.push(newRule)
-      d.routing.push(defaultRule)
+      const defaultIdx = d.routing.findIndex((r) => 'default' in r && r.default === true)
+      if (defaultIdx >= 0) {
+        d.routing.splice(defaultIdx, 0, newRule)
+      } else {
+        d.routing.push(newRule)
+      }
     })
     setAddRoutingPrompt(false)
   }
 
+  const addDefaultRoutingRule = () => {
+    update((d) => {
+      if (d.routing.some((r) => 'default' in r && r.default === true)) return
+      const fallbackAgent =
+        d.agents.find((a) => a.id === 'sr-developer')?.id ?? d.agents[0]?.id ?? ''
+      if (!fallbackAgent) return
+      const newRule: RoutingDefaultRule = { default: true, agent: fallbackAgent }
+      d.routing.push(newRule)
+    })
+  }
+
+  const setRoutingRuleAgent = (idx: number, agent: string) => {
+    update((d) => {
+      if (!d.routing[idx]) return
+      d.routing[idx].agent = agent
+    })
+  }
+
   const removeRoutingRule = (idx: number) => {
-    const rule = profile.routing[idx]
-    // Default profile keeps its terminal default rule locked. Custom profiles
-    // can delete everything.
-    if (isDefaultProfile && 'default' in rule && rule.default) return
+    // Every rule is removable — including the default catch-all. Users can
+    // rebuild their routing from scratch.
     update((d) => {
       d.routing.splice(idx, 1)
     })
@@ -218,11 +253,9 @@ export function ProfileEditor({
     if (target < 0 || target >= profile.routing.length) return
     const rule = profile.routing[idx]
     const targetRule = profile.routing[target]
-    // Default profile enforces: default rule stays last, others can't jump past it.
-    if (isDefaultProfile) {
-      if ('default' in rule && rule.default) return
-      if ('default' in targetRule && targetRule.default) return
-    }
+    // Keep the default rule last at all times — enforced regardless of profile type.
+    if ('default' in rule && rule.default) return
+    if ('default' in targetRule && targetRule.default) return
     update((d) => {
       const [item] = d.routing.splice(idx, 1)
       d.routing.splice(target, 0, item)
@@ -366,8 +399,7 @@ export function ProfileEditor({
                 <AgentRow
                   key={agent.id}
                   agent={agent}
-                  strictMode={isDefaultProfile}
-                  canRemove={profile.agents.length > 1 && (!isDefaultProfile || !BASELINE_REQUIRED_AGENTS.has(agent.id))}
+                  canRemove={!BASELINE_REQUIRED_AGENTS.has(agent.id)}
                   onModel={(m) => setAgentModel(idx, m)}
                   onRemove={() => removeAgent(idx)}
                 />
@@ -383,33 +415,56 @@ export function ProfileEditor({
           <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
             Routing ({profile.routing.length})
           </h2>
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={() => setAddRoutingPrompt(true)}
-            disabled={profile.agents.length === 0}
-            title={profile.agents.length === 0 ? 'Add at least one agent before creating routing rules' : undefined}
-          >
-            <Plus className="w-3.5 h-3.5 mr-1" /> Add rule
-          </Button>
+          <div className="flex items-center gap-1">
+            {!hasDefaultRoutingRule && (
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={addDefaultRoutingRule}
+                disabled={profile.agents.length === 0}
+                title={profile.agents.length === 0 ? 'Add at least one agent before creating routing rules' : undefined}
+              >
+                <Plus className="w-3.5 h-3.5 mr-1" /> Add default
+              </Button>
+            )}
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => setAddRoutingPrompt(true)}
+              disabled={profile.agents.length === 0}
+              title={profile.agents.length === 0 ? 'Add at least one agent before creating routing rules' : undefined}
+            >
+              <Plus className="w-3.5 h-3.5 mr-1" /> Add rule
+            </Button>
+          </div>
         </div>
         <p className="text-[11px] text-muted-foreground mb-2">
-          {isDefaultProfile
-            ? 'First matching rule wins. The default rule catches unmatched tasks and must stay at the end.'
-            : 'First matching rule wins. Routing is fully optional on custom profiles — leave empty to send everything to the first agent in the chain.'}
+          First matching rule wins. Rules are editable and removable, and the default catch-all
+          stays last when present. If you leave routing empty, the pipeline falls back to the
+          first developer-shaped agent in the chain.
         </p>
+        {agentsMissingRouting.length > 0 && (
+          <div className="mb-2 px-3 py-2 text-xs rounded-md border border-yellow-500/30 bg-yellow-500/10 text-yellow-500">
+            <div className="font-medium mb-1">Untargeted agents in the chain</div>
+            <div>
+              No routing rule points to: <span className="font-mono">{agentsMissingRouting.join(', ')}</span>.
+              Add a tag rule or retarget the default rule if you want them to run.
+            </div>
+          </div>
+        )}
         <div className="space-y-1.5">
           {profile.routing.map((rule, idx) => {
             const isDefault = 'default' in rule && rule.default === true
-            const locked = isDefaultProfile && isDefault
             return (
               <RoutingRow
                 key={idx}
                 rule={rule}
                 ordinal={idx + 1}
                 isLast={idx === profile.routing.length - 1}
-                canMove={!locked}
-                canRemove={!locked}
+                canMove={!isDefault}
+                canRemove={true}
+                chainAgents={profile.agents.map((a) => a.id)}
+                onAgentChange={(agent) => setRoutingRuleAgent(idx, agent)}
                 onUp={() => moveRoutingRule(idx, -1)}
                 onDown={() => moveRoutingRule(idx, 1)}
                 onRemove={() => removeRoutingRule(idx)}
@@ -426,22 +481,20 @@ export function ProfileEditor({
 
 function AgentRow({
   agent,
-  strictMode,
   canRemove,
   onModel,
   onRemove,
 }: {
   agent: ProfileAgent
-  strictMode: boolean
   canRemove: boolean
   onModel: (m: ModelAlias) => void
   onRemove: () => void
 }) {
-  // Badges + pins only apply under strict mode (default profile). Custom
-  // profiles get free reordering and removal.
-  const isRequired = strictMode && BASELINE_REQUIRED_AGENTS.has(agent.id)
-  const pinnedFirst = strictMode && agent.id === 'sr-architect'
-  const pinnedLast = strictMode && agent.id === 'sr-merge-resolver'
+  // Baseline is required + pinned on every profile. Architect first,
+  // merge-resolver last.
+  const isRequired = BASELINE_REQUIRED_AGENTS.has(agent.id)
+  const pinnedFirst = agent.id === 'sr-architect'
+  const pinnedLast = agent.id === 'sr-merge-resolver'
   // sr-merge-resolver and sr-architect stay draggable like the rest; the
   // ProfileEditor's reorder handler snaps them back to first/last slots
   // after any drop so the pipeline invariant is preserved at the data layer
@@ -502,9 +555,7 @@ function AgentRow({
         title={
           canRemove
             ? 'Remove'
-            : isRequired
-              ? 'Required baseline agent (default profile)'
-              : 'At least one agent must remain'
+            : 'Required baseline agent — the pipeline depends on this row'
         }
       >
         <X className="w-3 h-3" />
@@ -519,6 +570,8 @@ function RoutingRow({
   isLast,
   canMove,
   canRemove,
+  chainAgents,
+  onAgentChange,
   onUp,
   onDown,
   onRemove,
@@ -528,6 +581,8 @@ function RoutingRow({
   isLast: boolean
   canMove: boolean
   canRemove: boolean
+  chainAgents: string[]
+  onAgentChange: (agent: string) => void
   onUp: () => void
   onDown: () => void
   onRemove: () => void
@@ -550,7 +605,18 @@ function RoutingRow({
         </span>
       )}
       <span className="text-xs text-muted-foreground">→</span>
-      <span className="text-sm font-mono">{rule.agent}</span>
+      <select
+        value={rule.agent}
+        onChange={(e) => onAgentChange(e.target.value)}
+        aria-label={isDefault ? 'Default routing target' : `Routing target for rule ${ordinal}`}
+        className="h-7 max-w-[15rem] px-2 text-xs font-mono rounded border border-border bg-background"
+      >
+        {chainAgents.map((agentId) => (
+          <option key={agentId} value={agentId}>
+            {agentId}
+          </option>
+        ))}
+      </select>
       <div className="flex gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
         {canMove && !isLast && (
           <button type="button" className="p-1 hover:bg-accent rounded" onClick={onDown} title="Move down">

--- a/client/src/components/agents/ProfilePicker.tsx
+++ b/client/src/components/agents/ProfilePicker.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Bot } from 'lucide-react'
 import { getApiBase } from '../../lib/api'
-import type { ProfileListEntry, UserPreferred } from './types'
+import type { ProfileListEntry } from './types'
 
 export type ProfileSelection =
   | { kind: 'profile'; name: string }
@@ -14,9 +14,9 @@ interface Props {
 }
 
 /**
- * Launch-time profile picker. Shows available profiles + a "legacy (no profile)"
+ * Launch-time profile picker. Shows available profiles + a "no profile"
  * option. Preselects the caller-provided value (which the caller should seed
- * from the project's preferred/default via `useDefaultProfileSelection`).
+ * from the project's default via `useDefaultProfileSelection`).
  */
 export function ProfilePicker({ value, onChange, compact = false }: Props) {
   const [profiles, setProfiles] = useState<ProfileListEntry[]>([])
@@ -63,35 +63,27 @@ export function ProfilePicker({ value, onChange, compact = false }: Props) {
             {p.isDefault ? ' (default)' : ''}
           </option>
         ))}
-        <option value="__legacy__">Legacy (no profile)</option>
+        <option value="__legacy__">No profile</option>
       </select>
     </label>
   )
 }
 
 /**
- * Resolve the picker's initial value: use the project's preferred profile,
- * else fall back to `default` if present in the list.
+ * Resolve the picker's initial value from the project's default profile.
  */
 export function useDefaultProfileSelection(): [ProfileSelection, (s: ProfileSelection) => void] {
   const [selection, setSelection] = useState<ProfileSelection>({ kind: 'legacy' })
 
   useEffect(() => {
     let cancelled = false
-    Promise.all([
-      fetch(`${getApiBase()}/profiles`).then((r) => (r.ok ? (r.json() as Promise<{ profiles: ProfileListEntry[] }>) : { profiles: [] })),
-      fetch(`${getApiBase()}/profiles/active`).then((r) => (r.ok ? (r.json() as Promise<{ preferred: UserPreferred | null }>) : { preferred: null })),
-    ])
-      .then(([profilesData, activeData]) => {
+    fetch(`${getApiBase()}/profiles`)
+      .then((r) => (r.ok ? (r.json() as Promise<{ profiles: ProfileListEntry[] }>) : { profiles: [] }))
+      .then((profilesData) => {
         if (cancelled) return
         const { profiles } = profilesData
         if (profiles.length === 0) {
           setSelection({ kind: 'legacy' })
-          return
-        }
-        const preferredName = activeData.preferred?.profile
-        if (preferredName && profiles.some((p) => p.name === preferredName)) {
-          setSelection({ kind: 'profile', name: preferredName })
           return
         }
         const defaultP = profiles.find((p) => p.isDefault) ?? profiles[0]

--- a/client/src/components/agents/ProfilesTab.tsx
+++ b/client/src/components/agents/ProfilesTab.tsx
@@ -1,22 +1,21 @@
 import { useCallback, useEffect, useState } from 'react'
-import { Plus, Trash2, Copy, Save, Star, Wand2 } from 'lucide-react'
+import { Plus, Trash2, Copy, Save, Wand2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { getApiBase } from '../../lib/api'
 import { Button } from '../ui/button'
 import { ProfileEditor } from './ProfileEditor'
-import { ProfileAnalyticsCard } from './ProfileAnalyticsCard'
 import { ConfirmDialog, PromptDialog } from './PromptDialog'
-import type { Profile, ProfileListEntry, UserPreferred } from './types'
+import type { Profile, ProfileListEntry } from './types'
 
 export function ProfilesTab() {
   const [profiles, setProfiles] = useState<ProfileListEntry[]>([])
-  const [preferred, setPreferred] = useState<UserPreferred | null>(null)
   const [selected, setSelected] = useState<string | null>(null)
   const [editing, setEditing] = useState<Profile | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
   const [validationIssues, setValidationIssues] = useState<string[]>([])
+  const [agentsMissingRouting, setAgentsMissingRouting] = useState<string[]>([])
   const [createDialog, setCreateDialog] = useState(false)
   const [duplicateDialog, setDuplicateDialog] = useState<{ from: string } | null>(null)
   const [deleteDialog, setDeleteDialog] = useState<{ name: string } | null>(null)
@@ -25,17 +24,10 @@ export function ProfilesTab() {
     setLoading(true)
     setError(null)
     try {
-      const [profilesRes, activeRes] = await Promise.all([
-        fetch(`${getApiBase()}/profiles`),
-        fetch(`${getApiBase()}/profiles/active`),
-      ])
+      const profilesRes = await fetch(`${getApiBase()}/profiles`)
       if (!profilesRes.ok) throw new Error(`List failed: ${profilesRes.status}`)
       const profilesData = (await profilesRes.json()) as { profiles: ProfileListEntry[] }
       setProfiles(profilesData.profiles)
-      if (activeRes.ok) {
-        const activeData = (await activeRes.json()) as { preferred: UserPreferred | null }
-        setPreferred(activeData.preferred)
-      }
       if (profilesData.profiles.length > 0 && !selected) {
         setSelected(profilesData.profiles[0].name)
       }
@@ -202,7 +194,7 @@ export function ProfilesTab() {
   const duplicate = useCallback((name: string) => setDuplicateDialog({ from: name }), [])
   const remove = useCallback((name: string) => setDeleteDialog({ name }), [])
 
-  const save = useCallback(async (profile: Profile) => {
+  const save = useCallback(async (profile: Profile, missingRouting: string[]) => {
     setSaving(true)
     setError(null)
     try {
@@ -216,7 +208,14 @@ export function ProfilesTab() {
         throw new Error(err.error ?? `Save failed: ${res.status}`)
       }
       setEditing(profile)
-      toast.success('Profile saved', { description: profile.name })
+      if (missingRouting.length > 0) {
+        toast.warning('Profile saved with untargeted agents', {
+          description: `No routing rule points to: ${missingRouting.join(', ')}. Add a tag rule or retarget the default rule if you want them to run.`,
+          duration: 6000,
+        })
+      } else {
+        toast.success('Profile saved', { description: profile.name })
+      }
     } catch (e) {
       const message = (e as Error).message
       setError(message)
@@ -225,33 +224,6 @@ export function ProfilesTab() {
       setSaving(false)
     }
   }, [])
-
-  const markPreferred = useCallback(
-    async (name: string) => {
-      setSaving(true)
-      setError(null)
-      try {
-        const res = await fetch(`${getApiBase()}/profiles/active`, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ profile: name }),
-        })
-        if (!res.ok) {
-          const err = await res.json().catch(() => ({}))
-          throw new Error(err.error ?? `Set preferred failed: ${res.status}`)
-        }
-        setPreferred({ profile: name })
-        toast.success('Preferred profile set', { description: name })
-      } catch (e) {
-        const message = (e as Error).message
-        setError(message)
-        toast.error('Failed to set preferred profile', { description: message })
-      } finally {
-        setSaving(false)
-      }
-    },
-    [],
-  )
 
   const dialogs = (
     <>
@@ -335,7 +307,6 @@ export function ProfilesTab() {
   return (
     <div className="flex flex-col h-full">
       {dialogs}
-      <ProfileAnalyticsCard />
       <div className="flex flex-1 min-h-0">
       {/* Left: profile list */}
       <aside className="w-64 flex-shrink-0 border-r border-border flex flex-col">
@@ -350,7 +321,6 @@ export function ProfilesTab() {
         <div className="flex-1 overflow-auto px-2 pb-3">
           {profiles.map((p) => {
             const isSelected = p.name === selected
-            const isPreferred = preferred?.profile === p.name
             return (
               <div
                 key={p.name}
@@ -372,27 +342,8 @@ export function ProfilesTab() {
                   {p.isDefault && (
                     <span className="text-[10px] text-muted-foreground">(team default)</span>
                   )}
-                  {isPreferred && (
-                    <span
-                      className="inline-flex items-center gap-0.5 text-[9px] px-1 py-0.5 rounded bg-yellow-500/15 text-yellow-500 flex-shrink-0"
-                      title="This profile is your personal default — preselected when you open a launch dialog."
-                    >
-                      <Star className="w-2.5 h-2.5 fill-yellow-500" /> mine
-                    </span>
-                  )}
                 </div>
                 <div className="flex gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
-                  <button
-                    type="button"
-                    className="p-1 hover:bg-accent rounded"
-                    title="Set as my personal default — preselected for me at launch time (other devs keep the team default)"
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      void markPreferred(p.name)
-                    }}
-                  >
-                    <Star className="w-3 h-3" />
-                  </button>
                   <button
                     type="button"
                     className="p-1 hover:bg-accent rounded"
@@ -437,11 +388,12 @@ export function ProfilesTab() {
             profile={editing}
             onChange={setEditing}
             onValidityChange={setValidationIssues}
+            onSoftWarningsChange={(w) => setAgentsMissingRouting(w.agentsMissingRouting)}
             footer={
               <div className="flex items-center gap-2">
                 <Button
                   size="sm"
-                  onClick={() => void save(editing)}
+                  onClick={() => void save(editing, agentsMissingRouting)}
                   disabled={saving || validationIssues.length > 0}
                   title={validationIssues.length > 0 ? 'Fix validation issues before saving' : undefined}
                 >

--- a/client/src/components/agents/RailProfileSelector.tsx
+++ b/client/src/components/agents/RailProfileSelector.tsx
@@ -64,7 +64,7 @@ export function RailProfileSelector({ value, onChange }: Props) {
             {p.name}
           </option>
         ))}
-        <option value={LEGACY_VALUE}>legacy</option>
+        <option value={LEGACY_VALUE}>No profile</option>
       </select>
     </div>
   )

--- a/client/src/components/agents/RoutingRuleDialog.tsx
+++ b/client/src/components/agents/RoutingRuleDialog.tsx
@@ -1,7 +1,16 @@
 import { useEffect, useState } from 'react'
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
+
+const ROUTING_TAG_PATTERN = /^[a-z0-9][a-z0-9-]*$/
 
 interface Props {
   open: boolean
@@ -28,13 +37,20 @@ export function RoutingRuleDialog({ open, chainAgents, onConfirm, onCancel }: Pr
   }, [open, chainAgents])
 
   const parsedTags = tags.split(',').map((t) => t.trim()).filter(Boolean)
-  const canConfirm = parsedTags.length > 0 && chainAgents.includes(agent)
+  const invalidTags = parsedTags.filter((tag) => !ROUTING_TAG_PATTERN.test(tag))
+  const canConfirm =
+    parsedTags.length > 0 &&
+    invalidTags.length === 0 &&
+    chainAgents.includes(agent)
 
   return (
     <Dialog open={open} onOpenChange={(o) => { if (!o) onCancel() }}>
       <DialogContent className="max-w-md">
         <DialogHeader>
           <DialogTitle>Add routing rule</DialogTitle>
+          <DialogDescription>
+            Add a tag-matched routing rule using lowercase kebab-case tags.
+          </DialogDescription>
         </DialogHeader>
         <div className="py-2 space-y-3">
           <div>
@@ -46,11 +62,18 @@ export function RoutingRuleDialog({ open, chainAgents, onConfirm, onCancel }: Pr
               value={tags}
               onChange={(e) => setTags(e.target.value)}
               placeholder="frontend, ui"
+              aria-label="Tags"
               className="text-sm font-mono"
             />
             <p className="text-[11px] text-muted-foreground mt-1">
-              Comma-separated. Rule fires when any of these tags appears on a task.
+              Comma-separated. Use lowercase kebab-case like <code>frontend</code> or <code>api-design</code>.
             </p>
+            {invalidTags.length > 0 && (
+              <p className="text-[11px] text-red-400 mt-1">
+                Invalid tag{invalidTags.length === 1 ? '' : 's'}: {invalidTags.join(', ')}.
+                Tags must use lowercase letters, digits, and hyphens only.
+              </p>
+            )}
           </div>
           <div>
             <label className="block text-xs font-medium text-muted-foreground mb-1">
@@ -59,6 +82,7 @@ export function RoutingRuleDialog({ open, chainAgents, onConfirm, onCancel }: Pr
             <select
               value={agent}
               onChange={(e) => setAgent(e.target.value)}
+              aria-label="Route to"
               className="w-full h-9 px-2 text-sm rounded-md border border-border bg-background"
             >
               {chainAgents.map((a) => (

--- a/client/src/components/agents/__tests__/ProfileEditor.test.tsx
+++ b/client/src/components/agents/__tests__/ProfileEditor.test.tsx
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
+import { render } from '../../../test-utils'
+import { ProfileEditor } from '../ProfileEditor'
+import type { Profile } from '../types'
+
+function makeProfile(overrides?: Partial<Profile>): Profile {
+  return {
+    schemaVersion: 1,
+    name: 'data-heavy',
+    description: 'test profile',
+    orchestrator: { model: 'sonnet' },
+    agents: [
+      { id: 'sr-architect', required: true },
+      { id: 'sr-developer', required: true },
+      { id: 'custom-data-engineer', model: 'sonnet' },
+      { id: 'sr-reviewer', required: true },
+      { id: 'sr-merge-resolver', required: true },
+    ],
+    routing: [{ default: true, agent: 'sr-developer' }],
+    ...overrides,
+  }
+}
+
+describe('ProfileEditor', () => {
+  beforeEach(() => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ agents: [] }),
+    } as Response)
+  })
+
+  it('does not flag untargeted custom agents when routing is empty', async () => {
+    const onSoftWarningsChange = vi.fn()
+
+    await act(async () => {
+      render(
+        <ProfileEditor
+          profile={makeProfile({ routing: [] })}
+          onChange={vi.fn()}
+          onSoftWarningsChange={onSoftWarningsChange}
+        />,
+      )
+    })
+
+    await waitFor(() => {
+      expect(onSoftWarningsChange).toHaveBeenCalled()
+    })
+
+    expect(onSoftWarningsChange).toHaveBeenLastCalledWith({ agentsMissingRouting: [] })
+    expect(screen.queryByText(/untargeted agents in the chain/i)).not.toBeInTheDocument()
+  })
+
+  it('lets the user retarget the default rule to a custom agent', async () => {
+    const onChange = vi.fn()
+
+    await act(async () => {
+      render(<ProfileEditor profile={makeProfile()} onChange={onChange} />)
+    })
+
+    expect(screen.getByText(/untargeted agents in the chain/i)).toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText('Default routing target'), {
+      target: { value: 'custom-data-engineer' },
+    })
+
+    expect(onChange).toHaveBeenCalled()
+    expect(onChange.mock.calls.at(-1)?.[0]).toMatchObject({
+      routing: [{ default: true, agent: 'custom-data-engineer' }],
+    })
+  })
+})

--- a/client/src/components/agents/__tests__/RoutingRuleDialog.test.tsx
+++ b/client/src/components/agents/__tests__/RoutingRuleDialog.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, screen } from '@testing-library/react'
+import { render } from '../../../test-utils'
+import { RoutingRuleDialog } from '../RoutingRuleDialog'
+
+describe('RoutingRuleDialog', () => {
+  it('blocks invalid tags that do not match the profile schema', () => {
+    render(
+      <RoutingRuleDialog
+        open={true}
+        chainAgents={['sr-developer', 'custom-data-engineer']}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    fireEvent.change(screen.getByLabelText('Tags'), {
+      target: { value: 'frontend, Data Engineer' },
+    })
+
+    expect(screen.getByText(/invalid tag: Data Engineer/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Add rule' })).toBeDisabled()
+  })
+
+  it('submits trimmed valid kebab-case tags', () => {
+    const onConfirm = vi.fn()
+
+    render(
+      <RoutingRuleDialog
+        open={true}
+        chainAgents={['sr-developer', 'custom-data-engineer']}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    fireEvent.change(screen.getByLabelText('Tags'), {
+      target: { value: 'frontend, data-engineering' },
+    })
+    fireEvent.change(screen.getByLabelText('Route to'), {
+      target: { value: 'custom-data-engineer' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Add rule' }))
+
+    expect(onConfirm).toHaveBeenCalledWith(
+      ['frontend', 'data-engineering'],
+      'custom-data-engineer',
+    )
+  })
+})

--- a/client/src/components/agents/types.ts
+++ b/client/src/components/agents/types.ts
@@ -37,10 +37,6 @@ export interface ProfileListEntry {
   updatedAt: number
 }
 
-export interface UserPreferred {
-  profile: string
-}
-
 export const BASELINE_REQUIRED_AGENTS = new Set([
   'sr-architect',
   'sr-developer',

--- a/client/src/components/terminal/TerminalSidebar.tsx
+++ b/client/src/components/terminal/TerminalSidebar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Terminal as TerminalIcon, X } from 'lucide-react'
+import { Pencil, Terminal as TerminalIcon, X } from 'lucide-react'
 import { cn } from '../../lib/utils'
 import type { TerminalRef } from '../../context/TerminalsContext'
 
@@ -63,6 +63,11 @@ function SidebarItem({ session, active, onActivate, onRename, onKill }: SidebarI
     if (trimmed && trimmed !== session.name) onRename(trimmed)
     setEditing(false)
   }
+
+  function startEditing() {
+    setEditing(true)
+  }
+
   function cancel() {
     setEditing(false)
     setDraft(session.name)
@@ -79,7 +84,7 @@ function SidebarItem({ session, active, onActivate, onRename, onKill }: SidebarI
           if (editing) return
           if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onActivate() }
         }}
-        onDoubleClick={() => setEditing(true)}
+        onDoubleClick={startEditing}
         className={cn(
           'flex items-center gap-2 px-2 py-1.5 rounded-md text-xs cursor-pointer select-none',
           'transition-colors duration-120',
@@ -108,6 +113,23 @@ function SidebarItem({ session, active, onActivate, onRename, onKill }: SidebarI
           />
         ) : (
           <span className="flex-1 truncate">{session.name}</span>
+        )}
+        {!editing && (
+          <button
+            type="button"
+            aria-label={`Rename ${session.name}`}
+            title={`Rename ${session.name}`}
+            onClick={(e) => { e.stopPropagation(); startEditing() }}
+            className={cn(
+              'inline-flex items-center justify-center h-4 w-4 rounded',
+              'text-muted-foreground opacity-0 group-hover:opacity-100',
+              'hover:bg-border/40 hover:text-foreground',
+              'transition-opacity duration-120',
+              active && 'opacity-70',
+            )}
+          >
+            <Pencil className="h-3 w-3" />
+          </button>
         )}
         <button
           type="button"

--- a/client/src/components/terminal/__tests__/BottomPanel.test.tsx
+++ b/client/src/components/terminal/__tests__/BottomPanel.test.tsx
@@ -166,6 +166,19 @@ describe('BottomPanel', () => {
     expect(sawPatch).toBe(true)
   })
 
+  it('sidebar rename button triggers PATCH', () => {
+    const s: TerminalRef = { id: 's1', projectId: 'p', name: 'initial', cols: 80, rows: 24, createdAt: 1 }
+    const { getByLabelText, getByDisplayValue } = wrap(
+      <BottomPanel projectId="p" state={makeState({ sessions: [s], activeId: 's1' })} viewportHeight={800} statusBarHeight={28} />,
+    )
+    fireEvent.click(getByLabelText(/rename initial/i))
+    const input = getByDisplayValue('initial')
+    fireEvent.change(input, { target: { value: 'renamed-from-button' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    const sawPatch = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.some(([, init]) => init?.method === 'PATCH')
+    expect(sawPatch).toBe(true)
+  })
+
   it('sidebar ✕ triggers kill DELETE for that session', () => {
     const s1: TerminalRef = { id: 's1', projectId: 'p', name: 'one', cols: 80, rows: 24, createdAt: 1 }
     const s2: TerminalRef = { id: 's2', projectId: 'p', name: 'two', cols: 80, rows: 24, createdAt: 2 }

--- a/client/src/components/terminal/__tests__/TerminalSidebar.test.tsx
+++ b/client/src/components/terminal/__tests__/TerminalSidebar.test.tsx
@@ -52,6 +52,16 @@ describe('TerminalSidebar', () => {
     expect(onRename).toHaveBeenCalledWith('a', 'new name')
   })
 
+  it('enters rename when rename button is clicked', () => {
+    const onRename = vi.fn()
+    const s = makeSession('a', 'build')
+    const { getByLabelText, getByDisplayValue } = render(
+      <TerminalSidebar sessions={[s]} activeId="a" onActivate={() => {}} onRename={onRename} onKill={() => {}} />,
+    )
+    fireEvent.click(getByLabelText(/rename build/i))
+    expect(getByDisplayValue('build')).toBeDefined()
+  })
+
   it('cancels rename on Escape', () => {
     const onRename = vi.fn()
     const s = makeSession('a', 'keep')

--- a/client/src/hooks/__tests__/useKeyboardShortcuts.test.tsx
+++ b/client/src/hooks/__tests__/useKeyboardShortcuts.test.tsx
@@ -74,6 +74,21 @@ describe('useKeyboardShortcuts', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/')
   })
 
+  it('forwards cmd+5 to the project-page index handler', () => {
+    const onSwitchProjectPage = vi.fn()
+    renderHook(
+      () =>
+        useKeyboardShortcuts({
+          onOpenCheatsheet: vi.fn(),
+          onSwitchProjectPage,
+        }),
+      { wrapper },
+    )
+
+    fireKey('5', { metaKey: true, code: 'Digit5' })
+    expect(onSwitchProjectPage).toHaveBeenCalledWith(5)
+  })
+
   it('does not trigger shortcuts when typing in an input', () => {
     const onOpen = vi.fn()
     renderHook(() => useKeyboardShortcuts({ onOpenCheatsheet: onOpen }), { wrapper })

--- a/client/src/hooks/useKeyboardShortcuts.ts
+++ b/client/src/hooks/useKeyboardShortcuts.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useCallback, useState } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
+import { FEATURE_AGENTS_SECTION } from '../lib/feature-flags'
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -17,7 +18,13 @@ export const SHORTCUTS: Shortcut[] = [
   { keys: '⌘B', description: 'Toggle right sidebar', category: 'general' },
   { keys: '⌥⌘B', description: 'Toggle left sidebar', category: 'general' },
   { keys: '⌘J', description: 'Toggle terminal panel', category: 'general' },
-  { keys: '⌘1–4', description: 'Navigate to project page (Home/Jobs/Analytics/Settings)', category: 'general' },
+  {
+    keys: FEATURE_AGENTS_SECTION ? '⌘1–5' : '⌘1–4',
+    description: FEATURE_AGENTS_SECTION
+      ? 'Navigate to project page (Dashboard/Jobs/Analytics/Agents/Settings)'
+      : 'Navigate to project page (Dashboard/Jobs/Analytics/Settings)',
+    category: 'general',
+  },
   { keys: '⌥⌘1–9', description: 'Switch to project by position', category: 'general' },
 
   // Navigation
@@ -66,7 +73,7 @@ interface UseKeyboardShortcutsOptions {
   onToggleRightSidebar?: () => void
   /** Switch to project by 1-based index */
   onSwitchProject?: (index: number) => void
-  /** Navigate to project page by 1-based index (Home, Jobs, Analytics, Settings…) */
+  /** Navigate to project page by 1-based index (Dashboard, Jobs, Analytics, Agents, Settings…) */
   onSwitchProjectPage?: (index: number) => void
   /** Toggle the bottom terminal panel (Cmd+J / Ctrl+J) */
   onToggleTerminalPanel?: () => void

--- a/client/src/lib/__tests__/attachments.test.ts
+++ b/client/src/lib/__tests__/attachments.test.ts
@@ -3,7 +3,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 vi.mock('../api', () => ({ getApiBase: () => '/api/projects/proj-1' }))
 vi.mock('../auth', () => ({ getHubToken: vi.fn(() => null) }))
 
-import { uploadAttachment, deleteAttachment, deleteAllAttachments, listAttachments, attachmentFileUrl } from '../attachments'
+import {
+  ATTACHMENT_ACCEPT_MIME,
+  attachmentFileUrl,
+  deleteAllAttachments,
+  deleteAttachment,
+  isSupportedAttachmentFile,
+  listAttachments,
+  uploadAttachment,
+} from '../attachments'
 import { getHubToken } from '../auth'
 
 describe('attachments lib', () => {
@@ -125,6 +133,25 @@ describe('attachments lib', () => {
       vi.mocked(getHubToken).mockReturnValue('tok en+val')
       const url = attachmentFileUrl('1', 'att-1')
       expect(url).toContain('token=tok%20en%2Bval')
+    })
+  })
+
+  describe('isSupportedAttachmentFile', () => {
+    it('accepts .sql files even when the browser provides no mime type', () => {
+      const file = new File(['select 1;'], 'schema.sql')
+      expect(isSupportedAttachmentFile(file)).toBe(true)
+    })
+
+    it('accepts SQL mime types explicitly listed in the picker accept string', () => {
+      const file = new File(['select 1;'], 'schema.sql', { type: 'application/sql' })
+      expect(ATTACHMENT_ACCEPT_MIME).toContain('.sql')
+      expect(ATTACHMENT_ACCEPT_MIME).toContain('application/sql')
+      expect(isSupportedAttachmentFile(file)).toBe(true)
+    })
+
+    it('rejects unsupported non-sql files', () => {
+      const file = new File([''], 'video.mp4', { type: 'video/mp4' })
+      expect(isSupportedAttachmentFile(file)).toBe(false)
     })
   })
 })

--- a/client/src/lib/attachments.ts
+++ b/client/src/lib/attachments.ts
@@ -51,4 +51,13 @@ export function attachmentFileUrl(ticketKey: string | number, attachmentId: stri
 }
 
 export const ATTACHMENT_ACCEPT_MIME =
-  'image/jpeg,image/png,image/gif,image/webp,application/pdf,text/csv,text/plain,application/json,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel'
+  'image/jpeg,image/png,image/gif,image/webp,application/pdf,text/csv,text/plain,application/json,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel,application/sql,application/x-sql,text/sql,text/x-sql,.sql'
+
+const SUPPORTED_ATTACHMENT_MIMES = new Set(
+  ATTACHMENT_ACCEPT_MIME.split(',').filter((part) => !part.startsWith('.')),
+)
+const SQL_EXTENSION_RE = /\.sql$/i
+
+export function isSupportedAttachmentFile(file: Pick<File, 'name' | 'type'>): boolean {
+  return SUPPORTED_ATTACHMENT_MIMES.has(file.type) || SQL_EXTENSION_RE.test(file.name)
+}

--- a/client/src/pages/AgentsPage.tsx
+++ b/client/src/pages/AgentsPage.tsx
@@ -3,8 +3,9 @@ import { AlertTriangle } from 'lucide-react'
 import { getApiBase } from '../lib/api'
 import { ProfilesTab } from '../components/agents/ProfilesTab'
 import { AgentsCatalogTab } from '../components/agents/AgentsCatalogTab'
+import { ProfileAnalyticsCard } from '../components/agents/ProfileAnalyticsCard'
 
-type Tab = 'profiles' | 'catalog'
+type Tab = 'profiles' | 'usage' | 'catalog'
 
 interface CoreVersionStatus {
   version: string | null
@@ -17,7 +18,7 @@ const TAB_MEMORY_KEY = 'specrails-hub:agents-tab'
 function readTabMemory(): Tab {
   try {
     const v = localStorage.getItem(TAB_MEMORY_KEY)
-    if (v === 'profiles' || v === 'catalog') return v
+    if (v === 'profiles' || v === 'usage' || v === 'catalog') return v
   } catch {
     // localStorage unavailable
   }
@@ -79,15 +80,18 @@ export default function AgentsPage() {
         <div className="px-6 pt-4">
           <h1 className="text-lg font-semibold">Agents</h1>
           <p className="text-xs text-muted-foreground mt-0.5">
-            Manage agent profiles and the catalog of agents (upstream + custom) for this project.
+            Manage agent profiles and the catalog (upstream + custom) for this project.
           </p>
         </div>
         <div className="flex items-center gap-1 px-4 pt-3">
           <TabButton active={tab === 'profiles'} onClick={() => setTab('profiles')}>
             Profiles
           </TabButton>
+          <TabButton active={tab === 'usage'} onClick={() => setTab('usage')}>
+            Usage
+          </TabButton>
           <TabButton active={tab === 'catalog'} onClick={() => setTab('catalog')}>
-            Agents Catalog
+            Catalog
           </TabButton>
         </div>
       </div>
@@ -95,8 +99,17 @@ export default function AgentsPage() {
       {/* Body */}
       <div className="flex-1 min-w-0 overflow-auto">
         {tab === 'profiles' && <ProfilesTab />}
+        {tab === 'usage' && <UsageTab />}
         {tab === 'catalog' && <AgentsCatalogTab />}
       </div>
+    </div>
+  )
+}
+
+function UsageTab() {
+  return (
+    <div className="min-h-full">
+      <ProfileAnalyticsCard />
     </div>
   )
 }
@@ -125,4 +138,3 @@ function TabButton({
     </button>
   )
 }
-

--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -1,17 +1,16 @@
 import { useEffect, useState, useRef } from 'react'
-import { Link } from 'react-router-dom'
 import { toast } from 'sonner'
 import { getApiBase } from '../lib/api'
 import { useHub } from '../hooks/useHub'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../components/ui/card'
 import { Button } from '../components/ui/button'
 import { Input } from '../components/ui/input'
-import { ModelCombobox } from '../components/ModelCombobox'
 import type { ProjectConfig } from '../types'
 
 interface ProjectSettings {
   pipelineTelemetryEnabled: boolean
-  orchestratorModel: string
+  orchestratorModel?: string
+  prePrompt?: string
 }
 
 export default function SettingsPage() {
@@ -26,9 +25,8 @@ export default function SettingsPage() {
   const [isSavingJobThreshold, setIsSavingJobThreshold] = useState(false)
   const [telemetryEnabled, setTelemetryEnabled] = useState(false)
   const [isSavingTelemetry, setIsSavingTelemetry] = useState(false)
-  const [orchestratorModel, setOrchestratorModel] = useState('sonnet')
-  const [pendingOrchestratorModel, setPendingOrchestratorModel] = useState('sonnet')
-  const [isSavingOrchestratorModel, setIsSavingOrchestratorModel] = useState(false)
+  const [prePrompt, setPrePrompt] = useState('')
+  const [isSavingPrePrompt, setIsSavingPrePrompt] = useState(false)
 
   const cacheRef = useRef<Map<string, ProjectConfig>>(new Map())
 
@@ -86,16 +84,13 @@ export default function SettingsPage() {
         if (!res.ok) return
         const data = await res.json() as ProjectSettings
         setTelemetryEnabled(data.pipelineTelemetryEnabled ?? false)
-        const m = data.orchestratorModel ?? 'sonnet'
-        setOrchestratorModel(m)
-        setPendingOrchestratorModel(m)
+        setPrePrompt(data.prePrompt ?? '')
       } catch {
         // ignore
       }
     }
     void loadTelemetrySettings()
   }, [activeProjectId, isHubMode])
-
 
   async function saveDailyBudget() {
     setIsSavingBudget(true)
@@ -141,24 +136,6 @@ export default function SettingsPage() {
     }
   }
 
-  async function saveOrchestratorModel() {
-    setIsSavingOrchestratorModel(true)
-    try {
-      const res = await fetch(`${getApiBase()}/settings`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ orchestratorModel: pendingOrchestratorModel }),
-      })
-      if (!res.ok) throw new Error('Failed to save')
-      setOrchestratorModel(pendingOrchestratorModel)
-      toast.success(`Orchestrator model set to ${pendingOrchestratorModel}`)
-    } catch (err) {
-      toast.error('Failed to save orchestrator model', { description: (err as Error).message })
-    } finally {
-      setIsSavingOrchestratorModel(false)
-    }
-  }
-
   async function saveTelemetryToggle(enabled: boolean) {
     setIsSavingTelemetry(true)
     const prev = telemetryEnabled
@@ -176,6 +153,26 @@ export default function SettingsPage() {
       toast.error('Failed to save telemetry setting', { description: (err as Error).message })
     } finally {
       setIsSavingTelemetry(false)
+    }
+  }
+
+  async function savePrePrompt() {
+    setIsSavingPrePrompt(true)
+    try {
+      const res = await fetch(`${getApiBase()}/settings`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prePrompt }),
+      })
+      if (!res.ok) throw new Error('Failed to save')
+      const data = await res.json() as { settings?: ProjectSettings }
+      const savedValue = data.settings?.prePrompt ?? ''
+      setPrePrompt(savedValue)
+      toast.success(savedValue.trim() === '' ? 'Pre-prompt cleared' : 'Pre-prompt saved')
+    } catch (err) {
+      toast.error('Failed to save pre-prompt', { description: (err as Error).message })
+    } finally {
+      setIsSavingPrePrompt(false)
     }
   }
 
@@ -200,64 +197,6 @@ export default function SettingsPage() {
           </p>
         )}
       </div>
-
-      {/* Orchestrator Model Section — hub mode only */}
-      {isHubMode && (
-        <Card>
-          <CardHeader>
-            <CardTitle>Orchestrator Model</CardTitle>
-            <CardDescription>
-              Model used by the pipeline orchestrator (the CLI process that runs each job). Defaults to Sonnet.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <div className="flex justify-end">
-              <ModelCombobox
-                value={pendingOrchestratorModel}
-                onChange={setPendingOrchestratorModel}
-                disabled={isSavingOrchestratorModel}
-              />
-            </div>
-            <div className="flex justify-end">
-              <Button
-                size="sm"
-                variant="secondary"
-                className="h-7 text-xs"
-                disabled={isSavingOrchestratorModel || pendingOrchestratorModel === orchestratorModel}
-                onClick={saveOrchestratorModel}
-              >
-                {isSavingOrchestratorModel ? 'Saving...' : 'Save'}
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
-      )}
-
-      {/* Agent Models moved to Agents section (hub mode only) */}
-      {isHubMode && (
-        <Card>
-          <CardHeader>
-            <CardTitle>Agent Models</CardTitle>
-            <CardDescription>
-              Moved to the new Agents section. Per-agent models now live inside profiles
-              so you can run different chains/models per rail.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Link
-              to="/agents"
-              className="inline-flex items-center gap-2 h-8 px-3 rounded-md bg-primary/10 text-primary hover:bg-primary/20 text-xs font-medium transition-colors"
-            >
-              Open Agents → Profiles →
-            </Link>
-            <p className="text-[11px] text-muted-foreground mt-2">
-              Your existing per-agent model selections are preserved in the current agent
-              frontmatter; the first time you open Agents you'll be offered a one-click
-              migration into a <code>default</code> profile.
-            </p>
-          </CardContent>
-        </Card>
-      )}
 
       {/* Pipeline Telemetry Section — hub mode only */}
       {isHubMode && (
@@ -298,6 +237,43 @@ export default function SettingsPage() {
           </CardContent>
         </Card>
       )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Rail Pre-prompt</CardTitle>
+          <CardDescription>
+            Extra project-specific instructions appended to implement and batch-implement rail jobs after the ticket context and before execution.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-2">
+            <label htmlFor="project-pre-prompt" className="text-xs font-medium">
+              Pre-prompt
+            </label>
+            <textarea
+              id="project-pre-prompt"
+              value={prePrompt}
+              onChange={(e) => setPrePrompt(e.target.value)}
+              placeholder="Example: Prefer incremental changes, keep migrations backward compatible, and add tests for every rail change."
+              className="min-h-32 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/20"
+            />
+            <p className="text-xs text-muted-foreground">
+              Use this for stable project guidance that should accompany every rail implementation run.
+            </p>
+          </div>
+          <div className="flex justify-end">
+            <Button
+              size="sm"
+              variant="secondary"
+              className="h-7 text-xs"
+              disabled={isSavingPrePrompt}
+              onClick={savePrePrompt}
+            >
+              {isSavingPrePrompt ? 'Saving...' : 'Save pre-prompt'}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
 
       {/* Budget Section */}
       <Card>

--- a/client/src/pages/__tests__/SettingsPage.test.tsx
+++ b/client/src/pages/__tests__/SettingsPage.test.tsx
@@ -97,6 +97,18 @@ describe('SettingsPage', () => {
     })
   })
 
+  it('shows Rail Pre-prompt section after load', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => mockConfig,
+    })
+    render(<SettingsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Rail Pre-prompt')).toBeInTheDocument()
+      expect(screen.getByLabelText('Pre-prompt')).toBeInTheDocument()
+    })
+  })
+
   it('shows daily budget input after load', async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,

--- a/client/src/pages/__tests__/SettingsPageExtended.test.tsx
+++ b/client/src/pages/__tests__/SettingsPageExtended.test.tsx
@@ -116,6 +116,75 @@ describe('SettingsPage - extended coverage', () => {
     })
   })
 
+  it('loads prePrompt from project settings', async () => {
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (String(url).endsWith('/settings')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ pipelineTelemetryEnabled: false, orchestratorModel: 'sonnet', prePrompt: 'Always add release notes.' }),
+        })
+      }
+      if (String(url).endsWith('/budget')) {
+        return Promise.resolve({ ok: true, json: async () => ({ dailyBudgetUsd: null, jobCostThresholdUsd: null }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => mockConfig })
+    })
+
+    render(<SettingsPage />)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Pre-prompt')).toHaveValue('Always add release notes.')
+    })
+  })
+
+  it('saves prePrompt successfully', async () => {
+    const user = userEvent.setup()
+    const { toast } = await import('sonner')
+    const fetchMock = vi.fn().mockImplementation((url: string, opts?: RequestInit) => {
+      if (String(url).endsWith('/settings') && opts?.method === 'PATCH') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            ok: true,
+            settings: {
+              pipelineTelemetryEnabled: false,
+              orchestratorModel: 'sonnet',
+              prePrompt: 'Always write migration notes.',
+            },
+          }),
+        })
+      }
+      if (String(url).endsWith('/settings')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ pipelineTelemetryEnabled: false, orchestratorModel: 'sonnet', prePrompt: '' }),
+        })
+      }
+      if (String(url).endsWith('/budget')) {
+        return Promise.resolve({ ok: true, json: async () => ({ dailyBudgetUsd: null, jobCostThresholdUsd: null }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => mockConfig })
+    })
+    global.fetch = fetchMock
+
+    render(<SettingsPage />)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Pre-prompt')).toBeInTheDocument()
+    })
+
+    await user.type(screen.getByLabelText('Pre-prompt'), 'Always write migration notes.')
+    await user.click(screen.getByRole('button', { name: /save pre-prompt/i }))
+
+    await waitFor(() => {
+      const patchCall = fetchMock.mock.calls.find(
+        ([url, opts]: [string, RequestInit]) =>
+          String(url).endsWith('/settings') && opts?.method === 'PATCH'
+      )
+      expect(patchCall).toBeDefined()
+      expect(JSON.parse(patchCall![1].body as string)).toEqual({ prePrompt: 'Always write migration notes.' })
+      expect(toast.success).toHaveBeenCalledWith('Pre-prompt saved')
+    })
+  })
+
   it('saves daily budget successfully', async () => {
     const user = userEvent.setup()
     const { toast } = await import('sonner')

--- a/docs/profiles-quick-start.md
+++ b/docs/profiles-quick-start.md
@@ -18,34 +18,34 @@ the case).
 From any project, click **Agents** in the right sidebar (next to
 Dashboard/Jobs/Analytics/Settings).
 
-- **Profiles** tab — create, edit, select profiles.
-- **Agents Catalog** tab — read the upstream `sr-*` agents or author custom
+- **Profiles** tab — create and edit profiles.
+- **Usage** tab — see which profiles are actually being used.
+- **Catalog** tab — read the upstream `sr-*` agents or author custom
   `custom-*` ones via the Studio.
 
 If the project already has agents installed with per-agent model choices,
 the empty state offers **Migrate from current agents**: one click creates
 a `default` profile mirroring today's frontmatter.
 
-## 2. Catalog vs selection
+## 2. Saved profiles vs selection
 
 Two orthogonal concepts:
 
-- **Catalog** — the set of profiles in the project (`.specrails/profiles/*.json`).
+- **Saved profiles** — the set of profiles in the project (`.specrails/profiles/*.json`).
   Committed to git, shared with the team.
 - **Selection** — which profile this particular invocation uses. Per-rail,
   per-launch.
 
 Resolution order when no explicit selection is passed:
 
-1. The developer's preferred profile (`.specrails/profiles/.user-preferred.json`, gitignored).
-2. The profile named `default` (or `project-default`).
-3. Legacy mode (no profile active).
+1. The profile named `default` (or `project-default`).
+2. Legacy mode (no profile active).
 
 ## 3. Pick a profile at launch
 
 - **Single feature** (Implement Wizard): the footer has a Profile dropdown
-  preselected to your preferred profile. Picking a different one here
-  updates your preference for the next launch.
+  preselected to the project default profile when one exists. Picking a
+  different one only affects that launch.
 - **Batch** (Batch Implement Wizard): the footer has a batch-level picker
   that applies to every rail, plus a per-feature override table when you
   select more than one issue. Override the rows that need it; leave the
@@ -53,12 +53,12 @@ Resolution order when no explicit selection is passed:
 - **Dashboard rails**: each rail has a compact profile dropdown in its
   header. Pick once and it persists across launches of that rail.
 
-The "Legacy (no profile)" option is always available — use it to run a
+The "No profile" option is always available — use it to run a
 rail exactly as it did pre-4.1.0.
 
 ## 4. Author a custom agent (Agent Studio)
 
-From the Agents Catalog tab, create a new custom agent via:
+From the Catalog tab, create a new custom agent via:
 
 - **Template** — pick from Security Reviewer, Data Engineer, Performance
   Profiler, or UI/UX Polisher.
@@ -79,8 +79,8 @@ see output, token count, and duration inline.
 
 - A purple **profile badge** appears on each job row showing which profile
   it ran under.
-- The **Analytics card** above the Profiles tab shows usage per profile
-  for the last 7/30/90 days: jobs, success rate, avg tokens, avg duration.
+- The **Usage** tab shows usage per profile for the last 7/30/90 days:
+  jobs, success rate, avg tokens, avg duration.
 - The **diagnostic ZIP export** on a job includes `profile.json` with
   the exact snapshot that rail used.
 

--- a/openspec/specs/ticket-attachments/spec.md
+++ b/openspec/specs/ticket-attachments/spec.md
@@ -1,7 +1,7 @@
 # Ticket Attachments
 
 ### Requirement: Attachment upload endpoint
-The system SHALL expose `POST /api/projects/:projectId/tickets/:ticketId/attachments` accepting multipart form data with a single `file` field. Supported MIME types: `image/jpeg`, `image/png`, `image/gif`, `image/webp`, `application/pdf`, `text/csv`, `text/plain`, `application/json`, `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`, `application/vnd.ms-excel`. The server SHALL save the file to `~/.specrails/projects/<slug>/attachments/<ticketId>/<uuid>-<originalName>` and append an `Attachment` record to `ticket.attachments[]` in `local-tickets.json`.
+The system SHALL expose `POST /api/projects/:projectId/tickets/:ticketId/attachments` accepting multipart form data with a single `file` field. Supported MIME types: `image/jpeg`, `image/png`, `image/gif`, `image/webp`, `application/pdf`, `text/csv`, `text/plain`, `application/json`, `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`, `application/vnd.ms-excel`, and SQL files (including `.sql` uploads sent as `application/sql`, `application/x-sql`, `text/sql`, `text/x-sql`, or with no reliable browser MIME type). The server SHALL save the file to `~/.specrails/projects/<slug>/attachments/<ticketId>/<uuid>-<originalName>` and append an `Attachment` record to `ticket.attachments[]` in `local-tickets.json`.
 
 #### Scenario: Valid file uploaded
 - **WHEN** a supported file is POSTed to the upload endpoint
@@ -50,7 +50,7 @@ The system SHALL accept an optional `attachmentIds: string[]` field in the `POST
 - **THEN** each image's absolute path is inlined in the prompt as `@<absolutePath>` inside a `<user-attachment>` block so Claude CLI auto-resolves it for image understanding
 
 #### Scenario: Text-extractable attachments included
-- **WHEN** generate-spec is called with `attachmentIds` containing PDF, CSV, JSON, TXT, or Excel attachment IDs
+- **WHEN** generate-spec is called with `attachmentIds` containing PDF, CSV, JSON, TXT, SQL, or Excel attachment IDs
 - **THEN** the Claude CLI process receives extracted text content appended to the prompt for each attachment
 - **AND** each extracted block is wrapped in `<user-attachment id="<uuid>" name="<filename>" mime="<mimeType>">...</user-attachment>` delimiters
 - **AND** the system prompt instructs Claude to treat content inside `<user-attachment>` as untrusted user data, not as instructions

--- a/server/attachment-manager.test.ts
+++ b/server/attachment-manager.test.ts
@@ -5,6 +5,8 @@ import os from 'os'
 
 import {
   AttachmentManager,
+  isSupportedUploadedFile,
+  normalizeUploadedMimeType,
   SUPPORTED_MIME_TYPES,
   USER_ATTACHMENT_SYSTEM_NOTE,
   UploadedFile,
@@ -139,6 +141,18 @@ describe('AttachmentManager', () => {
       )
       expect(store.tickets['1'].attachments).toHaveLength(1)
       expect(store.tickets['1'].attachments[0].filename).toBe('test.txt')
+    })
+
+    it('accepts .sql uploads and stores them as text/plain', async () => {
+      const attachment = await manager.upload({
+        slug: 'proj',
+        ticketKey: '1',
+        projectPath: null,
+        file: makeFile({ originalname: 'schema.sql', mimetype: 'application/sql' }),
+      })
+
+      expect(attachment.filename).toBe('schema.sql')
+      expect(attachment.mimeType).toBe('text/plain')
     })
 
     it('skips store mutation for missing ticket when projectPath provided', async () => {
@@ -412,6 +426,18 @@ describe('AttachmentManager', () => {
       expect(result.textBlocks[0]).toContain(json)
     })
 
+    it('reads SQL files as raw utf-8', async () => {
+      const sql = 'select * from users;'
+      const att = await manager.upload({
+        slug: 'proj', ticketKey: '1', projectPath: null,
+        file: makeFile({ buffer: Buffer.from(sql), originalname: 'schema.sql', mimetype: '', size: sql.length }),
+      })
+
+      const result = await manager.getClaudeArgs('proj', '1', [att.id])
+      expect(result.textBlocks[0]).toContain(sql)
+      expect(result.textBlocks[0]).toContain('schema.sql')
+    })
+
     it('handles extraction failure gracefully', async () => {
       // Mock pdf-parse to fail
       vi.doMock('pdf-parse', () => {
@@ -443,6 +469,34 @@ describe('AttachmentManager', () => {
     })
   })
 
+  // ─── getPromptBlocksSync ──────────────────────────────────────────────────
+
+  describe('getPromptBlocksSync', () => {
+    it('inlines images as @<abs-path> references synchronously', async () => {
+      const att = await manager.upload({
+        slug: 'proj', ticketKey: '1', projectPath: null,
+        file: makeFile({ mimetype: 'image/png', originalname: 'sync-photo.png', buffer: Buffer.from('PNG') }),
+      })
+
+      const result = manager.getPromptBlocksSync('proj', '1', [att.id])
+      expect(result).toHaveLength(1)
+      expect(result[0]).toContain('@')
+      expect(result[0]).toContain('sync-photo.png')
+    })
+
+    it('falls back to a local file path for binary non-image attachments', async () => {
+      const att = await manager.upload({
+        slug: 'proj', ticketKey: '1', projectPath: null,
+        file: makeFile({ mimetype: 'application/pdf', originalname: 'brief.pdf', buffer: Buffer.from('%PDF') }),
+      })
+
+      const result = manager.getPromptBlocksSync('proj', '1', [att.id])
+      expect(result).toHaveLength(1)
+      expect(result[0]).toContain('local attachment path:')
+      expect(result[0]).toContain('brief.pdf')
+    })
+  })
+
   // ─── constants ─────────────────────────────────────────────────────────────
 
   describe('constants', () => {
@@ -459,6 +513,12 @@ describe('AttachmentManager', () => {
     it('USER_ATTACHMENT_SYSTEM_NOTE mentions user-attachment and untrusted', () => {
       expect(USER_ATTACHMENT_SYSTEM_NOTE).toContain('user-attachment')
       expect(USER_ATTACHMENT_SYSTEM_NOTE).toContain('untrusted')
+    })
+
+    it('normalizes SQL uploads to text/plain and treats them as supported', () => {
+      expect(normalizeUploadedMimeType('application/sql', 'schema.sql')).toBe('text/plain')
+      expect(normalizeUploadedMimeType('', 'schema.sql')).toBe('text/plain')
+      expect(isSupportedUploadedFile({ mimetype: '', originalname: 'schema.sql' })).toBe(true)
     })
   })
 })

--- a/server/project-router.test.ts
+++ b/server/project-router.test.ts
@@ -1585,6 +1585,7 @@ describe('project-router', () => {
       expect(res.status).toBe(200)
       expect(res.body.pipelineTelemetryEnabled).toBe(false)
       expect(res.body.orchestratorModel).toBe('sonnet')
+      expect(res.body.prePrompt).toBe('')
     })
   })
 
@@ -1628,6 +1629,26 @@ describe('project-router', () => {
         .send({ pipelineTelemetryEnabled: true })
       expect(res.status).toBe(200)
       expect(res.body.settings.pipelineTelemetryEnabled).toBe(true)
+    })
+
+    it('updates prePrompt', async () => {
+      const ctx = makeContext(db)
+      const { app } = createApp(new Map([['proj-1', ctx]]))
+      const res = await request(app)
+        .patch('/api/projects/proj-1/settings')
+        .send({ prePrompt: 'Prefer backward-compatible migrations.' })
+      expect(res.status).toBe(200)
+      expect(res.body.settings.prePrompt).toBe('Prefer backward-compatible migrations.')
+    })
+
+    it('rejects non-string prePrompt', async () => {
+      const ctx = makeContext(db)
+      const { app } = createApp(new Map([['proj-1', ctx]]))
+      const res = await request(app)
+        .patch('/api/projects/proj-1/settings')
+        .send({ prePrompt: 42 })
+      expect(res.status).toBe(400)
+      expect(res.body.error).toContain('prePrompt')
     })
 
     it('accepts empty body without error', async () => {

--- a/server/queue-manager.test.ts
+++ b/server/queue-manager.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { EventEmitter } from 'events'
 import { Readable } from 'stream'
-import { initDb } from './db'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { initDb, updateProjectSettings } from './db'
 
 // Mock child_process and uuid before importing queue-manager
 vi.mock('child_process', () => ({
@@ -27,6 +30,7 @@ import { spawn as mockSpawn, execSync as mockExecSync } from 'child_process'
 import treeKill from 'tree-kill'
 import { v4 as mockUuidV4 } from 'uuid'
 import { QueueManager, ClaudeNotFoundError, JobNotFoundError, JobAlreadyTerminalError } from './queue-manager'
+import { attachmentManager } from './attachment-manager'
 import type { WsMessage } from './types'
 
 function createMockChildProcess() {
@@ -35,6 +39,23 @@ function createMockChildProcess() {
   child.stderr = new Readable({ read() {} })
   child.pid = 12345
   return child
+}
+
+function makeProjectDirWithTickets(tickets: Record<string, Record<string, unknown>>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'queue-manager-test-'))
+  fs.mkdirSync(path.join(dir, '.specrails'), { recursive: true })
+  fs.writeFileSync(
+    path.join(dir, '.specrails', 'local-tickets.json'),
+    JSON.stringify({
+      schema_version: '1.0',
+      revision: 1,
+      last_updated: new Date().toISOString(),
+      next_id: 100,
+      tickets,
+    }),
+    'utf-8',
+  )
+  return dir
 }
 
 describe('QueueManager', () => {
@@ -1517,6 +1538,24 @@ describe('QueueManager', () => {
       expect(promptArg).toContain('local-tickets.json')
     })
 
+    it('embeds project pre-prompt in codex prompt for implement commands', () => {
+      vi.mocked(mockExecSync).mockReturnValue(Buffer.from('/usr/bin/codex'))
+      const child = createMockChildProcess()
+      vi.mocked(mockSpawn).mockReturnValue(child as any)
+      vi.mocked(mockUuidV4).mockReturnValue('codex-preprompt-job' as any)
+
+      const db = initDb(':memory:')
+      updateProjectSettings(db, { prePrompt: 'Always prefer additive schema changes.' })
+
+      const qmCodex = new QueueManager(broadcast, db, [], undefined, { provider: 'codex' })
+      qmCodex.enqueue('/specrails:implement #42')
+
+      const spawnCall = vi.mocked(mockSpawn).mock.calls[0]
+      const promptArg = spawnCall[1][1] as string
+      expect(promptArg).toContain('PROJECT PRE-PROMPT')
+      expect(promptArg).toContain('Always prefer additive schema changes.')
+    })
+
     it('passes --model flag to codex spawns using resolvedModel', () => {
       vi.mocked(mockExecSync).mockReturnValue(Buffer.from('/usr/bin/codex'))
       const child = createMockChildProcess()
@@ -1546,6 +1585,61 @@ describe('QueueManager', () => {
       const spawnArgs = vi.mocked(mockSpawn).mock.calls[0][1] as string[]
       expect(spawnArgs).toContain('--model')
       expect(spawnArgs).toContain('gpt-5.4-mini')
+    })
+
+    it('embeds referenced ticket attachments in the codex prompt', () => {
+      vi.mocked(mockExecSync).mockReturnValue(Buffer.from('/usr/bin/codex'))
+      const child = createMockChildProcess()
+      vi.mocked(mockSpawn).mockReturnValue(child as any)
+      vi.mocked(mockUuidV4).mockReturnValue('codex-attachments-job' as any)
+
+      const projectDir = makeProjectDirWithTickets({
+        '42': {
+          id: 42,
+          title: 'Visual spec',
+          description: 'Uses a mockup',
+          status: 'todo',
+          priority: 'medium',
+          labels: [],
+          assignee: null,
+          prerequisites: [],
+          metadata: {},
+          attachments: [{
+            id: 'att-1',
+            filename: 'mockup.png',
+            storedName: 'att-1-mockup.png',
+            mimeType: 'image/png',
+            size: 123,
+            addedAt: new Date().toISOString(),
+          }],
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+          created_by: 'user',
+          source: 'manual',
+        },
+      })
+
+      try {
+        const listSpy = vi.spyOn(attachmentManager, 'list').mockReturnValue([])
+        const blocksSpy = vi.spyOn(attachmentManager, 'getPromptBlocksSync').mockReturnValue([
+          '<user-attachment id="att-1" name="mockup.png" mime="image/png">\n@/tmp/mockup.png\n</user-attachment>',
+        ])
+
+        const qmCodex = new QueueManager(broadcast, undefined, [], projectDir, {
+          provider: 'codex',
+          projectSlug: 'proj',
+        })
+        qmCodex.enqueue('/specrails:implement #42')
+
+        const spawnCall = vi.mocked(mockSpawn).mock.calls[0]
+        const promptArg = spawnCall[1][1] as string
+        expect(listSpy).toHaveBeenCalledWith('proj', 42)
+        expect(blocksSpy).toHaveBeenCalledWith('proj', 42, ['att-1'])
+        expect(promptArg).toContain('Ticket #42 Attached Resources')
+        expect(promptArg).toContain('<user-attachment')
+      } finally {
+        fs.rmSync(projectDir, { recursive: true, force: true })
+      }
     })
 
     it('creates synthetic result event when codex exits code=0 with no result event', async () => {
@@ -1612,6 +1706,81 @@ describe('QueueManager', () => {
       if (secondSpawnArgs) {
         const prompt = secondSpawnArgs[1] as string
         expect(prompt).toContain('Parent result text')
+      }
+    })
+  })
+
+  describe('implement attachment context', () => {
+    it('embeds project pre-prompt in claude implement system prompt', () => {
+      vi.mocked(mockExecSync).mockReturnValue(Buffer.from('/usr/bin/claude'))
+      const child = createMockChildProcess()
+      vi.mocked(mockSpawn).mockReturnValue(child as any)
+      vi.mocked(mockUuidV4).mockReturnValue('claude-preprompt-job' as any)
+
+      const db = initDb(':memory:')
+      updateProjectSettings(db, { prePrompt: 'Favor minimal diffs and explicit tests.' })
+
+      const qmClaude = new QueueManager(broadcast, db, [], undefined)
+      qmClaude.enqueue('/specrails:implement #7')
+
+      const spawnArgs = vi.mocked(mockSpawn).mock.calls[0][1] as string[]
+      const appendIdx = spawnArgs.indexOf('--append-system-prompt')
+      expect(appendIdx).toBeGreaterThan(-1)
+      expect(spawnArgs[appendIdx + 1]).toContain('PROJECT PRE-PROMPT')
+      expect(spawnArgs[appendIdx + 1]).toContain('Favor minimal diffs and explicit tests.')
+    })
+
+    it('falls back to disk attachment metadata for claude implement prompts', () => {
+      vi.mocked(mockExecSync).mockReturnValue(Buffer.from('/usr/bin/claude'))
+      const child = createMockChildProcess()
+      vi.mocked(mockSpawn).mockReturnValue(child as any)
+      vi.mocked(mockUuidV4).mockReturnValue('claude-disk-attachments-job' as any)
+
+      const projectDir = makeProjectDirWithTickets({
+        '7': {
+          id: 7,
+          title: 'Visual spec',
+          description: 'No attachment metadata in the ticket store yet',
+          status: 'todo',
+          priority: 'medium',
+          labels: [],
+          assignee: null,
+          prerequisites: [],
+          metadata: {},
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+          created_by: 'user',
+          source: 'manual',
+        },
+      })
+
+      try {
+        const listSpy = vi.spyOn(attachmentManager, 'list').mockReturnValue([{
+          id: 'disk-att-1',
+          filename: 'wireframe.png',
+          storedName: 'disk-att-1-wireframe.png',
+          mimeType: 'image/png',
+          size: 456,
+          addedAt: new Date().toISOString(),
+        }])
+        const blocksSpy = vi.spyOn(attachmentManager, 'getPromptBlocksSync').mockReturnValue([
+          '<user-attachment id="disk-att-1" name="wireframe.png" mime="image/png">\n@/tmp/wireframe.png\n</user-attachment>',
+        ])
+
+        const qmClaude = new QueueManager(broadcast, undefined, [], projectDir, {
+          projectSlug: 'proj',
+        })
+        qmClaude.enqueue('/specrails:implement #7')
+
+        const spawnArgs = vi.mocked(mockSpawn).mock.calls[0][1] as string[]
+        const appendIdx = spawnArgs.indexOf('--append-system-prompt')
+        expect(appendIdx).toBeGreaterThan(-1)
+        expect(listSpy).toHaveBeenCalledWith('proj', 7)
+        expect(blocksSpy).toHaveBeenCalledWith('proj', 7, ['disk-att-1'])
+        expect(spawnArgs[appendIdx + 1]).toContain('Ticket #7 Attached Resources')
+        expect(spawnArgs[appendIdx + 1]).toContain('<user-attachment')
+      } finally {
+        fs.rmSync(projectDir, { recursive: true, force: true })
       }
     })
   })

--- a/server/queue-manager.ts
+++ b/server/queue-manager.ts
@@ -11,6 +11,8 @@ import { resetPhases, setActivePhases } from './hooks'
 import { createJob, finishJob, appendEvent, skipJob, getProjectSettings } from './db'
 import type { JobResult } from './db'
 import type { CommandInfo } from './config'
+import { attachmentManager, USER_ATTACHMENT_SYSTEM_NOTE } from './attachment-manager'
+import { readStore, resolveTicketStoragePath } from './ticket-store'
 
 // ─── Telemetry env helpers ────────────────────────────────────────────────────
 
@@ -142,7 +144,7 @@ export interface EnqueueOptions {
   dependsOnJobId?: string
   pipelineId?: string
   /** Agent profile name to apply for this spawn. If omitted, the QueueManager
-   *  resolves via .user-preferred.json → default. Pass null to force legacy
+   *  resolves via default. Pass null to force legacy
    *  mode (no profile), even if a default exists. */
   profileName?: string | null
 }
@@ -447,6 +449,54 @@ export class QueueManager {
     return info?.phases ?? []
   }
 
+  private _extractTicketIds(command: string): number[] {
+    const ids = new Set<number>()
+    for (const match of command.matchAll(/#(\d+)/g)) {
+      const id = Number.parseInt(match[1], 10)
+      if (!Number.isNaN(id)) ids.add(id)
+    }
+    return Array.from(ids)
+  }
+
+  private _buildImplementAttachmentContext(command: string): string {
+    if (!this._cwd || !this._projectSlug) return ''
+
+    const ticketIds = this._extractTicketIds(command)
+    if (ticketIds.length === 0) return ''
+
+    try {
+      const store = readStore(resolveTicketStoragePath(this._cwd))
+      const sections: string[] = []
+
+      for (const ticketId of ticketIds) {
+        const storeAttachmentIds = new Set(
+          (store.tickets[String(ticketId)]?.attachments ?? []).map((attachment) => attachment.id),
+        )
+        const diskAttachmentIds = attachmentManager
+          .list(this._projectSlug, ticketId)
+          .map((attachment) => attachment.id)
+        const attachmentIds = Array.from(new Set([...storeAttachmentIds, ...diskAttachmentIds]))
+        if (attachmentIds.length === 0) continue
+
+        const blocks = attachmentManager.getPromptBlocksSync(this._projectSlug, ticketId, attachmentIds)
+        if (blocks.length === 0) continue
+
+        sections.push(`## Ticket #${ticketId} Attached Resources\n\n${blocks.join('\n\n')}`)
+      }
+
+      if (sections.length === 0) return ''
+
+      return '\n\nIMPORTANT: Referenced ticket attachments are also part of the spec context. ' +
+        `You have explicit permission to read local attachment files stored under ~/.specrails/projects/${this._projectSlug}/attachments/<ticketId>/.\n\n` +
+        `${USER_ATTACHMENT_SYSTEM_NOTE}\n\n` +
+        'If a <user-attachment> block contains only a local file path, open that file directly before implementing.\n\n' +
+        sections.join('\n\n')
+    } catch (err) {
+      console.warn(`[queue-manager] failed to build attachment context: ${(err as Error).message}`)
+      return ''
+    }
+  }
+
   private _drainQueue(): void {
     if (this._activeJobId !== null) return
     if (this._paused) return
@@ -522,6 +572,17 @@ export class QueueManager {
         'You MUST read specs from this file. Do NOT attempt to fetch tickets from Jira, Linear, GitHub Issues, or any other external tracker. ' +
         'The #<id> references in the command correspond to ticket IDs inside .specrails/local-tickets.json.'
 
+      const attachmentContext = this._buildImplementAttachmentContext(commandToRun)
+      if (attachmentContext) {
+        systemAppend += attachmentContext
+      }
+
+      const prePrompt = this._db ? getProjectSettings(this._db).prePrompt.trim() : ''
+      if (prePrompt) {
+        systemAppend += '\n\nPROJECT PRE-PROMPT:\n' +
+          'Apply the following project-specific instructions in addition to the ticket/spec and its attached resources.\n\n' +
+          prePrompt
+      }
     }
 
     let binary: string

--- a/server/schemas/profile.v1.json
+++ b/server/schemas/profile.v1.json
@@ -38,7 +38,41 @@
       "type": "array",
       "minItems": 1,
       "items": { "$ref": "#/$defs/agentEntry" },
-      "description": "Ordered chain of agents that participate in the pipeline when this profile is active. At least one agent is required. The shipped `default` profile is additionally expected to include the baseline quartet (sr-architect, sr-developer, sr-reviewer, sr-merge-resolver) — that constraint is enforced by the hub for the default profile only; custom profiles can pick any non-empty subset for maximum flexibility."
+      "description": "Ordered chain of agents that participate in the pipeline when this profile is active. Every profile (default + custom) must include the baseline quartet (sr-architect, sr-developer, sr-reviewer, sr-merge-resolver) — the pipeline depends on all four. Custom profiles add optional agents on top of the baseline.",
+      "allOf": [
+        {
+          "description": "Required baseline agent: sr-architect",
+          "contains": {
+            "type": "object",
+            "properties": { "id": { "const": "sr-architect" } },
+            "required": ["id"]
+          }
+        },
+        {
+          "description": "Required baseline agent: sr-developer",
+          "contains": {
+            "type": "object",
+            "properties": { "id": { "const": "sr-developer" } },
+            "required": ["id"]
+          }
+        },
+        {
+          "description": "Required baseline agent: sr-reviewer",
+          "contains": {
+            "type": "object",
+            "properties": { "id": { "const": "sr-reviewer" } },
+            "required": ["id"]
+          }
+        },
+        {
+          "description": "Required baseline agent: sr-merge-resolver",
+          "contains": {
+            "type": "object",
+            "properties": { "id": { "const": "sr-merge-resolver" } },
+            "required": ["id"]
+          }
+        }
+      ]
     },
     "routing": {
       "type": "array",

--- a/server/telemetry.test.ts
+++ b/server/telemetry.test.ts
@@ -84,6 +84,24 @@ describe('getProjectSettings / updateProjectSettings', () => {
     updateProjectSettings(db, { orchestratorModel: 'opus' })
     expect(getProjectSettings(db).pipelineTelemetryEnabled).toBe(false)
   })
+
+  it('defaults prePrompt to an empty string', () => {
+    const db = makeDb()
+    expect(getProjectSettings(db).prePrompt).toBe('')
+  })
+
+  it('persists prePrompt when updated', () => {
+    const db = makeDb()
+    updateProjectSettings(db, { prePrompt: 'Always add regression tests.' })
+    expect(getProjectSettings(db).prePrompt).toBe('Always add regression tests.')
+  })
+
+  it('clears prePrompt when updated with whitespace', () => {
+    const db = makeDb()
+    updateProjectSettings(db, { prePrompt: 'Always add regression tests.' })
+    updateProjectSettings(db, { prePrompt: '   ' })
+    expect(getProjectSettings(db).prePrompt).toBe('')
+  })
 })
 
 // ─── Telemetry blob DB ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `QueueManager` builds an attachment context block for implement spawns: for every `#id` referenced in the command, concatenates prompt blocks from `AttachmentManager` (store + disk) and appends them to the system prompt, plus the project's pre-prompt.
- `profile.v1.json` schema hardened: every profile (default + custom) must contain the baseline quartet (`sr-architect`, `sr-developer`, `sr-reviewer`, `sr-merge-resolver`) via `allOf` + `contains`.
- UI polish on `ProfileEditor`, `ProfilesTab`, `ProfilePicker`, `RoutingRuleDialog`, `SettingsPage`, `AgentsPage`, `TerminalSidebar`.
- New tests: `ProfileEditor`, `RoutingRuleDialog`, attachments, queue-manager attachment injection, telemetry, project-router.

## Test plan

- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] Smoke: launch implement against ticket with attachments → verify attachment blocks in Claude's system prompt
- [ ] Smoke: launch implement with project pre-prompt set → verify appended after attachments
- [ ] Smoke: profile with missing baseline agent rejected by schema validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)