### PR TITLE
fix(release): set GitHub repo for updater asset upload

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -429,6 +429,7 @@ jobs:
       - name: Publish Tauri updater assets to GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           TAG="${{ steps.vars.outputs.tag }}"


### PR DESCRIPTION
## Summary
- set GH_REPO for gh release commands in the deploy job, since this job does not checkout the repo
- fixes the desktop release failure when uploading Tauri updater assets to GitHub Releases

## Testing
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/desktop-release.yml'); puts 'workflow yaml ok'"