### PR TITLE
feat(setup): check developer prerequisites before install

### DIFF
--- a/client/src/components/RailControls.tsx
+++ b/client/src/components/RailControls.tsx
@@ -24,11 +24,12 @@ export function RailControls({ mode, status, activeJobId, ticketCount, onModeCha
         <Button
           size="sm"
           variant="ghost"
-          className="h-5 w-5 p-0 rounded-full transition-all duration-200 text-[hsl(191_97%_77%)] hover:text-[hsl(191_97%_87%)] hover:bg-[hsl(191_97%_77%/0.1)] hover:shadow-[0_0_8px_hsl(191_97%_77%/0.4)]"
+          className="group h-6 px-2 gap-1 rounded-md border border-dracula-cyan/20 bg-dracula-cyan/5 text-[10px] font-semibold text-dracula-cyan transition-all duration-200 hover:-translate-y-px hover:border-dracula-cyan/50 hover:bg-dracula-cyan/15 hover:text-dracula-cyan hover:shadow-[0_0_14px_hsl(191_97%_77%/0.22)] active:translate-y-0 active:scale-[0.98]"
           onClick={() => navigate(`/jobs/${activeJobId}`)}
           title="View job log"
         >
-          <ScrollText className="w-2.5 h-2.5" />
+          <ScrollText className="w-3 h-3 transition-transform duration-200 group-hover:scale-110" />
+          <span>Log</span>
         </Button>
       )}
 

--- a/client/src/components/SetupWizard.tsx
+++ b/client/src/components/SetupWizard.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback, useLayoutEffect, memo } from 'react'
-import { Check, ArrowRight, Package, Bot, ChevronLeft, Settings2 } from 'lucide-react'
+import { Check, ArrowRight, Package, Bot, ChevronLeft, Settings2, AlertTriangle, CheckCircle2, ExternalLink, RefreshCw } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { Button } from './ui/button'
@@ -48,6 +48,66 @@ interface InstallConfig {
   modelOverrides: ModelOverrides
 }
 
+interface SetupPrerequisite {
+  key: 'node' | 'npm' | 'npx' | 'git'
+  label: string
+  command: string
+  required: boolean
+  installed: boolean
+  version?: string
+  installUrl: string
+  installHint: string
+}
+
+interface SetupPrerequisitesStatus {
+  ok: boolean
+  prerequisites: SetupPrerequisite[]
+  missingRequired: SetupPrerequisite[]
+}
+
+const DEFAULT_SETUP_PREREQUISITES: SetupPrerequisitesStatus = {
+  ok: true,
+  prerequisites: [
+    {
+      key: 'node',
+      label: 'Node.js',
+      command: 'node',
+      required: true,
+      installed: true,
+      installUrl: 'https://nodejs.org/en/download',
+      installHint: 'Install Node.js LTS, then restart SpecRails Hub.',
+    },
+    {
+      key: 'npm',
+      label: 'npm',
+      command: 'npm',
+      required: true,
+      installed: true,
+      installUrl: 'https://nodejs.org/en/download',
+      installHint: 'npm ships with Node.js LTS.',
+    },
+    {
+      key: 'npx',
+      label: 'npx',
+      command: 'npx',
+      required: true,
+      installed: true,
+      installUrl: 'https://nodejs.org/en/download',
+      installHint: 'npx ships with npm.',
+    },
+    {
+      key: 'git',
+      label: 'Git',
+      command: 'git',
+      required: true,
+      installed: true,
+      installUrl: 'https://git-scm.com/downloads',
+      installHint: 'Install Git, then restart SpecRails Hub.',
+    },
+  ],
+  missingRequired: [],
+}
+
 // Map full model IDs to short names used by specrails-core
 function toShortModelName(modelId: string): string {
   if (modelId.includes('opus')) return 'opus'
@@ -73,6 +133,103 @@ function buildDefaultConfig(): InstallConfig {
     modelPreset: 'balanced',
     modelOverrides: {},
   }
+}
+
+function isSetupPrerequisitesStatus(value: unknown): value is SetupPrerequisitesStatus {
+  const candidate = value as SetupPrerequisitesStatus
+  return Boolean(candidate) &&
+    typeof candidate.ok === 'boolean' &&
+    Array.isArray(candidate.prerequisites) &&
+    Array.isArray(candidate.missingRequired)
+}
+
+function SetupPrerequisitesPanel({
+  status,
+  onRefresh,
+  isRefreshing,
+}: {
+  status: SetupPrerequisitesStatus
+  onRefresh: () => void
+  isRefreshing: boolean
+}) {
+  const missingCount = status.missingRequired.length
+
+  return (
+    <div className={cn(
+      'rounded-lg border px-3 py-2',
+      status.ok
+        ? 'border-dracula-green/25 bg-dracula-green/5'
+        : 'border-dracula-purple/40 bg-dracula-purple/10'
+    )}>
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 min-w-0">
+          {status.ok ? (
+            <CheckCircle2 className="w-4 h-4 text-dracula-green flex-shrink-0" />
+          ) : (
+            <AlertTriangle className="w-4 h-4 text-dracula-purple flex-shrink-0" />
+          )}
+          <div className="min-w-0">
+            <p className="text-xs font-medium text-foreground">
+              {status.ok ? 'Developer tools ready' : `${missingCount} developer tool${missingCount === 1 ? '' : 's'} required`}
+            </p>
+            <p className="text-[11px] text-muted-foreground">
+              SpecRails needs Node.js, npm, npx and Git available on PATH.
+            </p>
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={onRefresh}
+          disabled={isRefreshing}
+          className="h-7 px-2 gap-1.5 text-[11px] flex-shrink-0"
+        >
+          <RefreshCw className={cn('w-3 h-3', isRefreshing && 'animate-spin')} />
+          Refresh
+        </Button>
+      </div>
+
+      {!status.ok && (
+        <div className="mt-2 grid grid-cols-2 gap-2">
+          {status.prerequisites.map((item) => (
+            <div
+              key={item.key}
+              className={cn(
+                'flex items-center justify-between gap-2 rounded-md border px-2 py-1.5 text-[11px]',
+                item.installed
+                  ? 'border-border/30 bg-background/30 text-muted-foreground'
+                  : 'border-dracula-purple/30 bg-background/50 text-foreground'
+              )}
+            >
+              <div className="min-w-0">
+                <div className="flex items-center gap-1.5">
+                  {item.installed ? (
+                    <CheckCircle2 className="w-3 h-3 text-dracula-green flex-shrink-0" />
+                  ) : (
+                    <AlertTriangle className="w-3 h-3 text-dracula-purple flex-shrink-0" />
+                  )}
+                  <span className="font-medium truncate">{item.label}</span>
+                </div>
+                <p className="truncate text-muted-foreground">{item.installed ? item.version ?? 'Detected' : item.installHint}</p>
+              </div>
+              {!item.installed && (
+                <a
+                  href={item.installUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex h-6 w-6 items-center justify-center rounded-md text-dracula-purple hover:bg-dracula-purple/15 flex-shrink-0"
+                  aria-label={`Install ${item.label}`}
+                >
+                  <ExternalLink className="w-3 h-3" />
+                </a>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
 }
 
 // ─── Initial checkpoint states ────────────────────────────────────────────────
@@ -141,15 +298,22 @@ function AgentSelectionStep({
   onInstall,
   onSkip,
   provider,
+  prerequisites,
+  onRefreshPrerequisites,
+  isRefreshingPrerequisites,
 }: {
   config: InstallConfig
   onChange: (config: InstallConfig) => void
   onInstall: () => void
   onSkip: () => void
   provider: 'claude' | 'codex'
+  prerequisites: SetupPrerequisitesStatus
+  onRefreshPrerequisites: () => void
+  isRefreshingPrerequisites: boolean
 }) {
   const [activeTab, setActiveTab] = useState<AgentSelectionTab>('agents')
   const selectedAgents = ALL_AGENTS.filter((a) => config.selectedAgents.includes(a.id))
+  const installDisabled = config.selectedAgents.length === 0 || !prerequisites.ok
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
@@ -166,6 +330,12 @@ function AgentSelectionStep({
             </p>
           </div>
         </div>
+
+        <SetupPrerequisitesPanel
+          status={prerequisites}
+          onRefresh={onRefreshPrerequisites}
+          isRefreshing={isRefreshingPrerequisites}
+        />
 
         {/* Tier selector */}
         <TierSelector
@@ -242,7 +412,7 @@ function AgentSelectionStep({
             size="sm"
             className="gap-2"
             onClick={onInstall}
-            disabled={config.selectedAgents.length === 0}
+            disabled={installDisabled}
           >
             <Package className="w-3.5 h-3.5" />
             {config.tier === 'quick' ? 'Quick Install' : 'Install & Enrich'}
@@ -551,6 +721,8 @@ export function SetupWizard({ project, onComplete: rawOnComplete, onSkip: rawOnS
   const [streamingText, setStreamingText] = useState('')
   const [isStreaming, setIsStreaming] = useState(cached?.isStreaming ?? false)
   const [sessionId, setSessionId] = useState<string | null>(cached?.sessionId ?? null)
+  const [setupPrerequisites, setSetupPrerequisites] = useState<SetupPrerequisitesStatus>(DEFAULT_SETUP_PREREQUISITES)
+  const [isRefreshingPrerequisites, setIsRefreshingPrerequisites] = useState(false)
 
   const pendingEnrichStart = useRef(false)
   const streamingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -585,6 +757,24 @@ export function SetupWizard({ project, onComplete: rawOnComplete, onSkip: rawOnS
       })
     }
   }, [project.id])
+
+  const refreshSetupPrerequisites = useCallback(async () => {
+    setIsRefreshingPrerequisites(true)
+    try {
+      const res = await fetch('/api/hub/setup-prerequisites')
+      if (!res.ok) return
+      const data = await res.json()
+      if (isSetupPrerequisitesStatus(data)) setSetupPrerequisites(data)
+    } catch {
+      // Keep the optimistic default; the backend install guard still validates before spawning.
+    } finally {
+      setIsRefreshingPrerequisites(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    refreshSetupPrerequisites()
+  }, [refreshSetupPrerequisites])
 
   // On remount after tab switch: check if the install/enrich finished while we were away
   useEffect(() => {
@@ -781,6 +971,18 @@ export function SetupWizard({ project, onComplete: rawOnComplete, onSkip: rawOnS
     const cfg = installConfigRef.current
     const provider = (project as { provider?: 'claude' | 'codex' }).provider ?? 'claude'
 
+    if (!setupPrerequisites.ok) {
+      setWizardStep({
+        step: 'error',
+        retryStep: 'installing',
+        message: [
+          'SpecRails setup needs Node.js, npm, npx and Git available on PATH before it can install this project.',
+          'Install the missing tools, restart SpecRails Hub, then retry setup.',
+        ].join('\n\n'),
+      })
+      return
+    }
+
     // Ensure core agents are always included
     const selectedWithCore = [...new Set([...CORE_AGENTS, ...cfg.selectedAgents])]
     const excluded = ALL_AGENTS.map((a) => a.id).filter((id) => !selectedWithCore.includes(id))
@@ -891,6 +1093,9 @@ export function SetupWizard({ project, onComplete: rawOnComplete, onSkip: rawOnS
             onInstall={handleInstall}
             onSkip={onSkip}
             provider={(project as { provider?: 'claude' | 'codex' }).provider ?? 'claude'}
+            prerequisites={setupPrerequisites}
+            onRefreshPrerequisites={refreshSetupPrerequisites}
+            isRefreshingPrerequisites={isRefreshingPrerequisites}
           />
         )}
 

--- a/server/hub-router.ts
+++ b/server/hub-router.ts
@@ -11,6 +11,7 @@ import { WebhookManager } from './webhook-manager'
 import { createSpecrailsTechClient } from './specrails-tech-client'
 import { checkCoreCompat, getCLIStatus, detectAvailableCLIs } from './core-compat'
 import { getHubAnalytics, getHubTodayStats, getHubRecentJobs } from './hub-analytics'
+import { getSetupPrerequisitesStatus } from './setup-prerequisites'
 import type { AnalyticsOpts, AnalyticsPeriod } from './types'
 
 function slugify(name: string): string {
@@ -134,6 +135,10 @@ export function createHubRouter(
     const tiers: ('quick' | 'full')[] = ['quick']
     if (providers.claude) tiers.push('full')
     res.json({ claude: providers.claude, codex: false, tiers })
+  })
+
+  router.get('/setup-prerequisites', (_req, res) => {
+    res.json(getSetupPrerequisitesStatus())
   })
 
   // POST /api/hub/projects — register a new project by path

--- a/server/setup-manager.test.ts
+++ b/server/setup-manager.test.ts
@@ -278,9 +278,32 @@ describe('SetupManager', () => {
       expect(vi.mocked(mockSpawn)).not.toHaveBeenCalled()
     })
 
+    it('fails before spawn when Git is missing from PATH', () => {
+      vi.mocked(mockSpawnSync).mockImplementation((cmd: any, args: any) => {
+        if (cmd === 'which' && Array.isArray(args)) {
+          return { status: args[0] === 'git' ? 1 : 0, stdout: '', stderr: '' } as any
+        }
+        return { status: 0, stdout: `${cmd} 1.0.0\n`, stderr: '' } as any
+      })
+
+      sm.startInstall('p1', '/path/to/project')
+
+      const errors = getBroadcastedByType(broadcast, 'setup_error')
+      expect(errors).toHaveLength(1)
+      expect(errors[0].error).toContain('Git')
+      expect(errors[0].error).toContain('PATH')
+      expect(vi.mocked(mockSpawn)).not.toHaveBeenCalled()
+    })
+
     it('resolves SPECRAILS_CORE_BIN command names to absolute paths before spawn', () => {
       process.env.SPECRAILS_CORE_BIN = 'specrails-core'
       vi.mocked(mockSpawnSync).mockImplementation((cmd: any, args: any) => {
+        if (cmd === 'which' && Array.isArray(args) && ['node', 'npm', 'npx', 'git'].includes(args[0])) {
+          return { status: 0, stdout: `/usr/bin/${args[0]}\n`, stderr: '' } as any
+        }
+        if (['node', 'npm', 'npx', 'git'].includes(cmd) && Array.isArray(args) && args[0] === '--version') {
+          return { status: 0, stdout: `${cmd} 1.0.0\n`, stderr: '' } as any
+        }
         if (cmd === 'which' && Array.isArray(args) && args[0] === 'specrails-core') {
           return { status: 0, stdout: '/opt/homebrew/bin/specrails-core\n', stderr: '' } as any
         }

--- a/server/setup-manager.ts
+++ b/server/setup-manager.ts
@@ -7,6 +7,7 @@ import treeKill from 'tree-kill'
 import type { WsMessage } from './types'
 import { findCoreContract, detectCLISync, CLIProvider } from './core-compat'
 import { spawnAiCli } from './util/cli-prompt'
+import { formatMissingSetupPrerequisites } from './setup-prerequisites'
 
 /**
  * specrails-core's installer (Node-native from v4.2.0 onward, bash
@@ -644,6 +645,16 @@ export class SetupManager {
     this._advanceCheckpoint(projectId, 'config_written')
     this._completeCheckpoint(projectId, 'config_written')
 
+    const missingPrerequisites = formatMissingSetupPrerequisites()
+    if (missingPrerequisites) {
+      this._broadcast({
+        type: 'setup_error',
+        projectId,
+        error: missingPrerequisites,
+      })
+      return
+    }
+
     const probe = probeCoreRuntimeVersion(projectPath)
     if (!probe.ok) {
       this._broadcast({
@@ -779,6 +790,16 @@ export class SetupManager {
     const tier = parsedConfig?.tier ?? 'full'
     this._projectTiers.set(projectId, tier)
     this._initCheckpoints(projectId)
+
+    const missingPrerequisites = formatMissingSetupPrerequisites()
+    if (missingPrerequisites) {
+      this._broadcast({
+        type: 'setup_error',
+        projectId,
+        error: missingPrerequisites,
+      })
+      return
+    }
 
     const probe = probeCoreRuntimeVersion(projectPath)
     if (!probe.ok) {

--- a/server/setup-prerequisites.test.ts
+++ b/server/setup-prerequisites.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('child_process', () => ({
+  spawnSync: vi.fn(),
+}))
+
+import { spawnSync } from 'child_process'
+import {
+  formatMissingSetupPrerequisites,
+  getSetupPrerequisitesStatus,
+  type SetupPrerequisitesStatus,
+} from './setup-prerequisites'
+
+const mockSpawnSync = vi.mocked(spawnSync)
+
+describe('setup prerequisites', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('reports all required tools as installed with versions', () => {
+    mockSpawnSync.mockImplementation((cmd: any, args: any) => {
+      if (cmd === 'which') return { status: 0 } as any
+      return { status: 0, stdout: `${cmd} v1.2.3\nextra\n`, stderr: '' } as any
+    })
+
+    const status = getSetupPrerequisitesStatus()
+
+    expect(status.ok).toBe(true)
+    expect(status.missingRequired).toEqual([])
+    expect(status.prerequisites).toHaveLength(4)
+    expect(status.prerequisites.map((item) => item.command)).toEqual(['node', 'npm', 'npx', 'git'])
+    expect(status.prerequisites.every((item) => item.installed)).toBe(true)
+    expect(status.prerequisites.find((item) => item.command === 'git')?.version).toBe('git v1.2.3')
+  })
+
+  it('reports missing Git without probing its version', () => {
+    mockSpawnSync.mockImplementation((cmd: any, args: any) => {
+      if (cmd === 'which') {
+        return { status: args[0] === 'git' ? 1 : 0 } as any
+      }
+      return { status: 0, stdout: `${cmd} v1.2.3\n`, stderr: '' } as any
+    })
+
+    const status = getSetupPrerequisitesStatus()
+
+    expect(status.ok).toBe(false)
+    expect(status.missingRequired.map((item) => item.command)).toEqual(['git'])
+    expect(mockSpawnSync).not.toHaveBeenCalledWith('git', ['--version'], expect.anything())
+  })
+
+  it('handles command lookup and version failures conservatively', () => {
+    mockSpawnSync.mockImplementation((cmd: any, args: any) => {
+      if (cmd === 'which') {
+        if (args[0] === 'node') return { error: new Error('lookup failed') } as any
+        return { status: 0 } as any
+      }
+      if (cmd === 'npm') return { status: 1, stdout: '', stderr: 'npm failed' } as any
+      if (cmd === 'npx') return { error: new Error('version failed') } as any
+      return { status: 0, stdout: undefined, stderr: 'git version 2.50.0\n' } as any
+    })
+
+    const status = getSetupPrerequisitesStatus()
+
+    expect(status.ok).toBe(false)
+    expect(status.missingRequired.map((item) => item.command)).toEqual(['node'])
+    expect(status.prerequisites.find((item) => item.command === 'npm')?.version).toBeUndefined()
+    expect(status.prerequisites.find((item) => item.command === 'npx')?.version).toBeUndefined()
+    expect(status.prerequisites.find((item) => item.command === 'git')?.version).toBe('git version 2.50.0')
+  })
+
+  it('formats missing prerequisite guidance and returns null when ready', () => {
+    const ready: SetupPrerequisitesStatus = {
+      ok: true,
+      prerequisites: [],
+      missingRequired: [],
+    }
+    const missing: SetupPrerequisitesStatus = {
+      ok: false,
+      prerequisites: [],
+      missingRequired: [
+        {
+          key: 'git',
+          label: 'Git',
+          command: 'git',
+          required: true,
+          installed: false,
+          installUrl: 'https://git-scm.com/downloads',
+          installHint: 'Install Git and restart SpecRails Hub.',
+        },
+      ],
+    }
+
+    expect(formatMissingSetupPrerequisites(ready)).toBeNull()
+    expect(formatMissingSetupPrerequisites(missing)).toContain('Git (git) is not on PATH')
+    expect(formatMissingSetupPrerequisites(missing)).toContain('restart SpecRails Hub')
+  })
+})

--- a/server/setup-prerequisites.ts
+++ b/server/setup-prerequisites.ts
@@ -1,0 +1,111 @@
+import { spawnSync } from 'child_process'
+
+const WHICH_CMD = process.platform === 'win32' ? 'where' : 'which'
+
+export interface SetupPrerequisite {
+  key: 'node' | 'npm' | 'npx' | 'git'
+  label: string
+  command: string
+  required: boolean
+  installed: boolean
+  version?: string
+  installUrl: string
+  installHint: string
+}
+
+export interface SetupPrerequisitesStatus {
+  ok: boolean
+  prerequisites: SetupPrerequisite[]
+  missingRequired: SetupPrerequisite[]
+}
+
+function commandExists(command: string): boolean {
+  const result = spawnSync(WHICH_CMD, [command], {
+    env: process.env,
+    shell: process.platform === 'win32',
+    stdio: 'ignore',
+  })
+  return !result.error && (result.status ?? 1) === 0
+}
+
+function commandVersion(command: string): string | undefined {
+  const result = spawnSync(command, ['--version'], {
+    env: process.env,
+    shell: process.platform === 'win32',
+    encoding: 'utf-8',
+    timeout: 5_000,
+  })
+  if (result.error || (result.status ?? 1) !== 0) return undefined
+  const output = `${result.stdout ?? result.stderr ?? ''}`.trim()
+  return output.split(/\r?\n/)[0]?.trim() || undefined
+}
+
+export function getSetupPrerequisitesStatus(): SetupPrerequisitesStatus {
+  const definitions: Array<Omit<SetupPrerequisite, 'installed' | 'version'>> = [
+    {
+      key: 'node',
+      label: 'Node.js',
+      command: 'node',
+      required: true,
+      installUrl: 'https://nodejs.org/en/download',
+      installHint: process.platform === 'win32'
+        ? 'Install Node.js LTS, then restart SpecRails Hub so Windows refreshes PATH.'
+        : 'Install Node.js LTS, then restart SpecRails Hub so PATH is refreshed.',
+    },
+    {
+      key: 'npm',
+      label: 'npm',
+      command: 'npm',
+      required: true,
+      installUrl: 'https://nodejs.org/en/download',
+      installHint: 'npm ships with Node.js LTS.',
+    },
+    {
+      key: 'npx',
+      label: 'npx',
+      command: 'npx',
+      required: true,
+      installUrl: 'https://nodejs.org/en/download',
+      installHint: 'npx ships with npm and is required to run specrails-core.',
+    },
+    {
+      key: 'git',
+      label: 'Git',
+      command: 'git',
+      required: true,
+      installUrl: process.platform === 'win32'
+        ? 'https://git-scm.com/download/win'
+        : 'https://git-scm.com/downloads',
+      installHint: process.platform === 'win32'
+        ? 'Install Git for Windows and enable the option that adds Git to PATH, then restart SpecRails Hub.'
+        : 'Install Git and restart SpecRails Hub if PATH changed.',
+    },
+  ]
+
+  const prerequisites = definitions.map((definition) => {
+    const installed = commandExists(definition.command)
+    return {
+      ...definition,
+      installed,
+      version: installed ? commandVersion(definition.command) : undefined,
+    }
+  })
+  const missingRequired = prerequisites.filter((item) => item.required && !item.installed)
+  return {
+    ok: missingRequired.length === 0,
+    prerequisites,
+    missingRequired,
+  }
+}
+
+export function formatMissingSetupPrerequisites(status = getSetupPrerequisitesStatus()): string | null {
+  if (status.ok) return null
+
+  return [
+    'SpecRails setup needs a few developer tools before it can install this project.',
+    '',
+    ...status.missingRequired.map((item) => `- ${item.label} (${item.command}) is not on PATH. ${item.installHint}`),
+    '',
+    'Install the missing tools, restart SpecRails Hub, then retry setup.',
+  ].join('\n')
+}


### PR DESCRIPTION
## Summary
- add a setup prerequisite endpoint for Node.js, npm, npx and Git
- show a premium prerequisite panel in the setup wizard with refresh and install links
- block setup before spawning specrails-core when required tools are missing, avoiding raw code 10 failures

## Testing
- npm run typecheck
- npx vitest run server/setup-manager.test.ts
- cd client && npx vitest run src/components/__tests__/SetupWizard.test.tsx