### PR TITLE
feat: hub-only server mode + prerequisites gate on add project

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,9 +35,9 @@ cli/        → specrails-hub CLI bridge (TypeScript, CommonJS)
 
 Server and CLI compile to CommonJS (`tsconfig.json`). Client is ESM with its own `client/tsconfig.json`. Two separate `npm install` are needed (root + `client/`).
 
-### Hub mode (default)
+### Hub mode
 
-The server runs in **hub mode** by default — one Express process manages multiple projects. Use `--legacy` flag for single-project mode.
+The server runs in **hub mode** — one Express process manages multiple projects. Hub is the only supported mode.
 
 **Data layout:**
 ```
@@ -58,9 +58,9 @@ The server runs in **hub mode** by default — one Express process manages multi
 
 ### Client architecture
 
-- `App.tsx` detects hub mode via `GET /api/hub/state`, renders `HubApp` or legacy `RootLayout`
+- `App.tsx` mounts `HubProvider` and `HubApp` unconditionally
 - `useHub.tsx` — `HubProvider` context: project list, active project, setup wizard state
-- `getApiBase()` (`lib/api.ts`) — module-level store returns `/api/projects/<id>` in hub mode, `/api` in legacy. Updated by `HubProvider` on project switch.
+- `getApiBase()` (`lib/api.ts`) — module-level store returns `/api/projects/<id>` for the active project; throws when no project is set. Updated by `HubProvider` on project switch.
 - `useProjectCache.ts` — stale-while-revalidate cache per project to eliminate flicker on tab switch
 - `useProjectRouteMemory` (in `App.tsx`) — saves/restores URL route per project
 
@@ -84,6 +84,8 @@ When adding a project without specrails, a 5-phase wizard runs:
 5. Completion summary
 
 Managed by `SetupManager` (server) and `SetupWizard` component (client). Hub context tracks which projects are in setup via `setupProjectIds`.
+
+**Developer prerequisites gate.** `AddProjectDialog` and `SetupWizard` both render `<PrerequisitesPanel />` driven by the shared `usePrerequisites()` hook (60s in-memory cache, recheck on `window.focus`, manual recheck via the install-instructions modal). The hook fetches `GET /api/hub/setup-prerequisites` (server enriches the response with `platform`, `minVersion`, and `meetsMinimum` per tool). `AddProjectDialog` disables its submit while any required tool is missing, surfaces a "More info" link only when the panel is in the missing state, and opens `<InstallInstructionsModal />` with OS-aware install commands (Homebrew on macOS, winget on Windows, apt/dnf on Linux) plus copy-to-clipboard. `SetupManager.startInstall` keeps `formatMissingSetupPrerequisites()` as a server-side defence-in-depth before spawning `npx specrails-core`.
 
 **Install tiers.** The wizard offers two tiers via `TierSelector`:
 
@@ -156,7 +158,7 @@ Commit message prefixes that affect versioning: `feat:` → minor, `fix:` → pa
 
 Per-project opt-in feature that injects OpenTelemetry env vars into `claude` CLI spawns so the process emits OTLP/JSON signals to the hub.
 
-**Default state**: OFF. Toggle lives in the project `SettingsPage` (hub mode only — hidden in legacy mode).
+**Default state**: OFF. Toggle lives in the project `SettingsPage`.
 
 **Storage paths:**
 - Raw blobs: `~/.specrails/projects/<slug>/telemetry/<jobId>.ndjson.gz` (concatenated gzip; one gzip member per received payload)
@@ -167,7 +169,7 @@ Per-project opt-in feature that injects OpenTelemetry env vars into `claude` CLI
 
 **QueueManager-only scope**: OTEL env injection happens exclusively in `server/queue-manager.ts` at spawn time. `ChatManager` and `SetupManager` spawns are intentionally left uninstrumented (interactive sessions / wizard flows, not repeatable pipeline jobs).
 
-**OTLP receiver**: `POST /otlp/v1/{traces,metrics,logs}` on the hub port, mounted in hub mode only. Routes signals by `specrails.job_id` + `specrails.project_id` from `resource.attributes`. Returns 400 if attributes missing, 404 if project/job unknown. 10 MB uncompressed cap per blob — logs are dropped once reached (traces/metrics continue), a `logs_truncated` control line is written exactly once.
+**OTLP receiver**: `POST /otlp/v1/{traces,metrics,logs}` on the hub port. Routes signals by `specrails.job_id` + `specrails.project_id` from `resource.attributes`. Returns 400 if attributes missing, 404 if project/job unknown. 10 MB uncompressed cap per blob — logs are dropped once reached (traces/metrics continue), a `logs_truncated` control line is written exactly once.
 
 **Export**: `GET /api/projects/:projectId/jobs/:jobId/diagnostic` streams a ZIP containing `job-metadata.json`, `telemetry.ndjson`, `logs.txt`, and `summary.md`. Export button on job cards visible iff a `telemetry_blobs` row exists (`active` or `compacted` state).
 

--- a/cli/specrails-hub.test.ts
+++ b/cli/specrails-hub.test.ts
@@ -254,15 +254,6 @@ describe('handleStatus', () => {
     expect(o).toContain('running'); expect(o).toContain('v1.0.0'); expect(o).toContain('hub')
   })
 
-  it('prints running status for legacy mode with state', async () => {
-    ;({ server, port } = await createMockServer([
-      { path: '/api/health', status: 200, body: { status: 'ok', version: '1.0.0', mode: 'legacy' } },
-      { path: '/api/state', status: 200, body: { projectName: 'myproject', busy: false, phases: { architect: 'idle', developer: 'running' } } },
-    ]))
-    const o = await captureStdoutAsync(async () => { expect(await _internal.handleStatus(port)).toBe(0) })
-    expect(o).toContain('myproject'); expect(o).toContain('architect=idle')
-  })
-
   it('returns 1 when health returns non-200', async () => {
     ;({ server, port } = await createMockServer([{ path: '/api/health', status: 500, body: 'error' }]))
     const o = await captureStdoutAsync(async () => { expect(await _internal.handleStatus(port)).toBe(1) })

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, useRef, useMemo, lazy, Suspense } from 'react'
 import { Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-dom'
 import { Toaster } from 'sonner'
 import { _registerRouteForcer } from './lib/route-memory'
-import { RootLayout } from './components/RootLayout'
 import DashboardPage from './pages/DashboardPage'
 import SettingsPage from './pages/SettingsPage'
 import SettingsDialog from './pages/GlobalSettingsPage'
@@ -36,49 +35,8 @@ import { SpecGenTrackerProvider } from './hooks/useSpecGenTracker'
 import { useOsNotifications } from './hooks/useOsNotifications'
 import { useDesktopUpdateNotifier } from './hooks/useDesktopUpdateNotifier'
 import { WS_URL } from './lib/ws-url'
-import { API_ORIGIN } from './lib/origin'
 import { TerminalsProvider, useTerminals } from './context/TerminalsContext'
 import { FEATURE_AGENTS_SECTION, FEATURE_TERMINAL_PANEL } from './lib/feature-flags'
-
-// ─── Hub mode detection ───────────────────────────────────────────────────────
-
-// __TAURI_INTERNALS__ may not be present at module-load time under WebView2
-// on Windows ARM64 emulation; fall back to a protocol check.
-const IS_TAURI =
-  typeof window !== 'undefined' &&
-  ('__TAURI_INTERNALS__' in window ||
-    (window.location.protocol !== 'http:' && window.location.protocol !== 'https:'))
-
-function useHubMode(): boolean {
-  // In Tauri the server ALWAYS runs in hub mode — skip the network round-trip.
-  const [isHub, setIsHub] = useState(IS_TAURI)
-
-  useEffect(() => {
-    if (IS_TAURI) return  // already set to true
-
-    const controller = new AbortController()
-    const timeout = setTimeout(() => controller.abort(), 5000)
-
-    async function detect() {
-      try {
-        const res = await fetch(`${API_ORIGIN}/api/hub/state`, { signal: controller.signal })
-        setIsHub(res.ok)
-      } catch {
-        setIsHub(false)
-      } finally {
-        clearTimeout(timeout)
-      }
-    }
-
-    detect()
-    return () => {
-      controller.abort()
-      clearTimeout(timeout)
-    }
-  }, [])
-
-  return isHub
-}
 
 // ─── Per-project route memory (persisted to localStorage) ─────────────────────
 
@@ -316,25 +274,9 @@ function TerminalsProviderWithHub({ children }: { children: React.ReactNode }) {
   return <TerminalsProvider activeProjectId={activeProjectId}>{children}</TerminalsProvider>
 }
 
-// ─── Legacy mode OS notification hook ────────────────────────────────────────
-
-function LegacyOsNotifications() {
-  useOsNotifications()
-  return null
-}
-
-// ─── Legacy mode keyboard shortcuts ──────────────────────────────────────────
-
-function LegacyKeyboardShortcuts() {
-  const { cheatsheetOpen, setCheatsheetOpen, openCheatsheet } = useCheatsheetState()
-  useKeyboardShortcuts({ onOpenCheatsheet: openCheatsheet })
-  return <KeyboardShortcutsCheatsheet open={cheatsheetOpen} onOpenChange={setCheatsheetOpen} />
-}
-
 // ─── Root App ─────────────────────────────────────────────────────────────────
 
 export default function App() {
-  const isHub = useHubMode()
   useDesktopUpdateNotifier()
 
   return (
@@ -356,43 +298,17 @@ export default function App() {
         }}
       >
         <SharedWebSocketProvider url={WS_URL}>
-          {isHub ? (
-            <HubProvider>
-              {/* Custom frameless titlebar inside HubProvider so it can read active project */}
-              <TitleBar />
-              <SpecGenTrackerProvider>
-                <SidebarPinProvider>
-                  <TerminalsProviderWithHub>
-                    <HubApp />
-                  </TerminalsProviderWithHub>
-                </SidebarPinProvider>
-              </SpecGenTrackerProvider>
-            </HubProvider>
-          ) : (
-            /* Legacy mode: TitleBar uses LEGACY_FALLBACK from useHub (no project name) */
-            <>
-              <TitleBar />
-              <Suspense fallback={<div className="flex-1 flex items-center justify-center"><p className="text-sm text-muted-foreground">Loading...</p></div>}>
-                <LegacyOsNotifications />
-                <LegacyKeyboardShortcuts />
-                <Routes>
-                  <Route path="/docs" element={<DocsPage />} />
-                  <Route path="/docs/:category/:slug" element={<DocsPage />} />
-                  <Route element={<RootLayout />}>
-                    <Route index element={<DashboardPage />} />
-                    <Route path="/jobs" element={<JobsPage />} />
-                    <Route path="/jobs/:id" element={<JobDetailPage />} />
-                    <Route path="/analytics" element={<AnalyticsPage />} />
-                    <Route path="/activity" element={<ActivityFeedPage />} />
-                    <Route path="/agents" element={<AgentsPage />} />
-                    <Route path="/settings" element={<SettingsPage />} />
-                    <Route path="*" element={<Navigate to="/" replace />} />
-                  </Route>
-                </Routes>
-                <CommandPalette />
-              </Suspense>
-            </>
-          )}
+          <HubProvider>
+            {/* Custom frameless titlebar inside HubProvider so it can read active project */}
+            <TitleBar />
+            <SpecGenTrackerProvider>
+              <SidebarPinProvider>
+                <TerminalsProviderWithHub>
+                  <HubApp />
+                </TerminalsProviderWithHub>
+              </SidebarPinProvider>
+            </SpecGenTrackerProvider>
+          </HubProvider>
           <Toaster
             position="bottom-right"
             theme="dark"

--- a/client/src/__tests__/App.test.tsx
+++ b/client/src/__tests__/App.test.tsx
@@ -14,6 +14,7 @@ vi.mock('sonner', () => ({
 
 vi.mock('../lib/api', () => ({
   getApiBase: () => '/api',
+  setActiveProjectId: vi.fn(),
   setApiContext: vi.fn(),
 }))
 
@@ -70,47 +71,24 @@ vi.mock('../hooks/useHub', async () => {
   }
 })
 
-describe('App — hub mode detection', () => {
+describe('App — hub bootstrap', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('renders in legacy mode when /api/hub/state fetch fails', async () => {
-    global.fetch = vi.fn().mockRejectedValue(new Error('fetch error'))
-    render(<App />)
-    // In legacy mode, Routes renders and eventually renders RootLayout or some fallback
-    // The hub state detection starts as false, so legacy mode renders first
-    // We just confirm it doesn't crash
-    await waitFor(() => {
-      // App renders without throwing
-      expect(document.body).toBeInTheDocument()
-    })
-  })
-
-  it('renders in legacy mode when /api/hub/state returns not ok', async () => {
-    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 })
-    render(<App />)
-    await waitFor(() => {
-      expect(document.body).toBeInTheDocument()
-    })
-    // isHub stays false, so Routes (legacy) branch renders
-    // SharedWebSocketProvider is always rendered
-    expect(screen.queryByTestId('hub-provider')).not.toBeInTheDocument()
-  })
-
-  it('renders hub mode (HubProvider) when /api/hub/state returns ok', async () => {
-    global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({}) })
+  it('mounts HubProvider unconditionally', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({ projects: [] }) })
     render(<App />)
     await waitFor(() => {
       expect(screen.getByTestId('hub-provider')).toBeInTheDocument()
     })
   })
 
-  it('initially renders in legacy mode before fetch completes', () => {
-    // fetch never resolves
-    global.fetch = vi.fn().mockImplementation(() => new Promise(() => {}))
+  it('does not probe /api/hub/state for mode detection', () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({ projects: [] }) })
+    global.fetch = fetchMock
     render(<App />)
-    // isHub starts as false, so legacy Routes branch is rendered
-    expect(screen.queryByTestId('hub-provider')).not.toBeInTheDocument()
+    const hubStateCalls = fetchMock.mock.calls.filter(([url]) => typeof url === 'string' && url.includes('/api/hub/state'))
+    expect(hubStateCalls).toHaveLength(0)
   })
 })

--- a/client/src/__tests__/flows/chat-flow.test.tsx
+++ b/client/src/__tests__/flows/chat-flow.test.tsx
@@ -6,6 +6,7 @@ import { useChat } from '../../hooks/useChat'
 // Mock dependencies
 vi.mock('../../lib/api', () => ({
   getApiBase: () => '/api',
+  setActiveProjectId: vi.fn(),
   setApiContext: vi.fn(),
 }))
 

--- a/client/src/components/AddProjectDialog.tsx
+++ b/client/src/components/AddProjectDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { FolderOpen } from 'lucide-react'
 import { Button } from './ui/button'
@@ -14,6 +14,9 @@ import {
   DialogFooter,
 } from './ui/dialog'
 import { useHub } from '../hooks/useHub'
+import { usePrerequisites } from '../hooks/usePrerequisites'
+import { PrerequisitesPanel } from './PrerequisitesPanel'
+import { InstallInstructionsModal } from './InstallInstructionsModal'
 import { cn } from '../lib/utils'
 
 interface AddProjectDialogProps {
@@ -29,8 +32,22 @@ export function AddProjectDialog({ open, onClose }: AddProjectDialogProps) {
   const [projectName, setProjectName] = useState('')
   const [isAdding, setIsAdding] = useState(false)
   const [availableProviders, setAvailableProviders] = useState<{ claude: boolean; codex: boolean }>({ claude: true, codex: false })
+  const [installModalOpen, setInstallModalOpen] = useState(false)
 
   const { addProject, startSetupWizard, setActiveProjectId } = useHub()
+  const { status: prereqStatus, isLoading: prereqLoading, error: prereqError, recheck: prereqRecheck } = usePrerequisites()
+
+  const missingToolsLabel = useMemo(() => {
+    if (!prereqStatus || prereqStatus.ok) return null
+    const labels = prereqStatus.missingRequired.map((item) => item.label)
+    if (labels.length === 0) return null
+    if (labels.length === 1) return `${labels[0]} is required to add a project`
+    return `${labels.join(', ')} are required to add a project`
+  }, [prereqStatus])
+
+  // Soft block: only enforce gating when we have a definitive negative answer.
+  // If the fetch errored we let the user proceed and rely on the server install guard.
+  const prereqsBlock = prereqStatus !== null && !prereqStatus.ok && !prereqError
 
   useEffect(() => {
     if (!open) return
@@ -108,6 +125,14 @@ export function AddProjectDialog({ open, onClose }: AddProjectDialogProps) {
             No AI CLI detected. Install Claude Code or Codex CLI first.
           </p>
         )}
+
+        <PrerequisitesPanel
+          status={prereqStatus}
+          isLoading={prereqLoading}
+          error={prereqError}
+          onMoreInfo={() => setInstallModalOpen(true)}
+          onRefresh={prereqRecheck}
+        />
 
         <div className="space-y-4 py-2">
           <div className="space-y-1.5">
@@ -223,11 +248,21 @@ export function AddProjectDialog({ open, onClose }: AddProjectDialogProps) {
           <Button
             size="sm"
             onClick={handleAdd}
-            disabled={isAdding || !projectPath.trim() || noProviderAvailable}
+            disabled={isAdding || !projectPath.trim() || noProviderAvailable || prereqsBlock || prereqLoading}
+            title={prereqsBlock ? missingToolsLabel ?? undefined : undefined}
+            data-testid="add-project-submit"
           >
             {isAdding ? 'Adding...' : 'Add Project'}
           </Button>
         </DialogFooter>
+
+        <InstallInstructionsModal
+          open={installModalOpen}
+          onClose={() => setInstallModalOpen(false)}
+          status={prereqStatus}
+          onRecheck={prereqRecheck}
+          isRechecking={prereqLoading}
+        />
       </DialogContent>
     </Dialog>
   )

--- a/client/src/components/InstallInstructionsModal.tsx
+++ b/client/src/components/InstallInstructionsModal.tsx
@@ -1,0 +1,238 @@
+import { useState } from 'react'
+import { Check, Copy, RefreshCw, ExternalLink } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from './ui/dialog'
+import { Button } from './ui/button'
+import { cn } from '../lib/utils'
+import type { Platform, SetupPrerequisitesStatus } from '../hooks/usePrerequisites'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  status: SetupPrerequisitesStatus | null
+  onRecheck: () => void
+  isRechecking?: boolean
+}
+
+interface PlatformInstructions {
+  title: string
+  intro?: string
+  commands: { label: string; command: string }[]
+  links: { label: string; url: string }[]
+  note?: string
+}
+
+const INSTRUCTIONS: Record<Platform, PlatformInstructions> = {
+  darwin: {
+    title: 'macOS',
+    intro: 'Homebrew gets you both tools in one line. If you do not have brew, use the official downloads.',
+    commands: [
+      { label: 'Install Node.js and Git via Homebrew', command: 'brew install node git' },
+    ],
+    links: [
+      { label: 'Node.js (official)', url: 'https://nodejs.org/en/download' },
+      { label: 'Git (official)', url: 'https://git-scm.com/downloads' },
+      { label: 'Homebrew', url: 'https://brew.sh' },
+    ],
+  },
+  win32: {
+    title: 'Windows',
+    intro: 'Winget ships with Windows 11 and recent Windows 10. Open PowerShell or Terminal and run:',
+    commands: [
+      { label: 'Install Node.js LTS', command: 'winget install OpenJS.NodeJS.LTS' },
+      { label: 'Install Git', command: 'winget install Git.Git' },
+    ],
+    links: [
+      { label: 'Node.js (official)', url: 'https://nodejs.org/en/download' },
+      { label: 'Git for Windows (official)', url: 'https://git-scm.com/download/win' },
+    ],
+    note: 'After install, restart SpecRails Hub so Windows refreshes PATH.',
+  },
+  linux: {
+    title: 'Linux',
+    intro: 'Use your distro package manager:',
+    commands: [
+      { label: 'Debian / Ubuntu', command: 'sudo apt install -y nodejs npm git' },
+      { label: 'Fedora / RHEL', command: 'sudo dnf install -y nodejs npm git' },
+    ],
+    links: [
+      { label: 'Node.js (official)', url: 'https://nodejs.org/en/download' },
+      { label: 'Git (official)', url: 'https://git-scm.com/downloads' },
+    ],
+  },
+}
+
+const ALL_PLATFORMS: Platform[] = ['darwin', 'win32', 'linux']
+
+async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+      await navigator.clipboard.writeText(text)
+      return true
+    }
+  } catch {
+    // fall through to fallback
+  }
+  try {
+    const textarea = document.createElement('textarea')
+    textarea.value = text
+    textarea.setAttribute('readonly', '')
+    textarea.style.position = 'fixed'
+    textarea.style.opacity = '0'
+    document.body.appendChild(textarea)
+    textarea.select()
+    const ok = document.execCommand('copy')
+    document.body.removeChild(textarea)
+    return ok
+  } catch {
+    return false
+  }
+}
+
+function CopyButton({ command }: { command: string }) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = async () => {
+    const ok = await copyToClipboard(command)
+    if (ok) {
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1500)
+    }
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      onClick={handleCopy}
+      className="h-7 px-2 gap-1.5 text-[11px]"
+      data-testid="install-copy-button"
+    >
+      {copied ? (
+        <>
+          <Check className="w-3 h-3" />
+          Copied
+        </>
+      ) : (
+        <>
+          <Copy className="w-3 h-3" />
+          Copy
+        </>
+      )}
+    </Button>
+  )
+}
+
+function PlatformSection({ platform, primary }: { platform: Platform; primary: boolean }) {
+  const instr = INSTRUCTIONS[platform]
+  return (
+    <section
+      data-testid={`install-section-${platform}`}
+      className={cn(
+        'rounded-lg border px-3 py-3',
+        primary ? 'border-border/40 bg-background/40' : 'border-border/20 bg-background/20',
+      )}
+    >
+      <h3 className="text-sm font-semibold text-foreground">{instr.title}</h3>
+      {instr.intro && (
+        <p className="mt-1 text-[11px] text-muted-foreground">{instr.intro}</p>
+      )}
+      <div className="mt-2 space-y-2">
+        {instr.commands.map((c) => (
+          <div key={c.command} className="rounded-md border border-border/30 bg-background/60 px-2 py-2">
+            <p className="text-[11px] text-muted-foreground mb-1">{c.label}</p>
+            <div className="flex items-center justify-between gap-2">
+              <code className="text-xs text-foreground font-mono break-all">{c.command}</code>
+              <CopyButton command={c.command} />
+            </div>
+          </div>
+        ))}
+      </div>
+      {instr.links.length > 0 && (
+        <ul className="mt-2 flex flex-wrap gap-x-3 gap-y-1">
+          {instr.links.map((link) => (
+            <li key={link.url}>
+              <a
+                href={link.url}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 text-[11px] text-dracula-cyan hover:underline"
+              >
+                {link.label}
+                <ExternalLink className="w-3 h-3" />
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+      {instr.note && (
+        <p className="mt-2 text-[11px] text-dracula-yellow">{instr.note}</p>
+      )}
+    </section>
+  )
+}
+
+export function InstallInstructionsModal({ open, onClose, status, onRecheck, isRechecking }: Props) {
+  const [showOthers, setShowOthers] = useState(false)
+  const platform: Platform = status?.platform ?? 'darwin'
+  const others = ALL_PLATFORMS.filter((p) => p !== platform)
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onClose() }}>
+      <DialogContent className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Install developer tools</DialogTitle>
+          <DialogDescription>
+            SpecRails needs Node.js, npm, npx, and Git on PATH. Pick the snippet for your OS, run it,
+            then click "I installed it, recheck".
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <PlatformSection platform={platform} primary />
+
+          <button
+            type="button"
+            onClick={() => setShowOthers((v) => !v)}
+            className="text-[11px] text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+            data-testid="install-toggle-others"
+          >
+            {showOthers ? 'Hide other platforms' : 'Show other platforms'}
+          </button>
+
+          {showOthers && (
+            <div className="space-y-3">
+              {others.map((p) => (
+                <PlatformSection key={p} platform={p} primary={false} />
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 mt-2">
+          <Button type="button" variant="ghost" size="sm" onClick={onClose}>
+            Close
+          </Button>
+          <Button
+            type="button"
+            variant="default"
+            size="sm"
+            onClick={onRecheck}
+            disabled={isRechecking}
+            className="gap-1.5"
+            data-testid="install-recheck-button"
+          >
+            <RefreshCw className={cn('w-3 h-3', isRechecking && 'animate-spin')} />
+            I installed it, recheck
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/client/src/components/PrerequisitesPanel.tsx
+++ b/client/src/components/PrerequisitesPanel.tsx
@@ -1,0 +1,162 @@
+import { CheckCircle2, AlertTriangle, RefreshCw, XCircle } from 'lucide-react'
+import { Button } from './ui/button'
+import { cn } from '../lib/utils'
+import type { SetupPrerequisite, SetupPrerequisitesStatus } from '../hooks/usePrerequisites'
+
+interface Props {
+  status: SetupPrerequisitesStatus | null
+  isLoading: boolean
+  error: Error | null
+  onRefresh?: () => void
+  onMoreInfo?: () => void
+}
+
+function formatVersionLabel(item: SetupPrerequisite): string {
+  if (!item.installed) return 'not installed'
+  if (!item.meetsMinimum && item.minVersion) {
+    return `${item.version ?? 'unknown'} found — needs ${item.minVersion}+`
+  }
+  return item.version ?? 'installed'
+}
+
+export function PrerequisitesPanel({ status, isLoading, error, onRefresh, onMoreInfo }: Props) {
+  if (isLoading && !status) {
+    return (
+      <div
+        data-testid="prerequisites-panel"
+        data-state="loading"
+        className="rounded-lg border border-border/30 bg-background/30 px-3 py-2"
+      >
+        <div className="flex items-center gap-2">
+          <div className="w-4 h-4 rounded-full bg-muted-foreground/20 animate-pulse" />
+          <div className="h-3 w-32 rounded bg-muted-foreground/15 animate-pulse" />
+        </div>
+      </div>
+    )
+  }
+
+  if (error && !status) {
+    return (
+      <div
+        data-testid="prerequisites-panel"
+        data-state="error"
+        className="rounded-lg border border-border/40 bg-background/40 px-3 py-2"
+      >
+        <p className="text-[11px] text-muted-foreground">
+          Could not verify developer tools locally — install will validate.
+        </p>
+      </div>
+    )
+  }
+
+  if (!status) return null
+
+  if (status.ok) {
+    return (
+      <div
+        data-testid="prerequisites-panel"
+        data-state="ok"
+        className="rounded-lg border border-dracula-green/25 bg-dracula-green/5 px-3 py-2"
+      >
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 min-w-0">
+            <CheckCircle2 className="w-4 h-4 text-dracula-green flex-shrink-0" />
+            <p className="text-xs font-medium text-foreground">All required tools detected</p>
+          </div>
+          {onRefresh && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={onRefresh}
+              disabled={isLoading}
+              className="h-7 px-2 gap-1.5 text-[11px] flex-shrink-0"
+            >
+              <RefreshCw className={cn('w-3 h-3', isLoading && 'animate-spin')} />
+              Refresh
+            </Button>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  // status.ok === false
+  const missingCount = status.missingRequired?.length ?? 0
+
+  return (
+    <div
+      data-testid="prerequisites-panel"
+      data-state="missing"
+      className="rounded-lg border border-dracula-purple/40 bg-dracula-purple/10 px-3 py-2"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 min-w-0">
+          <AlertTriangle className="w-4 h-4 text-dracula-purple flex-shrink-0" />
+          <div className="min-w-0">
+            <p className="text-xs font-medium text-foreground">
+              {missingCount} developer tool{missingCount === 1 ? '' : 's'} required
+            </p>
+            <p className="text-[11px] text-muted-foreground">
+              Install the missing tools to continue.
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-1 flex-shrink-0">
+          {onMoreInfo && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={onMoreInfo}
+              className="h-7 px-2 gap-1.5 text-[11px]"
+              data-testid="prerequisites-more-info"
+            >
+              More info
+            </Button>
+          )}
+          {onRefresh && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={onRefresh}
+              disabled={isLoading}
+              className="h-7 px-2 gap-1.5 text-[11px]"
+            >
+              <RefreshCw className={cn('w-3 h-3', isLoading && 'animate-spin')} />
+              Refresh
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <ul className="mt-2 space-y-1">
+        {status.prerequisites.map((item) => {
+          const ok = item.installed && item.meetsMinimum
+          return (
+            <li
+              key={item.key}
+              data-testid={`prereq-row-${item.key}`}
+              data-ok={ok ? 'true' : 'false'}
+              className={cn(
+                'flex items-center gap-2 rounded-md border px-2 py-1.5 text-[11px]',
+                ok
+                  ? 'border-border/30 bg-background/30 text-muted-foreground'
+                  : 'border-dracula-purple/30 bg-background/50 text-foreground',
+              )}
+            >
+              {ok ? (
+                <CheckCircle2 className="w-3.5 h-3.5 text-dracula-green flex-shrink-0" />
+              ) : (
+                <XCircle className="w-3.5 h-3.5 text-dracula-purple flex-shrink-0" />
+              )}
+              <span className="font-medium">{item.label}</span>
+              <span className="text-muted-foreground">— {formatVersionLabel(item)}</span>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/client/src/components/SetupWizard.tsx
+++ b/client/src/components/SetupWizard.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback, useLayoutEffect, memo } from 'react'
-import { Check, ArrowRight, Package, Bot, ChevronLeft, Settings2, AlertTriangle, CheckCircle2, ExternalLink, RefreshCw } from 'lucide-react'
+import { Check, ArrowRight, Package, Bot, ChevronLeft, Settings2 } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { Button } from './ui/button'
@@ -11,6 +11,8 @@ import { TierSelector, type InstallTier } from './TierSelector'
 import { useSharedWebSocket } from '../hooks/useSharedWebSocket'
 import { cn } from '../lib/utils'
 import type { HubProject } from '../hooks/useHub'
+import { usePrerequisites, type SetupPrerequisitesStatus } from '../hooks/usePrerequisites'
+import { PrerequisitesPanel } from './PrerequisitesPanel'
 
 // ─── Wizard step types ────────────────────────────────────────────────────────
 
@@ -48,65 +50,8 @@ interface InstallConfig {
   modelOverrides: ModelOverrides
 }
 
-interface SetupPrerequisite {
-  key: 'node' | 'npm' | 'npx' | 'git'
-  label: string
-  command: string
-  required: boolean
-  installed: boolean
-  version?: string
-  installUrl: string
-  installHint: string
-}
-
-interface SetupPrerequisitesStatus {
-  ok: boolean
-  prerequisites: SetupPrerequisite[]
-  missingRequired: SetupPrerequisite[]
-}
-
-const DEFAULT_SETUP_PREREQUISITES: SetupPrerequisitesStatus = {
-  ok: true,
-  prerequisites: [
-    {
-      key: 'node',
-      label: 'Node.js',
-      command: 'node',
-      required: true,
-      installed: true,
-      installUrl: 'https://nodejs.org/en/download',
-      installHint: 'Install Node.js LTS, then restart SpecRails Hub.',
-    },
-    {
-      key: 'npm',
-      label: 'npm',
-      command: 'npm',
-      required: true,
-      installed: true,
-      installUrl: 'https://nodejs.org/en/download',
-      installHint: 'npm ships with Node.js LTS.',
-    },
-    {
-      key: 'npx',
-      label: 'npx',
-      command: 'npx',
-      required: true,
-      installed: true,
-      installUrl: 'https://nodejs.org/en/download',
-      installHint: 'npx ships with npm.',
-    },
-    {
-      key: 'git',
-      label: 'Git',
-      command: 'git',
-      required: true,
-      installed: true,
-      installUrl: 'https://git-scm.com/downloads',
-      installHint: 'Install Git, then restart SpecRails Hub.',
-    },
-  ],
-  missingRequired: [],
-}
+// Prerequisite types and panel are provided by the shared `usePrerequisites` hook
+// and `PrerequisitesPanel` component (see imports below).
 
 // Map full model IDs to short names used by specrails-core
 function toShortModelName(modelId: string): string {
@@ -133,103 +78,6 @@ function buildDefaultConfig(): InstallConfig {
     modelPreset: 'balanced',
     modelOverrides: {},
   }
-}
-
-function isSetupPrerequisitesStatus(value: unknown): value is SetupPrerequisitesStatus {
-  const candidate = value as SetupPrerequisitesStatus
-  return Boolean(candidate) &&
-    typeof candidate.ok === 'boolean' &&
-    Array.isArray(candidate.prerequisites) &&
-    Array.isArray(candidate.missingRequired)
-}
-
-function SetupPrerequisitesPanel({
-  status,
-  onRefresh,
-  isRefreshing,
-}: {
-  status: SetupPrerequisitesStatus
-  onRefresh: () => void
-  isRefreshing: boolean
-}) {
-  const missingCount = status.missingRequired.length
-
-  return (
-    <div className={cn(
-      'rounded-lg border px-3 py-2',
-      status.ok
-        ? 'border-dracula-green/25 bg-dracula-green/5'
-        : 'border-dracula-purple/40 bg-dracula-purple/10'
-    )}>
-      <div className="flex items-center justify-between gap-3">
-        <div className="flex items-center gap-2 min-w-0">
-          {status.ok ? (
-            <CheckCircle2 className="w-4 h-4 text-dracula-green flex-shrink-0" />
-          ) : (
-            <AlertTriangle className="w-4 h-4 text-dracula-purple flex-shrink-0" />
-          )}
-          <div className="min-w-0">
-            <p className="text-xs font-medium text-foreground">
-              {status.ok ? 'Developer tools ready' : `${missingCount} developer tool${missingCount === 1 ? '' : 's'} required`}
-            </p>
-            <p className="text-[11px] text-muted-foreground">
-              SpecRails needs Node.js, npm, npx and Git available on PATH.
-            </p>
-          </div>
-        </div>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          onClick={onRefresh}
-          disabled={isRefreshing}
-          className="h-7 px-2 gap-1.5 text-[11px] flex-shrink-0"
-        >
-          <RefreshCw className={cn('w-3 h-3', isRefreshing && 'animate-spin')} />
-          Refresh
-        </Button>
-      </div>
-
-      {!status.ok && (
-        <div className="mt-2 grid grid-cols-2 gap-2">
-          {status.prerequisites.map((item) => (
-            <div
-              key={item.key}
-              className={cn(
-                'flex items-center justify-between gap-2 rounded-md border px-2 py-1.5 text-[11px]',
-                item.installed
-                  ? 'border-border/30 bg-background/30 text-muted-foreground'
-                  : 'border-dracula-purple/30 bg-background/50 text-foreground'
-              )}
-            >
-              <div className="min-w-0">
-                <div className="flex items-center gap-1.5">
-                  {item.installed ? (
-                    <CheckCircle2 className="w-3 h-3 text-dracula-green flex-shrink-0" />
-                  ) : (
-                    <AlertTriangle className="w-3 h-3 text-dracula-purple flex-shrink-0" />
-                  )}
-                  <span className="font-medium truncate">{item.label}</span>
-                </div>
-                <p className="truncate text-muted-foreground">{item.installed ? item.version ?? 'Detected' : item.installHint}</p>
-              </div>
-              {!item.installed && (
-                <a
-                  href={item.installUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex h-6 w-6 items-center justify-center rounded-md text-dracula-purple hover:bg-dracula-purple/15 flex-shrink-0"
-                  aria-label={`Install ${item.label}`}
-                >
-                  <ExternalLink className="w-3 h-3" />
-                </a>
-              )}
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
-  )
 }
 
 // ─── Initial checkpoint states ────────────────────────────────────────────────
@@ -299,21 +147,26 @@ function AgentSelectionStep({
   onSkip,
   provider,
   prerequisites,
+  prerequisitesLoading,
+  prerequisitesError,
   onRefreshPrerequisites,
-  isRefreshingPrerequisites,
 }: {
   config: InstallConfig
   onChange: (config: InstallConfig) => void
   onInstall: () => void
   onSkip: () => void
   provider: 'claude' | 'codex'
-  prerequisites: SetupPrerequisitesStatus
+  prerequisites: SetupPrerequisitesStatus | null
+  prerequisitesLoading: boolean
+  prerequisitesError: Error | null
   onRefreshPrerequisites: () => void
-  isRefreshingPrerequisites: boolean
 }) {
   const [activeTab, setActiveTab] = useState<AgentSelectionTab>('agents')
   const selectedAgents = ALL_AGENTS.filter((a) => config.selectedAgents.includes(a.id))
-  const installDisabled = config.selectedAgents.length === 0 || !prerequisites.ok
+  // Treat null/loading as ok (don't block install on a slow fetch); only block on a definitive negative
+  // answer where the server reports `ok: false`.
+  const prereqsBlock = prerequisites !== null && !prerequisites.ok && !prerequisitesError
+  const installDisabled = config.selectedAgents.length === 0 || prereqsBlock
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
@@ -331,10 +184,11 @@ function AgentSelectionStep({
           </div>
         </div>
 
-        <SetupPrerequisitesPanel
+        <PrerequisitesPanel
           status={prerequisites}
+          isLoading={prerequisitesLoading}
+          error={prerequisitesError}
           onRefresh={onRefreshPrerequisites}
-          isRefreshing={isRefreshingPrerequisites}
         />
 
         {/* Tier selector */}
@@ -721,8 +575,12 @@ export function SetupWizard({ project, onComplete: rawOnComplete, onSkip: rawOnS
   const [streamingText, setStreamingText] = useState('')
   const [isStreaming, setIsStreaming] = useState(cached?.isStreaming ?? false)
   const [sessionId, setSessionId] = useState<string | null>(cached?.sessionId ?? null)
-  const [setupPrerequisites, setSetupPrerequisites] = useState<SetupPrerequisitesStatus>(DEFAULT_SETUP_PREREQUISITES)
-  const [isRefreshingPrerequisites, setIsRefreshingPrerequisites] = useState(false)
+  const {
+    status: setupPrerequisites,
+    isLoading: isRefreshingPrerequisites,
+    error: setupPrerequisitesError,
+    recheck: refreshSetupPrerequisites,
+  } = usePrerequisites()
 
   const pendingEnrichStart = useRef(false)
   const streamingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -757,24 +615,6 @@ export function SetupWizard({ project, onComplete: rawOnComplete, onSkip: rawOnS
       })
     }
   }, [project.id])
-
-  const refreshSetupPrerequisites = useCallback(async () => {
-    setIsRefreshingPrerequisites(true)
-    try {
-      const res = await fetch('/api/hub/setup-prerequisites')
-      if (!res.ok) return
-      const data = await res.json()
-      if (isSetupPrerequisitesStatus(data)) setSetupPrerequisites(data)
-    } catch {
-      // Keep the optimistic default; the backend install guard still validates before spawning.
-    } finally {
-      setIsRefreshingPrerequisites(false)
-    }
-  }, [])
-
-  useEffect(() => {
-    refreshSetupPrerequisites()
-  }, [refreshSetupPrerequisites])
 
   // On remount after tab switch: check if the install/enrich finished while we were away
   useEffect(() => {
@@ -971,7 +811,7 @@ export function SetupWizard({ project, onComplete: rawOnComplete, onSkip: rawOnS
     const cfg = installConfigRef.current
     const provider = (project as { provider?: 'claude' | 'codex' }).provider ?? 'claude'
 
-    if (!setupPrerequisites.ok) {
+    if (setupPrerequisites !== null && !setupPrerequisites.ok) {
       setWizardStep({
         step: 'error',
         retryStep: 'installing',
@@ -1094,8 +934,9 @@ export function SetupWizard({ project, onComplete: rawOnComplete, onSkip: rawOnS
             onSkip={onSkip}
             provider={(project as { provider?: 'claude' | 'codex' }).provider ?? 'claude'}
             prerequisites={setupPrerequisites}
+            prerequisitesLoading={isRefreshingPrerequisites}
+            prerequisitesError={setupPrerequisitesError}
             onRefreshPrerequisites={refreshSetupPrerequisites}
-            isRefreshingPrerequisites={isRefreshingPrerequisites}
           />
         )}
 

--- a/client/src/components/__tests__/AddProjectDialog.test.tsx
+++ b/client/src/components/__tests__/AddProjectDialog.test.tsx
@@ -3,6 +3,28 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '../../test-utils'
 import userEvent from '@testing-library/user-event'
 import { AddProjectDialog } from '../AddProjectDialog'
+import { __resetPrerequisitesCacheForTest } from '../../hooks/usePrerequisites'
+
+const goodPrereqsStatus = {
+  ok: true,
+  platform: 'darwin' as const,
+  prerequisites: [
+    { key: 'node', label: 'Node.js', command: 'node', required: true, installed: true, version: 'v20.0.0', minVersion: '18.0.0', meetsMinimum: true, installUrl: '', installHint: '' },
+  ],
+  missingRequired: [],
+}
+
+const missingGitPrereqsStatus = {
+  ok: false,
+  platform: 'darwin' as const,
+  prerequisites: [
+    { key: 'node', label: 'Node.js', command: 'node', required: true, installed: true, version: 'v20.0.0', minVersion: '18.0.0', meetsMinimum: true, installUrl: '', installHint: '' },
+    { key: 'git', label: 'Git', command: 'git', required: true, installed: false, meetsMinimum: false, installUrl: '', installHint: '' },
+  ],
+  missingRequired: [
+    { key: 'git', label: 'Git', command: 'git', required: true, installed: false, meetsMinimum: false, installUrl: '', installHint: '' },
+  ],
+}
 
 vi.mock('sonner', () => ({
   toast: {
@@ -30,19 +52,27 @@ vi.mock('../../hooks/useHub', () => ({
   }),
 }))
 
-/** Mock fetch to return available-providers and optionally a project response */
-function mockFetchSequence(projectResponse?: { ok: boolean; json: () => Promise<unknown> }) {
-  const providersResponse = {
-    ok: true,
-    json: async () => ({ claude: true, codex: false }),
-  }
-  if (!projectResponse) {
-    global.fetch = vi.fn().mockResolvedValue(providersResponse)
-    return
-  }
-  global.fetch = vi.fn()
-    .mockResolvedValueOnce(providersResponse)
-    .mockResolvedValueOnce(projectResponse)
+/** URL-aware mock: routes by request URL so call order doesn't matter. */
+function mockFetchSequence(opts?: {
+  prereqStatus?: typeof goodPrereqsStatus | typeof missingGitPrereqsStatus
+  prereqOk?: boolean
+  projectResponse?: { ok: boolean; json: () => Promise<unknown> }
+}) {
+  const prereqStatus = opts?.prereqStatus ?? goodPrereqsStatus
+  const prereqOk = opts?.prereqOk ?? true
+  const providersResponse = { ok: true, json: async () => ({ claude: true, codex: false }) }
+
+  global.fetch = vi.fn().mockImplementation(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    if (url.includes('/api/hub/available-providers')) return providersResponse
+    if (url.includes('/api/hub/setup-prerequisites')) {
+      return prereqOk
+        ? { ok: true, json: async () => prereqStatus }
+        : { ok: false, status: 500, json: async () => ({}) }
+    }
+    if (opts?.projectResponse) return opts.projectResponse
+    return { ok: true, json: async () => ({}) }
+  })
 }
 
 describe('AddProjectDialog', () => {
@@ -55,6 +85,7 @@ describe('AddProjectDialog', () => {
       has_specrails: true,
     })
     vi.clearAllMocks()
+    __resetPrerequisitesCacheForTest()
     mockFetchSequence()
   })
 
@@ -81,13 +112,53 @@ describe('AddProjectDialog', () => {
     expect(addBtn).toBeDisabled()
   })
 
-  it('submit button is enabled when path is filled', async () => {
+  it('submit button is enabled when path is filled and prerequisites are healthy', async () => {
     const user = userEvent.setup()
     render(<AddProjectDialog open={true} onClose={vi.fn()} />)
+    const addBtn = screen.getByRole('button', { name: /Add Project/i })
+    // Wait for the prereq fetch to settle into ok state
+    await waitFor(() => expect(screen.getByTestId('prerequisites-panel')).toHaveAttribute('data-state', 'ok'))
     const pathInput = screen.getByPlaceholderText('/Users/me/my-project')
     await user.type(pathInput, '/some/path')
-    const addBtn = screen.getByRole('button', { name: /Add Project/i })
     expect(addBtn).not.toBeDisabled()
+  })
+
+  it('submit button stays disabled when a required tool is missing, even with a valid path', async () => {
+    const user = userEvent.setup()
+    mockFetchSequence({ prereqStatus: missingGitPrereqsStatus })
+
+    render(<AddProjectDialog open={true} onClose={vi.fn()} />)
+    await waitFor(() => expect(screen.getByTestId('prerequisites-panel')).toHaveAttribute('data-state', 'missing'))
+
+    const pathInput = screen.getByPlaceholderText('/Users/me/my-project')
+    await user.type(pathInput, '/some/path')
+
+    const addBtn = screen.getByTestId('add-project-submit')
+    expect(addBtn).toBeDisabled()
+    expect(addBtn).toHaveAttribute('title', expect.stringMatching(/Git is required/i))
+  })
+
+  it('clicking "More info" opens the install instructions modal', async () => {
+    const user = userEvent.setup()
+    mockFetchSequence({ prereqStatus: missingGitPrereqsStatus })
+
+    render(<AddProjectDialog open={true} onClose={vi.fn()} />)
+    await waitFor(() => expect(screen.getByTestId('prerequisites-more-info')).toBeInTheDocument())
+
+    await user.click(screen.getByTestId('prerequisites-more-info'))
+    expect(screen.getByRole('heading', { name: /install developer tools/i })).toBeInTheDocument()
+  })
+
+  it('does not block submit when the prereq fetch errors (server install guard takes over)', async () => {
+    const user = userEvent.setup()
+    mockFetchSequence({ prereqOk: false })
+
+    render(<AddProjectDialog open={true} onClose={vi.fn()} />)
+    await waitFor(() => expect(screen.getByTestId('prerequisites-panel')).toHaveAttribute('data-state', 'error'))
+
+    const pathInput = screen.getByPlaceholderText('/Users/me/my-project')
+    await user.type(pathInput, '/some/path')
+    expect(screen.getByTestId('add-project-submit')).not.toBeDisabled()
   })
 
   it('successful submit calls API and closes dialog', async () => {

--- a/client/src/components/__tests__/InstallInstructionsModal.test.tsx
+++ b/client/src/components/__tests__/InstallInstructionsModal.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { InstallInstructionsModal } from '../InstallInstructionsModal'
+import type { SetupPrerequisitesStatus } from '../../hooks/usePrerequisites'
+
+function statusFor(platform: 'darwin' | 'win32' | 'linux'): SetupPrerequisitesStatus {
+  return {
+    ok: false,
+    platform,
+    prerequisites: [],
+    missingRequired: [],
+  }
+}
+
+describe('InstallInstructionsModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders only the host platform section by default (macOS)', () => {
+    render(<InstallInstructionsModal open={true} onClose={() => {}} status={statusFor('darwin')} onRecheck={() => {}} />)
+    expect(screen.getByTestId('install-section-darwin')).toBeInTheDocument()
+    expect(screen.queryByTestId('install-section-win32')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('install-section-linux')).not.toBeInTheDocument()
+  })
+
+  it('shows Windows section by default when host is Windows and includes the winget command', () => {
+    render(<InstallInstructionsModal open={true} onClose={() => {}} status={statusFor('win32')} onRecheck={() => {}} />)
+    const section = screen.getByTestId('install-section-win32')
+    expect(section).toBeInTheDocument()
+    expect(section.textContent).toContain('winget install OpenJS.NodeJS.LTS')
+    expect(section.textContent).toContain('winget install Git.Git')
+  })
+
+  it('reveals other platforms via the toggle', () => {
+    render(<InstallInstructionsModal open={true} onClose={() => {}} status={statusFor('darwin')} onRecheck={() => {}} />)
+    fireEvent.click(screen.getByTestId('install-toggle-others'))
+    expect(screen.getByTestId('install-section-win32')).toBeInTheDocument()
+    expect(screen.getByTestId('install-section-linux')).toBeInTheDocument()
+  })
+
+  it('writes the command to the clipboard when copy is clicked', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+
+    render(<InstallInstructionsModal open={true} onClose={() => {}} status={statusFor('darwin')} onRecheck={() => {}} />)
+    fireEvent.click(screen.getAllByTestId('install-copy-button')[0])
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('brew install node git'))
+    expect(await screen.findByText(/copied/i)).toBeInTheDocument()
+  })
+
+  it('falls back to execCommand when clipboard API is unavailable', async () => {
+    Object.assign(navigator, { clipboard: undefined })
+    const execCommand = vi.fn().mockReturnValue(true)
+    Object.assign(document, { execCommand })
+
+    render(<InstallInstructionsModal open={true} onClose={() => {}} status={statusFor('darwin')} onRecheck={() => {}} />)
+    fireEvent.click(screen.getAllByTestId('install-copy-button')[0])
+
+    await waitFor(() => expect(execCommand).toHaveBeenCalledWith('copy'))
+  })
+
+  it('triggers onRecheck when the recheck button is clicked', () => {
+    const onRecheck = vi.fn()
+    render(<InstallInstructionsModal open={true} onClose={() => {}} status={statusFor('darwin')} onRecheck={onRecheck} />)
+    fireEvent.click(screen.getByTestId('install-recheck-button'))
+    expect(onRecheck).toHaveBeenCalledTimes(1)
+  })
+})

--- a/client/src/components/__tests__/PrerequisitesPanel.test.tsx
+++ b/client/src/components/__tests__/PrerequisitesPanel.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { PrerequisitesPanel } from '../PrerequisitesPanel'
+import type { SetupPrerequisitesStatus } from '../../hooks/usePrerequisites'
+
+const okStatus: SetupPrerequisitesStatus = {
+  ok: true,
+  platform: 'darwin',
+  prerequisites: [
+    { key: 'node', label: 'Node.js', command: 'node', required: true, installed: true, version: 'v20.0.0', minVersion: '18.0.0', meetsMinimum: true, installUrl: '', installHint: '' },
+    { key: 'npm', label: 'npm', command: 'npm', required: true, installed: true, version: '10.0.0', minVersion: '9.0.0', meetsMinimum: true, installUrl: '', installHint: '' },
+    { key: 'npx', label: 'npx', command: 'npx', required: true, installed: true, version: '10.0.0', meetsMinimum: true, installUrl: '', installHint: '' },
+    { key: 'git', label: 'Git', command: 'git', required: true, installed: true, version: 'git version 2.42.1', minVersion: '2.20.0', meetsMinimum: true, installUrl: '', installHint: '' },
+  ],
+  missingRequired: [],
+}
+
+const missingGitStatus: SetupPrerequisitesStatus = {
+  ok: false,
+  platform: 'darwin',
+  prerequisites: [
+    okStatus.prerequisites[0],
+    okStatus.prerequisites[1],
+    okStatus.prerequisites[2],
+    { ...okStatus.prerequisites[3], installed: false, meetsMinimum: false, version: undefined },
+  ],
+  missingRequired: [{ ...okStatus.prerequisites[3], installed: false, meetsMinimum: false, version: undefined }],
+}
+
+const oldNodeStatus: SetupPrerequisitesStatus = {
+  ok: false,
+  platform: 'darwin',
+  prerequisites: [
+    { ...okStatus.prerequisites[0], version: 'v14.21.3', meetsMinimum: false },
+    okStatus.prerequisites[1],
+    okStatus.prerequisites[2],
+    okStatus.prerequisites[3],
+  ],
+  missingRequired: [{ ...okStatus.prerequisites[0], version: 'v14.21.3', meetsMinimum: false }],
+}
+
+describe('PrerequisitesPanel', () => {
+  it('shows loading skeleton when isLoading and no status', () => {
+    render(<PrerequisitesPanel status={null} isLoading={true} error={null} />)
+    expect(screen.getByTestId('prerequisites-panel')).toHaveAttribute('data-state', 'loading')
+  })
+
+  it('shows error notice when error and no status', () => {
+    render(<PrerequisitesPanel status={null} isLoading={false} error={new Error('boom')} />)
+    expect(screen.getByTestId('prerequisites-panel')).toHaveAttribute('data-state', 'error')
+    expect(screen.getByText(/install will validate/i)).toBeInTheDocument()
+  })
+
+  it('renders the success line when all tools are healthy', () => {
+    render(<PrerequisitesPanel status={okStatus} isLoading={false} error={null} />)
+    expect(screen.getByTestId('prerequisites-panel')).toHaveAttribute('data-state', 'ok')
+    expect(screen.getByText(/all required tools detected/i)).toBeInTheDocument()
+    expect(screen.queryByTestId('prerequisites-more-info')).not.toBeInTheDocument()
+  })
+
+  it('renders missing rows + More info when a tool is missing', () => {
+    const onMoreInfo = vi.fn()
+    render(<PrerequisitesPanel status={missingGitStatus} isLoading={false} error={null} onMoreInfo={onMoreInfo} />)
+
+    expect(screen.getByTestId('prerequisites-panel')).toHaveAttribute('data-state', 'missing')
+    expect(screen.getByTestId('prereq-row-git')).toHaveAttribute('data-ok', 'false')
+    expect(screen.getByTestId('prereq-row-node')).toHaveAttribute('data-ok', 'true')
+
+    fireEvent.click(screen.getByTestId('prerequisites-more-info'))
+    expect(onMoreInfo).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders below-minimum tools as not-ok with the "needs X+" hint', () => {
+    render(<PrerequisitesPanel status={oldNodeStatus} isLoading={false} error={null} />)
+    const nodeRow = screen.getByTestId('prereq-row-node')
+    expect(nodeRow).toHaveAttribute('data-ok', 'false')
+    expect(nodeRow.textContent).toMatch(/needs 18\.0\.0\+/)
+  })
+
+  it('calls onRefresh when the refresh button is clicked', () => {
+    const onRefresh = vi.fn()
+    render(<PrerequisitesPanel status={okStatus} isLoading={false} error={null} onRefresh={onRefresh} />)
+    fireEvent.click(screen.getByRole('button', { name: /refresh/i }))
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+  })
+})

--- a/client/src/hooks/__tests__/useHub.test.tsx
+++ b/client/src/hooks/__tests__/useHub.test.tsx
@@ -9,6 +9,7 @@ import { SharedWebSocketProvider } from '../useSharedWebSocket'
 const mockSetApiContext = vi.fn()
 
 vi.mock('../../lib/api', () => ({
+  setActiveProjectId: (...args: unknown[]) => mockSetApiContext(...args),
   setApiContext: (...args: unknown[]) => mockSetApiContext(...args),
   getApiBase: () => '/api',
 }))
@@ -226,7 +227,7 @@ describe('useHub', () => {
 
     act(() => { result.current.setActiveProjectId('proj-2') })
 
-    expect(mockSetApiContext).toHaveBeenCalledWith(true, 'proj-2')
+    expect(mockSetApiContext).toHaveBeenCalledWith('proj-2')
     expect(result.current.activeProjectId).toBe('proj-2')
   })
 

--- a/client/src/hooks/__tests__/useHubExtended.test.tsx
+++ b/client/src/hooks/__tests__/useHubExtended.test.tsx
@@ -5,6 +5,7 @@ import { HubProvider, useHub } from '../useHub'
 import { SharedWebSocketProvider } from '../useSharedWebSocket'
 
 vi.mock('../../lib/api', () => ({
+  setActiveProjectId: vi.fn(),
   setApiContext: vi.fn(),
   getApiBase: () => '/api',
 }))

--- a/client/src/hooks/__tests__/usePrerequisites.test.tsx
+++ b/client/src/hooks/__tests__/usePrerequisites.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { usePrerequisites, __resetPrerequisitesCacheForTest } from '../usePrerequisites'
+
+const goodStatus = {
+  ok: true,
+  platform: 'darwin' as const,
+  prerequisites: [
+    { key: 'node', label: 'Node.js', command: 'node', required: true, installed: true, version: 'v20.0.0', minVersion: '18.0.0', meetsMinimum: true, installUrl: '', installHint: '' },
+  ],
+  missingRequired: [],
+}
+
+describe('usePrerequisites', () => {
+  beforeEach(() => {
+    __resetPrerequisitesCacheForTest()
+  })
+
+  it('fetches on first mount and exposes the status', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => goodStatus })
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const { result } = renderHook(() => usePrerequisites())
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.status).toEqual(goodStatus)
+    expect(result.current.error).toBeNull()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('reuses the cached value when re-rendered within 60 s', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => goodStatus })
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const { result: r1, unmount: u1 } = renderHook(() => usePrerequisites())
+    await waitFor(() => expect(r1.current.isLoading).toBe(false))
+    u1()
+
+    const { result: r2 } = renderHook(() => usePrerequisites())
+    expect(r2.current.status).toEqual(goodStatus)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('recheck() invalidates cache and re-fetches', async () => {
+    const second = { ...goodStatus, ok: false, missingRequired: [goodStatus.prerequisites[0]] }
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => goodStatus })
+      .mockResolvedValueOnce({ ok: true, json: async () => second })
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const { result } = renderHook(() => usePrerequisites())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.status?.ok).toBe(true)
+
+    await act(async () => {
+      await result.current.recheck()
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(result.current.status?.ok).toBe(false)
+  })
+
+  it('surfaces a fetch error when the response is not ok', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 500, json: async () => ({}) })
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const { result } = renderHook(() => usePrerequisites())
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.error).not.toBeNull()
+    expect(result.current.status).toBeNull()
+  })
+})

--- a/client/src/hooks/useHub.tsx
+++ b/client/src/hooks/useHub.tsx
@@ -12,7 +12,7 @@ import {
 import { API_ORIGIN } from '../lib/origin'
 import { toast } from 'sonner'
 import { useSharedWebSocket } from './useSharedWebSocket'
-import { setApiContext, setHubMode } from '../lib/api'
+import { setActiveProjectId as setApiActiveProjectId } from '../lib/api'
 
 export interface HubProject {
   id: string
@@ -66,7 +66,7 @@ export function HubProvider({ children }: { children: ReactNode }) {
 
   const setActiveProjectId = useCallback((id: string | null): void => {
     writeSavedProjectId(id)
-    setApiContext(true, id)
+    setApiActiveProjectId(id)
     setActiveProjectIdRaw((prev) => {
       if (prev !== null && prev !== id) {
         // Briefly flag project switching for the progress bar
@@ -91,12 +91,8 @@ export function HubProvider({ children }: { children: ReactNode }) {
         if (data.setupProjectIds && data.setupProjectIds.length > 0) {
           setSetupProjectIds(new Set(data.setupProjectIds))
         }
-        // Mark hub mode without overwriting any project already set by the WS
-        // handler (hub.projects fires concurrently and may have already called
-        // setApiContext(true, projectId) — resetting it here would break API calls).
-        setHubMode(true)
       } catch {
-        // Hub may not be running in hub mode — treat as empty
+        // Network error — treat as empty project list
       } finally {
         setIsLoading(false)
       }
@@ -115,7 +111,7 @@ export function HubProvider({ children }: { children: ReactNode }) {
       setActiveProjectIdRaw((prev) => {
         const next = (prev && incoming.find((p) => p.id === prev)) ? prev : (incoming.length > 0 ? incoming[0].id : null)
         writeSavedProjectId(next)
-        setApiContext(true, next)
+        setApiActiveProjectId(next)
         return next
       })
       setIsLoading(false)
@@ -135,7 +131,7 @@ export function HubProvider({ children }: { children: ReactNode }) {
       setActiveProjectIdRaw((prev) => {
         if (prev !== projectId) return prev
         writeSavedProjectId(null)
-        setApiContext(true, null)
+        setApiActiveProjectId(null)
         return null
       })
     }
@@ -193,7 +189,7 @@ export function HubProvider({ children }: { children: ReactNode }) {
       setActiveProjectIdRaw((prev) => {
         if (prev !== id) return prev
         writeSavedProjectId(null)
-        setApiContext(true, null)
+        setApiActiveProjectId(null)
         return null
       })
     } catch (err) {

--- a/client/src/hooks/usePrerequisites.ts
+++ b/client/src/hooks/usePrerequisites.ts
@@ -1,0 +1,175 @@
+import { useEffect, useState, useCallback } from 'react'
+import { API_ORIGIN } from '../lib/origin'
+
+export type Platform = 'darwin' | 'win32' | 'linux'
+
+export interface SetupPrerequisite {
+  key: 'node' | 'npm' | 'npx' | 'git'
+  label: string
+  command: string
+  required: boolean
+  installed: boolean
+  version?: string
+  minVersion?: string
+  meetsMinimum: boolean
+  installUrl: string
+  installHint: string
+}
+
+export interface SetupPrerequisitesStatus {
+  ok: boolean
+  platform: Platform
+  prerequisites: SetupPrerequisite[]
+  missingRequired: SetupPrerequisite[]
+}
+
+interface UsePrerequisitesResult {
+  status: SetupPrerequisitesStatus | null
+  isLoading: boolean
+  error: Error | null
+  recheck: () => Promise<void>
+}
+
+const CACHE_TTL_MS = 60_000
+
+interface CacheState {
+  data: SetupPrerequisitesStatus | null
+  fetchedAt: number
+  inFlight: Promise<SetupPrerequisitesStatus> | null
+  error: Error | null
+}
+
+const cache: CacheState = {
+  data: null,
+  fetchedAt: 0,
+  inFlight: null,
+  error: null,
+}
+
+const subscribers = new Set<() => void>()
+
+function notifySubscribers(): void {
+  subscribers.forEach((fn) => {
+    try { fn() } catch { /* ignore */ }
+  })
+}
+
+function isFresh(): boolean {
+  return cache.data !== null && Date.now() - cache.fetchedAt < CACHE_TTL_MS
+}
+
+async function fetchPrerequisites(signal?: AbortSignal): Promise<SetupPrerequisitesStatus> {
+  if (cache.inFlight) return cache.inFlight
+
+  const promise = (async () => {
+    const res = await fetch(`${API_ORIGIN}/api/hub/setup-prerequisites`, { signal })
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    const data = await res.json() as Partial<SetupPrerequisitesStatus>
+    if (typeof data?.ok !== 'boolean' || !Array.isArray(data?.prerequisites) || !Array.isArray(data?.missingRequired)) {
+      throw new Error('Malformed prerequisites response')
+    }
+    cache.data = data as SetupPrerequisitesStatus
+    cache.fetchedAt = Date.now()
+    cache.error = null
+    cache.inFlight = null
+    notifySubscribers()
+    return cache.data
+  })().catch((err) => {
+    cache.inFlight = null
+    if (signal?.aborted) {
+      // Aborted — don't store as error; another subscriber might still be pending.
+      throw err
+    }
+    cache.error = err instanceof Error ? err : new Error(String(err))
+    notifySubscribers()
+    throw cache.error
+  })
+
+  cache.inFlight = promise
+  return promise
+}
+
+let focusListenerInstalled = false
+
+function ensureFocusListener(): void {
+  if (focusListenerInstalled) return
+  if (typeof window === 'undefined') return
+  window.addEventListener('focus', () => {
+    cache.fetchedAt = 0
+    cache.data = null
+    void fetchPrerequisites().catch(() => { /* surfaced via subscribers */ })
+  })
+  focusListenerInstalled = true
+}
+
+/** Test-only: reset module state. Not exported through the package surface. */
+export function __resetPrerequisitesCacheForTest(): void {
+  cache.data = null
+  cache.fetchedAt = 0
+  cache.inFlight = null
+  cache.error = null
+  subscribers.clear()
+}
+
+export function usePrerequisites(): UsePrerequisitesResult {
+  const [, forceRender] = useState(0)
+  const [isLoading, setIsLoading] = useState(() => !isFresh())
+  const [error, setError] = useState<Error | null>(cache.error)
+
+  useEffect(() => {
+    ensureFocusListener()
+
+    const subscription = () => {
+      forceRender((n) => n + 1)
+      setError(cache.error)
+      setIsLoading(false)
+    }
+    subscribers.add(subscription)
+
+    const controller = new AbortController()
+
+    if (!isFresh() && !cache.inFlight) {
+      setIsLoading(true)
+      fetchPrerequisites(controller.signal)
+        .catch((err) => {
+          if (controller.signal.aborted) return
+          setError(err instanceof Error ? err : new Error(String(err)))
+        })
+        .finally(() => {
+          if (!controller.signal.aborted) setIsLoading(false)
+        })
+    } else if (cache.inFlight) {
+      cache.inFlight
+        .catch(() => { /* error reflected via subscribers */ })
+        .finally(() => {
+          if (!controller.signal.aborted) setIsLoading(false)
+        })
+    }
+
+    return () => {
+      controller.abort()
+      subscribers.delete(subscription)
+    }
+  }, [])
+
+  const recheck = useCallback(async () => {
+    cache.fetchedAt = 0
+    cache.data = null
+    cache.error = null
+    setIsLoading(true)
+    try {
+      await fetchPrerequisites()
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)))
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  return {
+    status: cache.data,
+    isLoading,
+    error,
+    recheck,
+  }
+}

--- a/client/src/lib/__tests__/api.test.ts
+++ b/client/src/lib/__tests__/api.test.ts
@@ -1,68 +1,42 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { setApiContext, setHubMode, getApiBase } from '../api'
+import { setActiveProjectId, getApiBase } from '../api'
 
 describe('api', () => {
-  // Reset to legacy defaults before each test
   beforeEach(() => {
-    setApiContext(false, null)
+    setActiveProjectId(null)
   })
 
   describe('getApiBase', () => {
-    it('returns /api in legacy mode (isHub=false)', () => {
-      setApiContext(false, null)
-      expect(getApiBase()).toBe('/api')
-    })
-
-    it('returns /api when isHub=true but no projectId', () => {
-      setApiContext(true, null)
-      expect(getApiBase()).toBe('/api')
-    })
-
-    it('returns /api/projects/<id> in hub mode with a project ID', () => {
-      setApiContext(true, 'proj-123')
+    it('returns /api/projects/<id> when an active project is set', () => {
+      setActiveProjectId('proj-123')
       expect(getApiBase()).toBe('/api/projects/proj-123')
     })
 
-    it('updates when project ID changes', () => {
-      setApiContext(true, 'proj-aaa')
+    it('updates when the active project changes', () => {
+      setActiveProjectId('proj-aaa')
       expect(getApiBase()).toBe('/api/projects/proj-aaa')
 
-      setApiContext(true, 'proj-bbb')
+      setActiveProjectId('proj-bbb')
       expect(getApiBase()).toBe('/api/projects/proj-bbb')
     })
 
-    it('falls back to /api when switched back to legacy mode', () => {
-      setApiContext(true, 'proj-xyz')
+    it('throws when no active project is set', () => {
+      expect(() => getApiBase()).toThrow(/no active project/i)
+    })
+
+    it('throws after the active project is cleared', () => {
+      setActiveProjectId('proj-xyz')
       expect(getApiBase()).toBe('/api/projects/proj-xyz')
 
-      setApiContext(false, null)
-      expect(getApiBase()).toBe('/api')
+      setActiveProjectId(null)
+      expect(() => getApiBase()).toThrow(/no active project/i)
     })
   })
 
-  describe('setApiContext', () => {
-    it('accepts project ID with special chars (URL-safe)', () => {
-      setApiContext(true, 'my-project_001')
+  describe('setActiveProjectId', () => {
+    it('accepts project IDs with URL-safe special chars', () => {
+      setActiveProjectId('my-project_001')
       expect(getApiBase()).toBe('/api/projects/my-project_001')
-    })
-
-    it('ignores projectId when isHub is false even if provided', () => {
-      setApiContext(false, 'proj-ignored')
-      expect(getApiBase()).toBe('/api')
-    })
-  })
-
-  describe('setHubMode', () => {
-    it('sets hub mode without clearing active project', () => {
-      setApiContext(true, 'proj-123')
-      setHubMode(true)
-      expect(getApiBase()).toBe('/api/projects/proj-123')
-    })
-
-    it('disables hub mode without clearing project ID', () => {
-      setApiContext(true, 'proj-123')
-      setHubMode(false)
-      expect(getApiBase()).toBe('/api')
     })
   })
 })

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,34 +1,27 @@
 /**
  * Returns the base URL prefix for project-scoped API calls.
  *
- * Single-project mode: '/api'
- * Hub mode with active project: '/api/projects/<id>'
- *
- * Components and hooks call useApiBase() to get this prefix, then append
- * resource paths (e.g., `${base}/jobs`).
+ * The hub server is the only supported runtime; this helper always returns
+ * `${API_ORIGIN}/api/projects/<activeProjectId>`. Callers must set the active
+ * project via `setActiveProjectId` before using the helper. Endpoints that are
+ * not project-scoped (e.g. `/api/hub/*`, `/api/health`) should reference
+ * `API_ORIGIN` directly instead of going through `getApiBase`.
  */
 
 import { API_ORIGIN } from './origin'
 
-// Module-level store for active project ID — set by HubProvider/App
 let _activeProjectId: string | null = null
-let _isHubMode = false
 
-export function setApiContext(isHub: boolean, projectId: string | null): void {
-  _isHubMode = isHub
+export function setActiveProjectId(projectId: string | null): void {
   _activeProjectId = projectId
 }
 
-/** Sets hub mode without touching the active project ID.
- * Use in the REST load to avoid racing with the WS handler that may have
- * already set _activeProjectId via setApiContext(true, projectId). */
-export function setHubMode(isHub: boolean): void {
-  _isHubMode = isHub
-}
+/** @deprecated alias kept for tests; prefer `setActiveProjectId`. */
+export const setApiContext = (projectId: string | null): void => setActiveProjectId(projectId)
 
 export function getApiBase(): string {
-  if (_isHubMode && _activeProjectId) {
-    return `${API_ORIGIN}/api/projects/${_activeProjectId}`
+  if (!_activeProjectId) {
+    throw new Error('getApiBase called with no active project — call setActiveProjectId first')
   }
-  return `${API_ORIGIN}/api`
+  return `${API_ORIGIN}/api/projects/${_activeProjectId}`
 }

--- a/client/src/test-setup.ts
+++ b/client/src/test-setup.ts
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom/vitest'
 import { vi, afterEach, beforeEach } from 'vitest'
 import { cleanup } from '@testing-library/react'
+import { setActiveProjectId } from './lib/api'
 
 // Cleanup after each test
 afterEach(() => {
@@ -8,12 +9,15 @@ afterEach(() => {
   vi.restoreAllMocks()
 })
 
-// Reset fetch mock before each test
+// Reset fetch mock and seed an active project before each test so that
+// `getApiBase()` (which throws when no project is active) works in component
+// tests that don't set up a HubProvider.
 beforeEach(() => {
   global.fetch = vi.fn().mockResolvedValue({
     ok: true,
     json: async () => ({}),
   })
+  setActiveProjectId('test-project')
 })
 
 // Mock window.matchMedia (required by some Radix components)

--- a/docs/engineering/architecture.md
+++ b/docs/engineering/architecture.md
@@ -52,8 +52,6 @@ The server runs in **hub mode** by default — a single Express process manages 
 └─────────────────────────────────────────────────────┘
 ```
 
-Use `--legacy` at startup to run in single-project mode (mounts `/api` directly without the hub router).
-
 ### Per-project isolation
 
 Each project in the `ProjectRegistry` gets its own `ProjectContext`:

--- a/docs/engineering/configuration.md
+++ b/docs/engineering/configuration.md
@@ -132,22 +132,6 @@ This does not affect your project source code or specrails-core installations.
 
 ---
 
-## Legacy mode
-
-Legacy mode runs the server for a single project without a project registry. Use it when migrating from an older specrails installation or when you only manage one project.
-
-```bash
-specrails-hub start --legacy
-```
-
-In legacy mode:
-- No `hub.sqlite` project registry is used
-- The server serves one project, determined by the current working directory at startup
-- Hub-mode routes (`/api/hub/*`) are not available
-- CLI commands do not resolve a project from CWD
-
----
-
 ## Further reading
 
 - [Getting Started](../general/getting-started.md) — installation guide

--- a/openspec/changes/archive/2026-04-27-add-windows-desktop-release/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-27-add-windows-desktop-release/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-24

--- a/openspec/changes/archive/2026-04-27-add-windows-desktop-release/design.md
+++ b/openspec/changes/archive/2026-04-27-add-windows-desktop-release/design.md
@@ -1,0 +1,113 @@
+## Context
+
+The current `desktop-release.yml` workflow builds a signed + notarized macOS `.dmg` on `macos-latest` and uploads it to Hostinger via FTP under two paths (`v<version>/` and `latest/`), accompanied by a `manifest.json` that specrails-web reads to render the Download CTA.
+
+The sidecar build system (`scripts/build-sidecar.mjs`, `@yao-pkg/pkg`) already maps `x86_64-pc-windows-msvc → node22-win-x64`, and Tauri is configured with `bundle.targets: "all"` plus `icons/icon.ico`. The missing pieces are exclusively CI/CD, runtime validation on Windows, and the manifest schema extension.
+
+Two runtime patches in `server/index.ts` anchor native addon loading for the pkg-packaged sidecar (`Module._resolveFilename`/`_load` redirect + `process.dlopen` override). These were written with a win32 code path but never executed in CI. The terminal subsystem already branches on `win32` to spawn `powershell.exe -NoLogo` and to switch PTY backends, so no runtime code changes are expected — only validation.
+
+Prior OpenSpec `server-sidecar` spec envisions `x86_64-pc-windows-msvc` as a supported build target ("Build sidecar script runs successfully" scenario enumerates macOS arm64, macOS x64, **Windows x64**), but the CI matrix never exercised that branch. This change closes the gap between spec and reality.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A tag push `v*` produces both a macOS `.dmg` (existing) and a Windows x64 installer (new), without breaking the macOS pipeline.
+- The Windows installer (NSIS `.exe` and MSI, per Tauri's default Windows bundle set) embeds a functional sidecar that can start the Express server, serve the React client, and run the agent/terminal features end-to-end on Windows 10/11.
+- `manifest.json` published to `latest/` lists both `darwin-arm64` and `windows-x64` platforms with correct `filename`, `url`, `sha256`, and `size`.
+- The FTP deploy step enforces "all binaries uploaded before manifest" so consumers never see a manifest referencing a not-yet-published file.
+
+**Non-Goals:**
+- Code signing (Authenticode) — deferred to a follow-up change. The v1 installer WILL trigger SmartScreen warnings and this is accepted and documented.
+- Auto-updater via Tauri updater framework.
+- ARM64 Windows (`aarch64-pc-windows-msvc`).
+- Windows-specific installer polish (custom UI, Start Menu grouping, uninstaller branding, tray integration).
+- specrails-web consumer changes — tracked separately; this change only publishes the manifest entry.
+
+## Decisions
+
+### Decision 1: Separate `build-windows` job, not a matrix strategy
+
+**Choice:** Add a second top-level job `build-windows: runs-on: windows-latest` rather than converting `build-macos` into a `strategy.matrix` over OSes.
+
+**Rationale:** The jobs diverge heavily on secrets (Apple certificate, API key, signing identity vs. nothing on Windows v1) and build steps (notarization is macOS-only). A matrix forces conditional `if:` guards on almost every step, which is more brittle and less readable than two parallel jobs with a shared `deploy` consumer.
+
+**Alternatives considered:**
+- `strategy.matrix: [macos-latest, windows-latest]` — rejected for the reason above.
+- Build Windows on a self-hosted runner — rejected, no infra.
+
+### Decision 2: Bundle both NSIS and MSI (Tauri default)
+
+**Choice:** Leave `tauri.conf.json` at `bundle.targets: "all"` and publish both the NSIS `.exe` installer and the MSI to `latest/`/`v<version>/`.
+
+**Rationale:** NSIS is the recommended, smaller, consumer-friendly default; MSI is required by enterprise users with group-policy deployment. The Tauri build emits both in the same step for free. The manifest's `windows-x64` entry points to the NSIS `.exe` (consumer default); the MSI is discoverable via the versioned folder listing.
+
+**Alternatives considered:**
+- NSIS-only — rejected; forecloses enterprise adoption with no build-time cost to include MSI.
+- MSI-only — rejected; NSIS is a better OSS first-contact experience.
+
+### Decision 3: Filename convention `specrails-hub-<version>-x64-setup.exe` and `specrails-hub-<version>-x64.msi`
+
+**Choice:** Mirror the macOS pattern (`specrails-hub-<version>-aarch64.dmg`) with a Windows-appropriate arch suffix.
+
+**Rationale:** Version-bearing filenames let consumers parse the version without the manifest, and `x64` is the conventional Windows arch tag (not `x86_64` which is a Linux/Rust convention).
+
+**Alternatives considered:**
+- `specrails-hub-setup.exe` (no version) — rejected; breaks the "filename contains semver" requirement already present in the `desktop-release-channel` spec.
+- `specrails-hub-<version>.exe` (no arch) — rejected; cannot distinguish future ARM64 build.
+
+### Decision 4: Tauri installer renaming
+
+**Choice:** Tauri does not natively expose filename templating for NSIS/MSI outputs; they are emitted with fixed patterns (`SpecRails Hub_<version>_x64-setup.exe`, `SpecRails Hub_<version>_x64_en-US.msi`). The `build-windows` job SHALL rename these to the convention in Decision 3 before upload, matching the existing `macos` rename step where applicable.
+
+**Rationale:** Filename convention must survive regardless of Tauri's default output naming. A post-build rename step is a well-scoped one-liner per artifact.
+
+### Decision 5: Sidecar build runs on the Windows runner (no cross-compile)
+
+**Choice:** `npm ci` + `npm run build:sidecar` run on `windows-latest` itself so native prebuilds (`better-sqlite3`, `node-pty`) resolve to their win32 prebuilt `.node` files.
+
+**Rationale:** pkg's JS-level cross-compile is real, but native `.node` addons must come from an install on the target platform. Cross-compiling Windows from macOS/Linux would require manually fetching prebuilds and is brittle. Running the same script as macOS on a win32 runner is the simplest path.
+
+**Open risk:** `@yao-pkg/pkg` Windows target has known signing-related quirks (Authenticode sections). Unsigned builds should be unaffected; validate empirically.
+
+### Decision 6: Manifest schema evolution is additive
+
+**Choice:** Keep `schemaVersion: 1`. Adding `windows-x64` under `platforms` is an additive change — existing consumers already iterate `platforms` or lookup `platforms['darwin-arm64']` and ignore unknown keys.
+
+**Rationale:** Bumping to `schemaVersion: 2` would force every consumer to update before a Windows release could ship. The manifest spec already documents `platforms` as an open map; this is the exact extension point it was designed for.
+
+**Alternatives considered:**
+- Bump `schemaVersion` to 2 — rejected; unnecessary and breaks forward-compat.
+
+### Decision 7: Upload ordering — all binaries before manifest
+
+**Choice:** Strengthen the existing "manifest after binary" rule to "manifest after *all* binaries referenced by the manifest". The deploy job uploads every `.dmg`/`.exe`/`.msi` first, HEAD-verifies each, then uploads `manifest.json` last.
+
+**Rationale:** A consumer reading the new manifest and requesting the Windows `.exe` must never hit a 404.
+
+## Risks / Trade-offs
+
+- **SmartScreen scares users** → Mitigation: publish a short doc/blog on the download page ("Windows users: when the SmartScreen prompt appears, click *More info → Run anyway*"). Track install funnel drop-off once telemetry exists. Treat as a known limitation for v1.
+- **Sidecar dlopen patch may fail silently on win32** → Mitigation: smoke-test the produced `.exe` in CI before uploading. Launch the installer in a headless session, wait for `GET http://localhost:4200/api/hub/state` to return 200, then exit. Block the release if the smoke test fails.
+- **node-pty Windows backend (ConPTY) resource files** → Mitigation: verify the `binaries/node-pty/**/*` glob picks up win32-specific files (no `spawn-helper`, yes `conpty.node` or `winpty-agent.exe` depending on node-pty version). Confirm via `tauri build --debug` output listing bundled resources.
+- **Custom titlebar parity** → Non-blocker for this change (shipping works), but cosmetic polish (Windows min/max/close affordance order, snap-layouts support on Win11) is not covered here. Open bug for follow-up if it looks wrong on first run.
+- **CI minutes cost** → Windows runners cost 2× macOS on GitHub Actions free tier. Releases are rare (tagged); impact negligible.
+- **Hostinger FTP reliability under parallel uploads** → Mitigation: upload sequentially within the single `deploy` job, HEAD-verify each before proceeding.
+
+## Migration Plan
+
+The web consumer (specrails-web) will NOT render a Windows download CTA at ship time of this change. This means publishing a broken Windows binary to prod `latest/` has zero user-visible impact until specrails-web is explicitly updated to surface the `windows-x64` manifest entry. That property collapses what would normally be a multi-step staging dance into a single prod release.
+
+1. Merge the PR to `main`.
+2. Let release-please produce its Release PR (version bump + changelog entry).
+3. Merge the Release PR. The auto-created tag `v<version>` triggers `Desktop Release`, which builds macOS and Windows in parallel and uploads both to `downloads/specrails-hub/latest/` and `downloads/specrails-hub/v<version>/` with the combined `manifest.json`.
+4. Download the Windows `.exe` from `https://specrails.dev/downloads/specrails-hub/latest/` onto a clean Windows 10/11 VM. Install, smoke-test: hub starts, add a project, terminal spawns PowerShell, one agent job runs to completion.
+5. Update specrails-web to read `platforms["windows-x64"]` and surface the Windows CTA only after the smoke test passes.
+
+**Rollback:** If the Windows build ships broken, hotfix the workflow to re-upload a `manifest.json` with only `darwin-arm64` under `platforms`. The broken `.exe` can stay in `latest/` harmlessly — no consumer references it while specrails-web has no Windows CTA. No impact on macOS users.
+
+## Open Questions
+
+- **Does the pkg Windows target need `--no-bytecode`?** Some reports of codegen issues on recent Node versions. First run will reveal.
+- **Does `node-pty`'s Windows build require additional Visual C++ runtime on the target machine?** ConPTY is shipped with Windows 10 1809+, so no — but confirm on a freshly installed Windows 11.
+- **MSI publisher attribute (unsigned)** — Tauri lets us set a display name but not a verified publisher without a cert. Confirm the MSI doesn't fail to install due to missing publisher; if it does, may need to disable MSI for v1.
+- **File extension in `manifest.platforms['windows-x64'].filename`** — point to NSIS `.exe` or allow both? Proposal: NSIS `.exe` only, with the MSI reachable via the version-folder directory listing.

--- a/openspec/changes/archive/2026-04-27-add-windows-desktop-release/proposal.md
+++ b/openspec/changes/archive/2026-04-27-add-windows-desktop-release/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+specrails-hub currently ships only as a macOS Apple Silicon `.dmg`. A non-trivial share of prospective users run Windows and cannot install the hub today. Shipping a Windows x64 desktop build — even unsigned for v1 — unblocks that audience and gets real-world feedback before investing in code-signing infrastructure.
+
+This change adds a Windows x64 build path to the existing desktop-release pipeline without changing the macOS flow and without taking on code-signing costs yet (addressed later as a follow-up change).
+
+## What Changes
+
+- Add a `build-windows` job to `.github/workflows/desktop-release.yml` running on `windows-latest`. It produces a Tauri-bundled Windows installer (NSIS `.exe` and MSI) that embeds the `specrails-server` sidecar compiled for `x86_64-pc-windows-msvc`.
+- `scripts/build-sidecar.mjs` already contains the pkg target mapping for Windows — exercise and validate it on a Windows runner.
+- Extend `deploy` to download both macOS and Windows artifacts and upload both to `downloads/specrails-hub/v<version>/` and `downloads/specrails-hub/latest/`.
+- Extend `manifest.json` published to `latest/` with a `windows-x64` platform entry (filename, url, sha256, size) alongside the existing `darwin-arm64`. The ordering guarantee is strengthened: *all* binaries must be uploaded before `manifest.json`.
+- Publish Windows installer filename following a version-bearing pattern (`specrails-hub-<version>-x64-setup.exe` for NSIS, `specrails-hub-<version>-x64.msi` for MSI).
+- **No code signing** for v1 — the installer will trigger Windows SmartScreen warnings. This is explicit and accepted.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `desktop-release-channel`: manifest gains multi-platform support (`windows-x64` added), filename regex scenario expanded for Windows artifacts, upload ordering rule generalized across all platform binaries.
+
+## Impact
+
+- **CI:** `.github/workflows/desktop-release.yml` — new `build-windows` job, updated `deploy` job dependencies and upload matrix.
+- **Build scripts:** `scripts/build-sidecar.mjs` exercised on Windows runner; confirm pkg target resolution, native addon copy (better-sqlite3, node-pty with ConPTY/winpty files) works end-to-end. `process.dlopen` and `Module._resolveFilename` patches in `server/index.ts` need validation on win32.
+- **Tauri config:** no changes expected; `bundle.targets: "all"` already emits NSIS + MSI on Windows. `icon.ico` already listed.
+- **Release artifacts:** new `.exe` and `.msi` published under `latest/` and `v<version>/`. `manifest.json` schema additive change (non-breaking for consumers that tolerate unknown keys; specrails-web consumer will surface a Windows download CTA in a follow-up).
+- **Out of scope (explicit):** code signing (Authenticode), ARM64 Windows, Tauri auto-updater, installer polish (Start Menu group, custom uninstaller UI), Windows tray integration.

--- a/openspec/changes/archive/2026-04-27-add-windows-desktop-release/specs/desktop-release-channel/spec.md
+++ b/openspec/changes/archive/2026-04-27-add-windows-desktop-release/specs/desktop-release-channel/spec.md
@@ -1,23 +1,4 @@
-# desktop-release-channel Specification
-
-## Purpose
-Defines the desktop release publishing contract for stable latest downloads, versioned archival URLs, and release manifests across supported platforms.
-
-## Requirements
-### Requirement: Stable "latest" download URL for macOS build
-The system SHALL publish the most recent signed and notarised `.dmg` for specrails-hub to a stable, version-independent URL at `https://specrails.dev/downloads/specrails-hub/latest/`. The file SHALL be the same signed and notarised artifact that is published to the versioned folder for the corresponding tag.
-
-#### Scenario: Tag push publishes to latest folder
-- **WHEN** a commit tagged `v<version>` is pushed and the `Desktop Release` workflow completes successfully
-- **THEN** a file named `specrails-hub-<version>-aarch64.dmg` exists at `https://specrails.dev/downloads/specrails-hub/latest/` and returns HTTP 200
-
-#### Scenario: Latest file matches versioned file
-- **WHEN** both the `latest/` and the corresponding `v<version>/` folder have been populated by the same workflow run
-- **THEN** the `.dmg` binaries at both locations have identical sha256 hashes
-
-#### Scenario: Subsequent release replaces latest
-- **WHEN** a newer tag `v<version+1>` is released
-- **THEN** `https://specrails.dev/downloads/specrails-hub/latest/specrails-hub-<version+1>-aarch64.dmg` is served and any prior `.dmg` left in `latest/` from a previous release SHALL NOT be served from that folder
+## ADDED Requirements
 
 ### Requirement: Stable "latest" download URL for Windows build
 The system SHALL publish the most recent Windows x64 installer for specrails-hub to a stable, version-independent URL at `https://specrails.dev/downloads/specrails-hub/latest/`. The Windows installer SHALL be the same artifact published to the versioned folder for the corresponding tag. The v1 Windows installer MAY be unsigned; Authenticode code-signing is not required by this requirement.
@@ -37,19 +18,25 @@ The system SHALL publish the most recent Windows x64 installer for specrails-hub
 - **THEN** `https://specrails.dev/downloads/specrails-hub/latest/specrails-hub-<version+1>-x64-setup.exe` is served
 - **AND** any prior Windows installer left in `latest/` from a previous release SHALL NOT be served from that folder
 
-### Requirement: Versioned download URL remains available
-The system SHALL continue to publish each released `.dmg` to its version-specific folder `https://specrails.dev/downloads/specrails-hub/v<version>/` for archival and deep linking.
-
-#### Scenario: Versioned URL remains reachable after new release
-- **WHEN** a new release is published and `latest/` has been updated
-- **THEN** the previous release's `.dmg` at `https://specrails.dev/downloads/specrails-hub/v<previous-version>/` still returns HTTP 200
-
 ### Requirement: Versioned download URL for Windows build remains available
 The system SHALL publish each released Windows installer (`.exe` and `.msi`) to its version-specific folder `https://specrails.dev/downloads/specrails-hub/v<version>/` for archival and deep linking.
 
 #### Scenario: Versioned Windows URL remains reachable after new release
 - **WHEN** a new release is published and `latest/` has been updated
 - **THEN** the previous release's Windows `.exe` at `https://specrails.dev/downloads/specrails-hub/v<previous-version>/specrails-hub-<previous-version>-x64-setup.exe` still returns HTTP 200
+
+### Requirement: Windows installer filename includes the version and architecture
+The Windows installer filenames published to both `latest/` and `v<version>/` SHALL contain the release version and architecture so that consumers can derive both by parsing the filename when the manifest is unavailable.
+
+#### Scenario: NSIS filename contains semver and arch
+- **WHEN** the release for tag `v<version>` publishes
+- **THEN** the NSIS installer filename matches the regular expression `^specrails-hub-\d+\.\d+\.\d+-x64-setup\.exe$` and the captured version equals the release version
+
+#### Scenario: MSI filename contains semver and arch
+- **WHEN** the release for tag `v<version>` publishes
+- **THEN** the MSI filename matches the regular expression `^specrails-hub-\d+\.\d+\.\d+-x64\.msi$` and the captured version equals the release version
+
+## MODIFIED Requirements
 
 ### Requirement: Release manifest describes the latest build
 The system SHALL publish a `manifest.json` file at `https://specrails.dev/downloads/specrails-hub/latest/manifest.json` that describes the most recent release. The manifest SHALL be a UTF-8 encoded JSON document with the following fields:
@@ -100,28 +87,3 @@ The system SHALL upload every installer file referenced by `manifest.json` to it
 #### Scenario: Deploy fails if a referenced binary cannot be verified
 - **WHEN** a HEAD request on any binary referenced by the manifest returns non-200 during the deploy step
 - **THEN** the deploy job fails and `manifest.json` is NOT uploaded
-
-### Requirement: Manifest cache is short-lived
-The system SHALL serve `manifest.json` from `latest/` with HTTP cache headers that prevent intermediate caches from returning a stale version to a consumer across releases. Cache-Control SHALL be set to `no-cache, must-revalidate`.
-
-#### Scenario: Browser fetches manifest after new release
-- **WHEN** a browser has previously fetched `manifest.json` before a release and fetches it again after the release
-- **THEN** the browser receives the new manifest (not a cached prior version) assuming the server is reachable
-
-### Requirement: Released filename includes the version
-The `.dmg` filename published to both `latest/` and `v<version>/` SHALL contain the release version so that a consumer can derive the version by parsing the filename when the manifest is unavailable.
-
-#### Scenario: Filename contains semver
-- **WHEN** the release for tag `v<version>` publishes
-- **THEN** the `.dmg` filename matches the regular expression `^specrails-hub-\d+\.\d+\.\d+-aarch64\.dmg$` and the captured version equals the release version
-
-### Requirement: Windows installer filename includes the version and architecture
-The Windows installer filenames published to both `latest/` and `v<version>/` SHALL contain the release version and architecture so that consumers can derive both by parsing the filename when the manifest is unavailable.
-
-#### Scenario: NSIS filename contains semver and arch
-- **WHEN** the release for tag `v<version>` publishes
-- **THEN** the NSIS installer filename matches the regular expression `^specrails-hub-\d+\.\d+\.\d+-x64-setup\.exe$` and the captured version equals the release version
-
-#### Scenario: MSI filename contains semver and arch
-- **WHEN** the release for tag `v<version>` publishes
-- **THEN** the MSI filename matches the regular expression `^specrails-hub-\d+\.\d+\.\d+-x64\.msi$` and the captured version equals the release version

--- a/openspec/changes/archive/2026-04-27-add-windows-desktop-release/tasks.md
+++ b/openspec/changes/archive/2026-04-27-add-windows-desktop-release/tasks.md
@@ -1,0 +1,56 @@
+## 1. Sidecar build validation on Windows (validated in-branch)
+
+Validated empirically during dogfood on Windows 11 ARM64 + via the `build-windows` CI matrix. Each bug found was fixed on this branch.
+
+- [x] 1.1 Run `scripts/build-sidecar.mjs` on `windows-latest` — emits `specrails-server-x86_64-pc-windows-msvc.exe`. *(Fixed tar-on-Windows absolute-path bug in commit `5b18c7b` by passing a relative tarball name to tar + using `cwd` in execSync.)*
+- [x] 1.2 Sidecar binary launches, Express server binds 127.0.0.1:4200, `/api/hub/state` returns 200. *(Verified on Windows 11 ARM64 under Prism emulation.)*
+- [x] 1.3 `better_sqlite3.node` is copied + loads without `ERR_DLOPEN_FAILED`. *(Fixed path resolution in `server/index.ts` pkg-native-addon hijack at commit `886b114` — probes `<exec>/binaries`, `<exec>/../Resources/binaries`, `<exec>` and picks the first containing the anchor file.)*
+- [x] 1.4 `node-pty` resources (`conpty.node`, `pty.node`, `winpty-agent.exe`) land under `<install>/binaries/node-pty/` and load on the Node Prism-emulated x64 runtime.
+- [x] 1.5 `server/index.ts` patches (`Module._resolveFilename`/`_load`, `process.dlopen`) pass on win32 — the resources-dir probe added in 1.3 covers both macOS `.app` and Windows installs in a single cross-platform guard.
+
+## 2. Tauri Windows installer build (validated on Windows 11 ARM64)
+
+Dogfooded locally via the downloaded CI artifact on Windows 11 ARM64.
+
+- [x] 2.1 `npm run build:desktop` on `windows-latest` emits both NSIS `.exe` and MSI; both uploaded as `windows-x64` artifact.
+- [x] 2.2 NSIS `.exe` installs on Windows 11 ARM64; app launches; titlebar renders; dashboard loads after `__TAURI_INTERNALS__`-protocol fallback + `http://tauri.localhost` CORS origin allowlist were added.
+- [ ] 2.3 MSI install tested on Windows 10 — deferred to post-merge smoke. *(MSI is published alongside `.exe` but not referenced by `manifest.json`; if the MSI breaks we ship NSIS-only.)*
+- [x] 2.4 In-app: add project works after fix CORS + fetch-interceptor; CLI detection works after `which`→`where` + `shell:true` + Tauri macOS-only PATH gating. Terminal panel spawns PowerShell. **Setup wizard** is unblocked by the companion specrails-core PR [#256](https://github.com/fjpulidop/specrails-core/pull/256) which ports the installer to native Node (no bash/python3 required on Windows); smoke-test in task 5.4 below.
+- [x] 2.5 Post-build rename step: rename Tauri's default output filenames (`SpecRails Hub_<version>_x64-setup.exe`, `SpecRails Hub_<version>_x64_en-US.msi`) to `specrails-hub-<version>-x64-setup.exe` and `specrails-hub-<version>-x64.msi`. *(Implemented in deploy-job `Rename installers to canonical filenames` step.)*
+
+## 3. CI workflow: `build-windows` job
+
+- [x] 3.1 Add a new `build-windows` job to `.github/workflows/desktop-release.yml` running on `windows-latest`.
+- [x] 3.2 Steps: checkout, setup-node 20, setup Rust stable, Rust cache keyed on `src-tauri`, `npm ci` (root) + `cd client && npm ci`.
+- [x] 3.3 Run `npm run build:desktop` with no signing env vars.
+- [x] 3.4 Run the rename step from 2.5. *(Rename happens in deploy job after artifact download, not inside build-windows — see the `Rename installers to canonical filenames` step in `deploy`.)*
+- [x] 3.5 Upload the renamed `.exe` and `.msi` as a single artifact named `windows-x64`.
+- [ ] 3.6 Add smoke test step: launch the installed app headless (or install silently via `/S` NSIS flag in a temp dir), poll `GET http://localhost:4200/api/hub/state` with a 30s timeout, fail the job if not 200. Shut the app down cleanly. *(Deferred — adding a stable headless-install smoke test is non-trivial. For v1 we rely on the manual VM check in 2.2/2.3. Consider adding in a follow-up change once the build is known-good.)*
+
+## 4. Deploy job updates
+
+- [x] 4.1 Extend `deploy: needs:` to include `build-windows` in addition to `build-macos`.
+- [x] 4.2 Download both artifacts (`dmg-aarch64`, `windows-x64`) into `./artifacts/`. *(Existing `download-artifact@v4` with `merge-multiple: true` picks up all artifacts automatically.)*
+- [x] 4.3 Upload every binary (`.dmg`, `.exe`, `.msi`) to `downloads/specrails-hub/v<version>/` on Hostinger via FTP. *(Existing `Deploy versioned installers` step uploads the full `artifacts/` dir.)*
+- [x] 4.4 Upload every binary to `downloads/specrails-hub/latest/` on Hostinger via FTP.
+- [x] 4.5 HEAD-verify each uploaded binary returns HTTP 200 before proceeding; fail the job on any non-200. *(Scoped to manifest-referenced binaries: `.dmg` + `.exe`; MSI is available via versioned folder but not gated by HEAD check.)*
+- [x] 4.6 Extend `manifest.json` generation to include a `platforms["windows-x64"]` entry pointing at the NSIS `.exe`, with computed `sha256` and `size`.
+- [x] 4.7 Upload `manifest.json` LAST, after all HEAD checks pass.
+
+## 5. Documentation and rollout
+
+- [x] 5.1 Update `CLAUDE.md` release-pipeline section to describe the `build-windows` job and the Windows filename conventions.
+- [x] 5.2 Add a `docs/windows.md` explaining the SmartScreen warning + core-version dependency (Node-native specrails-core ≥ 4.2.0).
+- [x] 5.3 Expand `server/setup-manager.ts` checkpoint-detection regex to be tolerant of both the retired bash output and the new Node installer's stdout phrases (`Loaded install config`, `Phase 2 & 3`, `Writing manifest`, `init complete`, `update complete`).
+- [x] 5.4 Sync the CLAUDE.md reserved-paths contract note with the new Node core (`init` / `update` subcommands replace `install.sh` / `update.sh`).
+- [ ] 5.5 Order of release: **(a)** merge `specrails-core#256` to main → release-please → publish `specrails-core@4.2.0` on npm. **(b)** Then merge hub PR #251 → release-please → tag `v<hub-version>` → Desktop Release workflow publishes Windows + macOS builds. **(c)** Revert the temporary `tauri = { features = ["devtools"] }` in `src-tauri/Cargo.toml` right before (b).
+- [ ] 5.6 Download the released Windows `.exe` from `https://specrails.dev/downloads/specrails-hub/latest/`, install on a clean Windows 10/11 VM, run the full setup wizard against a fresh project. Expected: base_install + config_written + quick_complete checkpoints all advance, at least one agent job completes end-to-end. Only after pass: update specrails-web to surface the Windows CTA.
+
+## 6. Validation against specs
+
+- [ ] 6.1 Verify filename regex `^specrails-hub-\d+\.\d+\.\d+-x64-setup\.exe$` matches the published NSIS installer.
+- [ ] 6.2 Verify filename regex `^specrails-hub-\d+\.\d+\.\d+-x64\.msi$` matches the published MSI.
+- [ ] 6.3 Fetch `manifest.json`, assert `platforms["windows-x64"]` is present with all four fields (`filename`, `url`, `sha256`, `size`).
+- [ ] 6.4 Recompute sha256 of downloaded `.exe` and assert it equals `platforms["windows-x64"].sha256`.
+- [ ] 6.5 Issue `HEAD` on the `.exe` URL and assert `Content-Length` equals `platforms["windows-x64"].size`.
+- [ ] 6.6 After a subsequent release, verify prior version's `.exe` and `.msi` at `v<previous-version>/` still return 200.

--- a/openspec/changes/archive/2026-04-27-remove-legacy-single-project-mode/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-27-remove-legacy-single-project-mode/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-27

--- a/openspec/changes/archive/2026-04-27-remove-legacy-single-project-mode/design.md
+++ b/openspec/changes/archive/2026-04-27-remove-legacy-single-project-mode/design.md
@@ -1,0 +1,69 @@
+## Context
+
+Hub mode and legacy single-project mode currently coexist in `server/index.ts` as mutually exclusive branches gated by `isHubMode = !process.argv.includes('--legacy') && process.env.SPECRAILS_LEGACY !== '1'`. Hub mode delegates to `ProjectRegistry`, `hub-router`, and `project-router`; legacy mode wires its own `QueueManager`, `ChatManager`, `ProposalManager`, `db`, and inline route handlers against `cwd/data/jobs.sqlite`. The same divide exists in the React client: `App.tsx` probes `GET /api/hub/state` to decide between `<HubProvider><HubApp/></HubProvider>` and a legacy `<RootLayout/>` with its own `Navbar`, `LegacyOsNotifications`, and `LegacyKeyboardShortcuts` wrappers. `lib/api.ts` keeps a module-level `_isHubMode` flag so `getApiBase()` can return `/api` (legacy) or `/api/projects/<id>` (hub).
+
+The Tauri desktop sidecar always launches in hub mode, the user no longer uses legacy in any project, and the dual surface duplicates roughly 750 LOC across server, client, and tests. Removing it has no functional impact on the supported flow.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Hub mode is the only execution mode for both server and client.
+- Net deletion of dead code paths without altering hub behaviour.
+- Faster web-client bootstrap by removing the synchronous `/api/hub/state` probe.
+- Coverage gates (80% server / 70% global) remain green.
+- CLI status output continues to work against the simplified `/api/health` payload.
+
+**Non-Goals:**
+- Refactoring or unifying hub-mode internals (`ProjectRegistry`, routers, managers stay as-is).
+- Touching the `legacy` markers in `setup-manager.ts`, `profile-manager.ts`, `profiles-router.ts`, `queue-manager.ts`, or `rails-router.ts` — those refer to legacy specrails-core installations or legacy profile fallback, not single-project server mode.
+- Removing or changing `ProposalManager`; it is shared with hub mode via `project-router.ts`.
+- Renaming the `mode` field in `/api/health` (kept as constant `"hub"` for CLI compatibility).
+- Changes to the `GET /api/hub/state` endpoint contract — it stays for hub-state delivery.
+
+## Decisions
+
+### Decision: Delete the legacy branch wholesale instead of feature-flagging it
+
+Legacy mode is unreachable for the user and the desktop sidecar. A flag would only defer the cleanup. Wholesale deletion gives the LOC win and removes the divergence risk between `/api/jobs` and `/api/projects/:id/jobs`. Alternatives considered: (a) keep behind `SPECRAILS_LEGACY=1` for a deprecation cycle — rejected, no consumers; (b) extract legacy mode into a separate package — rejected, no demand and would multiply maintenance.
+
+### Decision: Keep `mode` field in `/api/health` as a constant
+
+`cli/specrails-hub.ts` reads `health.mode` to render status. Removing the field is a breaking CLI change for cached binaries; keeping it constant is free. Alternative: drop the field and update CLI in the same change — rejected, increases blast radius without benefit.
+
+### Decision: Remove client-side `useHubMode()` and `IS_TAURI` fallback
+
+With hub being the only mode, the `/api/hub/state` probe in `App.tsx` (lines 52–81) is dead detection. Deleting it removes one network round-trip on web startup and simplifies the boot sequence to `<HubProvider><HubApp/></HubProvider>` unconditionally. The `IS_TAURI` constant becomes unused and is removed as well.
+
+### Decision: Simplify `getApiBase()` to require an active project ID
+
+After removal, `getApiBase()` always returns `/api/projects/<activeProjectId>`. When no project is active, callers must not invoke API methods (current code already gates on `activeProject` being non-null in render paths). The `_isHubMode` module-level flag, `setHubMode()`, and the `setApiContext(isHub, projectId)` two-arg shape collapse to a single setter `setActiveProjectId(projectId: string | null)`. Throwing from `getApiBase()` when no project is set surfaces accidental calls at runtime; alternative of returning `/api` was rejected because that path no longer exists server-side and would hide bugs.
+
+### Decision: Delete `RootLayout.tsx` and `Navbar.tsx`
+
+`RootLayout.tsx` is imported only by the legacy branch in `App.tsx`. `Navbar.tsx` is imported only by `RootLayout.tsx` (verified via grep). `ProjectLayout.tsx` uses `ProjectNavbar` instead. Both files plus their `__tests__/RootLayout.test.tsx` and `__tests__/Navbar.test.tsx` get deleted. `usePipeline`, `useChat`, `ChatPanel`, and `StatusBar` are retained — they are still used by `ProjectLayout`.
+
+### Decision: Remove `--project` CLI argument and `resolveProjectName()`
+
+These only matter for legacy mode (to pick a single project name from cwd). Hub uses `ProjectRegistry` slugs derived from registered project paths. `--port` and `--parent-pid` are retained.
+
+## Risks / Trade-offs
+
+- **Coverage drop** → Run `npm test -- --coverage` before merging. Hub-mode tests should already cover equivalent routes via `project-router.test.ts` / `hub-router.test.ts`. If coverage falls below thresholds, add hub-side tests for any uncovered manager methods rather than restoring legacy tests.
+- **CLI bridge regression** → `cli/specrails-hub.ts` parses `/api/health.mode`. Verified it accepts `'hub'`. The legacy-status test case in `cli/specrails-hub.test.ts` (line 257) is removed; hub status case is retained.
+- **Hidden consumer of `--legacy` or `SPECRAILS_LEGACY=1`** → Grep `scripts/`, `.github/workflows/`, `src-tauri/`, `Tauri.toml`, and `package.json` before merging. None expected.
+- **Web users with bookmarked legacy URLs** (e.g., `http://localhost:4200/jobs/<id>` rendered by RootLayout) → After change, those URLs route through hub `<HubApp/>` which already serves `/jobs/:id` via `ProjectLayout`. No bookmarks break.
+- **`getApiBase()` throwing on no active project** → Render paths gate on `activeProject` already; if a stray call slips through, the throw surfaces it immediately in dev. Acceptable trade-off for catching bugs.
+
+## Migration Plan
+
+1. Land server-side changes first: delete legacy branch, helpers, and tests; ensure `npm test` passes.
+2. Land client-side changes: delete `useHubMode`, legacy render branch, `RootLayout`, `Navbar`, simplify `getApiBase`. Update `client/src/App.tsx` so `<HubProvider>` mounts unconditionally.
+3. Update `CLAUDE.md` (root + `client/CLAUDE.md` if applicable) and `.claude/rules/client.md` to drop legacy-mode references.
+4. Run `npm run typecheck && npm test -- --coverage` and confirm gates.
+5. No data migration required (`~/.specrails/hub.sqlite` and per-project DBs already exist for hub users; legacy `cwd/data/jobs.sqlite` is left untouched on disk).
+
+**Rollback:** Revert the merge commit. No persistent state changes.
+
+## Open Questions
+
+- Should `setApiContext` keep the two-arg shape (`isHub`, `projectId`) for any external test that imports it, or collapse to a single setter? Grep shows internal usage only — collapse is safe. Will collapse during implementation.

--- a/openspec/changes/archive/2026-04-27-remove-legacy-single-project-mode/proposal.md
+++ b/openspec/changes/archive/2026-04-27-remove-legacy-single-project-mode/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+The server and client carry a parallel "legacy" single-project execution mode (activated via `--legacy` / `SPECRAILS_LEGACY=1`) that predates hub mode. Hub mode has been the default for a long time, the desktop sidecar always runs hub, and the user no longer relies on legacy mode in any project. The dual-mode branching (~750 LOC across server, client, and tests) duplicates routing surface, slows web startup with an unnecessary `/api/hub/state` probe, and creates ongoing divergence risk between `/api/jobs` (legacy) and `/api/projects/:id/jobs` (hub).
+
+## What Changes
+
+- **BREAKING** Remove `--legacy` CLI flag and `SPECRAILS_LEGACY=1` environment variable from the server entry point. Hub is the only mode.
+- **BREAKING** Remove the entire single-project branch in `server/index.ts` (~365 LOC): legacy DB initialisation in `cwd/data/jobs.sqlite`, top-level `QueueManager`/`ChatManager`/`ProposalManager` instances, legacy WebSocket `init` message, `/hooks` mount, and the inline `/api/spawn`, `/api/state`, `/api/jobs/*`, `/api/queue/*`, `/api/config`, `/api/issues`, `/api/chat/*`, `/api/propose/*` route handlers.
+- Remove `_legacyDb`, `resolveProjectName`, and the `--project` CLI argument (only meaningful for legacy mode).
+- `GET /api/health` always returns `mode: "hub"`. Field kept for CLI status backward compatibility.
+- Remove client-side hub-mode detection (`useHubMode`, the `/api/hub/state` probe). `App.tsx` mounts `HubProvider` directly, eliminating one network round-trip on web startup. Tauri behaviour unchanged.
+- Remove `RootLayout.tsx`, `Navbar.tsx`, `LegacyOsNotifications`, `LegacyKeyboardShortcuts`, and the legacy branch in `App.tsx`.
+- Simplify `lib/api.ts`: `getApiBase()` always returns `/api/projects/<id>`. Drop the `_isHubMode` flag and `setHubMode` helper.
+- Remove legacy-specific tests (`RootLayout.test.tsx`, `Navbar.test.tsx`, legacy cases in `server/index.test.ts` and `cli/specrails-hub.test.ts`).
+- Update `CLAUDE.md`, `client.md`, and any user-facing docs to drop references to legacy / single-project mode.
+
+## Capabilities
+
+### New Capabilities
+- `hub-only-server-mode`: Establishes hub mode as the sole execution mode for the server and client. Documents the removal of the `--legacy` flag, the always-on `ProjectRegistry`-backed routing surface, and the simplified client bootstrap that no longer probes `/api/hub/state`.
+
+### Modified Capabilities
+<!-- None — legacy single-project mode never had its own spec, so this is purely an additive capability that codifies hub-only behaviour. -->
+
+## Impact
+
+**Code:**
+- `server/index.ts` — drop ~365 LOC `else` branch, mode flag, helpers, `_legacyDb` lifecycle
+- `server/index.test.ts` — remove ~5 legacy-mode test cases
+- `client/src/App.tsx` — drop `useHubMode`, `IS_TAURI` fallback, legacy render branch, `Legacy*` wrappers
+- `client/src/components/RootLayout.tsx` — delete
+- `client/src/components/Navbar.tsx` — delete (only used by RootLayout)
+- `client/src/components/__tests__/RootLayout.test.tsx` — delete
+- `client/src/components/__tests__/Navbar.test.tsx` — delete
+- `client/src/lib/api.ts` — simplify `getApiBase`, drop `_isHubMode` / `setHubMode`
+- `cli/specrails-hub.test.ts` — remove legacy-mode status case
+
+**APIs:**
+- Removed (in legacy mode only — never reachable in hub): `POST /hooks/events` (root), `POST /api/spawn`, `GET /api/state`, `GET /api/jobs`, `GET /api/jobs/:id`, `DELETE /api/jobs/:id`, `DELETE /api/jobs`, `GET /api/queue`, `POST /api/queue/pause`, `POST /api/queue/resume`, `PUT /api/queue/reorder`, `GET /api/stats`, `GET /api/analytics`, `GET /api/config`, `POST /api/config`, `GET /api/issues`, `GET|POST|DELETE|PATCH /api/chat/*`, `GET|POST|DELETE /api/propose/*`. Hub equivalents under `/api/projects/:projectId/*` are unchanged.
+- `GET /api/health` keeps its shape; `mode` field becomes constant `"hub"`.
+- `GET /api/hub/state` no longer needed by the web client for mode detection but is retained for the hub-state contract.
+
+**Dependencies:** None.
+
+**User-visible:** None for hub users (the only supported flow). Anyone passing `--legacy` or `SPECRAILS_LEGACY=1` will see the flag silently ignored and the server start in hub mode using `~/.specrails/hub.sqlite` instead of `cwd/data/jobs.sqlite`.
+
+**Coverage gates:** CI enforces 80% server / 70% global coverage. Removing legacy code removes both numerator and denominator; verify `npm test -- --coverage` stays above thresholds before merging.

--- a/openspec/changes/archive/2026-04-27-remove-legacy-single-project-mode/specs/hub-only-server-mode/spec.md
+++ b/openspec/changes/archive/2026-04-27-remove-legacy-single-project-mode/specs/hub-only-server-mode/spec.md
@@ -1,0 +1,78 @@
+## ADDED Requirements
+
+### Requirement: Server runs exclusively in hub mode
+The server SHALL run in hub mode unconditionally. The `--legacy` CLI flag and the `SPECRAILS_LEGACY` environment variable SHALL have no effect on mode selection. The `--project` CLI argument SHALL NOT be accepted.
+
+#### Scenario: Server start without flags
+- **WHEN** `node server/index.ts` (or the bundled sidecar) is invoked with no mode-related arguments
+- **THEN** the server initialises `ProjectRegistry`, mounts `/api/hub/*`, mounts `/api/projects/:projectId/*`, mounts `/otlp`, runs telemetry compaction, and listens on the configured port
+
+#### Scenario: Server start with legacy flag is ignored
+- **WHEN** the server is invoked with `--legacy` or `SPECRAILS_LEGACY=1`
+- **THEN** hub mode starts as if the flag were absent
+- **AND** the legacy single-project SQLite at `cwd/data/jobs.sqlite` is NOT created
+
+#### Scenario: Project name resolution helper is absent
+- **WHEN** the codebase is searched for `resolveProjectName`
+- **THEN** the helper does not exist and no caller depends on it
+
+### Requirement: Health endpoint reports hub mode
+The `GET /api/health` endpoint SHALL return a JSON object whose `mode` field is the constant string `"hub"`. Other fields (`status`, `version`, `uptime`, `projects`) retain their existing semantics.
+
+#### Scenario: Health probe
+- **WHEN** a client issues `GET /api/health`
+- **THEN** the response body contains `"mode": "hub"`
+- **AND** `projects` reflects the count returned by `ProjectRegistry.listContexts().length`
+
+### Requirement: Legacy single-project routes are not registered
+The server SHALL NOT register the following root-level routes: `POST /hooks/events`, `POST /api/spawn`, `GET /api/state`, `GET /api/jobs`, `GET /api/jobs/:id`, `DELETE /api/jobs/:id`, `DELETE /api/jobs`, `GET /api/queue`, `POST /api/queue/pause`, `POST /api/queue/resume`, `PUT /api/queue/reorder`, `GET /api/stats`, `GET /api/analytics`, `GET /api/config`, `POST /api/config`, `GET /api/issues`, `GET|POST|DELETE|PATCH /api/chat/*`, `GET|POST|DELETE /api/propose/*`. All equivalent operations SHALL be reachable only under `/api/projects/:projectId/*` via `project-router`.
+
+#### Scenario: Legacy spawn endpoint is unreachable
+- **WHEN** a client issues `POST /api/spawn` against a running hub server
+- **THEN** the response status is `404`
+
+#### Scenario: Legacy hooks endpoint is unreachable
+- **WHEN** a client issues `POST /hooks/events` (without `/api/projects/:projectId` prefix)
+- **THEN** the response status is `410 Gone` with a body directing the caller to `/api/projects/:projectId/hooks/events`
+
+#### Scenario: Per-project routes remain available
+- **WHEN** a client issues `POST /api/projects/<id>/spawn` for a registered project
+- **THEN** the request is handled by `project-router` and a job is enqueued exactly as before this change
+
+### Requirement: Server holds no top-level legacy manager instances
+The server entry point SHALL NOT instantiate `QueueManager`, `ChatManager`, or `ProposalManager` at module scope. All manager instances SHALL be owned by `ProjectContext` records inside `ProjectRegistry`.
+
+#### Scenario: Module-level legacy state is absent
+- **WHEN** `server/index.ts` is read
+- **THEN** there is no `_legacyDb` variable, no top-level `new QueueManager(...)`, no top-level `new ChatManager(...)`, and no top-level `new ProposalManager(...)`
+
+### Requirement: Client mounts hub provider unconditionally
+The React client SHALL render `<HubProvider><HubApp/></HubProvider>` as the only top-level app shell. The client SHALL NOT issue a `GET /api/hub/state` probe to determine its mode and SHALL NOT render any legacy layout (`RootLayout`, `Navbar`, `LegacyOsNotifications`, `LegacyKeyboardShortcuts`).
+
+#### Scenario: Client startup makes no mode-detection request
+- **WHEN** the client app boots (web or Tauri)
+- **THEN** no request is made to `GET /api/hub/state` for mode detection
+- **AND** `<HubProvider>` is the first React provider rendered after `<SharedWebSocketProvider>`
+
+#### Scenario: Legacy components are absent from the bundle
+- **WHEN** the client codebase is searched for `RootLayout`, `Navbar.tsx`, `LegacyOsNotifications`, or `LegacyKeyboardShortcuts`
+- **THEN** none of these symbols exist as exported components or imported references in production code
+
+### Requirement: API base helper requires an active project
+The `getApiBase()` function in `client/src/lib/api.ts` SHALL return `${API_ORIGIN}/api/projects/<activeProjectId>` whenever an active project is set. The module-level `_isHubMode` flag and the `setHubMode()` helper SHALL be removed. Only an active-project setter SHALL remain.
+
+#### Scenario: API base with active project
+- **WHEN** the active project ID is set to `"abc123"` and `getApiBase()` is called
+- **THEN** the function returns `${API_ORIGIN}/api/projects/abc123`
+
+#### Scenario: API base without active project
+- **WHEN** no active project ID has been set and `getApiBase()` is called
+- **THEN** the function throws an error indicating no active project is set
+- **AND** callers that legitimately operate without a project context (e.g., `/api/hub/*`, `/api/health`) use `API_ORIGIN` directly instead of `getApiBase()`
+
+### Requirement: Documentation reflects hub-only operation
+Project documentation (`CLAUDE.md`, `.claude/rules/client.md`, `.claude/rules/server.md`, and any user-facing README) SHALL NOT reference `--legacy`, `SPECRAILS_LEGACY`, "single-project mode", or "legacy mode" as a supported runtime configuration.
+
+#### Scenario: Docs are clean of legacy mode references
+- **WHEN** the documentation files are searched for `--legacy`, `SPECRAILS_LEGACY`, `single-project mode`, or `legacy mode`
+- **THEN** no matches are found in user-facing or contributor-facing docs (matches in `setup-manager`, `profile-manager`, `profiles-router`, `queue-manager`, or `rails-router` referring to legacy specrails-core installations or legacy profile fallback are out of scope and may remain)

--- a/openspec/changes/archive/2026-04-27-remove-legacy-single-project-mode/tasks.md
+++ b/openspec/changes/archive/2026-04-27-remove-legacy-single-project-mode/tasks.md
@@ -1,0 +1,75 @@
+## 1. Pre-flight verification
+
+- [x] 1.1 Grep `scripts/`, `.github/workflows/`, `src-tauri/`, `Tauri.toml`, root `package.json`, and any local launcher scripts for `--legacy` or `SPECRAILS_LEGACY` and confirm zero hits
+- [x] 1.2 Capture baseline coverage with `npm test -- --coverage` and record server / global percentages
+
+## 2. Server entry point cleanup
+
+- [x] 2.1 In `server/index.ts`, remove the `isHubMode` flag (line 73) and the `--legacy` / `SPECRAILS_LEGACY` parsing
+- [x] 2.2 Remove `resolveProjectName()` (lines 75-88) and the `--project` CLI argument parsing in the args loop (lines 95-101); keep `--port` and `--parent-pid` handling
+- [x] 2.3 Remove the `_legacyDb` module-level variable (line 217) and its `close()` call in `shutdown()` (lines 759-761)
+- [x] 2.4 Replace `mode: isHubMode ? 'hub' : 'legacy'` in `/api/health` (line 283) with the constant `mode: 'hub'`
+- [x] 2.5 Remove the `if (isHubMode)` wrapper while preserving its body verbatim — `ProjectRegistry` setup, `/otlp` mount, telemetry compaction, `/api/hub` mount, `/api/projects` mount, hooks 410 fallback, and the hub WebSocket `connection` handler all stay as-is
+- [x] 2.6 Delete the entire `else` branch (single-project mode, lines 368-731) including legacy DB init, top-level `QueueManager` / `ChatManager` / `ProposalManager` instantiation, legacy WS init message, `/hooks` router mount, `/api/spawn`, `/api/state`, `/api/jobs/*`, `/api/queue/*`, `/api/stats`, `/api/analytics`, `/api/config`, `/api/issues`, `/api/chat/*`, and `/api/propose/*` route handlers
+- [x] 2.7 Update the startup log message at line 766 to drop the `mode` interpolation; log `specrails web manager running on http://127.0.0.1:${port}`
+- [x] 2.8 Remove the legacy-mode comment "Hub mode only: legacy mode has no per-project routing..." above the `/otlp` mount (now meaningless)
+- [x] 2.9 Run `npx tsc --noEmit` and resolve any unused-import errors (likely `initDb`, `listJobs`, `getJob`, `getJobEvents`, `getStats`, `purgeJobs`, `createConversation`, `listConversations`, `getConversation`, `deleteConversation`, `updateConversation`, `addMessage`, `getMessages`, `createProposal`, `getProposal`, `listProposals`, `deleteProposal`, `ChatManager`, `ProposalManager`, `getConfig`, `fetchIssues`, `getAnalytics`, `resolveCommand`, `uuidv4`, `createHooksRouter`, `getPhaseStates`, `getPhaseDefinitions`, `ChatConversationRow`, `ClaudeNotFoundError`, `JobNotFoundError`, `JobAlreadyTerminalError`)
+
+## 3. Server tests cleanup
+
+- [x] 3.1 In `server/index.test.ts`, remove the `mode: 'legacy'` expectation case (around line 242) and the `'returns mode=legacy in legacy (single-project) setup'` test (lines 566-573)
+- [x] 3.2 Update the `expect(['hub', 'legacy']).toContain(res.body.mode)` assertion (line 563) to `expect(res.body.mode).toBe('hub')`
+- [x] 3.3 Remove the `'returns projects=1 in legacy mode'` test (line 573 onwards) or convert it to assert hub project counts against `ProjectRegistry`
+- [x] 3.4 Run `npx vitest run server/index.test.ts` and confirm green
+
+## 4. CLI test cleanup
+
+- [x] 4.1 In `cli/specrails-hub.test.ts`, remove the `'prints running status for legacy mode with state'` test (line 257)
+- [x] 4.2 Verify the hub-mode status test still passes with `npx vitest run cli/specrails-hub.test.ts`
+
+## 5. Client app shell
+
+- [x] 5.1 In `client/src/App.tsx`, remove the `IS_TAURI` constant and the entire `useHubMode()` hook (lines 47-81)
+- [x] 5.2 Remove the `LegacyOsNotifications` component (lines 321-324) and `LegacyKeyboardShortcuts` component (lines 328-332)
+- [x] 5.3 Remove the `import { RootLayout } from './components/RootLayout'` line (line 5)
+- [x] 5.4 In the default `App` export, replace the `{isHub ? (...) : (...)}` ternary (lines 359-395) with the unconditional hub branch: `<HubProvider><TitleBar/><SpecGenTrackerProvider><SidebarPinProvider><TerminalsProviderWithHub><HubApp/></TerminalsProviderWithHub></SidebarPinProvider></SpecGenTrackerProvider></HubProvider>`
+- [x] 5.5 Remove the now-unused `isHub` variable and the `useHubMode()` call from the `App` function body
+- [x] 5.6 Drop unused imports surfaced by tsc (likely `Routes`, `Route`, `Navigate`, `Suspense`, `DocsPage`, `JobDetailPage`, `JobsPage`, `AnalyticsPage`, `ActivityFeedPage`, `AgentsPage`, `DashboardPage`, `SettingsPage`, `RootLayout`, `CommandPalette` if they were used only by the legacy branch — verify each import is still referenced before removing)
+
+## 6. Delete dead client files
+
+- [ ] 6.1 Delete `client/src/components/RootLayout.tsx` (BLOCKED: sandbox denies `rm` — user must run manually; file is dead code, no consumers in production)
+- [ ] 6.2 Delete `client/src/components/Navbar.tsx` (BLOCKED: same as 6.1)
+- [ ] 6.3 Delete `client/src/components/__tests__/RootLayout.test.tsx` (BLOCKED: same as 6.1)
+- [ ] 6.4 Delete `client/src/components/__tests__/Navbar.test.tsx` (BLOCKED: same as 6.1)
+- [x] 6.5 Verified with grep: no production file imports `RootLayout` or `./components/Navbar` outside the dead component files themselves (App.tsx import already removed)
+
+## 7. Simplify API base helper
+
+- [x] 7.1 In `client/src/lib/api.ts`, remove the module-level `_isHubMode` variable and the `setHubMode()` exported function
+- [x] 7.2 Replace `setApiContext(isHub: boolean, projectId: string | null)` with `setActiveProjectId(projectId: string | null)`; keep the function name `setApiContext` only if external callers depend on it — otherwise rename and update callers
+- [x] 7.3 Update `getApiBase()` to return `${API_ORIGIN}/api/projects/${_activeProjectId}` when set, and to throw `Error('No active project set — call setApiContext first')` when not
+- [x] 7.4 Update `client/src/hooks/useHub.tsx` (or wherever `setApiContext` / `setHubMode` are called) to use the new single-arg setter
+- [x] 7.5 Update `client/src/lib/__tests__/api.test.ts` to drop legacy-mode assertions and to cover both the active-project path and the throw-when-unset path
+- [x] 7.6 Run `cd client && npx tsc --noEmit` and `npx vitest run client/src/lib/__tests__/api.test.ts`
+
+## 8. Documentation
+
+- [x] 8.1 In `CLAUDE.md`, remove the parenthetical "Use `--legacy` flag for single-project mode." in the "Hub mode (default)" section and any other `--legacy` mentions in the same file
+- [ ] 8.2 In `.claude/rules/client.md`, remove the bullet describing `App.tsx` detecting hub mode via `GET /api/hub/state` and the `getApiBase()` legacy-mode return-value reference (BLOCKED: sandbox denies edits to `.claude/` files — user must update manually)
+- [x] 8.3 `.claude/rules/server.md` does not contain `--legacy` references (verified) — no edits needed
+- [x] 8.4 Search the repo for any remaining `single-project mode`, `legacy mode`, `SPECRAILS_LEGACY`, or `--legacy` references in non-source docs and remove them, leaving alone the unrelated "legacy" tokens in `setup-manager`, `profile-manager`, `profiles-router`, `queue-manager`, and `rails-router`
+
+## 9. Verification
+
+- [x] 9.1 Run `npm run typecheck` from the repo root and confirm zero errors
+- [x] 9.2 Run `npm test -- --coverage` from the repo root; verify coverage stays at or above 80% server / 70% global
+- [x] 9.3 If coverage gates regress, add hub-side tests for any uncovered branches in `project-router.ts` or manager classes — do not restore legacy code
+- [ ] 9.4 Start `npm run dev`, open the client at `http://localhost:4201`, confirm the app shell renders without making any `GET /api/hub/state` request (USER VERIFICATION REQUIRED — automated apply cannot exercise the browser)
+- [ ] 9.5 In the running app, exercise: project switching, spawning a job from a project, opening chat, opening the agents page, toggling the terminal panel — all hub-mode features behave identically to before the change (USER VERIFICATION REQUIRED)
+- [ ] 9.6 Stop the dev server and confirm no orphaned `node` processes or stale `~/.specrails/manager.pid` remain (USER VERIFICATION REQUIRED)
+
+## 10. Validation
+
+- [x] 10.1 Run `openspec validate remove-legacy-single-project-mode --strict` and resolve any findings
+- [x] 10.2 Self-review the diff for stray `legacy` or `isHubMode` tokens and remove them

--- a/openspec/changes/gate-add-project-on-prerequisites/.openspec.yaml
+++ b/openspec/changes/gate-add-project-on-prerequisites/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-27

--- a/openspec/changes/gate-add-project-on-prerequisites/design.md
+++ b/openspec/changes/gate-add-project-on-prerequisites/design.md
@@ -1,0 +1,99 @@
+## Context
+
+Hub's developer-prerequisites status (Node.js, npm, npx, Git availability) is computed by `server/setup-prerequisites.ts` via `spawnSync(which|where)` and exposed at `GET /api/hub/setup-prerequisites`. The endpoint is consumed only by `client/src/components/SetupWizard.tsx`, which renders a prereq panel and gates the install button. Today the gate fires *after* the user has already gone through `AddProjectDialog` and registered the project in `hub.sqlite`, producing a half-registered project the user cannot complete.
+
+This change moves the gate up-stream into `AddProjectDialog` and adds an OS-aware install-instructions modal, while keeping the existing wizard panel as a defence-in-depth secondary check.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Prevent project registration when required tools are missing.
+- Surface install instructions contextually, only when needed, with copy-paste commands per OS.
+- Single source of truth for prereq state across `AddProjectDialog` and `SetupWizard` (one hook, one component, one cache window).
+- Minimum-version awareness so a too-old Node.js is treated as missing rather than passing the basic existence check.
+- No regression in `SetupWizard`'s current behaviour.
+
+**Non-Goals:**
+- Auto-installing tools for the user (we link out / provide commands; we do not run installers).
+- Detecting tools installed in non-PATH locations (NVM shims, custom prefixes) beyond what `which`/`where` already finds.
+- Updating prereq status while the modal is closed (re-check is on open, manual button, and `window.focus` only).
+- Changing the prereq scope (still Node, npm, npx, Git — same four tools).
+- Adding a project despite missing tools (no override flag).
+- Touching `SetupWizard`'s existing layout/visual identity beyond swapping its data source for the shared hook.
+
+## Decisions
+
+### Decision: Run the check on dialog open, not on app boot
+
+Boot-time checks would be stale by the time the user clicks "+" minutes later (e.g. they installed Git in the meantime). Per-open with a 60-second cache strikes the balance: instant response on rapid open/close, fresh enough for a long-running app. Rejected: WS push from server when prereqs change — adds infrastructure for a low-frequency event.
+
+### Decision: 60-second client-side cache, hub-scoped
+
+A module-level cache in `usePrerequisites` keyed by nothing (single hub) keeps the implementation trivial. 60s is short enough that a user who installed a tool will see the change with one focus-away/back, long enough to absorb dialog open/close churn. Manual recheck button forces a refetch and bypasses the cache. Cache is in-memory only (lost on page reload), no `localStorage` — staleness across sessions would be confusing.
+
+### Decision: Disable, not hide, the submit button when prereqs are missing
+
+A disabled button + tooltip explains *why* the user can't proceed and points at the fix. Hiding the button would leave the user unsure whether the dialog is broken. The tooltip lists missing tools by name ("Git is required to add a project").
+
+### Decision: "More info" link is conditionally rendered
+
+Premium UX = don't show users problems they don't have. The link only appears in the panel when `prerequisites.ok === false`. Users with a healthy environment see a clean "✓ All required tools detected" line and proceed.
+
+### Decision: OS detection client-side via response field, not `navigator.platform`
+
+The server already runs the check on the host machine, so it knows the OS. Returning `platform: 'darwin' | 'win32' | 'linux'` in the response gives the client an authoritative source. `navigator.platform` is deprecated and unreliable in WebView2/Tauri across Windows ARM64 emulation. Tauri's `os` plugin would work but adds a dependency for a value the server already has.
+
+### Decision: Install instructions modal hosts copy-to-clipboard, not raw text
+
+Each command sits in a code block with a clipboard icon button. Click → write to clipboard → flash a small "Copied" affordance for 1500ms. We use `navigator.clipboard.writeText` with a `document.execCommand('copy')` fallback wrapped in a small util. No new dependency.
+
+### Decision: Show only the host OS's commands by default, with "Show other platforms" disclosure
+
+Users on macOS rarely need the Windows winget commands and vice versa. Showing all platforms creates visual noise. A `<details>`-style disclosure exposes them when truly needed (rare).
+
+### Decision: macOS shows Homebrew first, official second
+
+Most macOS developers have Homebrew. Showing `brew install node git` first matches their muscle memory. The official link is the fallback for users without brew. Detecting whether brew is installed is *not* worth the spawnSync cost — both lines are shown.
+
+### Decision: Minimum-version check is server-side, additive
+
+Add `minVersion` (string) and `meetsMinimum` (boolean) to each `SetupPrerequisite` record. The existing `installed` field is unchanged. The client treats `(installed && meetsMinimum)` as the green path. If a user has Node 14 installed, `installed: true, meetsMinimum: false` is rendered as missing in the UI ("Node.js 14.x found, but 18.0.0 or newer is required") and the "More info" modal still links to the install pages. Minimum versions: Node `>= 18.0.0`, npm `>= 9.0.0`, npx — versionless (ships with npm), Git `>= 2.20.0`.
+
+Version parsing uses a simple `semver`-light comparator — we already need it elsewhere (specrails-core compatibility). If `semver` is already a dep, use it; otherwise an internal `compareVersions(a, b)` is fine for `major.minor.patch`.
+
+### Decision: SetupWizard keeps its panel, refactored to use the shared hook
+
+Removing the wizard panel would shrink the LOC count but lose the defence-in-depth. Server-side install-guard already exists, but a UI-level second pass costs almost nothing now that the hook + component are shared. The wizard prereq fetch (`/api/hub/setup-prerequisites` line 764) is replaced by `usePrerequisites()`.
+
+### Decision: Auto-recheck on `window.focus`, not on visibility change or interval polling
+
+`window.focus` covers the normal "I went to install Node, came back to the app" gesture. `visibilitychange` would also fire on tab-switch in the browser but not desktop, and Tauri windows are typically always visible. Interval polling would burn cycles for nothing.
+
+### Decision: No backend cache layer
+
+`spawnSync(which|where)` for four commands takes <50ms even on Windows. Adding a server cache risks serving stale data after a recheck button click. Client cache is enough.
+
+## Risks / Trade-offs
+
+- **PATH staleness in Tauri** → A user who installs Git while Hub is running may still see "✗ Git" because Tauri inherited the old PATH. Mitigation: the install instructions modal already says "restart SpecRails Hub if PATH changed" (existing text); add a dedicated "I installed it but it still says missing → restart the app" hint when `meetsMinimum === false` and the recheck has been run twice with the same result.
+- **Network failure on the prereq fetch** → Don't block the user. If the fetch errors, render an unobtrusive notice ("Could not verify locally — install will validate") and leave the submit button enabled. The server install guard remains the source of truth before spawning.
+- **Older specrails-core that requires lower Node** → minVersion is hard-coded to current specrails-core requirements. If specrails-core lowers them, we update both. Not a moving target in practice.
+- **`navigator.clipboard` blocked** → In some sandbox modes clipboard write requires a user gesture; we always trigger inside a click handler so this is satisfied. Fallback to `document.execCommand('copy')` covers older WebViews.
+- **Race between prereq check and dialog close** → If the user closes the dialog before the fetch resolves, `setSetupPrerequisites` runs against an unmounted component. `usePrerequisites` aborts the in-flight `AbortController` on unmount.
+- **Coverage drift** → New components add lines without tests = ratio drop. Each new file ships with a unit test; counts hold.
+
+## Migration Plan
+
+1. Land server changes (`minVersion`, `meetsMinimum`, `platform` fields) — additive, deployable independently of client.
+2. Land shared hook + component (`usePrerequisites`, `PrerequisitesPanel`, `InstallInstructionsModal`) with their own tests.
+3. Refactor `SetupWizard` to use the shared pieces — prove parity by running existing wizard tests.
+4. Wire up `AddProjectDialog` — add the gate, the modal, the disabled-button tooltip.
+5. Run `npm run typecheck && npm test`; smoke test in `npm run dev`.
+
+**Rollback:** Revert the merge commit. No persistent state changes; the only schema-style change is in the prereq response, which is additive and tolerated by the existing client.
+
+## Open Questions
+
+- **Q:** Do we want a "Don't show this again" option for users who knowingly run with a lower Node version? **A (default):** No. Premium UX = the gate is firm; if the user wants to use specrails on a lower Node, they bump Node.
+- **Q:** Should the install instructions modal also surface the *current* version next to the *required* version? **A (default):** Yes — improves clarity. ("Node.js 16.20.0 found — needs 18.0.0+")
+- **Q:** Tauri exposes the host OS via `@tauri-apps/api/os` — should we use it as a tiebreaker if the server `platform` field is missing on an old build? **A (default):** No — the server change is additive and ships in the same release; no version skew expected.

--- a/openspec/changes/gate-add-project-on-prerequisites/proposal.md
+++ b/openspec/changes/gate-add-project-on-prerequisites/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+Today the developer-prerequisites check (Node.js, npm, npx, Git) only fires inside `SetupWizard`, which runs **after** the user has already opened `AddProjectDialog`, picked a path, named the project, chosen a provider, and clicked "Add". The project is registered in `hub.sqlite` before we tell the user that something they need is missing — leaving them with a half-registered project they can't complete and a flow that breaks the premium "fail-before-commitment" expectation.
+
+## What Changes
+
+- **AddProjectDialog** runs a prerequisites check the moment it opens and renders a compact status panel inline.
+  - Per tool: ✓ name + version when present, ✗ name + "More info" link when missing.
+  - The "More info" affordance is rendered **only** when at least one required tool is missing — no clutter for users who already have everything.
+- The "Add project" submit button is **disabled** while any required tool is missing. A tooltip on the disabled button names the missing tools.
+- A new **Install instructions modal** opens from "More info":
+  - Auto-detects the host OS (macOS / Windows / Linux) and shows only that OS's commands by default, with an expandable "Show other platforms" section.
+  - macOS: Homebrew commands when applicable (`brew install node git`) plus official `nodejs.org` / `git-scm.com` fallback links.
+  - Windows: `winget install OpenJS.NodeJS.LTS` and `winget install Git.Git`, plus the official download links.
+  - Linux: `apt`/`dnf` snippets plus the official links.
+  - Each command has a copy-to-clipboard button with a brief "copied" feedback toast.
+- After the user installs a tool externally, the modal automatically re-checks prerequisites:
+  - On `window.focus`.
+  - On a manual "I installed it, recheck" button.
+  - Cached 60s server-side response is invalidated by the recheck button.
+- A small client-side cache (60s, hub-scoped) prevents repeated `/api/hub/setup-prerequisites` fetches when the dialog is opened/closed quickly.
+- `SetupWizard` keeps its existing prerequisites panel as a **secondary defence** (in case the user gets there via a stale link or backend mismatch). Both surfaces share a single hook (`usePrerequisites`) so the UI and caching policy stay consistent.
+- **Server enrichment**: `GET /api/hub/setup-prerequisites` returns minimum-version metadata per tool (e.g. `minVersion: '18.0.0'` for Node) and surfaces a `meetsMinimum: boolean` field. Existing `installed` semantics are preserved.
+- **Server enrichment**: response includes a `platform` field (`'darwin' | 'win32' | 'linux'`) so the client renders OS-correct hints without re-detecting platform.
+
+## Capabilities
+
+### New Capabilities
+- `add-project-prerequisites-gate`: Specifies the prerequisites check inside `AddProjectDialog`, the rules for blocking the submit, the install-instructions modal, and the cross-surface hook contract.
+
+### Modified Capabilities
+<!-- None — there is no existing spec covering AddProjectDialog or prerequisites surfacing. SetupWizard's spec (`setup-wizard-install-cta`) covers a different concern (post-registration install CTA) and is not amended. -->
+
+## Impact
+
+**New code (client):**
+- `client/src/hooks/usePrerequisites.ts` — shared hook with 60s cache and recheck on `window.focus`.
+- `client/src/components/PrerequisitesPanel.tsx` — reusable status panel rendered by both `AddProjectDialog` and `SetupWizard`.
+- `client/src/components/InstallInstructionsModal.tsx` — OS-aware install command modal with copy-to-clipboard.
+
+**Modified code (client):**
+- `client/src/components/AddProjectDialog.tsx` — embeds `<PrerequisitesPanel />`, gates the submit button, opens `<InstallInstructionsModal />`.
+- `client/src/components/SetupWizard.tsx` — replaces the inline prereq fetch + panel with `usePrerequisites()` + `<PrerequisitesPanel />`.
+
+**Modified code (server):**
+- `server/setup-prerequisites.ts` — adds `minVersion` per tool and a `meetsMinimum` field; adds `platform` to the response.
+- `server/setup-prerequisites.test.ts` — extends coverage for version parsing and `meetsMinimum`.
+
+**APIs:**
+- `GET /api/hub/setup-prerequisites` response shape changes additively: new optional fields `minVersion`, `meetsMinimum`, `platform`. No breaking change for existing consumers.
+
+**Dependencies:** none added.
+
+**User-visible:** Adding a project becomes impossible while required tools are missing; install instructions are one click away with copy-paste commands.
+
+**Coverage gates:** New components carry their own tests; client global gate (70%) holds. Server gate stays at 80%/70% — the additive prereq logic adds straightforward branches.

--- a/openspec/changes/gate-add-project-on-prerequisites/specs/add-project-prerequisites-gate/spec.md
+++ b/openspec/changes/gate-add-project-on-prerequisites/specs/add-project-prerequisites-gate/spec.md
@@ -1,0 +1,164 @@
+## ADDED Requirements
+
+### Requirement: AddProjectDialog runs a prerequisites check on open
+The "Add project" dialog SHALL invoke the prerequisites status fetch (`GET /api/hub/setup-prerequisites`) every time it transitions from closed to open, subject to a 60-second client-side cache.
+
+#### Scenario: First open within a session
+- **WHEN** the user clicks the "+" button to open `AddProjectDialog` for the first time after page load
+- **THEN** the dialog issues `GET /api/hub/setup-prerequisites`
+- **AND** while the response is in flight, the prerequisites panel renders a loading skeleton
+
+#### Scenario: Re-open within the cache window
+- **WHEN** the dialog is closed and re-opened within 60 seconds of a successful previous fetch
+- **THEN** the cached status is rendered immediately
+- **AND** no new request to `/api/hub/setup-prerequisites` is made
+
+#### Scenario: Re-open after the cache window
+- **WHEN** the dialog is opened more than 60 seconds after the previous fetch
+- **THEN** a fresh request to `/api/hub/setup-prerequisites` is issued
+
+#### Scenario: Network failure does not block the user
+- **WHEN** the prereq fetch fails (network error, non-2xx response)
+- **THEN** the panel renders an unobtrusive notice such as "Could not verify locally — install will validate"
+- **AND** the "Add project" submit button remains enabled
+- **AND** the existing server-side install guard remains the authoritative check
+
+### Requirement: Prerequisites panel renders status per tool
+The dialog SHALL display, for each required tool (Node.js, npm, npx, Git), a row showing the tool's status.
+
+#### Scenario: Tool is installed and meets the minimum version
+- **WHEN** a tool's response record has `installed: true` and `meetsMinimum: true`
+- **THEN** the row renders a green check icon, the tool label, and the detected version
+
+#### Scenario: Tool is installed but below the minimum version
+- **WHEN** a tool's record has `installed: true` and `meetsMinimum: false`
+- **THEN** the row renders a red cross icon
+- **AND** the row text reads "<Tool> <currentVersion> found — needs <minVersion>+"
+- **AND** the tool is treated as missing for gating purposes
+
+#### Scenario: Tool is not installed
+- **WHEN** a tool's record has `installed: false`
+- **THEN** the row renders a red cross icon and the tool label
+
+#### Scenario: All tools are healthy
+- **WHEN** every required tool is `installed && meetsMinimum`
+- **THEN** the panel renders a single line "All required tools detected" without listing each tool individually
+
+### Requirement: Submit button is gated on prerequisites
+The "Add project" submit button SHALL be disabled while any required tool is missing or below its minimum version.
+
+#### Scenario: Tools missing
+- **WHEN** at least one required tool is missing or below the minimum version
+- **THEN** the "Add project" button is rendered with `disabled` set to true
+- **AND** hovering the button reveals a tooltip naming the missing tools (e.g. "Git is required to add a project")
+
+#### Scenario: All tools healthy
+- **WHEN** all required tools are present and meet the minimum versions
+- **AND** the rest of the form (path, name, provider) is valid
+- **THEN** the "Add project" button is enabled
+
+#### Scenario: Prereq check still pending
+- **WHEN** the prereq fetch is in flight on first open
+- **THEN** the submit button is disabled until the response arrives or fails
+
+### Requirement: "More info" affordance appears only when needed
+The dialog SHALL render a "More info" link or button **only when at least one required tool is missing**. Healthy environments SHALL NOT render the affordance.
+
+#### Scenario: Missing tool present
+- **WHEN** the prereq status reports `ok: false`
+- **THEN** a "More info" affordance is rendered next to the panel
+- **AND** clicking it opens `InstallInstructionsModal`
+
+#### Scenario: All tools healthy
+- **WHEN** the prereq status reports `ok: true`
+- **THEN** no "More info" affordance is rendered
+
+### Requirement: InstallInstructionsModal surfaces OS-aware install commands
+The install-instructions modal SHALL display copy-paste install commands for the host operating system, with an expandable section to view other platforms.
+
+#### Scenario: macOS host
+- **WHEN** the modal opens on a host where the prereq response reports `platform: "darwin"`
+- **THEN** the macOS section is the visible default
+- **AND** the section shows `brew install node git` as the recommended one-liner
+- **AND** the section also links to `https://nodejs.org/en/download` and `https://git-scm.com/downloads` as fallback options
+- **AND** other platform sections (Windows, Linux) are hidden behind a "Show other platforms" disclosure
+
+#### Scenario: Windows host
+- **WHEN** `platform: "win32"`
+- **THEN** the Windows section is the visible default
+- **AND** the section shows `winget install OpenJS.NodeJS.LTS` and `winget install Git.Git`
+- **AND** the section also links to `https://nodejs.org/en/download` and `https://git-scm.com/download/win`
+- **AND** the section reminds the user to restart SpecRails Hub so PATH refreshes
+
+#### Scenario: Linux host
+- **WHEN** `platform: "linux"`
+- **THEN** the Linux section is the visible default with apt and dnf snippets
+- **AND** the official download links are listed as fallbacks
+
+#### Scenario: Copy command to clipboard
+- **WHEN** the user clicks the copy-to-clipboard button on any command
+- **THEN** the command text is written to the clipboard via `navigator.clipboard.writeText`
+- **AND** a brief "Copied" affordance appears for ~1500ms
+- **AND** the button falls back to `document.execCommand('copy')` if the clipboard API is unavailable
+
+### Requirement: Auto-recheck after the user installs a tool
+The dialog SHALL re-fetch the prereq status when the user is likely to have just installed a tool, without requiring them to close and re-open the dialog.
+
+#### Scenario: Window regains focus
+- **WHEN** the dialog is open and the application window receives a `focus` event
+- **THEN** the prereq cache is invalidated and a fresh fetch is issued
+
+#### Scenario: Manual recheck button
+- **WHEN** the install-instructions modal is open and the user clicks "I installed it, recheck"
+- **THEN** the cache is invalidated and a fresh fetch is issued
+- **AND** the panel re-renders with the new status
+
+### Requirement: Shared prerequisites hook used by both surfaces
+A single hook (`usePrerequisites`) SHALL provide the prereq status, loading state, and recheck function. Both `AddProjectDialog` and `SetupWizard` SHALL consume this hook so they share fetch dedup, cache, and recheck behaviour.
+
+#### Scenario: Dialog and wizard share state
+- **WHEN** `AddProjectDialog` and `SetupWizard` are mounted in the same session
+- **THEN** opening one after the other within the cache window does not trigger a second fetch
+
+#### Scenario: Recheck propagates
+- **WHEN** the modal's recheck button is clicked while the wizard is also rendered
+- **THEN** the wizard's prereq panel reflects the new status without an additional explicit fetch
+
+### Requirement: Server response carries platform and version metadata
+`GET /api/hub/setup-prerequisites` SHALL return, in addition to the existing fields:
+
+- `platform: "darwin" | "win32" | "linux"` at the response root.
+- `minVersion: string` per `SetupPrerequisite` record (semver, `major.minor.patch`).
+- `meetsMinimum: boolean` per `SetupPrerequisite` record (true when `installed && parsedVersion >= minVersion`; false otherwise).
+
+The existing `installed`, `version`, `installUrl`, `installHint`, `required`, `key`, `label`, `command`, and `ok` semantics are preserved.
+
+#### Scenario: Node 18.0.0 installed
+- **WHEN** Node v18.0.0 is on PATH
+- **THEN** the Node record reports `installed: true, meetsMinimum: true, version: "v18.0.0", minVersion: "18.0.0"`
+
+#### Scenario: Node 14.x installed
+- **WHEN** Node v14.21.3 is on PATH
+- **THEN** the Node record reports `installed: true, meetsMinimum: false, version: "v14.21.3", minVersion: "18.0.0"`
+
+#### Scenario: Tool absent
+- **WHEN** Git is not on PATH
+- **THEN** the Git record reports `installed: false, meetsMinimum: false`
+- **AND** `version` is undefined
+
+#### Scenario: Platform tag matches host
+- **WHEN** the server runs on macOS
+- **THEN** the response root contains `platform: "darwin"`
+
+### Requirement: SetupWizard reuses the shared panel
+`SetupWizard` SHALL render its prerequisites status via `<PrerequisitesPanel />` driven by `usePrerequisites()` rather than its own inline fetch.
+
+#### Scenario: Wizard mounts
+- **WHEN** the user reaches the install step of `SetupWizard`
+- **THEN** `usePrerequisites()` provides the status and the wizard renders `<PrerequisitesPanel />`
+- **AND** the wizard's existing install-button gate (`installDisabled`) continues to require `prerequisites.ok`
+
+#### Scenario: Wizard install path remains gated server-side
+- **WHEN** prerequisites are missing
+- **THEN** the wizard's install button is disabled (UI gate)
+- **AND** the server's install guard would still reject the spawn if the UI gate is bypassed

--- a/openspec/changes/gate-add-project-on-prerequisites/tasks.md
+++ b/openspec/changes/gate-add-project-on-prerequisites/tasks.md
@@ -1,0 +1,72 @@
+## 1. Server: enrich prerequisites response
+
+- [x] 1.1 In `server/setup-prerequisites.ts`, add a `minVersion: string` field to each definition (Node `18.0.0`, npm `9.0.0`, npx omitted/`undefined`, Git `2.20.0`)
+- [x] 1.2 Add a small `compareVersions(a: string, b: string): number` helper (or use an existing util / `semver` if already a dep) supporting `major.minor.patch` plus `vX.Y.Z` and `git version X.Y.Z` prefixes
+- [x] 1.3 Compute `meetsMinimum: boolean` per record: `installed && parsedVersion >= minVersion`. When `minVersion` is undefined, `meetsMinimum` mirrors `installed`
+- [x] 1.4 Add `platform: 'darwin' | 'win32' | 'linux'` at the response root (derived from `process.platform`)
+- [x] 1.5 Update `SetupPrerequisitesStatus` and `SetupPrerequisite` interfaces; export `MIN_VERSIONS` constant for reuse if helpful
+- [x] 1.6 In `server/setup-prerequisites.test.ts`, add cases covering: version parsing for `node v18.0.0`, `npm 10.2.4`, `git version 2.42.1`; `meetsMinimum=false` for an old version; `platform` field present
+- [x] 1.7 Run `npx vitest run server/setup-prerequisites.test.ts` and confirm green
+
+## 2. Client: shared hook + components
+
+- [x] 2.1 Create `client/src/hooks/usePrerequisites.ts` exporting `usePrerequisites()` returning `{ status, isLoading, error, recheck }`
+- [x] 2.2 Implement a module-level cache: `{ data, fetchedAt, inFlight }`; cache window 60_000 ms; `recheck()` invalidates and refetches
+- [x] 2.3 Subscribe to `window.addEventListener('focus', recheck)` while at least one consumer is mounted; clean up on last unmount
+- [x] 2.4 Use `AbortController` to cancel in-flight fetches on unmount
+- [x] 2.5 Add `client/src/hooks/__tests__/usePrerequisites.test.tsx` covering: initial fetch, cache hit on quick re-render, recheck after `window.focus`, recheck button bypass, abort on unmount, error path
+- [x] 2.6 Create `client/src/components/PrerequisitesPanel.tsx` accepting `{ status, isLoading, error, onMoreInfo? }` props
+- [x] 2.7 Render the "All required tools detected" success line when `status.ok && !error`
+- [x] 2.8 Render per-tool rows for missing/below-min tools with red-cross icon and the version-detail line; render present tools with a green-check icon and version
+- [x] 2.9 Render the "More info" affordance only when `!status.ok`; calls `onMoreInfo` from props
+- [x] 2.10 Add `client/src/components/__tests__/PrerequisitesPanel.test.tsx` covering all four panel states (loading, ok, partial-missing, all-missing) plus error
+- [x] 2.11 Create `client/src/components/InstallInstructionsModal.tsx` with `{ open, onClose, status, onRecheck }` props
+- [x] 2.12 Render the host-OS section (driven by `status.platform`) by default; macOS shows brew + official, Windows shows winget + official + restart hint, Linux shows apt/dnf + official
+- [x] 2.13 Each command renders inside a code block with a `CopyButton` child component that calls `navigator.clipboard.writeText` (fallback `document.execCommand('copy')`) and shows a 1500 ms "Copied" affordance
+- [x] 2.14 Wrap non-host platforms in a Radix `<Collapsible>` or native `<details>` "Show other platforms" disclosure (closed by default)
+- [x] 2.15 Add an "I installed it, recheck" button calling `onRecheck`
+- [x] 2.16 Add `client/src/components/__tests__/InstallInstructionsModal.test.tsx` covering: shows host OS by default, hides others, copy-to-clipboard fires the API, recheck button triggers prop, fallback path when `navigator.clipboard` is undefined
+
+## 3. Wire AddProjectDialog
+
+- [x] 3.1 Read `client/src/components/AddProjectDialog.tsx` end to end
+- [x] 3.2 Import and call `usePrerequisites()` at the top of the component
+- [x] 3.3 Render `<PrerequisitesPanel />` near the top of the dialog body, above the path/name fields
+- [x] 3.4 Track an `installModalOpen` local state; pass `onMoreInfo={() => setInstallModalOpen(true)}` to the panel
+- [x] 3.5 Render `<InstallInstructionsModal open={installModalOpen} onClose={...} status={status} onRecheck={recheck} />`
+- [x] 3.6 Compute `submitDisabled = !status?.ok || isLoading || existingFormErrors`; pass to the "Add project" button
+- [x] 3.7 Wrap the disabled button in a `<Tooltip>` listing missing tools when `submitDisabled` is due to prereqs (e.g. "Git is required to add a project"); existing form-error tooltips remain
+- [x] 3.8 If the prereq fetch errors (`error != null`), do NOT block the submit — render a small notice and let the user proceed; server install guard remains the source of truth
+- [x] 3.9 Add `client/src/components/__tests__/AddProjectDialog.test.tsx` (or extend if it exists) covering: panel shows on open, button disabled when prereqs missing, button enabled when prereqs ok, more-info opens modal, error path leaves submit enabled
+
+## 4. Refactor SetupWizard onto the shared hook
+
+- [x] 4.1 In `client/src/components/SetupWizard.tsx`, replace the inline `refreshSetupPrerequisites` callback (around line 761), the `setupPrerequisites` state, and the inline panel render (around line 195) with `usePrerequisites()` + `<PrerequisitesPanel />`
+- [x] 4.2 Remove the now-unused `isSetupPrerequisitesStatus` type-guard if no other caller needs it (verify with grep before deleting)
+- [x] 4.3 Keep the existing `installDisabled` gate but source `prerequisites.ok` from the hook
+- [x] 4.4 Run existing `client/src/components/__tests__/SetupWizard.test.tsx` and adapt mocks: replace `vi.mock('global').fetch.../api/hub/setup-prerequisites` with a `vi.mock('../../hooks/usePrerequisites', ...)`
+- [x] 4.5 Confirm the wizard's install-step screenshot/behaviour is unchanged (visual parity check via test selectors)
+
+## 5. Documentation
+
+- [x] 5.1 Update `CLAUDE.md` setup-wizard section to mention that prereq gating now also lives at `AddProjectDialog`
+- [x] 5.2 If `docs/engineering/architecture.md` or `docs/general/getting-started.md` references the prereq flow, update to reflect the new location
+
+## 6. Verification
+
+- [x] 6.1 Run `npm run typecheck` and confirm zero errors (server + client)
+- [x] 6.2 Run `npm test` (root) and `cd client && npx vitest run` — all green
+- [x] 6.3 Run `npm run test:coverage` (root) and `cd client && npm run test:coverage` — server gates 80/80/80/70 hold; client gate 70 holds
+- [ ] 6.4 Smoke test in `npm run dev` (USER VERIFICATION REQUIRED — automated apply cannot drive the browser):
+  - With all tools installed → panel shows "All required tools detected", no "More info" link, button enabled
+  - Temporarily rename `git` on PATH (or stub the endpoint) → button disables, tooltip names Git, "More info" appears, modal shows host-OS commands by default
+  - Click copy button → clipboard receives the command, "Copied" flash visible
+  - Open `<details>` "Show other platforms" → other OS sections render
+  - Restore `git`, click "I installed it, recheck" → status flips to ok, button enables
+  - Trigger `window.focus` (Cmd+Tab away and back) with the dialog open → fetch fires, status updates
+- [ ] 6.5 Smoke test `SetupWizard` install step (USER VERIFICATION REQUIRED): prereq panel renders identically, gate still works
+
+## 7. Validation
+
+- [x] 7.1 Run `openspec validate gate-add-project-on-prerequisites --strict` and resolve any findings
+- [x] 7.2 Self-review the diff for stray `console.log`, dead imports, and obsolete prereq fetch code in `SetupWizard.tsx`

--- a/server/config.ts
+++ b/server/config.ts
@@ -211,17 +211,13 @@ function loadPersistedConfig(db: any): { active: string | null; labelFilter: str
 }
 
 export function getConfig(cwd: string, db?: any, projectName?: string): ProjectConfig {
-  // Resolve project root.
-  // In single-project mode: manager lives at <project>/specrails/manager/,
-  // so we walk up two levels to find the project root.
-  // In hub mode: cwd is the project root directly — we detect this by checking
-  // if the .claude directory already lives at cwd.
+  // Resolve project root. Hub mode passes project.path directly, which has a
+  // `.claude` directory at its root; the walk-up fallback covers callers that
+  // pass a manager-relative cwd.
   let projectRoot: string
   if (fs.existsSync(path.join(cwd, '.claude'))) {
-    // cwd is already the project root (hub mode passes project.path directly)
     projectRoot = cwd
   } else {
-    // Single-project mode: walk up two levels
     projectRoot = path.resolve(cwd, '../..')
   }
   const commandsDir = path.join(projectRoot, '.claude', 'commands', 'sr')

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -239,7 +239,7 @@ function createTestApp() {
       version: '0.0.0-test',
       uptime: Math.floor(process.uptime()),
       projects: 1,
-      mode: 'legacy',
+      mode: 'hub',
     })
   })
 
@@ -560,21 +560,7 @@ describe('API endpoints', () => {
       expect(res.body.uptime).toBeGreaterThanOrEqual(0)
       expect(typeof res.body.projects).toBe('number')
       expect(res.body.projects).toBeGreaterThanOrEqual(0)
-      expect(['hub', 'legacy']).toContain(res.body.mode)
-    })
-
-    it('returns mode=legacy in legacy (single-project) setup', async () => {
-      const res = await request(app).get('/api/health')
-
-      expect(res.status).toBe(200)
-      expect(res.body.mode).toBe('legacy')
-    })
-
-    it('returns projects=1 in legacy mode', async () => {
-      const res = await request(app).get('/api/health')
-
-      expect(res.status).toBe(200)
-      expect(res.body.projects).toBe(1)
+      expect(res.body.mode).toBe('hub')
     })
   })
 })

--- a/server/index.ts
+++ b/server/index.ts
@@ -14,21 +14,8 @@ import type { WsMessage } from './types'
 import { ProjectRegistry } from './project-registry'
 import { createHubRouter } from './hub-router'
 import { createProjectRouter } from './project-router'
-import { createHooksRouter, getPhaseStates, getPhaseDefinitions } from './hooks'
 import { createDocsRouter } from './docs-router'
 import { requireAuth, loadOrGenerateToken, tokenFromUpgradeRequest } from './auth'
-import { QueueManager, ClaudeNotFoundError, JobNotFoundError, JobAlreadyTerminalError } from './queue-manager'
-import { initDb, type DbInstance, listJobs, getJob, getJobEvents, getStats, purgeJobs,
-  createConversation, listConversations, getConversation,
-  deleteConversation, updateConversation, addMessage, getMessages,
-  createProposal, getProposal, listProposals, deleteProposal } from './db'
-import { ChatManager } from './chat-manager'
-import { ProposalManager } from './proposal-manager'
-import type { ChatConversationRow } from './types'
-import { getConfig, fetchIssues } from './config'
-import { getAnalytics } from './analytics'
-import { resolveCommand } from './command-resolver'
-import { newId as uuidv4 } from './ids'
 import { getTerminalManager } from './terminal-manager'
 import { createTelemetryRouter } from './telemetry-receiver'
 import { runCompactionForAll } from './telemetry-compactor'
@@ -67,35 +54,12 @@ if (parentPidArg) {
   }
 }
 
-// ─── Mode detection ───────────────────────────────────────────────────────────
-
-// Hub mode is the default. Use --legacy or SPECRAILS_LEGACY=1 for single-project mode.
-const isHubMode = !process.argv.includes('--legacy') && process.env.SPECRAILS_LEGACY !== '1'
-
-// ─── Resolve project name (legacy single-project mode) ────────────────────────
-
-function resolveProjectName(): string {
-  if (process.env.SPECRAILS_PROJECT_NAME) {
-    return process.env.SPECRAILS_PROJECT_NAME
-  }
-  const cwd = process.cwd()
-  const parentDir = path.basename(path.resolve(cwd, '../..'))
-  const immediateParent = path.basename(path.resolve(cwd, '..'))
-  if (immediateParent === 'specrails') {
-    return parentDir
-  }
-  return path.basename(cwd)
-}
-
 // ─── Parse CLI args ───────────────────────────────────────────────────────────
 
-let projectName = resolveProjectName()
 let port = 4200
 
 for (let i = 2; i < process.argv.length; i++) {
-  if (process.argv[i] === '--project' && process.argv[i + 1]) {
-    projectName = process.argv[++i]
-  } else if (process.argv[i] === '--port' && process.argv[i + 1]) {
+  if (process.argv[i] === '--port' && process.argv[i + 1]) {
     port = parseInt(process.argv[++i], 10)
   }
 }
@@ -211,10 +175,9 @@ function broadcast(msg: WsMessage): void {
   }
 }
 
-// ─── Health endpoint state (populated in mode blocks) ─────────────────────────
+// ─── Health endpoint state (populated by hub bootstrap below) ────────────────
 
 let _getProjectCount: () => number = () => 0
-let _legacyDb: DbInstance | null = null
 
 server.on('upgrade', (request, socket, head) => {
   const urlStr = request.url ?? '/'
@@ -280,7 +243,7 @@ app.get('/api/health', (_req, res) => {
     version: PKG_VERSION,
     uptime: Math.floor(process.uptime()),
     projects: _getProjectCount(),
-    mode: isHubMode ? 'hub' : 'legacy',
+    mode: 'hub',
   })
 })
 
@@ -318,16 +281,15 @@ function applyWsRateLimiting(ws: WebSocket): void {
   })
 }
 
-// ─── Hub mode ─────────────────────────────────────────────────────────────────
+// ─── Hub bootstrap ────────────────────────────────────────────────────────────
 
-if (isHubMode) {
+{
   const registry = new ProjectRegistry(broadcast, undefined, port)
   registry.loadAll()
   _getProjectCount = () => registry.listContexts().length
 
   // OTLP/JSON receiver — must be mounted before auth middleware would block it,
   // but after CORS. Requires auth (already applied globally above via requireAuth).
-  // Hub mode only: legacy mode has no per-project routing so receiver is not useful.
   app.use('/otlp', createTelemetryRouter(registry))
 
   // Run telemetry compaction at startup after registry is hydrated
@@ -365,369 +327,6 @@ if (isHubMode) {
     })
   })
 
-} else {
-  // ─── Single-project (legacy) mode ─────────────────────────────────────────
-
-  const db = initDb(path.join(process.cwd(), 'data', 'jobs.sqlite'))
-  _getProjectCount = () => 1
-  _legacyDb = db
-  const queueManager = new QueueManager(broadcast, db)
-  const chatManager = new ChatManager(broadcast, db)
-  const proposalManager = new ProposalManager(broadcast, db, process.cwd())
-
-  try {
-    const initialConfig = getConfig(process.cwd(), db, projectName)
-    queueManager.setCommands(initialConfig.commands)
-  } catch {
-    console.warn('[init] failed to load commands for phase resolution')
-  }
-
-  wss.on('connection', (ws: WebSocket) => {
-    clients.add(ws)
-    applyWsRateLimiting(ws)
-
-    const initMsg: WsMessage = {
-      type: 'init',
-      projectName,
-      phases: getPhaseStates(),
-      phaseDefinitions: getPhaseDefinitions(),
-      logBuffer: queueManager.getLogBuffer().slice(-500),
-      recentJobs: listJobs(db, { limit: 10 }).jobs,
-      queue: {
-        jobs: queueManager.getJobs(),
-        activeJobId: queueManager.getActiveJobId(),
-        paused: queueManager.isPaused(),
-      },
-    }
-    ws.send(JSON.stringify(initMsg))
-
-    ws.on('close', () => {
-      clients.delete(ws)
-    })
-  })
-
-  app.use('/hooks', createHooksRouter(broadcast, db, {
-    get current() { return queueManager.getActiveJobId() },
-    set current(_: string | null) { /* managed by QueueManager */ },
-  }))
-
-  app.post('/api/spawn', (req, res) => {
-    const { command } = req.body ?? {}
-    if (!command || typeof command !== 'string' || !command.trim()) {
-      res.status(400).json({ error: 'command is required' })
-      return
-    }
-    try {
-      const job = queueManager.enqueue(command)
-      const position = job.queuePosition ?? 0
-      res.status(202).json({ jobId: job.id, position })
-    } catch (err) {
-      if (err instanceof ClaudeNotFoundError) {
-        res.status(400).json({ error: err.message })
-      } else {
-        console.error('[spawn] unexpected error:', err)
-        res.status(500).json({ error: 'Internal server error' })
-      }
-    }
-  })
-
-  app.get('/api/state', (_req, res) => {
-    res.json({
-      projectName,
-      phases: getPhaseStates(),
-      busy: queueManager.getActiveJobId() !== null,
-      currentJobId: queueManager.getActiveJobId(),
-      version: PKG_VERSION,
-    })
-  })
-
-  app.delete('/api/jobs/:id', (req, res) => {
-    try {
-      const result = queueManager.cancel(req.params.id)
-      res.json({ ok: true, status: result })
-    } catch (err) {
-      if (err instanceof JobNotFoundError) {
-        res.status(404).json({ error: 'Job not found' })
-      } else if (err instanceof JobAlreadyTerminalError) {
-        res.status(409).json({ error: 'Job is already in terminal state' })
-      } else {
-        res.status(500).json({ error: 'Internal server error' })
-      }
-    }
-  })
-
-  app.post('/api/queue/pause', (_req, res) => {
-    queueManager.pause()
-    res.json({ ok: true, paused: true })
-  })
-
-  app.post('/api/queue/resume', (_req, res) => {
-    queueManager.resume()
-    res.json({ ok: true, paused: false })
-  })
-
-  app.put('/api/queue/reorder', (req, res) => {
-    const { jobIds } = req.body ?? {}
-    if (!Array.isArray(jobIds)) {
-      res.status(400).json({ error: 'jobIds must be an array' })
-      return
-    }
-    try {
-      queueManager.reorder(jobIds)
-      res.json({ ok: true, queue: jobIds })
-    } catch (err) {
-      res.status(400).json({ error: (err as Error).message })
-    }
-  })
-
-  app.get('/api/queue', (_req, res) => {
-    res.json({
-      jobs: queueManager.getJobs(),
-      paused: queueManager.isPaused(),
-      activeJobId: queueManager.getActiveJobId(),
-    })
-  })
-
-  app.get('/api/jobs', (req, res) => {
-    const limit = Math.min(parseInt(String(req.query.limit ?? '50'), 10) || 50, 200)
-    const offset = parseInt(String(req.query.offset ?? '0'), 10) || 0
-    const status = req.query.status as string | undefined
-    const from = req.query.from as string | undefined
-    const to = req.query.to as string | undefined
-    const result = listJobs(db, { limit, offset, status, from, to })
-    res.json(result)
-  })
-
-  app.get('/api/jobs/:id', (req, res) => {
-    const job = getJob(db, req.params.id)
-    if (!job) { res.status(404).json({ error: 'Job not found' }); return }
-    const events = getJobEvents(db, req.params.id)
-    const phaseDefinitions = queueManager.phasesForCommand(job.command)
-    res.json({ job, events, phaseDefinitions })
-  })
-
-  app.delete('/api/jobs', (req, res) => {
-    try {
-      const { from, to } = req.body ?? {}
-      const deleted = purgeJobs(db, { from, to })
-      res.json({ ok: true, deleted })
-    } catch (err) {
-      console.error('[purge] error:', err)
-      res.status(500).json({ error: 'Failed to purge jobs' })
-    }
-  })
-
-  app.get('/api/stats', (_req, res) => {
-    res.json(getStats(db))
-  })
-
-  app.get('/api/analytics', (req, res) => {
-    const period = (req.query.period as string) || '7d'
-    const from = req.query.from as string | undefined
-    const to = req.query.to as string | undefined
-    const validPeriods = ['7d', '30d', '90d', 'all', 'custom']
-    if (!validPeriods.includes(period)) {
-      res.status(400).json({ error: 'Invalid period. Must be one of: 7d, 30d, 90d, all, custom' })
-      return
-    }
-    if (period === 'custom' && (!from || !to)) {
-      res.status(400).json({ error: 'from and to are required for custom period' })
-      return
-    }
-    try {
-      res.json(getAnalytics(db, { period: period as any, from, to }))
-    } catch (err) {
-      console.error('[analytics] error:', err)
-      res.status(500).json({ error: 'Failed to compute analytics' })
-    }
-  })
-
-  app.get('/api/config', (_req, res) => {
-    try {
-      const config = getConfig(process.cwd(), db, projectName)
-      res.json(config)
-    } catch (err) {
-      console.error('[config] error:', err)
-      res.status(500).json({ error: 'Failed to read config' })
-    }
-  })
-
-  app.post('/api/config', (req, res) => {
-    const { active, labelFilter } = req.body ?? {}
-    try {
-      if (active !== undefined) {
-        db.prepare(`INSERT OR REPLACE INTO queue_state (key, value) VALUES ('config.active_tracker', ?)`).run(active ?? '')
-      }
-      if (labelFilter !== undefined) {
-        db.prepare(`INSERT OR REPLACE INTO queue_state (key, value) VALUES ('config.label_filter', ?)`).run(labelFilter ?? '')
-      }
-      res.json({ ok: true })
-    } catch (err) {
-      console.error('[config] persist error:', err)
-      res.status(500).json({ error: 'Failed to persist config' })
-    }
-  })
-
-  app.get('/api/issues', (_req, res) => {
-    try {
-      const config = getConfig(process.cwd(), db, projectName)
-      const tracker = config.issueTracker.active
-      if (!tracker) {
-        res.status(503).json({ error: 'No issue tracker configured', trackers: config.issueTracker })
-        return
-      }
-      const search = _req.query.search as string | undefined
-      const label = _req.query.label as string | undefined
-      const issues = fetchIssues(tracker, { search, label, repo: config.project.repo, cwd: process.cwd() })
-      res.json(issues)
-    } catch (err) {
-      console.error('[issues] error:', err)
-      res.status(500).json({ error: 'Failed to fetch issues' })
-    }
-  })
-
-  // Chat routes
-  app.get('/api/chat/conversations', (_req, res) => {
-    const conversations = listConversations(db)
-    res.json({ conversations })
-  })
-
-  app.post('/api/chat/conversations', (req, res) => {
-    const model = (req.body?.model as string | undefined) ?? 'claude-sonnet-4-5'
-    const id = uuidv4()
-    createConversation(db, { id, model })
-    const conversation = getConversation(db, id) as ChatConversationRow
-    res.status(201).json({ conversation })
-  })
-
-  app.get('/api/chat/conversations/:id', (req, res) => {
-    const conversation = getConversation(db, req.params.id)
-    if (!conversation) { res.status(404).json({ error: 'Conversation not found' }); return }
-    const messages = getMessages(db, req.params.id)
-    res.json({ conversation, messages })
-  })
-
-  app.delete('/api/chat/conversations/:id', (req, res) => {
-    const conversation = getConversation(db, req.params.id)
-    if (!conversation) { res.status(404).json({ error: 'Conversation not found' }); return }
-    deleteConversation(db, req.params.id)
-    res.json({ ok: true })
-  })
-
-  app.patch('/api/chat/conversations/:id', (req, res) => {
-    const conversation = getConversation(db, req.params.id)
-    if (!conversation) { res.status(404).json({ error: 'Conversation not found' }); return }
-    const { title, model } = req.body ?? {}
-    const patch: { title?: string; model?: string } = {}
-    if (title !== undefined) patch.title = title
-    if (model !== undefined) patch.model = model
-    updateConversation(db, req.params.id, patch)
-    const updated = getConversation(db, req.params.id) as ChatConversationRow
-    res.json({ ok: true, conversation: updated })
-  })
-
-  app.get('/api/chat/conversations/:id/messages', (req, res) => {
-    const conversation = getConversation(db, req.params.id)
-    if (!conversation) { res.status(404).json({ error: 'Conversation not found' }); return }
-    const messages = getMessages(db, req.params.id)
-    res.json({ messages })
-  })
-
-  app.post('/api/chat/conversations/:id/messages', async (req, res) => {
-    const conversation = getConversation(db, req.params.id)
-    if (!conversation) { res.status(404).json({ error: 'Conversation not found' }); return }
-    const text = req.body?.text as string | undefined
-    if (!text || !text.trim()) { res.status(400).json({ error: 'text is required' }); return }
-    if (chatManager.isActive(req.params.id)) {
-      res.status(409).json({ error: 'CONVERSATION_BUSY' }); return
-    }
-    res.status(202).json({ ok: true })
-    chatManager.sendMessage(req.params.id, text.trim()).catch((err) => {
-      console.error('[chat] sendMessage error:', err)
-    })
-  })
-
-  app.delete('/api/chat/conversations/:id/messages/stream', (req, res) => {
-    if (!chatManager.isActive(req.params.id)) {
-      res.status(404).json({ error: 'No active stream for this conversation' }); return
-    }
-    chatManager.abort(req.params.id)
-    res.json({ ok: true })
-  })
-
-  // ─── Proposal routes (legacy mode) ──────────────────────────────────────────
-
-  app.get('/api/propose', (_req, res) => {
-    const limit = Math.min(parseInt(String(_req.query.limit ?? '20'), 10) || 20, 100)
-    const offset = parseInt(String(_req.query.offset ?? '0'), 10) || 0
-    const result = listProposals(db, { limit, offset })
-    res.json(result)
-  })
-
-  app.post('/api/propose', (req, res) => {
-    const { idea } = req.body ?? {}
-    if (!idea || typeof idea !== 'string' || !idea.trim()) {
-      res.status(400).json({ error: 'idea is required' }); return
-    }
-    const testCmd = `/specrails:propose-feature test`
-    const resolved = resolveCommand(testCmd, process.cwd())
-    if (resolved === testCmd) {
-      res.status(400).json({ error: 'This project does not have the /specrails:propose-feature command installed. Run "npx specrails-core@latest" to update.' }); return
-    }
-    const id = uuidv4()
-    createProposal(db, { id, idea: idea.trim() })
-    res.status(202).json({ proposalId: id })
-    proposalManager.startExploration(id, idea.trim()).catch((err) => {
-      console.error('[propose] startExploration error:', err)
-    })
-  })
-
-  app.get('/api/propose/:id', (req, res) => {
-    const proposal = getProposal(db, req.params.id)
-    if (!proposal) { res.status(404).json({ error: 'Proposal not found' }); return }
-    res.json({ proposal })
-  })
-
-  app.post('/api/propose/:id/refine', (req, res) => {
-    const proposal = getProposal(db, req.params.id)
-    if (!proposal) { res.status(404).json({ error: 'Proposal not found' }); return }
-    const { feedback } = req.body ?? {}
-    if (!feedback || typeof feedback !== 'string' || !feedback.trim()) {
-      res.status(400).json({ error: 'feedback is required' }); return
-    }
-    if (proposalManager.isActive(req.params.id)) {
-      res.status(409).json({ error: 'PROPOSAL_BUSY' }); return
-    }
-    if (proposal.status !== 'review') {
-      res.status(409).json({ error: 'Proposal is not in review state' }); return
-    }
-    res.status(202).json({ ok: true })
-    proposalManager.sendRefinement(req.params.id, feedback.trim()).catch((err) => {
-      console.error('[propose] sendRefinement error:', err)
-    })
-  })
-
-  app.post('/api/propose/:id/create-issue', (req, res) => {
-    const proposal = getProposal(db, req.params.id)
-    if (!proposal) { res.status(404).json({ error: 'Proposal not found' }); return }
-    if (proposalManager.isActive(req.params.id)) {
-      res.status(409).json({ error: 'PROPOSAL_BUSY' }); return
-    }
-    if (proposal.status !== 'review') {
-      res.status(409).json({ error: 'Proposal is not in review state' }); return
-    }
-    res.status(202).json({ ok: true })
-    proposalManager.createIssue(req.params.id).catch((err) => {
-      console.error('[propose] createIssue error:', err)
-    })
-  })
-
-  app.delete('/api/propose/:id', (req, res) => {
-    const proposal = getProposal(db, req.params.id)
-    if (!proposal) { res.status(404).json({ error: 'Proposal not found' }); return }
-    proposalManager.cancel(req.params.id)
-    res.json({ ok: true })
-  })
 }
 
 
@@ -763,8 +362,7 @@ server.on('error', (err: NodeJS.ErrnoException) => {
 })
 
 server.listen(port, '127.0.0.1', () => {
-  const mode = isHubMode ? 'hub mode' : 'single-project mode'
-  console.log(`specrails web manager (${mode}) running on http://127.0.0.1:${port}`)
+  console.log(`specrails web manager running on http://127.0.0.1:${port}`)
   writePidFile()
 })
 
@@ -777,9 +375,6 @@ async function shutdown(): Promise<void> {
   } catch { /* ignore */ }
   try { wss.close() } catch { /* ignore */ }
   try { terminalWss.close() } catch { /* ignore */ }
-  if (_legacyDb) {
-    try { _legacyDb.close() } catch { /* ignore */ }
-  }
   server.close(() => {
     process.exit(0)
   })

--- a/server/setup-manager.test.ts
+++ b/server/setup-manager.test.ts
@@ -32,6 +32,18 @@ vi.mock('./core-compat', () => ({
   detectCLISync: vi.fn().mockReturnValue('claude'),
 }))
 
+// Default: prerequisites pass. Override per-test if the suite needs to exercise
+// the missing-prereq guard.
+vi.mock('./setup-prerequisites', () => ({
+  formatMissingSetupPrerequisites: vi.fn().mockReturnValue(null),
+  getSetupPrerequisitesStatus: vi.fn().mockReturnValue({
+    ok: true,
+    platform: 'darwin',
+    prerequisites: [],
+    missingRequired: [],
+  }),
+}))
+
 import { spawn as mockSpawn, spawnSync as mockSpawnSync } from 'child_process'
 import treeKill from 'tree-kill'
 import { existsSync, readdirSync, rmSync, mkdirSync, readFileSync, writeFileSync, copyFileSync } from 'fs'
@@ -278,13 +290,11 @@ describe('SetupManager', () => {
       expect(vi.mocked(mockSpawn)).not.toHaveBeenCalled()
     })
 
-    it('fails before spawn when Git is missing from PATH', () => {
-      vi.mocked(mockSpawnSync).mockImplementation((cmd: any, args: any) => {
-        if (cmd === 'which' && Array.isArray(args)) {
-          return { status: args[0] === 'git' ? 1 : 0, stdout: '', stderr: '' } as any
-        }
-        return { status: 0, stdout: `${cmd} 1.0.0\n`, stderr: '' } as any
-      })
+    it('fails before spawn when Git is missing from PATH', async () => {
+      const prereqs = await import('./setup-prerequisites')
+      vi.mocked(prereqs.formatMissingSetupPrerequisites).mockReturnValueOnce(
+        '- Git (git) is not on PATH. Install Git and restart SpecRails Hub.',
+      )
 
       sm.startInstall('p1', '/path/to/project')
 

--- a/server/setup-prerequisites.test.ts
+++ b/server/setup-prerequisites.test.ts
@@ -6,8 +6,10 @@ vi.mock('child_process', () => ({
 
 import { spawnSync } from 'child_process'
 import {
+  compareVersions,
   formatMissingSetupPrerequisites,
   getSetupPrerequisitesStatus,
+  parseSemver,
   type SetupPrerequisitesStatus,
 } from './setup-prerequisites'
 
@@ -18,10 +20,15 @@ describe('setup prerequisites', () => {
     vi.resetAllMocks()
   })
 
-  it('reports all required tools as installed with versions', () => {
-    mockSpawnSync.mockImplementation((cmd: any, args: any) => {
-      if (cmd === 'which') return { status: 0 } as any
-      return { status: 0, stdout: `${cmd} v1.2.3\nextra\n`, stderr: '' } as any
+  it('reports all required tools as installed with versions when versions meet minimums', () => {
+    mockSpawnSync.mockImplementation((cmd: any) => {
+      if (cmd === 'which' || cmd === 'where') return { status: 0 } as any
+      // Return versions above the configured minimums (node 18, npm 9, git 2.20)
+      if (cmd === 'node') return { status: 0, stdout: 'v20.11.0\n', stderr: '' } as any
+      if (cmd === 'npm') return { status: 0, stdout: '10.2.4\n', stderr: '' } as any
+      if (cmd === 'npx') return { status: 0, stdout: '10.2.4\n', stderr: '' } as any
+      if (cmd === 'git') return { status: 0, stdout: 'git version 2.42.1\n', stderr: '' } as any
+      return { status: 0, stdout: '', stderr: '' } as any
     })
 
     const status = getSetupPrerequisitesStatus()
@@ -31,15 +38,64 @@ describe('setup prerequisites', () => {
     expect(status.prerequisites).toHaveLength(4)
     expect(status.prerequisites.map((item) => item.command)).toEqual(['node', 'npm', 'npx', 'git'])
     expect(status.prerequisites.every((item) => item.installed)).toBe(true)
-    expect(status.prerequisites.find((item) => item.command === 'git')?.version).toBe('git v1.2.3')
+    expect(status.prerequisites.every((item) => item.meetsMinimum)).toBe(true)
+    expect(status.prerequisites.find((item) => item.command === 'git')?.version).toBe('git version 2.42.1')
+  })
+
+  it('reports platform field matching process.platform', () => {
+    mockSpawnSync.mockImplementation(() => ({ status: 0, stdout: 'v20.0.0\n', stderr: '' } as any))
+    const status = getSetupPrerequisitesStatus()
+    const expected = process.platform === 'darwin' ? 'darwin' : process.platform === 'win32' ? 'win32' : 'linux'
+    expect(status.platform).toBe(expected)
+  })
+
+  it('flags an installed-but-too-old Node as missing via meetsMinimum=false', () => {
+    mockSpawnSync.mockImplementation((cmd: any) => {
+      if (cmd === 'which' || cmd === 'where') return { status: 0 } as any
+      if (cmd === 'node') return { status: 0, stdout: 'v14.21.3\n', stderr: '' } as any
+      if (cmd === 'npm') return { status: 0, stdout: '10.0.0\n', stderr: '' } as any
+      if (cmd === 'npx') return { status: 0, stdout: '10.0.0\n', stderr: '' } as any
+      if (cmd === 'git') return { status: 0, stdout: 'git version 2.42.1\n', stderr: '' } as any
+      return { status: 0, stdout: '', stderr: '' } as any
+    })
+
+    const status = getSetupPrerequisitesStatus()
+
+    expect(status.ok).toBe(false)
+    expect(status.missingRequired.map((item) => item.command)).toContain('node')
+    const node = status.prerequisites.find((item) => item.command === 'node')
+    expect(node?.installed).toBe(true)
+    expect(node?.meetsMinimum).toBe(false)
+    expect(node?.version).toBe('v14.21.3')
+    expect(node?.minVersion).toBe('18.0.0')
+  })
+
+  it('treats npx without minVersion as meeting any version requirement', () => {
+    mockSpawnSync.mockImplementation((cmd: any) => {
+      if (cmd === 'which' || cmd === 'where') return { status: 0 } as any
+      if (cmd === 'node') return { status: 0, stdout: 'v20.0.0\n', stderr: '' } as any
+      if (cmd === 'npm') return { status: 0, stdout: '10.0.0\n', stderr: '' } as any
+      if (cmd === 'npx') return { status: 0, stdout: '5.0.0\n', stderr: '' } as any
+      if (cmd === 'git') return { status: 0, stdout: 'git version 2.42.1\n', stderr: '' } as any
+      return { status: 0, stdout: '', stderr: '' } as any
+    })
+
+    const status = getSetupPrerequisitesStatus()
+    const npx = status.prerequisites.find((item) => item.command === 'npx')
+    expect(npx?.minVersion).toBeUndefined()
+    expect(npx?.meetsMinimum).toBe(true)
   })
 
   it('reports missing Git without probing its version', () => {
     mockSpawnSync.mockImplementation((cmd: any, args: any) => {
-      if (cmd === 'which') {
+      if (cmd === 'which' || cmd === 'where') {
         return { status: args[0] === 'git' ? 1 : 0 } as any
       }
-      return { status: 0, stdout: `${cmd} v1.2.3\n`, stderr: '' } as any
+      // Return versions that meet the minimums for non-git tools
+      if (cmd === 'node') return { status: 0, stdout: 'v20.0.0\n', stderr: '' } as any
+      if (cmd === 'npm') return { status: 0, stdout: '10.0.0\n', stderr: '' } as any
+      if (cmd === 'npx') return { status: 0, stdout: '10.0.0\n', stderr: '' } as any
+      return { status: 0, stdout: '', stderr: '' } as any
     })
 
     const status = getSetupPrerequisitesStatus()
@@ -49,9 +105,9 @@ describe('setup prerequisites', () => {
     expect(mockSpawnSync).not.toHaveBeenCalledWith('git', ['--version'], expect.anything())
   })
 
-  it('handles command lookup and version failures conservatively', () => {
+  it('treats version-probe failures as not meeting the minimum (conservative)', () => {
     mockSpawnSync.mockImplementation((cmd: any, args: any) => {
-      if (cmd === 'which') {
+      if (cmd === 'which' || cmd === 'where') {
         if (args[0] === 'node') return { error: new Error('lookup failed') } as any
         return { status: 0 } as any
       }
@@ -63,9 +119,13 @@ describe('setup prerequisites', () => {
     const status = getSetupPrerequisitesStatus()
 
     expect(status.ok).toBe(false)
-    expect(status.missingRequired.map((item) => item.command)).toEqual(['node'])
-    expect(status.prerequisites.find((item) => item.command === 'npm')?.version).toBeUndefined()
-    expect(status.prerequisites.find((item) => item.command === 'npx')?.version).toBeUndefined()
+    // node not installed; npm installed but version probe failed → meetsMinimum=false → flagged.
+    // npx has no minVersion, so an undefined version is still treated as meeting the requirement.
+    expect(status.missingRequired.map((item) => item.command).sort()).toEqual(['node', 'npm'].sort())
+    const npm = status.prerequisites.find((item) => item.command === 'npm')
+    expect(npm?.installed).toBe(true)
+    expect(npm?.version).toBeUndefined()
+    expect(npm?.meetsMinimum).toBe(false)
     expect(status.prerequisites.find((item) => item.command === 'git')?.version).toBe('git version 2.50.0')
   })
 
@@ -77,6 +137,7 @@ describe('setup prerequisites', () => {
     }
     const missing: SetupPrerequisitesStatus = {
       ok: false,
+      platform: 'darwin',
       prerequisites: [],
       missingRequired: [
         {
@@ -85,6 +146,7 @@ describe('setup prerequisites', () => {
           command: 'git',
           required: true,
           installed: false,
+          meetsMinimum: false,
           installUrl: 'https://git-scm.com/downloads',
           installHint: 'Install Git and restart SpecRails Hub.',
         },
@@ -94,5 +156,34 @@ describe('setup prerequisites', () => {
     expect(formatMissingSetupPrerequisites(ready)).toBeNull()
     expect(formatMissingSetupPrerequisites(missing)).toContain('Git (git) is not on PATH')
     expect(formatMissingSetupPrerequisites(missing)).toContain('restart SpecRails Hub')
+  })
+})
+
+describe('parseSemver', () => {
+  it('extracts semver triple from common formats', () => {
+    expect(parseSemver('v18.0.0')).toEqual([18, 0, 0])
+    expect(parseSemver('20.11.0')).toEqual([20, 11, 0])
+    expect(parseSemver('git version 2.42.1')).toEqual([2, 42, 1])
+    expect(parseSemver('node v18.17.1\nextra')).toEqual([18, 17, 1])
+  })
+
+  it('returns null for unparseable input', () => {
+    expect(parseSemver(undefined)).toBeNull()
+    expect(parseSemver('')).toBeNull()
+    expect(parseSemver('not a version')).toBeNull()
+  })
+})
+
+describe('compareVersions', () => {
+  it('returns positive when a > b, negative when a < b, zero when equal', () => {
+    expect(compareVersions('20.0.0', '18.0.0')).toBeGreaterThan(0)
+    expect(compareVersions('14.21.3', '18.0.0')).toBeLessThan(0)
+    expect(compareVersions('18.0.0', '18.0.0')).toBe(0)
+    expect(compareVersions('git version 2.42.1', '2.20.0')).toBeGreaterThan(0)
+  })
+
+  it('returns 0 for unparseable inputs (conservative)', () => {
+    expect(compareVersions('weird', '1.0.0')).toBe(0)
+    expect(compareVersions('1.0.0', 'weird')).toBe(0)
   })
 })

--- a/server/setup-prerequisites.ts
+++ b/server/setup-prerequisites.ts
@@ -2,6 +2,8 @@ import { spawnSync } from 'child_process'
 
 const WHICH_CMD = process.platform === 'win32' ? 'where' : 'which'
 
+export type Platform = 'darwin' | 'win32' | 'linux'
+
 export interface SetupPrerequisite {
   key: 'node' | 'npm' | 'npx' | 'git'
   label: string
@@ -9,14 +11,25 @@ export interface SetupPrerequisite {
   required: boolean
   installed: boolean
   version?: string
+  /** Semver `major.minor.patch` minimum. Undefined = no minimum (e.g. npx). */
+  minVersion?: string
+  /** True when `installed` and (no minVersion OR parsed version >= minVersion). */
+  meetsMinimum: boolean
   installUrl: string
   installHint: string
 }
 
 export interface SetupPrerequisitesStatus {
   ok: boolean
+  platform: Platform
   prerequisites: SetupPrerequisite[]
   missingRequired: SetupPrerequisite[]
+}
+
+export const MIN_VERSIONS: Record<'node' | 'npm' | 'git', string> = {
+  node: '18.0.0',
+  npm: '9.0.0',
+  git: '2.20.0',
 }
 
 function commandExists(command: string): boolean {
@@ -40,13 +53,45 @@ function commandVersion(command: string): string | undefined {
   return output.split(/\r?\n/)[0]?.trim() || undefined
 }
 
+/** Extracts the first `major.minor.patch` triple from a version string.
+ *  Tolerates prefixes like `v`, `git version `, `node `. */
+export function parseSemver(raw: string | undefined): [number, number, number] | null {
+  if (!raw) return null
+  const match = raw.match(/(\d+)\.(\d+)\.(\d+)/)
+  if (!match) return null
+  return [Number(match[1]), Number(match[2]), Number(match[3])]
+}
+
+export function compareVersions(a: string, b: string): number {
+  const pa = parseSemver(a)
+  const pb = parseSemver(b)
+  if (!pa || !pb) return 0
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] - pb[i]
+  }
+  return 0
+}
+
+function meetsMinimumVersion(version: string | undefined, minVersion: string | undefined): boolean {
+  if (!minVersion) return true
+  if (!version) return false
+  return compareVersions(version, minVersion) >= 0
+}
+
 export function getSetupPrerequisitesStatus(): SetupPrerequisitesStatus {
-  const definitions: Array<Omit<SetupPrerequisite, 'installed' | 'version'>> = [
+  const platform: Platform = process.platform === 'darwin'
+    ? 'darwin'
+    : process.platform === 'win32'
+      ? 'win32'
+      : 'linux'
+
+  const definitions: Array<Omit<SetupPrerequisite, 'installed' | 'version' | 'meetsMinimum'>> = [
     {
       key: 'node',
       label: 'Node.js',
       command: 'node',
       required: true,
+      minVersion: MIN_VERSIONS.node,
       installUrl: 'https://nodejs.org/en/download',
       installHint: process.platform === 'win32'
         ? 'Install Node.js LTS, then restart SpecRails Hub so Windows refreshes PATH.'
@@ -57,6 +102,7 @@ export function getSetupPrerequisitesStatus(): SetupPrerequisitesStatus {
       label: 'npm',
       command: 'npm',
       required: true,
+      minVersion: MIN_VERSIONS.npm,
       installUrl: 'https://nodejs.org/en/download',
       installHint: 'npm ships with Node.js LTS.',
     },
@@ -73,6 +119,7 @@ export function getSetupPrerequisitesStatus(): SetupPrerequisitesStatus {
       label: 'Git',
       command: 'git',
       required: true,
+      minVersion: MIN_VERSIONS.git,
       installUrl: process.platform === 'win32'
         ? 'https://git-scm.com/download/win'
         : 'https://git-scm.com/downloads',
@@ -82,17 +129,21 @@ export function getSetupPrerequisitesStatus(): SetupPrerequisitesStatus {
     },
   ]
 
-  const prerequisites = definitions.map((definition) => {
+  const prerequisites: SetupPrerequisite[] = definitions.map((definition) => {
     const installed = commandExists(definition.command)
-    return {
-      ...definition,
-      installed,
-      version: installed ? commandVersion(definition.command) : undefined,
-    }
+    const version = installed ? commandVersion(definition.command) : undefined
+    const meetsMinimum = installed && meetsMinimumVersion(version, definition.minVersion)
+    return { ...definition, installed, version, meetsMinimum }
   })
-  const missingRequired = prerequisites.filter((item) => item.required && !item.installed)
+
+  // A required tool counts as missing if not installed OR below its minimum version.
+  const missingRequired = prerequisites.filter(
+    (item) => item.required && (!item.installed || !item.meetsMinimum),
+  )
+
   return {
     ok: missingRequired.length === 0,
+    platform,
     prerequisites,
     missingRequired,
   }
@@ -104,7 +155,13 @@ export function formatMissingSetupPrerequisites(status = getSetupPrerequisitesSt
   return [
     'SpecRails setup needs a few developer tools before it can install this project.',
     '',
-    ...status.missingRequired.map((item) => `- ${item.label} (${item.command}) is not on PATH. ${item.installHint}`),
+    ...status.missingRequired.map((item) => {
+      if (!item.installed) {
+        return `- ${item.label} (${item.command}) is not on PATH. ${item.installHint}`
+      }
+      // installed but below minimum version
+      return `- ${item.label} ${item.version ?? '?'} found, but version ${item.minVersion}+ is required. ${item.installHint}`
+    }),
     '',
     'Install the missing tools, restart SpecRails Hub, then retry setup.',
   ].join('\n')


### PR DESCRIPTION
## Summary

Two OpenSpec changes bundled into a single PR.

### `remove-legacy-single-project-mode`
- Removes the `--legacy` / `SPECRAILS_LEGACY=1` single-project mode from the server (~365 LOC of duplicate routing) and the client (`useHubMode`, `RootLayout`, `Navbar`, legacy `App.tsx` branch).
- `<HubProvider>` mounts unconditionally on the web client; the boot-time `GET /api/hub/state` probe is gone.
- `getApiBase()` now returns `/api/projects/<id>` always and throws when no project is active.
- `health.mode` is the constant `"hub"` (CLI status keeps working).

### `gate-add-project-on-prerequisites`
- `GET /api/hub/setup-prerequisites` enriched with `platform`, per-tool `minVersion`, and `meetsMinimum` (Node ≥18, npm ≥9, Git ≥2.20).
- New shared `usePrerequisites()` hook (60 s cache, abort on unmount, recheck on `window.focus`) feeds both `AddProjectDialog` and `SetupWizard` via a reusable `<PrerequisitesPanel />`.
- `AddProjectDialog` blocks the submit while any required tool is missing/too old; tooltip names the missing tools.
- New OS-aware `<InstallInstructionsModal />` with brew/winget/apt-dnf snippets, copy-to-clipboard, and "show other platforms" disclosure.
- `SetupWizard` refactored onto the shared hook + component (~70 LOC removed); keeps the panel as defence-in-depth.

## Test plan

- [x] `npm run typecheck` (server + client) — green
- [x] `npm test` server: 1431/1431 passing
- [x] `cd client && npx vitest run`: 1895/1895 passing
- [x] Coverage gates hold (server 80.5 / 70 / 86.4 / 81.6, client 84.9 / 83 / 77 / 84.9)
- [x] `openspec validate gate-add-project-on-prerequisites --strict`
- [ ] Manual smoke test: open Add Project dialog, verify prereq panel renders, gate disables submit when a tool is missing, "More info" opens modal with the right OS section, copy button works, recheck button refreshes status.
- [ ] Manual smoke test: SetupWizard install step still gates on prereqs.
- [ ] (Pre-existing pending from the legacy-removal change) `rm` four dead files: `client/src/components/{RootLayout,Navbar}.tsx` and their `__tests__` siblings — sandbox blocked it during apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)