### PR TITLE
fix: use Claude Code model aliases in chat

### DIFF
--- a/client/src/components/ChatInput.tsx
+++ b/client/src/components/ChatInput.tsx
@@ -4,9 +4,9 @@ import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip'
 import { cn } from '../lib/utils'
 
 const CLAUDE_MODEL_OPTIONS = [
-  { value: 'claude-opus-4-7', label: 'Opus 4.7' },
-  { value: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
-  { value: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
+  { value: 'opus', label: 'Opus' },
+  { value: 'sonnet', label: 'Sonnet' },
+  { value: 'haiku', label: 'Haiku' },
 ]
 
 const CODEX_MODEL_OPTIONS = [

--- a/client/src/components/ModelCombobox.tsx
+++ b/client/src/components/ModelCombobox.tsx
@@ -14,9 +14,9 @@ interface ModelOption {
 }
 
 export const MODEL_OPTIONS: ModelOption[] = [
-  { alias: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4-6',          tier: 'Balanced',     tierColor: 'neutral' },
-  { alias: 'opus',   label: 'Opus',   fullId: 'claude-opus-4-7',            tier: 'Most capable', tierColor: 'accent'  },
-  { alias: 'haiku',  label: 'Haiku',  fullId: 'claude-haiku-4-5-20251001',  tier: 'Fastest',      tierColor: 'green'   },
+  { alias: 'sonnet', label: 'Sonnet', fullId: 'Claude Code alias: sonnet', tier: 'Balanced',     tierColor: 'neutral' },
+  { alias: 'opus',   label: 'Opus',   fullId: 'Claude Code alias: opus',   tier: 'Most capable', tierColor: 'accent'  },
+  { alias: 'haiku',  label: 'Haiku',  fullId: 'Claude Code alias: haiku',  tier: 'Fastest',      tierColor: 'green'   },
 ]
 
 function tierBadgeClass(color: ModelOption['tierColor']): string {

--- a/client/src/components/ModelSelector.tsx
+++ b/client/src/components/ModelSelector.tsx
@@ -17,11 +17,9 @@ export interface ModelOverrides {
 }
 
 export const CLAUDE_MODELS = [
-  { value: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
-  { value: 'claude-opus-4-5', label: 'Claude Opus 4.5' },
-  { value: 'claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5' },
-  { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
-  { value: 'claude-opus-4-7', label: 'Claude Opus 4.7' },
+  { value: 'sonnet', label: 'Claude Sonnet' },
+  { value: 'opus', label: 'Claude Opus' },
+  { value: 'haiku', label: 'Claude Haiku' },
 ]
 
 export const CODEX_MODELS = [
@@ -32,15 +30,15 @@ export const CODEX_MODELS = [
 
 // Preset → default model per provider (matches specrails-core MODEL_PRESETS)
 export const PRESET_DEFAULTS: Record<ModelPreset, { claude: string; codex: string }> = {
-  balanced: { claude: 'claude-sonnet-4-6', codex: 'gpt-5.4-mini' },
-  budget: { claude: 'claude-haiku-4-5-20251001', codex: 'gpt-5.4-mini' },
-  max: { claude: 'claude-sonnet-4-6', codex: 'gpt-5.4-mini' },
+  balanced: { claude: 'sonnet', codex: 'gpt-5.4-mini' },
+  budget: { claude: 'haiku', codex: 'gpt-5.4-mini' },
+  max: { claude: 'sonnet', codex: 'gpt-5.4-mini' },
 }
 
 // "max" preset: Opus for architect + PM, Sonnet for rest (matches specrails-core)
 const MAX_OVERRIDES: Record<string, { claude: string; codex: string }> = {
-  'sr-architect': { claude: 'claude-opus-4-7', codex: 'gpt-5.3-codex' },
-  'sr-product-manager': { claude: 'claude-opus-4-7', codex: 'gpt-5.3-codex' },
+  'sr-architect': { claude: 'opus', codex: 'gpt-5.3-codex' },
+  'sr-product-manager': { claude: 'opus', codex: 'gpt-5.3-codex' },
 }
 
 export function getDefaultModel(

--- a/client/src/components/__tests__/ChatInput.test.tsx
+++ b/client/src/components/__tests__/ChatInput.test.tsx
@@ -6,7 +6,7 @@ import { ChatInput } from '../ChatInput'
 
 const defaultProps = {
   conversationId: 'conv-1',
-  model: 'claude-sonnet-4-6',
+  model: 'sonnet',
   hasMessages: false,
   isStreaming: false,
   onSend: vi.fn(),
@@ -114,9 +114,9 @@ describe('ChatInput', () => {
   })
 
   it('model selector shows current model', () => {
-    render(<ChatInput {...defaultProps} model="claude-sonnet-4-6" />)
+    render(<ChatInput {...defaultProps} model="sonnet" />)
     const select = screen.getByRole('combobox') as HTMLSelectElement
-    expect(select.value).toBe('claude-sonnet-4-6')
+    expect(select.value).toBe('sonnet')
   })
 
   it('model selector is disabled when hasMessages is true', () => {
@@ -136,8 +136,8 @@ describe('ChatInput', () => {
     const onModelChange = vi.fn()
     render(<ChatInput {...defaultProps} onModelChange={onModelChange} />)
     const select = screen.getByRole('combobox')
-    await user.selectOptions(select, 'claude-opus-4-7')
-    expect(onModelChange).toHaveBeenCalledWith('claude-opus-4-7')
+    await user.selectOptions(select, 'opus')
+    expect(onModelChange).toHaveBeenCalledWith('opus')
   })
 
   it('when provider=codex, dropdown lists gpt-5.4-mini as the first option', () => {

--- a/client/src/components/__tests__/ModelCombobox.test.tsx
+++ b/client/src/components/__tests__/ModelCombobox.test.tsx
@@ -6,10 +6,10 @@ import { ModelCombobox } from '../ModelCombobox'
 
 // ─── ModelCombobox ────────────────────────────────────────────────────────────
 //
-// ModelCombobox is a Radix Select wrapping the three Claude model aliases:
-//   sonnet  → label "Sonnet", tier badge "Balanced", full ID "claude-sonnet-4-6"
-//   opus    → label "Opus",   tier badge "Most capable", full ID "claude-opus-4-7"
-//   haiku   → label "Haiku",  tier badge "Fastest",     full ID "claude-haiku-4-5-20251001"
+// ModelCombobox is a Radix Select wrapping the three Claude Code model aliases:
+//   sonnet  → label "Sonnet", tier badge "Balanced"
+//   opus    → label "Opus",   tier badge "Most capable"
+//   haiku   → label "Haiku",  tier badge "Fastest"
 //
 // Tests verify: static render, option display, onChange callback, disabled state.
 // Radix Select portals render in document.body — queried via screen.getByRole.
@@ -78,21 +78,21 @@ describe('ModelCombobox', () => {
     const user = userEvent.setup()
     render(<ModelCombobox value="sonnet" onChange={vi.fn()} />)
     await user.click(screen.getByRole('combobox'))
-    expect(screen.getByText(/claude-sonnet-4-6/i)).toBeInTheDocument()
+    expect(screen.getByText(/alias: sonnet/i)).toBeInTheDocument()
   })
 
   it('shows full model ID for opus option', async () => {
     const user = userEvent.setup()
     render(<ModelCombobox value="sonnet" onChange={vi.fn()} />)
     await user.click(screen.getByRole('combobox'))
-    expect(screen.getByText(/claude-opus-4-7/i)).toBeInTheDocument()
+    expect(screen.getByText(/alias: opus/i)).toBeInTheDocument()
   })
 
   it('shows full model ID for haiku option', async () => {
     const user = userEvent.setup()
     render(<ModelCombobox value="sonnet" onChange={vi.fn()} />)
     await user.click(screen.getByRole('combobox'))
-    expect(screen.getByText(/claude-haiku-4-5-20251001/i)).toBeInTheDocument()
+    expect(screen.getByText(/alias: haiku/i)).toBeInTheDocument()
   })
 
   it('calls onChange with "opus" when opus option is selected', async () => {

--- a/client/src/components/__tests__/ModelSelector.test.tsx
+++ b/client/src/components/__tests__/ModelSelector.test.tsx
@@ -11,27 +11,27 @@ const SAMPLE_AGENTS: AgentDef[] = [
 
 describe('getDefaultModel', () => {
   it('returns sonnet for non-special agents in balanced preset (claude)', () => {
-    expect(getDefaultModel('sr-developer', 'balanced', 'claude')).toBe('claude-sonnet-4-6')
+    expect(getDefaultModel('sr-developer', 'balanced', 'claude')).toBe('sonnet')
   })
 
   it('returns sonnet for architect in balanced preset (claude)', () => {
-    expect(getDefaultModel('sr-architect', 'balanced', 'claude')).toBe('claude-sonnet-4-6')
+    expect(getDefaultModel('sr-architect', 'balanced', 'claude')).toBe('sonnet')
   })
 
   it('returns sonnet for product-manager in balanced preset (claude)', () => {
-    expect(getDefaultModel('sr-product-manager', 'balanced', 'claude')).toBe('claude-sonnet-4-6')
+    expect(getDefaultModel('sr-product-manager', 'balanced', 'claude')).toBe('sonnet')
   })
 
   it('returns haiku for budget preset (claude)', () => {
-    expect(getDefaultModel('sr-developer', 'budget', 'claude')).toBe('claude-haiku-4-5-20251001')
+    expect(getDefaultModel('sr-developer', 'budget', 'claude')).toBe('haiku')
   })
 
   it('returns sonnet for non-special agents in max preset (claude)', () => {
-    expect(getDefaultModel('sr-developer', 'max', 'claude')).toBe('claude-sonnet-4-6')
+    expect(getDefaultModel('sr-developer', 'max', 'claude')).toBe('sonnet')
   })
 
   it('returns opus for architect in max preset (claude)', () => {
-    expect(getDefaultModel('sr-architect', 'max', 'claude')).toBe('claude-opus-4-7')
+    expect(getDefaultModel('sr-architect', 'max', 'claude')).toBe('opus')
   })
 
   it('returns gpt-5.4-mini for budget preset (codex)', () => {
@@ -114,7 +114,7 @@ describe('ModelSelector', () => {
         agents={SAMPLE_AGENTS}
         provider="claude"
         preset="balanced"
-        overrides={{ 'sr-developer': 'claude-opus-4-7' }}
+        overrides={{ 'sr-developer': 'opus' }}
         onPresetChange={vi.fn()}
         onOverrideChange={vi.fn()}
       />
@@ -129,7 +129,7 @@ describe('ModelSelector', () => {
         agents={SAMPLE_AGENTS}
         provider="claude"
         preset="balanced"
-        overrides={{ 'sr-developer': 'claude-opus-4-7' }}
+        overrides={{ 'sr-developer': 'opus' }}
         onPresetChange={vi.fn()}
         onOverrideChange={onOverrideChange}
       />
@@ -145,7 +145,7 @@ describe('ModelSelector', () => {
         agents={SAMPLE_AGENTS}
         provider="claude"
         preset="balanced"
-        overrides={{ 'sr-developer': 'claude-opus-4-7', 'sr-architect': 'claude-haiku-4-5-20251001' }}
+        overrides={{ 'sr-developer': 'opus', 'sr-architect': 'haiku' }}
         onPresetChange={vi.fn()}
         onOverrideChange={vi.fn()}
       />

--- a/client/src/hooks/useChat.ts
+++ b/client/src/hooks/useChat.ts
@@ -217,7 +217,7 @@ export function useChat(): UseChatReturn {
     })
   }, [])
 
-  const createConversation = useCallback(async (model = 'claude-sonnet-4-6') => {
+  const createConversation = useCallback(async (model = 'sonnet') => {
     try {
       const res = await fetch(`${getApiBase()}/chat/conversations`, {
         method: 'POST',
@@ -345,7 +345,7 @@ export function useChat(): UseChatReturn {
       const res = await fetch(`${getApiBase()}/chat/conversations`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ model: 'claude-sonnet-4-6' }),
+        body: JSON.stringify({ model: 'sonnet' }),
       })
       if (!res.ok) return null
       const data = await res.json() as { conversation: ChatConversationSummary }

--- a/server/chat-manager.test.ts
+++ b/server/chat-manager.test.ts
@@ -112,6 +112,24 @@ describe('ChatManager', () => {
     expect(doneMsgs[0].fullText).toBe('Hello back!')
   })
 
+  it('normalizes legacy Claude model ids to Claude Code aliases before spawning', async () => {
+    const convId = setupConversation('claude-sonnet-4-6')
+    const child = createMockChildProcess()
+    vi.mocked(mockSpawn).mockReturnValue(child as any)
+
+    const sendPromise = cm.sendMessage(convId, 'Hello world')
+
+    const spawnArgs = vi.mocked(mockSpawn).mock.calls[0][1] as string[]
+    const modelIdx = spawnArgs.indexOf('--model')
+    expect(modelIdx).toBeGreaterThan(-1)
+    expect(spawnArgs[modelIdx + 1]).toBe('sonnet')
+
+    pushLine(child, assistantEvent('Hello'))
+    pushLine(child, resultEvent('sess-abc'))
+    await finishProcess(child, 0)
+    await sendPromise
+  })
+
   // ─── Test 2: abort triggers chat_error { error: 'aborted' } ───────────────
 
   it('abort triggers chat_error with aborted reason', async () => {
@@ -251,6 +269,21 @@ describe('ChatManager', () => {
     const errors = getBroadcastedByType(broadcast, 'chat_error')
     expect(errors).toHaveLength(1)
     expect(errors[0].error).toContain('code 1')
+  })
+
+  it('includes stderr in chat_error when process exits with non-zero code', async () => {
+    const convId = setupConversation()
+    const child = createMockChildProcess()
+    vi.mocked(mockSpawn).mockReturnValue(child as any)
+
+    const sendPromise = cm.sendMessage(convId, 'Fail with stderr')
+    child.stderr.push('Authentication failed\n')
+    await finishProcess(child, 1)
+    await sendPromise
+
+    const errors = getBroadcastedByType(broadcast, 'chat_error')
+    expect(errors).toHaveLength(1)
+    expect(errors[0].error).toContain('Authentication failed')
   })
 
   // ─── Test 10: already active conversation ──────────────────────────────────

--- a/server/chat-manager.ts
+++ b/server/chat-manager.ts
@@ -35,6 +35,27 @@ function codexOnPath(): boolean {
   }
 }
 
+function normalizeClaudeCodeModel(model: string | null | undefined): string {
+  switch (model) {
+    case 'claude-sonnet-4-6':
+    case 'claude-sonnet-4-5':
+    case 'claude-sonnet-4-0':
+    case 'claude-sonnet-4-20250514':
+      return 'sonnet'
+    case 'claude-opus-4-7':
+    case 'claude-opus-4-5':
+    case 'claude-opus-4-1-20250805':
+    case 'claude-opus-4-20250514':
+      return 'opus'
+    case 'claude-haiku-4-5-20251001':
+    case 'claude-3-5-haiku-20241022':
+    case 'claude-3-5-haiku-latest':
+      return 'haiku'
+    default:
+      return model || 'sonnet'
+  }
+}
+
 function extractTextFromEvent(event: Record<string, unknown>): string | null {
   const type = event.type as string
   if (type === 'assistant') {
@@ -288,7 +309,7 @@ export class ChatManager {
         : this._buildSystemPrompt()
       if (hasAttachments) systemPrompt = `${systemPrompt}\n\n${USER_ATTACHMENT_SYSTEM_NOTE}`
       args = [
-        '--model', conversation.model,
+        '--model', normalizeClaudeCodeModel(conversation.model),
         '--dangerously-skip-permissions',
         '--tools', 'default',
         '--output-format', 'stream-json',
@@ -314,10 +335,12 @@ export class ChatManager {
       cwd: this._cwd,
     })
 
+    let stderrBuf = ''
     // Drain stderr so the pipe buffer never fills up (child process would block otherwise)
-    child.stderr?.resume()
     child.stderr?.on('data', (chunk: Buffer) => {
-      console.error(`[chat-manager] claude stderr (${conversationId}):`, chunk.toString().trim())
+      const text = chunk.toString()
+      stderrBuf += text
+      console.error(`[chat-manager] ${binary} stderr (${conversationId}):`, text.trim())
     })
 
     this._activeProcesses.set(conversationId, child)
@@ -471,10 +494,13 @@ export class ChatManager {
             this._autoTitle(conversationId, userText, fullText)
           }
         } else {
+          const stderrTail = stderrBuf.trim().slice(-500)
           this._broadcast({
             type: 'chat_error',
             conversationId,
-            error: `Process exited with code ${code ?? 'unknown'}`,
+            error: stderrTail
+              ? `${binary} exited with code ${code ?? 'unknown'}: ${stderrTail}`
+              : `Process exited with code ${code ?? 'unknown'}`,
             timestamp: new Date().toISOString(),
           })
         }

--- a/server/db.ts
+++ b/server/db.ts
@@ -140,7 +140,7 @@ const MIGRATIONS: Migration[] = [
       CREATE TABLE IF NOT EXISTS chat_conversations (
         id           TEXT PRIMARY KEY,
         title        TEXT,
-        model        TEXT NOT NULL DEFAULT 'claude-sonnet-4-5',
+        model        TEXT NOT NULL DEFAULT 'sonnet',
         session_id   TEXT,
         created_at   TEXT NOT NULL DEFAULT (datetime('now')),
         updated_at   TEXT NOT NULL DEFAULT (datetime('now'))

--- a/server/project-router.ts
+++ b/server/project-router.ts
@@ -802,7 +802,7 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
 
   router.post('/:projectId/chat/conversations', (req: Request, res: Response) => {
     const { db } = ctx(req)
-    const model = (req.body?.model as string | undefined) ?? 'claude-sonnet-4-5'
+    const model = (req.body?.model as string | undefined) ?? 'sonnet'
     const id = uuidv4()
     createConversation(db, { id, model })
     const conversation = getConversation(db, id) as ChatConversationRow


### PR DESCRIPTION
## Summary
- use Claude Code model aliases (sonnet/opus/haiku) for Hub chat and Explore Spec conversations
- normalize legacy stored Claude model IDs before spawning Claude Code
- include Claude stderr details in chat errors so auth/model failures are visible to users

## Verification
- npx vitest run server/chat-manager.test.ts server/project-router.test.ts
- cd client && npx vitest run src/components/__tests__/ChatInput.test.tsx src/components/__tests__/ModelSelector.test.tsx src/components/__tests__/ModelCombobox.test.tsx src/hooks/__tests__/useChat.test.ts
- npm run typecheck