### PR TITLE
Fix terminal shortcut settings refresh

### DIFF
--- a/client/src/components/settings/TerminalSettingsSection.tsx
+++ b/client/src/components/settings/TerminalSettingsSection.tsx
@@ -12,6 +12,7 @@ import {
   type TerminalSettings,
   type TerminalRenderMode,
 } from '../../lib/terminal-settings-types'
+import { dispatchTerminalSettingsUpdated } from '../../lib/terminal-settings-events'
 
 interface Props {
   /** Hub mode edits hub_settings; project mode edits a per-project override layer. */
@@ -128,6 +129,7 @@ export function TerminalSettingsSection({ mode }: Props) {
         if (!res.ok) throw new Error((await res.text()) || 'patch failed')
         const updated = (await res.json()) as TerminalSettings
         setHub(updated); setSavedResolved(updated); setDraft(updated); setClearedFields(new Set())
+        dispatchTerminalSettingsUpdated({ mode: 'hub', projectId: null })
         toast.success('Terminal settings saved')
       } else if (activeProjectId) {
         const res = await fetch(`/api/projects/${activeProjectId}/terminal-settings`, {
@@ -139,6 +141,7 @@ export function TerminalSettingsSection({ mode }: Props) {
         const updated = (await res.json()) as ProjectResponse
         setHub(updated.hubDefaults); setOverride(updated.override); setSavedResolved(updated.resolved); setDraft(updated.resolved)
         setClearedFields(new Set())
+        dispatchTerminalSettingsUpdated({ mode: 'project', projectId: activeProjectId })
         toast.success('Terminal settings saved')
       }
     } catch (err) {

--- a/client/src/components/terminal/BottomPanel.tsx
+++ b/client/src/components/terminal/BottomPanel.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../context/TerminalsContext'
 import { openExternalUrl } from '../../lib/tauri-shell'
 import { DEFAULT_TERMINAL_SETTINGS, type TerminalSettings } from '../../lib/terminal-settings-types'
+import { TERMINAL_SETTINGS_UPDATED_EVENT, type TerminalSettingsUpdatedEventDetail } from '../../lib/terminal-settings-events'
 import { ShortcutContextMenu } from './ShortcutContextMenu'
 import { TerminalTopBar } from './TerminalTopBar'
 import { TerminalSidebar } from './TerminalSidebar'
@@ -30,20 +31,32 @@ export function BottomPanel({ projectId, state, viewportHeight, statusBarHeight 
   const [settings, setSettings] = useState<TerminalSettings>(DEFAULT_TERMINAL_SETTINGS)
   const [shortcutMenu, setShortcutMenu] = useState<{ x: number; y: number; kind: 'browser' | 'script' } | null>(null)
 
+  const loadSettings = useCallback(async (cancelled: () => boolean = () => false) => {
+    try {
+      const res = await fetch(`/api/projects/${projectId}/terminal-settings`)
+      if (!res.ok) return
+      const body = await res.json() as { resolved?: TerminalSettings }
+      if (!cancelled() && body?.resolved) setSettings(body.resolved)
+    } catch { /* ignore — keep current settings */ }
+  }, [projectId])
+
   // Resolve terminal settings (project override → hub default) for this project,
-  // so the Browser shortcut button uses the configured URL.
+  // so the shortcut buttons use the configured values.
   useEffect(() => {
     let cancelled = false
-    void (async () => {
-      try {
-        const res = await fetch(`/api/projects/${projectId}/terminal-settings`)
-        if (!res.ok) return
-        const body = await res.json() as { resolved?: TerminalSettings }
-        if (!cancelled && body?.resolved) setSettings(body.resolved)
-      } catch { /* ignore — keep defaults */ }
-    })()
+    void loadSettings(() => cancelled)
     return () => { cancelled = true }
-  }, [projectId])
+  }, [loadSettings])
+
+  useEffect(() => {
+    const onSettingsUpdated = (event: Event) => {
+      const detail = (event as CustomEvent<TerminalSettingsUpdatedEventDetail>).detail
+      if (detail?.mode === 'project' && detail.projectId !== projectId) return
+      void loadSettings()
+    }
+    window.addEventListener(TERMINAL_SETTINGS_UPDATED_EVENT, onSettingsUpdated)
+    return () => window.removeEventListener(TERMINAL_SETTINGS_UPDATED_EVENT, onSettingsUpdated)
+  }, [loadSettings, projectId])
 
   const maxHeight = Math.max(PANEL_MIN_HEIGHT, viewportHeight - statusBarHeight - 40)
   const userHeight = Math.min(Math.max(state.userHeight || DEFAULT_USER_HEIGHT, PANEL_MIN_HEIGHT), maxHeight)

--- a/client/src/components/terminal/__tests__/BottomPanel.test.tsx
+++ b/client/src/components/terminal/__tests__/BottomPanel.test.tsx
@@ -1,10 +1,19 @@
 /** @vitest-environment jsdom */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { BottomPanel } from '../BottomPanel'
 import { TerminalsProvider } from '../../../context/TerminalsContext'
 import type { ProjectPanelState, TerminalRef } from '../../../context/TerminalsContext'
+import { DEFAULT_TERMINAL_SETTINGS, type TerminalSettings } from '../../../lib/terminal-settings-types'
+import { TERMINAL_SETTINGS_UPDATED_EVENT } from '../../../lib/terminal-settings-events'
+import { openExternalUrl } from '../../../lib/tauri-shell'
+
+vi.mock('../../../lib/tauri-shell', () => ({
+  isTauri: () => false,
+  revealItemInDir: vi.fn(),
+  openExternalUrl: vi.fn(),
+}))
 
 vi.mock('@xterm/xterm', () => {
   class Terminal {
@@ -66,6 +75,7 @@ function makeState(overrides: Partial<ProjectPanelState> = {}): ProjectPanelStat
 describe('BottomPanel', () => {
   beforeEach(() => {
     global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) })
+    vi.mocked(openExternalUrl).mockClear()
     localStorage.clear()
   })
 
@@ -135,6 +145,55 @@ describe('BottomPanel', () => {
     )
     fireEvent.click(getByLabelText(/^new terminal$/i))
     expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('refreshes shortcut settings when terminal settings are saved', async () => {
+    const oldSettings: TerminalSettings = {
+      ...DEFAULT_TERMINAL_SETTINGS,
+      browserShortcutUrl: 'https://old.example',
+      quickScript: '',
+    }
+    const newSettings: TerminalSettings = {
+      ...oldSettings,
+      browserShortcutUrl: 'https://new.example',
+      quickScript: 'npm test',
+    }
+    let resolved = oldSettings
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (String(url).endsWith('/terminal-settings')) {
+        return Promise.resolve({ ok: true, json: async () => ({ resolved }) })
+      }
+      if (String(url).endsWith('/terminals')) {
+        return Promise.resolve({ ok: true, json: async () => ({ sessions: [] }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+    global.fetch = fetchMock
+
+    const s: TerminalRef = { id: 's1', projectId: 'p', name: 'zsh', cols: 80, rows: 24, createdAt: 1 }
+    const { getByLabelText } = wrap(
+      <BottomPanel projectId="p" state={makeState({ sessions: [s], activeId: 's1' })} viewportHeight={800} statusBarHeight={28} />,
+    )
+
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.some(([url]) => String(url).endsWith('/terminal-settings'))).toBe(true)
+    })
+    fireEvent.click(getByLabelText('Open in browser'))
+    expect(openExternalUrl).toHaveBeenLastCalledWith('https://old.example')
+    expect(getByLabelText('No active terminal to paste into')).toBeDisabled()
+
+    resolved = newSettings
+    window.dispatchEvent(new CustomEvent(TERMINAL_SETTINGS_UPDATED_EVENT, {
+      detail: { mode: 'project', projectId: 'p' },
+    }))
+
+    await waitFor(() => {
+      const terminalSettingsCalls = fetchMock.mock.calls.filter(([url]) => String(url).endsWith('/terminal-settings'))
+      expect(terminalSettingsCalls).toHaveLength(2)
+    })
+    fireEvent.click(getByLabelText('Open in browser'))
+    expect(openExternalUrl).toHaveBeenLastCalledWith('https://new.example')
+    expect(getByLabelText('Paste quick script into active terminal')).not.toBeDisabled()
   })
 
   it('kill-active button fires DELETE', () => {

--- a/client/src/lib/terminal-settings-events.ts
+++ b/client/src/lib/terminal-settings-events.ts
@@ -1,0 +1,11 @@
+export const TERMINAL_SETTINGS_UPDATED_EVENT = 'specrails:terminal-settings-updated'
+
+export interface TerminalSettingsUpdatedEventDetail {
+  mode: 'hub' | 'project'
+  projectId: string | null
+}
+
+export function dispatchTerminalSettingsUpdated(detail: TerminalSettingsUpdatedEventDetail): void {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(new CustomEvent(TERMINAL_SETTINGS_UPDATED_EVENT, { detail }))
+}


### PR DESCRIPTION
## Summary
- emit a client-side terminal settings update event after hub or project terminal settings save
- make the terminal bottom panel refetch resolved settings when that event fires
- add regression coverage for browser shortcut and quick script refresh behavior

## Tests
- cd client && npx vitest run src/components/terminal/__tests__/BottomPanel.test.tsx
- npm run typecheck