### PR TITLE
Fix terminal, Claude, and desktop chrome bugs

### DIFF
--- a/client/src/components/ChatInput.tsx
+++ b/client/src/components/ChatInput.tsx
@@ -4,9 +4,9 @@ import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip'
 import { cn } from '../lib/utils'
 
 const CLAUDE_MODEL_OPTIONS = [
-  { value: 'claude-opus-4-7', label: 'Opus 4.7' },
-  { value: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
-  { value: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
+  { value: 'opus', label: 'Opus' },
+  { value: 'sonnet', label: 'Sonnet' },
+  { value: 'haiku', label: 'Haiku' },
 ]
 
 const CODEX_MODEL_OPTIONS = [

--- a/client/src/components/ModelCombobox.tsx
+++ b/client/src/components/ModelCombobox.tsx
@@ -14,9 +14,9 @@ interface ModelOption {
 }
 
 export const MODEL_OPTIONS: ModelOption[] = [
-  { alias: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4-6',          tier: 'Balanced',     tierColor: 'neutral' },
-  { alias: 'opus',   label: 'Opus',   fullId: 'claude-opus-4-7',            tier: 'Most capable', tierColor: 'accent'  },
-  { alias: 'haiku',  label: 'Haiku',  fullId: 'claude-haiku-4-5-20251001',  tier: 'Fastest',      tierColor: 'green'   },
+  { alias: 'sonnet', label: 'Sonnet', fullId: 'Claude Code alias: sonnet', tier: 'Balanced',     tierColor: 'neutral' },
+  { alias: 'opus',   label: 'Opus',   fullId: 'Claude Code alias: opus',   tier: 'Most capable', tierColor: 'accent'  },
+  { alias: 'haiku',  label: 'Haiku',  fullId: 'Claude Code alias: haiku',  tier: 'Fastest',      tierColor: 'green'   },
 ]
 
 function tierBadgeClass(color: ModelOption['tierColor']): string {

--- a/client/src/components/ModelSelector.tsx
+++ b/client/src/components/ModelSelector.tsx
@@ -17,11 +17,9 @@ export interface ModelOverrides {
 }
 
 export const CLAUDE_MODELS = [
-  { value: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
-  { value: 'claude-opus-4-5', label: 'Claude Opus 4.5' },
-  { value: 'claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5' },
-  { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
-  { value: 'claude-opus-4-7', label: 'Claude Opus 4.7' },
+  { value: 'sonnet', label: 'Claude Sonnet' },
+  { value: 'opus', label: 'Claude Opus' },
+  { value: 'haiku', label: 'Claude Haiku' },
 ]
 
 export const CODEX_MODELS = [
@@ -32,15 +30,15 @@ export const CODEX_MODELS = [
 
 // Preset → default model per provider (matches specrails-core MODEL_PRESETS)
 export const PRESET_DEFAULTS: Record<ModelPreset, { claude: string; codex: string }> = {
-  balanced: { claude: 'claude-sonnet-4-6', codex: 'gpt-5.4-mini' },
-  budget: { claude: 'claude-haiku-4-5-20251001', codex: 'gpt-5.4-mini' },
-  max: { claude: 'claude-sonnet-4-6', codex: 'gpt-5.4-mini' },
+  balanced: { claude: 'sonnet', codex: 'gpt-5.4-mini' },
+  budget: { claude: 'haiku', codex: 'gpt-5.4-mini' },
+  max: { claude: 'sonnet', codex: 'gpt-5.4-mini' },
 }
 
 // "max" preset: Opus for architect + PM, Sonnet for rest (matches specrails-core)
 const MAX_OVERRIDES: Record<string, { claude: string; codex: string }> = {
-  'sr-architect': { claude: 'claude-opus-4-7', codex: 'gpt-5.3-codex' },
-  'sr-product-manager': { claude: 'claude-opus-4-7', codex: 'gpt-5.3-codex' },
+  'sr-architect': { claude: 'opus', codex: 'gpt-5.3-codex' },
+  'sr-product-manager': { claude: 'opus', codex: 'gpt-5.3-codex' },
 }
 
 export function getDefaultModel(

--- a/client/src/components/TitleBar.tsx
+++ b/client/src/components/TitleBar.tsx
@@ -20,12 +20,18 @@ function isMacOverlay(): boolean {
 interface WinButtonProps {
   onClick: () => void
   icon: React.ReactNode
-  hoverColor: string
+  hoverColor?: string
   hoverTextColor?: string
   ariaLabel: string
 }
 
-function WinButton({ onClick, icon, hoverColor, hoverTextColor = '#f8f8f2', ariaLabel }: WinButtonProps) {
+function WinButton({
+  onClick,
+  icon,
+  hoverColor = 'var(--color-accent)',
+  hoverTextColor = 'var(--color-accent-foreground)',
+  ariaLabel,
+}: WinButtonProps) {
   const [hovered, setHovered] = useState(false)
 
   return (
@@ -44,7 +50,7 @@ function WinButton({ onClick, icon, hoverColor, hoverTextColor = '#f8f8f2', aria
         border: 'none',
         cursor: 'pointer',
         background: hovered ? hoverColor : 'transparent',
-        color: hovered ? hoverTextColor : 'rgba(248,248,242,0.62)',
+        color: hovered ? hoverTextColor : 'var(--color-muted-foreground)',
         transition: 'background 0.12s ease, color 0.12s ease',
         WebkitAppRegion: 'no-drag',
       } as React.CSSProperties}
@@ -87,10 +93,12 @@ function SearchPill({ projectName }: { projectName: string | null }) {
         paddingLeft: 8,
         paddingRight: 8,
         borderRadius: 9999,
-        border: 'none',
+        border: '1px solid color-mix(in srgb, var(--color-border) 70%, transparent)',
         cursor: 'pointer',
-        background: hovered ? 'rgba(255,255,255,0.12)' : 'rgba(255,255,255,0.07)',
-        color: projectName ? '#f8f8f2' : 'rgba(248,248,242,0.45)',
+        background: hovered
+          ? 'color-mix(in srgb, var(--color-accent) 82%, transparent)'
+          : 'color-mix(in srgb, var(--color-surface) 72%, transparent)',
+        color: projectName ? 'var(--color-foreground)' : 'var(--color-muted-foreground)',
         fontSize: 12,
         fontWeight: 400,
         letterSpacing: 0,
@@ -103,7 +111,7 @@ function SearchPill({ projectName }: { projectName: string | null }) {
     >
       <Search
         size={11}
-        style={{ flexShrink: 0, opacity: projectName ? 0.7 : 0.45 }}
+        style={{ flexShrink: 0, opacity: projectName ? 0.72 : 0.48 }}
       />
       <span
         style={{
@@ -154,12 +162,12 @@ function MacTitleBar() {
         position: 'relative',
         height: 28,
         minHeight: 28,
-        background: '#282a36',
+        background: 'var(--color-background-deep)',
         display: 'flex',
         alignItems: 'center',
         userSelect: 'none',
         flexShrink: 0,
-        borderBottom: '1px solid #44475a',
+        borderBottom: '1px solid var(--color-border)',
       }}
     >
       <SearchPill projectName={activeProject?.name ?? null} />
@@ -191,14 +199,14 @@ function DefaultTitleBar() {
         position: 'relative',
         height: 36,
         minHeight: 36,
-        background: '#282a36',
+        background: 'var(--color-background-deep)',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'space-between',
         padding: '0 10px',
         userSelect: 'none',
         flexShrink: 0,
-        borderBottom: '1px solid #44475a',
+        borderBottom: '1px solid var(--color-border)',
       }}
     >
       <SearchPill projectName={activeProject?.name ?? null} />
@@ -219,20 +227,18 @@ function DefaultTitleBar() {
         <WinButton
           onClick={handleMinimize}
           icon={<Minus size={14} strokeWidth={1.8} />}
-          hoverColor="rgba(68,71,90,0.8)"
           ariaLabel="Minimize window"
         />
         <WinButton
           onClick={handleMaximize}
           icon={<Square size={12} strokeWidth={1.8} />}
-          hoverColor="rgba(68,71,90,0.8)"
           ariaLabel="Maximize window"
         />
         <WinButton
           onClick={handleClose}
           icon={<X size={15} strokeWidth={1.8} />}
-          hoverColor="rgba(255,85,85,0.92)"
-          hoverTextColor="#282a36"
+          hoverColor="var(--color-destructive)"
+          hoverTextColor="var(--color-destructive-foreground)"
           ariaLabel="Close window"
         />
       </div>

--- a/client/src/components/__tests__/ChatInput.test.tsx
+++ b/client/src/components/__tests__/ChatInput.test.tsx
@@ -6,7 +6,7 @@ import { ChatInput } from '../ChatInput'
 
 const defaultProps = {
   conversationId: 'conv-1',
-  model: 'claude-sonnet-4-6',
+  model: 'sonnet',
   hasMessages: false,
   isStreaming: false,
   onSend: vi.fn(),
@@ -114,9 +114,9 @@ describe('ChatInput', () => {
   })
 
   it('model selector shows current model', () => {
-    render(<ChatInput {...defaultProps} model="claude-sonnet-4-6" />)
+    render(<ChatInput {...defaultProps} model="sonnet" />)
     const select = screen.getByRole('combobox') as HTMLSelectElement
-    expect(select.value).toBe('claude-sonnet-4-6')
+    expect(select.value).toBe('sonnet')
   })
 
   it('model selector is disabled when hasMessages is true', () => {
@@ -136,8 +136,8 @@ describe('ChatInput', () => {
     const onModelChange = vi.fn()
     render(<ChatInput {...defaultProps} onModelChange={onModelChange} />)
     const select = screen.getByRole('combobox')
-    await user.selectOptions(select, 'claude-opus-4-7')
-    expect(onModelChange).toHaveBeenCalledWith('claude-opus-4-7')
+    await user.selectOptions(select, 'opus')
+    expect(onModelChange).toHaveBeenCalledWith('opus')
   })
 
   it('when provider=codex, dropdown lists gpt-5.4-mini as the first option', () => {

--- a/client/src/components/__tests__/ModelCombobox.test.tsx
+++ b/client/src/components/__tests__/ModelCombobox.test.tsx
@@ -6,10 +6,10 @@ import { ModelCombobox } from '../ModelCombobox'
 
 // ─── ModelCombobox ────────────────────────────────────────────────────────────
 //
-// ModelCombobox is a Radix Select wrapping the three Claude model aliases:
-//   sonnet  → label "Sonnet", tier badge "Balanced", full ID "claude-sonnet-4-6"
-//   opus    → label "Opus",   tier badge "Most capable", full ID "claude-opus-4-7"
-//   haiku   → label "Haiku",  tier badge "Fastest",     full ID "claude-haiku-4-5-20251001"
+// ModelCombobox is a Radix Select wrapping the three Claude Code model aliases:
+//   sonnet  → label "Sonnet", tier badge "Balanced"
+//   opus    → label "Opus",   tier badge "Most capable"
+//   haiku   → label "Haiku",  tier badge "Fastest"
 //
 // Tests verify: static render, option display, onChange callback, disabled state.
 // Radix Select portals render in document.body — queried via screen.getByRole.
@@ -78,21 +78,21 @@ describe('ModelCombobox', () => {
     const user = userEvent.setup()
     render(<ModelCombobox value="sonnet" onChange={vi.fn()} />)
     await user.click(screen.getByRole('combobox'))
-    expect(screen.getByText(/claude-sonnet-4-6/i)).toBeInTheDocument()
+    expect(screen.getByText(/alias: sonnet/i)).toBeInTheDocument()
   })
 
   it('shows full model ID for opus option', async () => {
     const user = userEvent.setup()
     render(<ModelCombobox value="sonnet" onChange={vi.fn()} />)
     await user.click(screen.getByRole('combobox'))
-    expect(screen.getByText(/claude-opus-4-7/i)).toBeInTheDocument()
+    expect(screen.getByText(/alias: opus/i)).toBeInTheDocument()
   })
 
   it('shows full model ID for haiku option', async () => {
     const user = userEvent.setup()
     render(<ModelCombobox value="sonnet" onChange={vi.fn()} />)
     await user.click(screen.getByRole('combobox'))
-    expect(screen.getByText(/claude-haiku-4-5-20251001/i)).toBeInTheDocument()
+    expect(screen.getByText(/alias: haiku/i)).toBeInTheDocument()
   })
 
   it('calls onChange with "opus" when opus option is selected', async () => {

--- a/client/src/components/__tests__/ModelSelector.test.tsx
+++ b/client/src/components/__tests__/ModelSelector.test.tsx
@@ -11,27 +11,27 @@ const SAMPLE_AGENTS: AgentDef[] = [
 
 describe('getDefaultModel', () => {
   it('returns sonnet for non-special agents in balanced preset (claude)', () => {
-    expect(getDefaultModel('sr-developer', 'balanced', 'claude')).toBe('claude-sonnet-4-6')
+    expect(getDefaultModel('sr-developer', 'balanced', 'claude')).toBe('sonnet')
   })
 
   it('returns sonnet for architect in balanced preset (claude)', () => {
-    expect(getDefaultModel('sr-architect', 'balanced', 'claude')).toBe('claude-sonnet-4-6')
+    expect(getDefaultModel('sr-architect', 'balanced', 'claude')).toBe('sonnet')
   })
 
   it('returns sonnet for product-manager in balanced preset (claude)', () => {
-    expect(getDefaultModel('sr-product-manager', 'balanced', 'claude')).toBe('claude-sonnet-4-6')
+    expect(getDefaultModel('sr-product-manager', 'balanced', 'claude')).toBe('sonnet')
   })
 
   it('returns haiku for budget preset (claude)', () => {
-    expect(getDefaultModel('sr-developer', 'budget', 'claude')).toBe('claude-haiku-4-5-20251001')
+    expect(getDefaultModel('sr-developer', 'budget', 'claude')).toBe('haiku')
   })
 
   it('returns sonnet for non-special agents in max preset (claude)', () => {
-    expect(getDefaultModel('sr-developer', 'max', 'claude')).toBe('claude-sonnet-4-6')
+    expect(getDefaultModel('sr-developer', 'max', 'claude')).toBe('sonnet')
   })
 
   it('returns opus for architect in max preset (claude)', () => {
-    expect(getDefaultModel('sr-architect', 'max', 'claude')).toBe('claude-opus-4-7')
+    expect(getDefaultModel('sr-architect', 'max', 'claude')).toBe('opus')
   })
 
   it('returns gpt-5.4-mini for budget preset (codex)', () => {
@@ -114,7 +114,7 @@ describe('ModelSelector', () => {
         agents={SAMPLE_AGENTS}
         provider="claude"
         preset="balanced"
-        overrides={{ 'sr-developer': 'claude-opus-4-7' }}
+        overrides={{ 'sr-developer': 'opus' }}
         onPresetChange={vi.fn()}
         onOverrideChange={vi.fn()}
       />
@@ -129,7 +129,7 @@ describe('ModelSelector', () => {
         agents={SAMPLE_AGENTS}
         provider="claude"
         preset="balanced"
-        overrides={{ 'sr-developer': 'claude-opus-4-7' }}
+        overrides={{ 'sr-developer': 'opus' }}
         onPresetChange={vi.fn()}
         onOverrideChange={onOverrideChange}
       />
@@ -145,7 +145,7 @@ describe('ModelSelector', () => {
         agents={SAMPLE_AGENTS}
         provider="claude"
         preset="balanced"
-        overrides={{ 'sr-developer': 'claude-opus-4-7', 'sr-architect': 'claude-haiku-4-5-20251001' }}
+        overrides={{ 'sr-developer': 'opus', 'sr-architect': 'haiku' }}
         onPresetChange={vi.fn()}
         onOverrideChange={vi.fn()}
       />

--- a/client/src/components/__tests__/TitleBar.test.tsx
+++ b/client/src/components/__tests__/TitleBar.test.tsx
@@ -1,0 +1,64 @@
+/** @vitest-environment jsdom */
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { TitleBar } from '../TitleBar'
+
+const mocks = vi.hoisted(() => ({
+  minimize: vi.fn(),
+  toggleMaximize: vi.fn(),
+  close: vi.fn(),
+  useHub: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({
+    minimize: mocks.minimize,
+    toggleMaximize: mocks.toggleMaximize,
+    close: mocks.close,
+  }),
+}))
+
+vi.mock('../../hooks/useHub', () => ({
+  useHub: () => mocks.useHub(),
+}))
+
+describe('TitleBar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.useHub.mockReturnValue({
+      projects: [{ id: 'p1', name: 'Project One' }],
+      activeProjectId: 'p1',
+    })
+    Object.defineProperty(window, '__TAURI_INTERNALS__', { value: {}, configurable: true })
+  })
+
+  it('renders nothing outside Tauri', () => {
+    delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__
+    const { container } = render(<TitleBar />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('uses theme tokens for the macOS overlay titlebar', () => {
+    Object.defineProperty(navigator, 'platform', { value: 'MacIntel', configurable: true })
+    render(<TitleBar />)
+
+    const titlebar = screen.getByLabelText('Search (⌘K)').parentElement as HTMLElement
+    expect(titlebar.style.background).toBe('var(--color-background-deep)')
+    expect(titlebar.style.borderBottom).toBe('1px solid var(--color-border)')
+    expect(screen.getByLabelText('Search (⌘K)')).toHaveStyle({
+      color: 'var(--color-foreground)',
+    })
+  })
+
+  it('uses theme tokens for default window controls', () => {
+    Object.defineProperty(navigator, 'platform', { value: 'Linux x86_64', configurable: true })
+    render(<TitleBar />)
+
+    const titlebar = screen.getByLabelText('Minimize window').closest('[data-tauri-drag-region]') as HTMLElement
+    expect(titlebar.style.background).toBe('var(--color-background-deep)')
+    expect(titlebar.style.borderBottom).toBe('1px solid var(--color-border)')
+    expect(screen.getByLabelText('Minimize window')).toHaveStyle({
+      color: 'var(--color-muted-foreground)',
+    })
+  })
+})

--- a/client/src/components/settings/TerminalSettingsSection.tsx
+++ b/client/src/components/settings/TerminalSettingsSection.tsx
@@ -12,6 +12,7 @@ import {
   type TerminalSettings,
   type TerminalRenderMode,
 } from '../../lib/terminal-settings-types'
+import { dispatchTerminalSettingsUpdated } from '../../lib/terminal-settings-events'
 
 interface Props {
   /** Hub mode edits hub_settings; project mode edits a per-project override layer. */
@@ -128,6 +129,7 @@ export function TerminalSettingsSection({ mode }: Props) {
         if (!res.ok) throw new Error((await res.text()) || 'patch failed')
         const updated = (await res.json()) as TerminalSettings
         setHub(updated); setSavedResolved(updated); setDraft(updated); setClearedFields(new Set())
+        dispatchTerminalSettingsUpdated({ mode: 'hub', projectId: null })
         toast.success('Terminal settings saved')
       } else if (activeProjectId) {
         const res = await fetch(`/api/projects/${activeProjectId}/terminal-settings`, {
@@ -139,6 +141,7 @@ export function TerminalSettingsSection({ mode }: Props) {
         const updated = (await res.json()) as ProjectResponse
         setHub(updated.hubDefaults); setOverride(updated.override); setSavedResolved(updated.resolved); setDraft(updated.resolved)
         setClearedFields(new Set())
+        dispatchTerminalSettingsUpdated({ mode: 'project', projectId: activeProjectId })
         toast.success('Terminal settings saved')
       }
     } catch (err) {

--- a/client/src/components/terminal/BottomPanel.tsx
+++ b/client/src/components/terminal/BottomPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { cn } from '../../lib/utils'
 import {
@@ -9,6 +9,7 @@ import {
 import { openExternalUrl } from '../../lib/tauri-shell'
 import { DEFAULT_TERMINAL_SETTINGS, type TerminalSettings } from '../../lib/terminal-settings-types'
 import { TERMINAL_SETTINGS_UPDATED_EVENT, type TerminalSettingsUpdatedEventDetail } from '../../lib/terminal-settings-events'
+import { registerTauriDragDrop } from '../../lib/tauri-drag-drop'
 import { ShortcutContextMenu } from './ShortcutContextMenu'
 import { TerminalTopBar } from './TerminalTopBar'
 import { TerminalSidebar } from './TerminalSidebar'
@@ -27,6 +28,7 @@ interface BottomPanelProps {
 export function BottomPanel({ projectId, state, viewportHeight, statusBarHeight }: BottomPanelProps) {
   const t = useTerminals()
   const navigate = useNavigate()
+  const panelRef = useRef<HTMLDivElement | null>(null)
   const [livePreviewHeight, setLivePreviewHeight] = useState<number | null>(null)
   const [settings, setSettings] = useState<TerminalSettings>(DEFAULT_TERMINAL_SETTINGS)
   const [shortcutMenu, setShortcutMenu] = useState<{ x: number; y: number; kind: 'browser' | 'script' } | null>(null)
@@ -66,6 +68,36 @@ export function BottomPanel({ projectId, state, viewportHeight, statusBarHeight 
 
   const canCreate = state.sessions.length < TERMINAL_MAX_PER_PROJECT
   const hasActive = state.activeId !== null
+
+  useEffect(() => {
+    let disposed = false
+    let controller: { dispose: () => void } | null = null
+    void registerTauriDragDrop(() => {
+      const panel = panelRef.current
+      const activeId = state.activeId
+      if (!panel || !activeId || state.visibility === 'hidden') return null
+      return {
+        viewportEl: panel,
+        writeText: (text: string) => {
+          if (t.writeToSession(activeId, text)) return true
+          const term = t.getTerminalInstance(activeId)
+          try {
+            term?.paste(text)
+            return Boolean(term)
+          } catch {
+            return false
+          }
+        },
+      }
+    }).then((c) => {
+      if (disposed) c.dispose()
+      else controller = c
+    })
+    return () => {
+      disposed = true
+      controller?.dispose()
+    }
+  }, [state.activeId, state.visibility, t])
 
   const handleCreate = useCallback(() => {
     if (!canCreate) return
@@ -124,6 +156,7 @@ export function BottomPanel({ projectId, state, viewportHeight, statusBarHeight 
 
   return (
     <div
+      ref={panelRef}
       className={cn(
         'relative flex flex-col shrink-0 bg-background/95',
         'border-t border-border/40',

--- a/client/src/components/terminal/BottomPanel.tsx
+++ b/client/src/components/terminal/BottomPanel.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../context/TerminalsContext'
 import { openExternalUrl } from '../../lib/tauri-shell'
 import { DEFAULT_TERMINAL_SETTINGS, type TerminalSettings } from '../../lib/terminal-settings-types'
+import { TERMINAL_SETTINGS_UPDATED_EVENT, type TerminalSettingsUpdatedEventDetail } from '../../lib/terminal-settings-events'
 import { ShortcutContextMenu } from './ShortcutContextMenu'
 import { TerminalTopBar } from './TerminalTopBar'
 import { TerminalSidebar } from './TerminalSidebar'
@@ -30,20 +31,32 @@ export function BottomPanel({ projectId, state, viewportHeight, statusBarHeight 
   const [settings, setSettings] = useState<TerminalSettings>(DEFAULT_TERMINAL_SETTINGS)
   const [shortcutMenu, setShortcutMenu] = useState<{ x: number; y: number; kind: 'browser' | 'script' } | null>(null)
 
+  const loadSettings = useCallback(async (cancelled: () => boolean = () => false) => {
+    try {
+      const res = await fetch(`/api/projects/${projectId}/terminal-settings`)
+      if (!res.ok) return
+      const body = await res.json() as { resolved?: TerminalSettings }
+      if (!cancelled() && body?.resolved) setSettings(body.resolved)
+    } catch { /* ignore — keep current settings */ }
+  }, [projectId])
+
   // Resolve terminal settings (project override → hub default) for this project,
-  // so the Browser shortcut button uses the configured URL.
+  // so the shortcut buttons use the configured values.
   useEffect(() => {
     let cancelled = false
-    void (async () => {
-      try {
-        const res = await fetch(`/api/projects/${projectId}/terminal-settings`)
-        if (!res.ok) return
-        const body = await res.json() as { resolved?: TerminalSettings }
-        if (!cancelled && body?.resolved) setSettings(body.resolved)
-      } catch { /* ignore — keep defaults */ }
-    })()
+    void loadSettings(() => cancelled)
     return () => { cancelled = true }
-  }, [projectId])
+  }, [loadSettings])
+
+  useEffect(() => {
+    const onSettingsUpdated = (event: Event) => {
+      const detail = (event as CustomEvent<TerminalSettingsUpdatedEventDetail>).detail
+      if (detail?.mode === 'project' && detail.projectId !== projectId) return
+      void loadSettings()
+    }
+    window.addEventListener(TERMINAL_SETTINGS_UPDATED_EVENT, onSettingsUpdated)
+    return () => window.removeEventListener(TERMINAL_SETTINGS_UPDATED_EVENT, onSettingsUpdated)
+  }, [loadSettings, projectId])
 
   const maxHeight = Math.max(PANEL_MIN_HEIGHT, viewportHeight - statusBarHeight - 40)
   const userHeight = Math.min(Math.max(state.userHeight || DEFAULT_USER_HEIGHT, PANEL_MIN_HEIGHT), maxHeight)

--- a/client/src/components/terminal/TerminalViewport.tsx
+++ b/client/src/components/terminal/TerminalViewport.tsx
@@ -4,7 +4,6 @@ import { TerminalSearchOverlay } from './TerminalSearchOverlay'
 import { TerminalContextMenu } from './TerminalContextMenu'
 import { revealItemInDir, isTauri } from '../../lib/tauri-shell'
 import { saveScrollbackToFile } from '../../lib/save-scrollback'
-import { registerTauriDragDrop } from '../../lib/tauri-drag-drop'
 import { quotePathList } from '../../lib/shell-quote'
 import { PromptGutter } from './PromptGutter'
 import { CommandTimingBadge } from './CommandTimingBadge'
@@ -122,28 +121,6 @@ export function TerminalViewport({ activeId }: TerminalViewportProps) {
       try { void navigator.clipboard?.writeText(selection) } catch { /* ignore */ }
     }
   }, [term])
-
-  // Register Tauri drag-drop listener. Returns active session/viewport on demand.
-  useEffect(() => {
-    let disposed = false
-    let controller: { dispose: () => void } | null = null
-    void registerTauriDragDrop(() => {
-      const slot = slotRef.current
-      const t = activeId ? terminals.getTerminalInstance(activeId) : null
-      if (!slot || !t) return null
-      return {
-        viewportEl: slot,
-        writeText: (text: string) => writeToActiveTerminal(text),
-      }
-    }).then((c) => {
-      if (disposed) c.dispose()
-      else controller = c
-    })
-    return () => {
-      disposed = true
-      controller?.dispose()
-    }
-  }, [activeId, terminals, writeToActiveTerminal])
 
   useEffect(() => {
     const slot = slotRef.current

--- a/client/src/components/terminal/TerminalViewport.tsx
+++ b/client/src/components/terminal/TerminalViewport.tsx
@@ -5,6 +5,7 @@ import { TerminalContextMenu } from './TerminalContextMenu'
 import { revealItemInDir, isTauri } from '../../lib/tauri-shell'
 import { saveScrollbackToFile } from '../../lib/save-scrollback'
 import { registerTauriDragDrop } from '../../lib/tauri-drag-drop'
+import { quotePathList } from '../../lib/shell-quote'
 import { PromptGutter } from './PromptGutter'
 import { CommandTimingBadge } from './CommandTimingBadge'
 
@@ -43,6 +44,17 @@ export function TerminalViewport({ activeId }: TerminalViewportProps) {
   const cwd = activeId ? terminals.getCwd(activeId) : null
   const [dragOver, setDragOver] = useState(false)
 
+  const pasteDroppedFiles = useCallback((files: FileList | null | undefined): boolean => {
+    if (!term || !files || files.length === 0) return false
+    const paths = Array.from(files)
+      .map((file) => getNativeFilePath(file))
+      .filter((path): path is string => Boolean(path))
+    if (paths.length === 0) return false
+    const isWindows = typeof navigator !== 'undefined' && /Win/i.test(navigator.platform || '')
+    try { term.paste(quotePathList(paths, isWindows)) } catch { return false }
+    return true
+  }, [term])
+
   const handleContextMenu = useCallback((ev: React.MouseEvent) => {
     // Always preventDefault so the WebView's native contextmenu does not show.
     ev.preventDefault()
@@ -54,6 +66,50 @@ export function TerminalViewport({ activeId }: TerminalViewportProps) {
       if (mode && mode !== 'none') return
     }
     setMenu({ x: ev.clientX, y: ev.clientY })
+  }, [term])
+
+  const handlePaste = useCallback((ev: React.ClipboardEvent<HTMLDivElement>) => {
+    if (!term) return
+    const text = ev.clipboardData.getData('text/plain')
+    if (!text) return
+    ev.preventDefault()
+    ev.stopPropagation()
+    try { term.paste(text) } catch { /* ignore */ }
+  }, [term])
+
+  const handleCopy = useCallback((ev: React.ClipboardEvent<HTMLDivElement>) => {
+    if (!term) return
+    const selection = term.getSelection()
+    if (!selection) return
+    ev.clipboardData.setData('text/plain', selection)
+    ev.preventDefault()
+    ev.stopPropagation()
+  }, [term])
+
+  const handleKeyDownCapture = useCallback((ev: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!term) return
+    const isMac = typeof navigator !== 'undefined' && /Mac/i.test(navigator.platform || '')
+    const cmd = isMac ? ev.metaKey : ev.ctrlKey
+    if (!cmd) return
+    if (ev.key === 'v' || ev.key === 'V') {
+      ev.preventDefault()
+      ev.stopPropagation()
+      try {
+        void navigator.clipboard?.readText().then((text) => {
+          if (text) {
+            try { term.paste(text) } catch { /* ignore */ }
+          }
+        })
+      } catch { /* ignore */ }
+      return
+    }
+    if (ev.key === 'c' || ev.key === 'C') {
+      const selection = term.getSelection()
+      if (!selection) return
+      ev.preventDefault()
+      ev.stopPropagation()
+      try { void navigator.clipboard?.writeText(selection) } catch { /* ignore */ }
+    }
   }, [term])
 
   // Register Tauri drag-drop listener. Returns active session/viewport on demand.
@@ -122,13 +178,31 @@ export function TerminalViewport({ activeId }: TerminalViewportProps) {
       role="presentation"
       data-terminal-viewport
       onContextMenu={handleContextMenu}
-      onDragEnter={(e) => { if (e.dataTransfer?.types?.includes('Files')) { e.preventDefault(); setDragOver(true) } }}
-      onDragOver={(e) => { if (e.dataTransfer?.types?.includes('Files')) { e.preventDefault(); setDragOver(true) } }}
+      onPasteCapture={handlePaste}
+      onCopyCapture={handleCopy}
+      onKeyDownCapture={handleKeyDownCapture}
+      tabIndex={-1}
+      onDragEnter={(e) => {
+        if (hasFileTransfer(e.dataTransfer)) {
+          e.preventDefault()
+          e.stopPropagation()
+          setDragOver(true)
+        }
+      }}
+      onDragOver={(e) => {
+        if (hasFileTransfer(e.dataTransfer)) {
+          e.preventDefault()
+          e.stopPropagation()
+          setDragOver(true)
+        }
+      }}
       onDragLeave={() => setDragOver(false)}
       onDrop={(e) => {
-        // Browser drop has no path; we render highlight only and let Tauri's
-        // native event handle the actual paste in the desktop app.
-        if (e.dataTransfer?.types?.includes('Files')) e.preventDefault()
+        if (hasFileTransfer(e.dataTransfer)) {
+          e.preventDefault()
+          e.stopPropagation()
+          pasteDroppedFiles(e.dataTransfer.files)
+        }
         setDragOver(false)
       }}
     >
@@ -152,4 +226,15 @@ export function TerminalViewport({ activeId }: TerminalViewportProps) {
       )}
     </div>
   )
+}
+
+function getNativeFilePath(file: File): string | null {
+  const path = (file as File & { path?: unknown }).path
+  if (typeof path === 'string' && path.length > 0) return path
+  return null
+}
+
+function hasFileTransfer(dataTransfer: DataTransfer | null): boolean {
+  if (!dataTransfer) return false
+  return Array.from(dataTransfer.types).includes('Files')
 }

--- a/client/src/components/terminal/TerminalViewport.tsx
+++ b/client/src/components/terminal/TerminalViewport.tsx
@@ -44,6 +44,18 @@ export function TerminalViewport({ activeId }: TerminalViewportProps) {
   const cwd = activeId ? terminals.getCwd(activeId) : null
   const [dragOver, setDragOver] = useState(false)
 
+  const writeToActiveTerminal = useCallback((text: string): boolean => {
+    if (!text) return false
+    if (activeId && terminals.writeToSession(activeId, text)) return true
+    if (!term) return false
+    try {
+      term.paste(text)
+      return true
+    } catch {
+      return false
+    }
+  }, [activeId, terminals, term])
+
   const pasteDroppedFiles = useCallback((files: FileList | null | undefined): boolean => {
     if (!term || !files || files.length === 0) return false
     const paths = Array.from(files)
@@ -51,9 +63,8 @@ export function TerminalViewport({ activeId }: TerminalViewportProps) {
       .filter((path): path is string => Boolean(path))
     if (paths.length === 0) return false
     const isWindows = typeof navigator !== 'undefined' && /Win/i.test(navigator.platform || '')
-    try { term.paste(quotePathList(paths, isWindows)) } catch { return false }
-    return true
-  }, [term])
+    return writeToActiveTerminal(quotePathList(paths, isWindows))
+  }, [term, writeToActiveTerminal])
 
   const handleContextMenu = useCallback((ev: React.MouseEvent) => {
     // Always preventDefault so the WebView's native contextmenu does not show.
@@ -74,8 +85,8 @@ export function TerminalViewport({ activeId }: TerminalViewportProps) {
     if (!text) return
     ev.preventDefault()
     ev.stopPropagation()
-    try { term.paste(text) } catch { /* ignore */ }
-  }, [term])
+    writeToActiveTerminal(text)
+  }, [term, writeToActiveTerminal])
 
   const handleCopy = useCallback((ev: React.ClipboardEvent<HTMLDivElement>) => {
     if (!term) return
@@ -97,7 +108,7 @@ export function TerminalViewport({ activeId }: TerminalViewportProps) {
       try {
         void navigator.clipboard?.readText().then((text) => {
           if (text) {
-            try { term.paste(text) } catch { /* ignore */ }
+            writeToActiveTerminal(text)
           }
         })
       } catch { /* ignore */ }
@@ -120,7 +131,10 @@ export function TerminalViewport({ activeId }: TerminalViewportProps) {
       const slot = slotRef.current
       const t = activeId ? terminals.getTerminalInstance(activeId) : null
       if (!slot || !t) return null
-      return { term: t, viewportEl: slot }
+      return {
+        viewportEl: slot,
+        writeText: (text: string) => writeToActiveTerminal(text),
+      }
     }).then((c) => {
       if (disposed) c.dispose()
       else controller = c
@@ -129,7 +143,7 @@ export function TerminalViewport({ activeId }: TerminalViewportProps) {
       disposed = true
       controller?.dispose()
     }
-  }, [activeId, terminals])
+  }, [activeId, terminals, writeToActiveTerminal])
 
   useEffect(() => {
     const slot = slotRef.current

--- a/client/src/components/terminal/__tests__/BottomPanel.test.tsx
+++ b/client/src/components/terminal/__tests__/BottomPanel.test.tsx
@@ -1,10 +1,19 @@
 /** @vitest-environment jsdom */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { BottomPanel } from '../BottomPanel'
 import { TerminalsProvider } from '../../../context/TerminalsContext'
 import type { ProjectPanelState, TerminalRef } from '../../../context/TerminalsContext'
+import { DEFAULT_TERMINAL_SETTINGS, type TerminalSettings } from '../../../lib/terminal-settings-types'
+import { TERMINAL_SETTINGS_UPDATED_EVENT } from '../../../lib/terminal-settings-events'
+import { openExternalUrl } from '../../../lib/tauri-shell'
+
+vi.mock('../../../lib/tauri-shell', () => ({
+  isTauri: () => false,
+  revealItemInDir: vi.fn(),
+  openExternalUrl: vi.fn(),
+}))
 
 vi.mock('@xterm/xterm', () => {
   class Terminal {
@@ -66,6 +75,7 @@ function makeState(overrides: Partial<ProjectPanelState> = {}): ProjectPanelStat
 describe('BottomPanel', () => {
   beforeEach(() => {
     global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) })
+    vi.mocked(openExternalUrl).mockClear()
     localStorage.clear()
   })
 
@@ -135,6 +145,55 @@ describe('BottomPanel', () => {
     )
     fireEvent.click(getByLabelText(/^new terminal$/i))
     expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('refreshes shortcut settings when terminal settings are saved', async () => {
+    const oldSettings: TerminalSettings = {
+      ...DEFAULT_TERMINAL_SETTINGS,
+      browserShortcutUrl: 'https://old.example',
+      quickScript: '',
+    }
+    const newSettings: TerminalSettings = {
+      ...oldSettings,
+      browserShortcutUrl: 'https://new.example',
+      quickScript: 'npm test',
+    }
+    let resolved = oldSettings
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (String(url).endsWith('/terminal-settings')) {
+        return Promise.resolve({ ok: true, json: async () => ({ resolved }) })
+      }
+      if (String(url).endsWith('/terminals')) {
+        return Promise.resolve({ ok: true, json: async () => ({ sessions: [] }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+    global.fetch = fetchMock
+
+    const s: TerminalRef = { id: 's1', projectId: 'p', name: 'zsh', cols: 80, rows: 24, createdAt: 1 }
+    const { getByLabelText } = wrap(
+      <BottomPanel projectId="p" state={makeState({ sessions: [s], activeId: 's1' })} viewportHeight={800} statusBarHeight={28} />,
+    )
+
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.some(([url]) => String(url).endsWith('/terminal-settings'))).toBe(true)
+    })
+    fireEvent.click(getByLabelText('Open in browser'))
+    expect(openExternalUrl).toHaveBeenLastCalledWith('https://old.example')
+    expect(getByLabelText('No active terminal to paste into')).toBeDisabled()
+
+    resolved = newSettings
+    window.dispatchEvent(new CustomEvent(TERMINAL_SETTINGS_UPDATED_EVENT, {
+      detail: { mode: 'project', projectId: 'p' },
+    }))
+
+    await waitFor(() => {
+      const terminalSettingsCalls = fetchMock.mock.calls.filter(([url]) => String(url).endsWith('/terminal-settings'))
+      expect(terminalSettingsCalls).toHaveLength(2)
+    })
+    fireEvent.click(getByLabelText('Open in browser'))
+    expect(openExternalUrl).toHaveBeenLastCalledWith('https://new.example')
+    expect(getByLabelText('Paste quick script into active terminal')).not.toBeDisabled()
   })
 
   it('kill-active button fires DELETE', () => {

--- a/client/src/components/terminal/__tests__/TerminalViewport.test.tsx
+++ b/client/src/components/terminal/__tests__/TerminalViewport.test.tsx
@@ -1,44 +1,163 @@
 /** @vitest-environment jsdom */
-import { describe, it, expect, vi } from 'vitest'
-import { render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, waitFor } from '@testing-library/react'
 import { TerminalViewport } from '../TerminalViewport'
-import { TerminalsProvider } from '../../../context/TerminalsContext'
 
-vi.mock('@xterm/xterm', () => {
-  class Terminal {
-    cols = 80; rows = 24; element: HTMLElement | null = null
-    loadAddon = vi.fn(); open = vi.fn(); focus = vi.fn(); dispose = vi.fn()
-    write = vi.fn(); onData = () => ({ dispose: vi.fn() }); onResize = () => ({ dispose: vi.fn() })
+const mocks = vi.hoisted(() => ({
+  useTerminals: vi.fn(),
+}))
+
+vi.mock('../../../context/TerminalsContext', () => ({
+  useTerminals: () => mocks.useTerminals(),
+}))
+
+vi.mock('../../../lib/tauri-shell', () => ({
+  isTauri: () => false,
+  revealItemInDir: vi.fn(),
+}))
+
+vi.mock('../PromptGutter', () => ({
+  PromptGutter: () => null,
+}))
+
+vi.mock('../CommandTimingBadge', () => ({
+  CommandTimingBadge: () => null,
+}))
+
+function makeTerm(overrides: Partial<FakeTerminal> = {}): FakeTerminal {
+  return {
+    paste: vi.fn(),
+    getSelection: vi.fn(() => ''),
+    modes: { mouseTrackingMode: 'none' },
+    ...overrides,
   }
-  return { Terminal }
-})
-vi.mock('@xterm/addon-fit', () => ({ FitAddon: class { fit = vi.fn() } }))
-vi.mock('@xterm/addon-web-links', () => ({ WebLinksAddon: class {} }))
-vi.mock('@xterm/xterm/css/xterm.css', () => ({}))
-class MockWebSocket extends EventTarget {
-  readyState = 0; binaryType = 'arraybuffer'
-  constructor(_: string) { super() }
-  send() {} close() { this.readyState = 3 }
 }
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-;(globalThis as any).WebSocket = MockWebSocket
+
+interface FakeTerminal {
+  paste: ReturnType<typeof vi.fn>
+  getSelection: ReturnType<typeof vi.fn>
+  modes: { mouseTrackingMode: string }
+}
+
+function mockTerminals(term: FakeTerminal | null = null) {
+  mocks.useTerminals.mockReturnValue({
+    subscribeOpenSearch: vi.fn(() => undefined),
+    getSearchAddon: vi.fn(() => null),
+    getTerminalInstance: vi.fn(() => term),
+    getCwd: vi.fn(() => null),
+    getContainer: vi.fn(() => null),
+    notifyAdopted: vi.fn(),
+    refitActive: vi.fn(),
+  })
+}
 
 describe('TerminalViewport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockTerminals(null)
+  })
+
   it('renders a slot element', () => {
-    const { container } = render(
-      <TerminalsProvider activeProjectId="p">
-        <TerminalViewport activeId={null} />
-      </TerminalsProvider>,
-    )
+    const { container } = render(<TerminalViewport activeId={null} />)
     expect(container.querySelector('[data-terminal-viewport]')).toBeTruthy()
   })
 
   it('returns without error when activeId has no container yet', () => {
-    const { container } = render(
-      <TerminalsProvider activeProjectId="p">
-        <TerminalViewport activeId="missing-id" />
-      </TerminalsProvider>,
-    )
+    const { container } = render(<TerminalViewport activeId="missing-id" />)
     expect(container.querySelector('[data-terminal-viewport]')).toBeTruthy()
+  })
+
+  it('pastes native file paths instead of allowing file previews on drop', () => {
+    const term = makeTerm()
+    mockTerminals(term)
+    const { container } = render(<TerminalViewport activeId="s1" />)
+    const slot = container.querySelector('[data-terminal-viewport]') as HTMLElement
+    const file = new File(['hello'], 'hello.txt', { type: 'text/plain' })
+    Object.defineProperty(file, 'path', { value: '/Users/javi/Desktop/hello.txt' })
+
+    const event = new Event('drop', { bubbles: true, cancelable: true })
+    Object.defineProperty(event, 'dataTransfer', {
+      value: {
+        types: ['Files'],
+        files: [file],
+      },
+    })
+    event.stopPropagation = vi.fn()
+    fireEvent(slot, event)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(event.stopPropagation).toHaveBeenCalled()
+    expect(term.paste).toHaveBeenCalledWith("'/Users/javi/Desktop/hello.txt'")
+  })
+
+  it('prevents file drops without native paths so the WebView does not render previews', () => {
+    const term = makeTerm()
+    mockTerminals(term)
+    const { container } = render(<TerminalViewport activeId="s1" />)
+    const slot = container.querySelector('[data-terminal-viewport]') as HTMLElement
+    const file = new File(['hello'], 'hello.txt', { type: 'text/plain' })
+
+    const event = new Event('drop', { bubbles: true, cancelable: true })
+    Object.defineProperty(event, 'dataTransfer', {
+      value: {
+        types: ['Files'],
+        files: [file],
+      },
+    })
+    event.stopPropagation = vi.fn()
+    fireEvent(slot, event)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(event.stopPropagation).toHaveBeenCalled()
+    expect(term.paste).not.toHaveBeenCalled()
+  })
+
+  it('captures native paste events and writes text to the terminal', () => {
+    const term = makeTerm()
+    mockTerminals(term)
+    const { container } = render(<TerminalViewport activeId="s1" />)
+    const slot = container.querySelector('[data-terminal-viewport]') as HTMLElement
+
+    fireEvent.paste(slot, {
+      clipboardData: {
+        getData: (format: string) => format === 'text/plain' ? 'npm test' : '',
+      },
+    })
+
+    expect(term.paste).toHaveBeenCalledWith('npm test')
+  })
+
+  it('uses navigator clipboard as a Cmd+V fallback', async () => {
+    const term = makeTerm()
+    mockTerminals(term)
+    Object.defineProperty(navigator, 'platform', { value: 'MacIntel', configurable: true })
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { readText: vi.fn().mockResolvedValue('echo hi') },
+      configurable: true,
+    })
+    const { container } = render(<TerminalViewport activeId="s1" />)
+    const slot = container.querySelector('[data-terminal-viewport]') as HTMLElement
+
+    fireEvent.keyDown(slot, { key: 'v', metaKey: true })
+
+    await waitFor(() => {
+      expect(term.paste).toHaveBeenCalledWith('echo hi')
+    })
+  })
+
+  it('captures native copy events when the terminal has a selection', () => {
+    const term = makeTerm({ getSelection: vi.fn(() => 'selected text') })
+    mockTerminals(term)
+    const { container } = render(<TerminalViewport activeId="s1" />)
+    const slot = container.querySelector('[data-terminal-viewport]') as HTMLElement
+    const setData = vi.fn()
+
+    fireEvent.copy(slot, {
+      clipboardData: {
+        setData,
+      },
+    })
+
+    expect(setData).toHaveBeenCalledWith('text/plain', 'selected text')
   })
 })

--- a/client/src/components/terminal/__tests__/TerminalViewport.test.tsx
+++ b/client/src/components/terminal/__tests__/TerminalViewport.test.tsx
@@ -39,11 +39,12 @@ interface FakeTerminal {
   modes: { mouseTrackingMode: string }
 }
 
-function mockTerminals(term: FakeTerminal | null = null) {
+function mockTerminals(term: FakeTerminal | null = null, writeToSession = vi.fn(() => false)) {
   mocks.useTerminals.mockReturnValue({
     subscribeOpenSearch: vi.fn(() => undefined),
     getSearchAddon: vi.fn(() => null),
     getTerminalInstance: vi.fn(() => term),
+    writeToSession,
     getCwd: vi.fn(() => null),
     getContainer: vi.fn(() => null),
     notifyAdopted: vi.fn(),
@@ -69,7 +70,8 @@ describe('TerminalViewport', () => {
 
   it('pastes native file paths instead of allowing file previews on drop', () => {
     const term = makeTerm()
-    mockTerminals(term)
+    const writeToSession = vi.fn(() => true)
+    mockTerminals(term, writeToSession)
     const { container } = render(<TerminalViewport activeId="s1" />)
     const slot = container.querySelector('[data-terminal-viewport]') as HTMLElement
     const file = new File(['hello'], 'hello.txt', { type: 'text/plain' })
@@ -87,7 +89,8 @@ describe('TerminalViewport', () => {
 
     expect(event.defaultPrevented).toBe(true)
     expect(event.stopPropagation).toHaveBeenCalled()
-    expect(term.paste).toHaveBeenCalledWith("'/Users/javi/Desktop/hello.txt'")
+    expect(writeToSession).toHaveBeenCalledWith('s1', "'/Users/javi/Desktop/hello.txt'")
+    expect(term.paste).not.toHaveBeenCalled()
   })
 
   it('prevents file drops without native paths so the WebView does not render previews', () => {
@@ -114,7 +117,8 @@ describe('TerminalViewport', () => {
 
   it('captures native paste events and writes text to the terminal', () => {
     const term = makeTerm()
-    mockTerminals(term)
+    const writeToSession = vi.fn(() => true)
+    mockTerminals(term, writeToSession)
     const { container } = render(<TerminalViewport activeId="s1" />)
     const slot = container.querySelector('[data-terminal-viewport]') as HTMLElement
 
@@ -124,12 +128,14 @@ describe('TerminalViewport', () => {
       },
     })
 
-    expect(term.paste).toHaveBeenCalledWith('npm test')
+    expect(writeToSession).toHaveBeenCalledWith('s1', 'npm test')
+    expect(term.paste).not.toHaveBeenCalled()
   })
 
   it('uses navigator clipboard as a Cmd+V fallback', async () => {
     const term = makeTerm()
-    mockTerminals(term)
+    const writeToSession = vi.fn(() => true)
+    mockTerminals(term, writeToSession)
     Object.defineProperty(navigator, 'platform', { value: 'MacIntel', configurable: true })
     Object.defineProperty(navigator, 'clipboard', {
       value: { readText: vi.fn().mockResolvedValue('echo hi') },
@@ -141,8 +147,9 @@ describe('TerminalViewport', () => {
     fireEvent.keyDown(slot, { key: 'v', metaKey: true })
 
     await waitFor(() => {
-      expect(term.paste).toHaveBeenCalledWith('echo hi')
+      expect(writeToSession).toHaveBeenCalledWith('s1', 'echo hi')
     })
+    expect(term.paste).not.toHaveBeenCalled()
   })
 
   it('captures native copy events when the terminal has a selection', () => {

--- a/client/src/hooks/useChat.ts
+++ b/client/src/hooks/useChat.ts
@@ -217,7 +217,7 @@ export function useChat(): UseChatReturn {
     })
   }, [])
 
-  const createConversation = useCallback(async (model = 'claude-sonnet-4-6') => {
+  const createConversation = useCallback(async (model = 'sonnet') => {
     try {
       const res = await fetch(`${getApiBase()}/chat/conversations`, {
         method: 'POST',
@@ -345,7 +345,7 @@ export function useChat(): UseChatReturn {
       const res = await fetch(`${getApiBase()}/chat/conversations`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ model: 'claude-sonnet-4-6' }),
+        body: JSON.stringify({ model: 'sonnet' }),
       })
       if (!res.ok) return null
       const data = await res.json() as { conversation: ChatConversationSummary }

--- a/client/src/lib/__tests__/tauri-drag-drop.test.ts
+++ b/client/src/lib/__tests__/tauri-drag-drop.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { isDropPositionInsideRect } from '../tauri-drag-drop'
+
+const rect = {
+  left: 500,
+  right: 900,
+  top: 400,
+  bottom: 800,
+} as DOMRect
+
+describe('tauri-drag-drop', () => {
+  it('accepts positions that are already in logical CSS pixels', () => {
+    expect(isDropPositionInsideRect({ x: 650, y: 600 }, rect, 2)).toBe(true)
+  })
+
+  it('accepts positions reported in physical pixels', () => {
+    expect(isDropPositionInsideRect({ x: 1300, y: 1200 }, rect, 2)).toBe(true)
+  })
+
+  it('rejects positions outside the viewport in either coordinate space', () => {
+    expect(isDropPositionInsideRect({ x: 100, y: 100 }, rect, 2)).toBe(false)
+  })
+})

--- a/client/src/lib/tauri-drag-drop.ts
+++ b/client/src/lib/tauri-drag-drop.ts
@@ -1,4 +1,3 @@
-import type { Terminal } from '@xterm/xterm'
 import { isTauri } from './tauri-shell'
 import { quotePathList } from './shell-quote'
 
@@ -6,33 +5,28 @@ export interface DragDropController {
   dispose: () => void
 }
 
+interface ActiveDropTarget {
+  viewportEl: HTMLElement
+  writeText: (text: string) => boolean
+}
+
 /**
  * Register a Tauri webview drag-drop listener. On drop, hit-test the drop
  * coordinates against the active viewport's bounding rect; if inside, pass the
- * shell-quoted paths to the active terminal via `term.paste`. Outside Tauri,
- * this function is a silent no-op.
+ * shell-quoted paths to the active terminal's PTY writer. Outside Tauri, this
+ * function is a silent no-op.
  *
- * `getActive` returns the active session's `{ term, viewportEl }` or null when
- * no session is active.
+ * `getActive` returns the active session's drop target or null when no session
+ * is active.
  */
 export async function registerTauriDragDrop(
-  getActive: () => { term: Terminal; viewportEl: HTMLElement } | null,
+  getActive: () => ActiveDropTarget | null,
 ): Promise<DragDropController> {
   if (!isTauri()) return { dispose: () => {} }
-  let unlisten: (() => void) | null = null
   try {
-    // Use indirected dynamic import so Vite's static analyser doesn't try to
-    // resolve a path that may not exist in plain-browser dev bundles.
-    // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
-    const mod = await ((new Function('s', 'return import(s)') as (s: string) => Promise<unknown>)('@tauri-apps/api/webview').catch(() => null))
-    const getCurrentWebview = (mod as unknown as { getCurrentWebview?: () => unknown })?.getCurrentWebview
-    const wv = getCurrentWebview ? getCurrentWebview() : null
-    if (!wv) return { dispose: () => {} }
-    const onDragDropEvent = (wv as unknown as {
-      onDragDropEvent?: (cb: (ev: { payload: { type: string; paths?: string[]; position?: { x: number; y: number } } }) => void) => Promise<() => void>
-    }).onDragDropEvent
-    if (typeof onDragDropEvent !== 'function') return { dispose: () => {} }
-
+    const unlisteners: Array<() => void> = []
+    let lastDropKey = ''
+    let lastDropAt = 0
     const isWindows = typeof navigator !== 'undefined' && /Win/i.test(navigator.platform || '')
 
     const cb = (ev: { payload: { type: string; paths?: string[]; position?: { x: number; y: number } } }) => {
@@ -40,20 +34,53 @@ export async function registerTauriDragDrop(
       if (!payload || payload.type !== 'drop') return
       const paths = payload.paths
       if (!paths || paths.length === 0) return
+      const pos = payload.position
+      if (!pos) return
+      const dropKey = `${paths.join('\0')}@${pos.x},${pos.y}`
+      const now = Date.now()
+      if (dropKey === lastDropKey && now - lastDropAt < 250) return
+      lastDropKey = dropKey
+      lastDropAt = now
+
       const active = getActive()
       if (!active) return
       const rect = active.viewportEl.getBoundingClientRect()
-      const pos = payload.position
-      if (!pos) return
       if (!isDropPositionInsideRect(pos, rect, window.devicePixelRatio || 1)) return
       const text = quotePathList(paths, isWindows)
-      try { active.term.paste(text) } catch { /* ignore */ }
+      try { active.writeText(text) } catch { /* ignore */ }
     }
-    unlisten = await onDragDropEvent(cb)
-    return { dispose: () => { try { unlisten?.() } catch { /* ignore */ } } }
+
+    // Use indirected dynamic import so Vite's static analyser doesn't try to
+    // resolve a path that may not exist in plain-browser dev bundles.
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+    const importTauri = new Function('s', 'return import(s)') as (s: string) => Promise<unknown>
+
+    const webviewMod = await importTauri('@tauri-apps/api/webview').catch(() => null)
+    const getCurrentWebview = (webviewMod as { getCurrentWebview?: () => unknown } | null)?.getCurrentWebview
+    const webview = getCurrentWebview ? getCurrentWebview() : null
+    const onWebviewDragDropEvent = getDragDropListener(webview)
+    if (onWebviewDragDropEvent) unlisteners.push(await onWebviewDragDropEvent(cb))
+
+    const windowMod = await importTauri('@tauri-apps/api/window').catch(() => null)
+    const getCurrentWindow = (windowMod as { getCurrentWindow?: () => unknown } | null)?.getCurrentWindow
+    const appWindow = getCurrentWindow ? getCurrentWindow() : null
+    const onWindowDragDropEvent = getDragDropListener(appWindow)
+    if (onWindowDragDropEvent) unlisteners.push(await onWindowDragDropEvent(cb))
+
+    if (unlisteners.length === 0) return { dispose: () => {} }
+    return { dispose: () => { for (const unlisten of unlisteners) { try { unlisten() } catch { /* ignore */ } } } }
   } catch {
     return { dispose: () => {} }
   }
+}
+
+function getDragDropListener(target: unknown):
+  | ((cb: (ev: { payload: { type: string; paths?: string[]; position?: { x: number; y: number } } }) => void) => Promise<() => void>)
+  | null {
+  const listener = (target as {
+    onDragDropEvent?: (cb: (ev: { payload: { type: string; paths?: string[]; position?: { x: number; y: number } } }) => void) => Promise<() => void>
+  } | null)?.onDragDropEvent
+  return typeof listener === 'function' ? listener.bind(target) : null
 }
 
 export function isDropPositionInsideRect(

--- a/client/src/lib/tauri-drag-drop.ts
+++ b/client/src/lib/tauri-drag-drop.ts
@@ -45,11 +45,7 @@ export async function registerTauriDragDrop(
       const rect = active.viewportEl.getBoundingClientRect()
       const pos = payload.position
       if (!pos) return
-      // Tauri reports positions in physical pixels; convert assuming the same
-      // device pixel ratio as the rect (which is in CSS px).
-      const x = pos.x / window.devicePixelRatio
-      const y = pos.y / window.devicePixelRatio
-      if (x < rect.left || x > rect.right || y < rect.top || y > rect.bottom) return
+      if (!isDropPositionInsideRect(pos, rect, window.devicePixelRatio || 1)) return
       const text = quotePathList(paths, isWindows)
       try { active.term.paste(text) } catch { /* ignore */ }
     }
@@ -58,4 +54,22 @@ export async function registerTauriDragDrop(
   } catch {
     return { dispose: () => {} }
   }
+}
+
+export function isDropPositionInsideRect(
+  pos: { x: number; y: number },
+  rect: Pick<DOMRect, 'left' | 'right' | 'top' | 'bottom'>,
+  scaleFactor: number,
+): boolean {
+  if (pointInsideRect(pos.x, pos.y, rect)) return true
+  const factor = Number.isFinite(scaleFactor) && scaleFactor > 0 ? scaleFactor : 1
+  return pointInsideRect(pos.x / factor, pos.y / factor, rect)
+}
+
+function pointInsideRect(
+  x: number,
+  y: number,
+  rect: Pick<DOMRect, 'left' | 'right' | 'top' | 'bottom'>,
+): boolean {
+  return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom
 }

--- a/client/src/lib/terminal-settings-events.ts
+++ b/client/src/lib/terminal-settings-events.ts
@@ -1,0 +1,11 @@
+export const TERMINAL_SETTINGS_UPDATED_EVENT = 'specrails:terminal-settings-updated'
+
+export interface TerminalSettingsUpdatedEventDetail {
+  mode: 'hub' | 'project'
+  projectId: string | null
+}
+
+export function dispatchTerminalSettingsUpdated(detail: TerminalSettingsUpdatedEventDetail): void {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(new CustomEvent(TERMINAL_SETTINGS_UPDATED_EVENT, { detail }))
+}

--- a/server/chat-manager.test.ts
+++ b/server/chat-manager.test.ts
@@ -112,6 +112,24 @@ describe('ChatManager', () => {
     expect(doneMsgs[0].fullText).toBe('Hello back!')
   })
 
+  it('normalizes legacy Claude model ids to Claude Code aliases before spawning', async () => {
+    const convId = setupConversation('claude-sonnet-4-6')
+    const child = createMockChildProcess()
+    vi.mocked(mockSpawn).mockReturnValue(child as any)
+
+    const sendPromise = cm.sendMessage(convId, 'Hello world')
+
+    const spawnArgs = vi.mocked(mockSpawn).mock.calls[0][1] as string[]
+    const modelIdx = spawnArgs.indexOf('--model')
+    expect(modelIdx).toBeGreaterThan(-1)
+    expect(spawnArgs[modelIdx + 1]).toBe('sonnet')
+
+    pushLine(child, assistantEvent('Hello'))
+    pushLine(child, resultEvent('sess-abc'))
+    await finishProcess(child, 0)
+    await sendPromise
+  })
+
   // ─── Test 2: abort triggers chat_error { error: 'aborted' } ───────────────
 
   it('abort triggers chat_error with aborted reason', async () => {
@@ -251,6 +269,21 @@ describe('ChatManager', () => {
     const errors = getBroadcastedByType(broadcast, 'chat_error')
     expect(errors).toHaveLength(1)
     expect(errors[0].error).toContain('code 1')
+  })
+
+  it('includes stderr in chat_error when process exits with non-zero code', async () => {
+    const convId = setupConversation()
+    const child = createMockChildProcess()
+    vi.mocked(mockSpawn).mockReturnValue(child as any)
+
+    const sendPromise = cm.sendMessage(convId, 'Fail with stderr')
+    child.stderr.push('Authentication failed\n')
+    await finishProcess(child, 1)
+    await sendPromise
+
+    const errors = getBroadcastedByType(broadcast, 'chat_error')
+    expect(errors).toHaveLength(1)
+    expect(errors[0].error).toContain('Authentication failed')
   })
 
   // ─── Test 10: already active conversation ──────────────────────────────────

--- a/server/chat-manager.ts
+++ b/server/chat-manager.ts
@@ -35,6 +35,27 @@ function codexOnPath(): boolean {
   }
 }
 
+function normalizeClaudeCodeModel(model: string | null | undefined): string {
+  switch (model) {
+    case 'claude-sonnet-4-6':
+    case 'claude-sonnet-4-5':
+    case 'claude-sonnet-4-0':
+    case 'claude-sonnet-4-20250514':
+      return 'sonnet'
+    case 'claude-opus-4-7':
+    case 'claude-opus-4-5':
+    case 'claude-opus-4-1-20250805':
+    case 'claude-opus-4-20250514':
+      return 'opus'
+    case 'claude-haiku-4-5-20251001':
+    case 'claude-3-5-haiku-20241022':
+    case 'claude-3-5-haiku-latest':
+      return 'haiku'
+    default:
+      return model || 'sonnet'
+  }
+}
+
 function extractTextFromEvent(event: Record<string, unknown>): string | null {
   const type = event.type as string
   if (type === 'assistant') {
@@ -288,7 +309,7 @@ export class ChatManager {
         : this._buildSystemPrompt()
       if (hasAttachments) systemPrompt = `${systemPrompt}\n\n${USER_ATTACHMENT_SYSTEM_NOTE}`
       args = [
-        '--model', conversation.model,
+        '--model', normalizeClaudeCodeModel(conversation.model),
         '--dangerously-skip-permissions',
         '--tools', 'default',
         '--output-format', 'stream-json',
@@ -314,10 +335,12 @@ export class ChatManager {
       cwd: this._cwd,
     })
 
+    let stderrBuf = ''
     // Drain stderr so the pipe buffer never fills up (child process would block otherwise)
-    child.stderr?.resume()
     child.stderr?.on('data', (chunk: Buffer) => {
-      console.error(`[chat-manager] claude stderr (${conversationId}):`, chunk.toString().trim())
+      const text = chunk.toString()
+      stderrBuf += text
+      console.error(`[chat-manager] ${binary} stderr (${conversationId}):`, text.trim())
     })
 
     this._activeProcesses.set(conversationId, child)
@@ -471,10 +494,13 @@ export class ChatManager {
             this._autoTitle(conversationId, userText, fullText)
           }
         } else {
+          const stderrTail = stderrBuf.trim().slice(-500)
           this._broadcast({
             type: 'chat_error',
             conversationId,
-            error: `Process exited with code ${code ?? 'unknown'}`,
+            error: stderrTail
+              ? `${binary} exited with code ${code ?? 'unknown'}: ${stderrTail}`
+              : `Process exited with code ${code ?? 'unknown'}`,
             timestamp: new Date().toISOString(),
           })
         }

--- a/server/db.ts
+++ b/server/db.ts
@@ -140,7 +140,7 @@ const MIGRATIONS: Migration[] = [
       CREATE TABLE IF NOT EXISTS chat_conversations (
         id           TEXT PRIMARY KEY,
         title        TEXT,
-        model        TEXT NOT NULL DEFAULT 'claude-sonnet-4-5',
+        model        TEXT NOT NULL DEFAULT 'sonnet',
         session_id   TEXT,
         created_at   TEXT NOT NULL DEFAULT (datetime('now')),
         updated_at   TEXT NOT NULL DEFAULT (datetime('now'))

--- a/server/project-router.ts
+++ b/server/project-router.ts
@@ -802,7 +802,7 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
 
   router.post('/:projectId/chat/conversations', (req: Request, res: Response) => {
     const { db } = ctx(req)
-    const model = (req.body?.model as string | undefined) ?? 'claude-sonnet-4-5'
+    const model = (req.body?.model as string | undefined) ?? 'sonnet'
     const id = uuidv4()
     createConversation(db, { id, model })
     const conversation = getConversation(db, id) as ChatConversationRow


### PR DESCRIPTION
## Summary
- use Claude Code model aliases in chat and normalize legacy stored Claude model names
- refresh resolved terminal shortcut settings after saving hub/project terminal settings
- prevent DOM file drops from rendering previews inside the terminal viewport
- paste native file paths into the active terminal when the WebView exposes them
- tolerate Tauri drag/drop coordinates reported in either logical or physical pixels
- capture copy/paste and Cmd/Ctrl clipboard shortcuts at the viewport level as a fallback for macOS/Tauri
- make the desktop titlebar, window controls, and search pill use theme CSS variables instead of Dracula hardcoded colors

## Tests
- npx vitest run server/chat-manager.test.ts server/project-router.test.ts
- cd client && npx vitest run src/components/terminal/__tests__/TerminalViewport.test.tsx src/components/terminal/__tests__/BottomPanel.test.tsx src/components/__tests__/ChatInput.test.tsx src/components/__tests__/ModelSelector.test.tsx src/components/__tests__/ModelCombobox.test.tsx src/hooks/__tests__/useChat.test.ts
- cd client && npx vitest run src/lib/__tests__/tauri-drag-drop.test.ts src/components/terminal/__tests__/TerminalViewport.test.tsx
- cd client && npx vitest run src/components/__tests__/TitleBar.test.tsx
- npm run typecheck