### PR TITLE
feat: per-project plugin system with Serena integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,26 @@ Releases are automated via release-please + GitHub Actions:
 
 Commit message prefixes that affect versioning: `feat:` → minor, `fix:` → patch, `feat!:` → major. Commits without a conventional prefix are ignored by release-please.
 
+### Plugin system (Integrations)
+
+Per-project marketplace of MCP-based integrations. Each project independently decides which plugins to install. v1 ships **bundled-only**: every plugin available is compiled into the hub binary; there is no remote registry, no user-installable plugins, and no third-party loading. **Zero changes are required in `specrails-core`** — plugins only contribute MCP server entries (via `.mcp.json`) and optionally a fragment in the already-protected `.claude/agents/custom-*.md` namespace.
+
+**Additivity is the central invariant.** Adding plugin N+1 must never mutate any artifact owned by plugin N or by the user. Each plugin's manifest declares `owns.mcpServers` / `owns.agentFragments`; ownership conflicts are detected at hub startup (`buildOwnershipMap`) and fail fast. All file mutations (`.mcp.json`, `state.json`) are surgical (read → modify only owned keys → atomic temp+rename) and serialised by an in-process file mutex.
+
+**Server (`server/plugin-manager.ts` + `server/plugins/`)**: `PluginManager` owns the lifecycle: `listAvailable`, `previewInstall`, `install` (with rollback on verify failure), `uninstall`, `verify` (timeout-bounded, default 2000ms), `removeOrphan`. State lives at `<project>/.specrails/plugins/state.json` (`{ schemaVersion: 1, plugins: { [name]: { version, installedAt, installedFiles, health, healthReason } } }`). `BUNDLED_PLUGINS` is a typed array in `server/plugins/index.ts` — registering a new plugin requires only appending an import. Helpers `PluginManager.mergeMcpServers` / `removeMcpServers` are the only sanctioned way to mutate `.mcp.json`.
+
+**REST (`server/plugins-router.ts`)** mounted at `/api/projects/:projectId/plugins`, gated by `SPECRAILS_PLUGINS_SECTION !== 'false'`: `GET /` (catalog with status `installed | not-installed | orphan | degraded`), `GET /:name/preview-install` (diff before mutation), `POST /:name/install` (with WS streaming progress via `plugin.install_progress`), `DELETE /:name` (uninstall or orphan removal), `GET /:name/health` (on-demand verify).
+
+**WS events**: `plugin.installed`, `plugin.uninstalled`, `plugin.health_changed`, `plugin.degraded`, `plugin.install_progress` — all `projectId`-scoped.
+
+**Rail integration (`server/queue-manager.ts` + `server/plugins/rail-integration.ts`)**: before spawning a `claude` rail process, `QueueManager` resolves installed plugins (parallel verify with per-plugin timeout), classifies into `active` and `degraded`, and writes a per-job snapshot to `~/.specrails/projects/<slug>/jobs/<jobId>/plugins.json` (chmod 400). It injects env vars `SPECRAILS_PLUGINS_ACTIVE` (CSV) and `SPECRAILS_PLUGINS_SNAPSHOT` (path). When pipeline telemetry is enabled, OTEL resource attrs include `specrails.plugins.active`, `specrails.plugins.degraded`, and `specrails.plugins.versions`. **Healthcheck failure is non-blocking** — degraded plugins emit `plugin.degraded` but the rail spawns normally. `ChatManager` inherits MCP config via `cwd` (no snapshot, no env injection); `SetupManager` ignores plugins entirely (project under construction).
+
+**Diagnostic export (`server/telemetry-export.ts`)**: includes `plugins.json` in the ZIP and a "Plugins" section in `summary.md` whenever a per-job plugin snapshot exists.
+
+**Bundled today**: `serena` (semantic code navigation via LSP+MCP). Manifest in `server/plugins/serena/manifest.ts`; install adds `mcpServers.serena` running `uvx --from git+https://github.com/oraios/serena ...`; verify probes `uvx serena --version`. The optional `templates/instructions.md` fragment lands at `<project>/.claude/agents/custom-serena.md`. Requires `uv` on PATH (auto-detected by an extended `setup-prerequisites.ts` with `includeUv: true`).
+
+**Reserved paths (per-project, hub-managed)**: `<project>/.mcp.json` (surgical merge), `<project>/.specrails/plugins/state.json`, `<project>/.specrails/plugins/snapshots/<jobId>.json`, `<project>/.claude/agents/custom-<plugin>.md`. Hub never wholesale rewrites any of these.
+
 ### Theme system
 
 Hub-wide UI theme selectable from `GlobalSettingsPage > Appearance`. Three built-ins: `dracula` (default), `aurora-light`, `obsidian-dark`. Persisted hub-wide as `hub_settings.ui_theme` (server) and mirrored to `localStorage['specrails-hub:ui-theme']` (client) with an inline anti-FOUC script in `client/index.html` that applies `data-theme` on `<html>` before React hydrates.

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -16,6 +16,7 @@ const JobsPage = lazy(() => import('./pages/JobsPage'))
 const AnalyticsPage = lazy(() => import('./pages/AnalyticsPage'))
 const ActivityFeedPage = lazy(() => import('./pages/ActivityFeedPage'))
 const AgentsPage = lazy(() => import('./pages/AgentsPage'))
+const IntegrationsPage = lazy(() => import('./pages/IntegrationsPage'))
 const HubAnalyticsPage = lazy(() => import('./pages/HubAnalyticsPage'))
 const DocsPage = lazy(() => import('./pages/DocsPage'))
 const DocsDialog = lazy(() => import('./components/DocsDialog'))
@@ -129,8 +130,8 @@ function HubApp() {
   // Keyboard shortcuts
   const { cheatsheetOpen, setCheatsheetOpen, openCheatsheet } = useCheatsheetState()
   const PROJECT_PAGES = FEATURE_AGENTS_SECTION
-    ? ['/', '/jobs', '/analytics', '/agents', '/settings']
-    : ['/', '/jobs', '/analytics', '/settings']
+    ? ['/', '/jobs', '/analytics', '/agents', '/integrations', '/settings']
+    : ['/', '/jobs', '/analytics', '/integrations', '/settings']
   useKeyboardShortcuts({
     onOpenCheatsheet: openCheatsheet,
     onToggleLeftSidebar: () => setLeftPinned((p) => !p),
@@ -227,6 +228,7 @@ function HubApp() {
                     <Route path="/analytics" element={<AnalyticsPage />} />
                     <Route path="/activity" element={<ActivityFeedPage />} />
                     <Route path="/agents" element={<AgentsPage />} />
+                    <Route path="/integrations" element={<IntegrationsPage />} />
                     <Route path="/settings" element={<SettingsPage />} />
                     <Route path="*" element={<Navigate to="/" replace />} />
                   </Route>

--- a/client/src/components/ProjectRightSidebar.tsx
+++ b/client/src/components/ProjectRightSidebar.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { NavLink } from 'react-router-dom'
-import { LayoutDashboard, Briefcase, BarChart3, Bot, Settings, PanelRight } from 'lucide-react'
+import { LayoutDashboard, Briefcase, BarChart3, Bot, Puzzle, Settings, PanelRight } from 'lucide-react'
 import { cn } from '../lib/utils'
 import { useSidebarPin } from '../context/SidebarPinContext'
 import { FEATURE_AGENTS_SECTION } from '../lib/feature-flags'
@@ -12,6 +12,7 @@ const navItems = [
   ...(FEATURE_AGENTS_SECTION
     ? [{ to: '/agents', end: false, icon: Bot, label: 'Agents' }]
     : []),
+  { to: '/integrations', end: false, icon: Puzzle, label: 'Integrations' },
   { to: '/settings', end: false, icon: Settings, label: 'Settings' },
 ]
 

--- a/client/src/pages/IntegrationsPage.tsx
+++ b/client/src/pages/IntegrationsPage.tsx
@@ -1,0 +1,701 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Puzzle, AlertTriangle, CheckCircle2, XCircle, Trash2, Download, Loader2 } from 'lucide-react'
+import { getApiBase } from '../lib/api'
+import { useHub } from '../hooks/useHub'
+import { useSharedWebSocket } from '../hooks/useSharedWebSocket'
+import { useProjectCache } from '../hooks/useProjectCache'
+
+interface PluginRequirement {
+  name: string
+  installed?: boolean
+  executable?: boolean
+  version?: string
+  meetsMinimum?: boolean
+  minVersion?: string
+}
+
+interface PluginCard {
+  name: string
+  version: string
+  description: string
+  whatItDoes: string[]
+  category?: string
+  requirements: PluginRequirement[]
+  status: 'installed' | 'deactivated' | 'not-installed' | 'orphan' | 'degraded'
+  installedAt?: string
+  health?: 'ok' | 'degraded' | 'unknown'
+  healthReason?: string
+  marketplaceConflicts?: string[]
+  marketplaceCachedButDisabled?: string[]
+  updateAvailable?: boolean
+}
+
+interface PreviewFile {
+  path: string
+  op: 'create' | 'modify'
+  summary?: string
+}
+
+interface PreviewResult {
+  pluginName: string
+  files: PreviewFile[]
+  requirements: Array<PluginRequirement>
+  platformNote?: string
+}
+
+interface PluginEvent {
+  type: string
+  projectId?: string
+  name?: string
+  reason?: string
+  status?: string
+  line?: string
+  version?: string
+}
+
+export default function IntegrationsPage() {
+  const { activeProjectId } = useHub()
+  const { registerHandler, unregisterHandler } = useSharedWebSocket()
+  const projectIdRef = useRef(activeProjectId)
+  useEffect(() => { projectIdRef.current = activeProjectId }, [activeProjectId])
+
+  const [error, setError] = useState<string | null>(null)
+  const [installingFor, setInstallingFor] = useState<string | null>(null)
+
+  const fetcher = useCallback(async (): Promise<PluginCard[]> => {
+    const r = await fetch(`${getApiBase()}/plugins`)
+    if (!r.ok) throw new Error(`HTTP ${r.status}`)
+    const data = await r.json()
+    return data.plugins ?? []
+  }, [])
+
+  const { data: plugins, isLoading, isFirstLoad, refresh } = useProjectCache<PluginCard[]>({
+    namespace: 'plugins',
+    projectId: activeProjectId,
+    initialValue: [],
+    fetcher,
+  })
+
+  // Auto-refresh on plugin lifecycle WS events.
+  useEffect(() => {
+    const handler = (raw: unknown) => {
+      const msg = raw as PluginEvent
+      if (!msg.type) return
+      if (msg.projectId && msg.projectId !== projectIdRef.current) return
+      if (msg.type.startsWith('plugin.')) refresh()
+    }
+    registerHandler('integrations-page', handler)
+    return () => unregisterHandler('integrations-page')
+  }, [registerHandler, unregisterHandler, refresh])
+
+  useEffect(() => {
+    if (!isLoading && !plugins) setError('Failed to load plugins')
+    else setError(null)
+  }, [isLoading, plugins])
+
+  const active = useMemo(() => (plugins ?? []).filter((p) => p.status !== 'orphan'), [plugins])
+  const orphans = useMemo(() => (plugins ?? []).filter((p) => p.status === 'orphan'), [plugins])
+
+  if (!activeProjectId) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-muted-foreground text-sm">
+        Select a project to manage integrations.
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col h-full bg-background">
+      <div className="flex-shrink-0 border-b border-border px-6 pt-4 pb-3 flex items-center gap-2">
+        <Puzzle className="w-4 h-4 text-accent-primary" />
+        <div className="flex-1">
+          <h1 className="text-lg font-semibold">Integrations</h1>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Per-project plugins. Each project decides which integrations to enable independently.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-auto p-6">
+        {isFirstLoad && isLoading ? (
+          <SkeletonGrid />
+        ) : error ? (
+          <ErrorState onRetry={refresh} />
+        ) : (plugins?.length ?? 0) === 0 ? (
+          <EmptyState />
+        ) : (
+          <>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {active.map((p) => (
+                <Card
+                  key={p.name}
+                  plugin={p}
+                  isInstalling={installingFor === p.name}
+                  onInstall={() => setInstallingFor(p.name)}
+                  onCloseInstall={() => { setInstallingFor(null); refresh() }}
+                />
+              ))}
+            </div>
+            {orphans.length > 0 && (
+              <div className="mt-10">
+                <h2 className="text-sm font-semibold text-muted-foreground mb-3 flex items-center gap-2">
+                  <AlertTriangle className="w-3.5 h-3.5" /> Deprecated
+                </h2>
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                  {orphans.map((p) => (
+                    <OrphanCard key={p.name} plugin={p} onRemoved={refresh} />
+                  ))}
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Card({
+  plugin,
+  isInstalling,
+  onInstall,
+  onCloseInstall,
+}: {
+  plugin: PluginCard
+  isInstalling: boolean
+  onInstall: () => void
+  onCloseInstall: () => void
+}) {
+  const [showUninstall, setShowUninstall] = useState(false)
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 flex flex-col gap-3">
+      <div className="flex items-start gap-2">
+        <div className="flex-1">
+          <div className="flex items-center gap-2">
+            <h3 className="text-sm font-semibold">{plugin.name}</h3>
+            <span className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
+              v{plugin.version}
+            </span>
+            {plugin.status === 'installed' && (
+              <span className="text-[10px] px-1.5 py-0.5 rounded bg-accent-success/20 text-accent-success flex items-center gap-1">
+                <CheckCircle2 className="w-3 h-3" /> Active
+              </span>
+            )}
+            {plugin.status === 'deactivated' && (
+              <span className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground flex items-center gap-1">
+                <XCircle className="w-3 h-3" /> Deactivated
+              </span>
+            )}
+            {plugin.status === 'degraded' && (
+              <span className="text-[10px] px-1.5 py-0.5 rounded bg-accent-warning/20 text-accent-warning flex items-center gap-1">
+                <AlertTriangle className="w-3 h-3" /> Degraded
+              </span>
+            )}
+            {plugin.updateAvailable && (
+              <span className="text-[10px] px-1.5 py-0.5 rounded bg-accent-info/20 text-accent-info flex items-center gap-1">
+                <Download className="w-3 h-3" /> Update available
+              </span>
+            )}
+          </div>
+          {plugin.category && (
+            <p className="text-[10px] text-muted-foreground mt-0.5">{plugin.category}</p>
+          )}
+        </div>
+      </div>
+
+      <p className="text-xs text-muted-foreground leading-relaxed">{plugin.description}</p>
+
+      {plugin.whatItDoes.length > 0 && (
+        <ul className="text-xs space-y-1 list-disc pl-4 text-foreground/80">
+          {plugin.whatItDoes.map((b, i) => <li key={i}>{b}</li>)}
+        </ul>
+      )}
+
+      {plugin.requirements.length > 0 && (
+        <div className="text-[10px] text-muted-foreground">
+          Requires: {plugin.requirements.map((r) => `${r.name}${r.minVersion ? ` ≥ ${r.minVersion}` : ''}`).join(', ')}
+        </div>
+      )}
+
+      {plugin.healthReason && plugin.status === 'degraded' && (
+        <div className="text-[11px] text-accent-warning">
+          {plugin.healthReason}
+        </div>
+      )}
+      {plugin.status === 'deactivated' && (
+        <div className="text-[11px] text-muted-foreground leading-relaxed">
+          Installed but deactivated — Claude won't load it next session. Toggle <strong>Active</strong> to re-enable.
+        </div>
+      )}
+      {plugin.marketplaceConflicts && plugin.marketplaceConflicts.length > 0 && (
+        <ConflictResolver pluginName={plugin.name} conflicts={plugin.marketplaceConflicts} />
+      )}
+      {plugin.marketplaceCachedButDisabled && plugin.marketplaceCachedButDisabled.length > 0 && (
+        <CachedButDisabledNotice keys={plugin.marketplaceCachedButDisabled} />
+      )}
+      {plugin.updateAvailable && <UpdateAvailable pluginName={plugin.name} />}
+
+      <div className="mt-auto pt-2 flex items-center justify-end gap-2">
+        {plugin.status === 'not-installed' ? (
+          <button
+            type="button"
+            onClick={onInstall}
+            className="text-xs px-3 py-1.5 rounded-md bg-accent-primary text-white hover:opacity-90"
+          >
+            Install
+          </button>
+        ) : (
+          <>
+            <ActiveToggle pluginName={plugin.name} active={plugin.status === 'installed'} />
+            <button
+              type="button"
+              onClick={() => setShowUninstall(true)}
+              className="text-xs px-3 py-1.5 rounded-md border border-border hover:bg-destructive/10 hover:text-destructive flex items-center gap-1.5"
+            >
+              <Trash2 className="w-3 h-3" /> Uninstall
+            </button>
+          </>
+        )}
+      </div>
+
+      {isInstalling && (
+        <InstallDialog pluginName={plugin.name} onClose={onCloseInstall} />
+      )}
+      {showUninstall && (
+        <UninstallDialog
+          pluginName={plugin.name}
+          onClose={() => setShowUninstall(false)}
+          onUninstalled={() => { setShowUninstall(false); /* parent refresh via WS */ }}
+        />
+      )}
+    </div>
+  )
+}
+
+function ActiveToggle({ pluginName, active }: { pluginName: string; active: boolean }) {
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const click = async () => {
+    setBusy(true); setError(null)
+    try {
+      const url = `${getApiBase()}/plugins/${pluginName}/${active ? 'deactivate' : 'activate'}`
+      const r = await fetch(url, { method: 'POST' })
+      if (!r.ok) throw new Error((await r.json()).error ?? `HTTP ${r.status}`)
+    } catch (err) {
+      setError((err as Error).message)
+    } finally { setBusy(false) }
+  }
+  return (
+    <div className="flex items-center gap-1.5">
+      <button
+        type="button"
+        disabled={busy}
+        onClick={click}
+        role="switch"
+        aria-checked={active}
+        className={`relative inline-flex items-center h-5 w-9 rounded-full transition-colors disabled:opacity-50 ${
+          active ? 'bg-accent-success' : 'bg-muted'
+        }`}
+        title={active ? 'Active — click to deactivate' : 'Deactivated — click to activate'}
+      >
+        <span
+          className={`inline-block h-4 w-4 rounded-full bg-white shadow transition-transform ${
+            active ? 'translate-x-4' : 'translate-x-0.5'
+          }`}
+        />
+      </button>
+      <span className="text-[10px] text-muted-foreground">{active ? 'Active' : 'Off'}</span>
+      {error && <span className="text-[10px] text-destructive">{error}</span>}
+    </div>
+  )
+}
+
+function CachedButDisabledNotice({ keys }: { keys: string[] }) {
+  return (
+    <div className="text-[11px] rounded-md border border-yellow-500/30 bg-yellow-500/5 p-2 leading-relaxed space-y-1">
+      <div className="flex items-start gap-1.5">
+        <AlertTriangle className="w-3 h-3 text-yellow-500 mt-0.5 flex-shrink-0" />
+        <span>
+          Claude has the marketplace plugin <strong>installed but disabled</strong> in its cache. It may still resolve
+          the server from <code className="bg-muted px-1 rounded">~/.claude/plugins/cache/...</code> even though the
+          toggle is off. To force project-scoped only, uninstall the marketplace plugin from Claude:
+        </span>
+      </div>
+      <div className="pl-5 space-y-0.5">
+        {keys.map((k) => (
+          <pre key={k} className="text-[10px] bg-muted/40 rounded px-1.5 py-0.5 inline-block font-mono">
+            /plugin uninstall {k}
+          </pre>
+        ))}
+      </div>
+      <div className="pl-5 text-[10px] text-muted-foreground">
+        Run inside an active Claude session, then restart Claude in this project.
+      </div>
+    </div>
+  )
+}
+
+function UpdateAvailable({ pluginName }: { pluginName: string }) {
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const click = async () => {
+    setBusy(true); setError(null)
+    try {
+      const r = await fetch(`${getApiBase()}/plugins/${pluginName}/update`, { method: 'POST' })
+      if (!r.ok) throw new Error((await r.json()).error ?? `HTTP ${r.status}`)
+    } catch (err) {
+      setError((err as Error).message)
+    } finally { setBusy(false) }
+  }
+  return (
+    <div className="text-[11px] rounded-md border border-accent-info/30 bg-accent-info/5 p-2 leading-relaxed space-y-1.5">
+      <div className="flex items-start gap-1.5">
+        <Download className="w-3 h-3 text-accent-info mt-0.5 flex-shrink-0" />
+        <span>
+          The bundled manifest changed since you installed (likely an upstream rename). Re-write{' '}
+          <code className="bg-muted px-1 rounded">.mcp.json</code> with the canonical entry — surgical, only the plugin's
+          owned keys are touched.
+        </span>
+      </div>
+      <button
+        type="button"
+        disabled={busy}
+        onClick={click}
+        className="text-[10px] px-2 py-0.5 rounded border border-accent-info/40 hover:bg-accent-info/10 disabled:opacity-50 flex items-center gap-1"
+      >
+        {busy && <Loader2 className="w-2.5 h-2.5 animate-spin" />}
+        Update <code>.mcp.json</code> entry
+      </button>
+      {error && <div className="text-destructive text-[10px]">{error}</div>}
+    </div>
+  )
+}
+
+
+function ConflictResolver({ pluginName, conflicts }: { pluginName: string; conflicts: string[] }) {
+  const [busy, setBusy] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const disable = async (key: string) => {
+    setBusy(key); setError(null)
+    try {
+      const r = await fetch(`${getApiBase()}/plugins/_marketplace/disable`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key }),
+      })
+      if (!r.ok) throw new Error((await r.json()).error ?? `HTTP ${r.status}`)
+    } catch (err) {
+      setError((err as Error).message)
+    } finally {
+      setBusy(null)
+    }
+  }
+  return (
+    <div className="text-[11px] rounded-md border border-yellow-500/30 bg-yellow-500/5 p-2 leading-relaxed space-y-1.5">
+      <div className="flex items-start gap-1.5">
+        <AlertTriangle className="w-3 h-3 text-yellow-500 mt-0.5 flex-shrink-0" />
+        <span>
+          <strong>{pluginName}</strong> is also enabled globally via Claude's plugin marketplace, which shadows this
+          project-scoped install. To make this card go Active, disable the global version below — it can be re-enabled
+          from Claude any time.
+        </span>
+      </div>
+      <div className="flex flex-wrap gap-1.5 pt-1">
+        {conflicts.map((key) => (
+          <button
+            key={key}
+            type="button"
+            disabled={busy === key}
+            onClick={() => disable(key)}
+            className="text-[10px] px-2 py-0.5 rounded border border-yellow-500/40 hover:bg-yellow-500/10 disabled:opacity-50 flex items-center gap-1"
+          >
+            {busy === key && <Loader2 className="w-2.5 h-2.5 animate-spin" />}
+            Disable <code>{key}</code>
+          </button>
+        ))}
+      </div>
+      {error && <div className="text-destructive">{error}</div>}
+    </div>
+  )
+}
+
+function OrphanCard({ plugin, onRemoved }: { plugin: PluginCard; onRemoved: () => void }) {
+  const [busy, setBusy] = useState(false)
+  const remove = async () => {
+    setBusy(true)
+    try {
+      await fetch(`${getApiBase()}/plugins/${plugin.name}`, { method: 'DELETE' })
+      onRemoved()
+    } finally { setBusy(false) }
+  }
+  return (
+    <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/5 p-4 flex flex-col gap-3">
+      <div className="flex items-center gap-2">
+        <h3 className="text-sm font-semibold">{plugin.name}</h3>
+        <span className="text-[10px] px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-500">
+          Orphan
+        </span>
+      </div>
+      <p className="text-xs text-muted-foreground">{plugin.description}</p>
+      <div className="flex items-center justify-end">
+        <button
+          type="button"
+          disabled={busy}
+          onClick={remove}
+          className="text-xs px-3 py-1.5 rounded-md border border-border hover:bg-destructive/10 hover:text-destructive flex items-center gap-1.5"
+        >
+          <Trash2 className="w-3 h-3" /> Remove orphan
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function InstallDialog({ pluginName, onClose }: { pluginName: string; onClose: () => void }) {
+  const [preview, setPreview] = useState<PreviewResult | null>(null)
+  const [previewError, setPreviewError] = useState<string | null>(null)
+  const [installing, setInstalling] = useState(false)
+  const [installError, setInstallError] = useState<string | null>(null)
+  const [logs, setLogs] = useState<string[]>([])
+  const [installingPrereq, setInstallingPrereq] = useState<string | null>(null)
+  const [prereqLogs, setPrereqLogs] = useState<string[]>([])
+  const { registerHandler, unregisterHandler } = useSharedWebSocket()
+
+  const fetchPreview = useCallback(() => {
+    setPreview(null)
+    setPreviewError(null)
+    fetch(`${getApiBase()}/plugins/${pluginName}/preview-install`)
+      .then((r) => r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)))
+      .then((data: PreviewResult) => setPreview(data))
+      .catch((err: Error) => setPreviewError(err.message))
+  }, [pluginName])
+
+  useEffect(() => {
+    fetchPreview()
+  }, [fetchPreview])
+
+  useEffect(() => {
+    const handler = (raw: unknown) => {
+      const msg = raw as PluginEvent & { prereq?: string; ok?: boolean }
+      if (msg.type === 'plugin.install_progress' && msg.name === pluginName && msg.line) {
+        setLogs((cur) => [...cur, msg.line!])
+      }
+      if (msg.type === 'plugin.prereq_install_progress' && msg.line) {
+        setPrereqLogs((cur) => [...cur, msg.line!])
+      }
+      if (msg.type === 'plugin.prereq_installed') {
+        setInstallingPrereq(null)
+        const reason = (msg as PluginEvent & { reason?: string }).reason
+        if (reason) setPrereqLogs((cur) => [...cur, `► ${reason}`])
+        // Re-fetch preview so prereq status flips to satisfied.
+        if (msg.ok) fetchPreview()
+      }
+    }
+    registerHandler(`install-${pluginName}`, handler)
+    return () => unregisterHandler(`install-${pluginName}`)
+  }, [pluginName, registerHandler, unregisterHandler, fetchPreview])
+
+  const installPrereq = async (prereq: string) => {
+    setInstallingPrereq(prereq)
+    setPrereqLogs([`Installing ${prereq}…`])
+    try {
+      await fetch(`${getApiBase()}/plugins/_prerequisites/${prereq}/install`, { method: 'POST' })
+    } catch (err) {
+      setPrereqLogs((cur) => [...cur, `Failed to start: ${(err as Error).message}`])
+      setInstallingPrereq(null)
+    }
+  }
+
+  const allPrereqsOk = (preview?.requirements ?? []).every((r) => r.installed && r.executable && r.meetsMinimum)
+
+  const submit = async () => {
+    setInstalling(true)
+    setInstallError(null)
+    try {
+      const r = await fetch(`${getApiBase()}/plugins/${pluginName}/install`, { method: 'POST' })
+      if (!r.ok) throw new Error((await r.json()).error ?? `HTTP ${r.status}`)
+      setTimeout(onClose, 1500)
+    } catch (err) {
+      setInstallError((err as Error).message)
+    } finally {
+      setInstalling(false)
+    }
+  }
+
+  return (
+    <ModalShell onClose={onClose} title={`Install ${pluginName}`}>
+      {previewError && <div className="text-xs text-destructive">{previewError}</div>}
+      {!preview && !previewError && (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Loader2 className="w-3 h-3 animate-spin" /> Computing changes…
+        </div>
+      )}
+      {preview && (
+        <>
+          {preview.platformNote && (
+            <div className="flex items-start gap-2 p-2.5 rounded-md border border-yellow-500/30 bg-yellow-500/5 text-[11px] leading-relaxed">
+              <AlertTriangle className="w-3.5 h-3.5 text-yellow-500 mt-0.5 flex-shrink-0" />
+              <span>{preview.platformNote}</span>
+            </div>
+          )}
+          <section>
+            <h4 className="text-xs font-semibold mb-1.5">Files that will change</h4>
+            <ul className="text-xs space-y-0.5 font-mono">
+              {preview.files.map((f, i) => (
+                <li key={i} className={f.op === 'create' ? 'text-accent-success' : 'text-accent-info'}>
+                  {f.op === 'create' ? '+ ' : '~ '}{f.path}
+                  {f.summary && <span className="text-muted-foreground"> {f.summary}</span>}
+                </li>
+              ))}
+            </ul>
+          </section>
+          {preview.requirements.length > 0 && (
+            <section>
+              <h4 className="text-xs font-semibold mb-1.5">Prerequisites</h4>
+              <ul className="text-xs space-y-1">
+                {preview.requirements.map((r) => {
+                  const ok = r.installed && r.executable && r.meetsMinimum
+                  const supportsAuto = r.name === 'uv'
+                  return (
+                    <li key={r.name} className="flex items-center gap-2">
+                      {ok
+                        ? <CheckCircle2 className="w-3 h-3 text-accent-success" />
+                        : <XCircle className="w-3 h-3 text-accent-warning" />}
+                      <span>{r.name}{r.minVersion ? ` ≥ ${r.minVersion}` : ''}</span>
+                      {r.version && <span className="text-muted-foreground">({r.version})</span>}
+                      {!ok && supportsAuto && (
+                        <button
+                          type="button"
+                          disabled={installingPrereq === r.name}
+                          onClick={() => installPrereq(r.name)}
+                          className="ml-auto text-[10px] px-2 py-0.5 rounded border border-border hover:bg-muted disabled:opacity-50 flex items-center gap-1"
+                        >
+                          {installingPrereq === r.name && <Loader2 className="w-2.5 h-2.5 animate-spin" />}
+                          Auto-install
+                        </button>
+                      )}
+                    </li>
+                  )
+                })}
+              </ul>
+              {prereqLogs.length > 0 && (
+                <pre className="mt-2 text-[11px] bg-muted/40 rounded p-2 max-h-24 overflow-auto font-mono">
+                  {prereqLogs.join('\n')}
+                </pre>
+              )}
+            </section>
+          )}
+          {logs.length > 0 && (
+            <section>
+              <h4 className="text-xs font-semibold mb-1.5">Progress</h4>
+              <pre className="text-[11px] bg-muted/40 rounded p-2 max-h-32 overflow-auto font-mono">
+                {logs.join('\n')}
+              </pre>
+            </section>
+          )}
+          {installError && <div className="text-xs text-destructive">{installError}</div>}
+        </>
+      )}
+      <div className="flex justify-end gap-2 pt-2">
+        <button type="button" onClick={onClose} className="text-xs px-3 py-1.5 rounded-md border border-border">
+          Cancel
+        </button>
+        <button
+          type="button"
+          disabled={!preview || !allPrereqsOk || installing}
+          onClick={submit}
+          className="text-xs px-3 py-1.5 rounded-md bg-accent-primary text-white disabled:opacity-50 flex items-center gap-1.5"
+        >
+          {installing ? <Loader2 className="w-3 h-3 animate-spin" /> : <Download className="w-3 h-3" />}
+          Install
+        </button>
+      </div>
+    </ModalShell>
+  )
+}
+
+function UninstallDialog({
+  pluginName,
+  onClose,
+  onUninstalled,
+}: {
+  pluginName: string
+  onClose: () => void
+  onUninstalled: () => void
+}) {
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const submit = async () => {
+    setBusy(true)
+    try {
+      const r = await fetch(`${getApiBase()}/plugins/${pluginName}`, { method: 'DELETE' })
+      if (!r.ok) throw new Error((await r.json()).error ?? `HTTP ${r.status}`)
+      onUninstalled()
+    } catch (err) {
+      setError((err as Error).message)
+    } finally { setBusy(false) }
+  }
+  return (
+    <ModalShell onClose={onClose} title={`Uninstall ${pluginName}?`}>
+      <p className="text-xs">This will revert plugin-managed entries in <code>.mcp.json</code> and remove any plugin-created files. Your code, history, and other plugins are not affected.</p>
+      {error && <div className="text-xs text-destructive">{error}</div>}
+      <div className="flex justify-end gap-2 pt-2">
+        <button type="button" onClick={onClose} className="text-xs px-3 py-1.5 rounded-md border border-border">
+          Cancel
+        </button>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={submit}
+          className="text-xs px-3 py-1.5 rounded-md bg-destructive text-white disabled:opacity-50 flex items-center gap-1.5"
+        >
+          {busy && <Loader2 className="w-3 h-3 animate-spin" />}
+          Uninstall
+        </button>
+      </div>
+    </ModalShell>
+  )
+}
+
+function ModalShell({ title, onClose, children }: { title: string; onClose: () => void; children: React.ReactNode }) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog" tabIndex={-1} onClick={onClose}>
+      <div className="bg-card border border-border rounded-lg shadow-xl w-full max-w-md p-5 flex flex-col gap-3" onClick={(e) => e.stopPropagation()}>
+        <h3 className="text-sm font-semibold">{title}</h3>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function SkeletonGrid() {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      {Array.from({ length: 3 }, (_, i) => (
+        <div key={i} className="rounded-lg border border-border bg-card p-4 h-40 animate-pulse" />
+      ))}
+    </div>
+  )
+}
+
+function ErrorState({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 gap-3 text-sm text-muted-foreground">
+      <AlertTriangle className="w-5 h-5 text-destructive" />
+      <p>Failed to load plugins.</p>
+      <button type="button" onClick={onRetry} className="text-xs px-3 py-1.5 rounded-md border border-border">
+        Retry
+      </button>
+    </div>
+  )
+}
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 gap-2 text-sm text-muted-foreground">
+      <Puzzle className="w-6 h-6" />
+      <p>No plugins are bundled with this hub build.</p>
+    </div>
+  )
+}

--- a/client/src/pages/__tests__/IntegrationsPage.test.tsx
+++ b/client/src/pages/__tests__/IntegrationsPage.test.tsx
@@ -1,0 +1,151 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '../../test-utils'
+import IntegrationsPage from '../IntegrationsPage'
+
+vi.mock('../../hooks/useHub', () => ({
+  useHub: () => ({
+    activeProjectId: 'proj-1',
+    projects: [],
+    isLoading: false,
+    setupProjectIds: new Set(),
+    setActiveProjectId: vi.fn(),
+    startSetupWizard: vi.fn(),
+    completeSetupWizard: vi.fn(),
+    addProject: vi.fn(),
+    removeProject: vi.fn(),
+  }),
+}))
+
+const handlers = new Map<string, (m: unknown) => void>()
+vi.mock('../../hooks/useSharedWebSocket', () => ({
+  useSharedWebSocket: () => ({
+    registerHandler: (id: string, fn: (m: unknown) => void) => { handlers.set(id, fn) },
+    unregisterHandler: (id: string) => { handlers.delete(id) },
+  }),
+}))
+
+vi.mock('../../lib/api', () => ({
+  getApiBase: () => '/api/projects/proj-1',
+}))
+
+const fetchMock = vi.fn()
+beforeEach(() => {
+  fetchMock.mockReset()
+  handlers.clear()
+  vi.stubGlobal('fetch', fetchMock)
+})
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+const sampleCatalog = {
+  plugins: [
+    {
+      name: 'serena',
+      version: '1.0.0',
+      description: 'Semantic nav',
+      whatItDoes: ['symbol lookup'],
+      requirements: [{ name: 'uv', minVersion: '0.1.0' }],
+      status: 'not-installed',
+    },
+  ],
+}
+
+describe('IntegrationsPage', () => {
+  it('renders cards for plugins from the catalog', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => sampleCatalog })
+    render(<IntegrationsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('serena')).toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: /install/i })).toBeInTheDocument()
+  })
+
+  it('opens install dialog and fetches preview', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, json: async () => sampleCatalog })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          pluginName: 'serena',
+          files: [{ path: '.mcp.json', op: 'create', summary: '+ mcpServers.serena' }],
+          requirements: [{ name: 'uv', installed: true, executable: true, meetsMinimum: true, version: '0.1.0' }],
+        }),
+      })
+    render(<IntegrationsPage />)
+    await waitFor(() => screen.getByText('serena'))
+    fireEvent.click(screen.getByRole('button', { name: /install/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/Files that will change/i)).toBeInTheDocument()
+    })
+    expect(screen.getByText(/\.mcp\.json/i)).toBeInTheDocument()
+  })
+
+  it('shows installed state with uninstall button', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        plugins: [{
+          ...sampleCatalog.plugins[0],
+          status: 'installed',
+          installedAt: 'now',
+          health: 'ok',
+        }],
+      }),
+    })
+    render(<IntegrationsPage />)
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /uninstall/i })).toBeInTheDocument()
+    })
+  })
+
+  it('shows Auto-install button when uv prerequisite is missing', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, json: async () => sampleCatalog })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          pluginName: 'serena',
+          files: [{ path: '.mcp.json', op: 'create' }],
+          requirements: [{ name: 'uv', installed: false, executable: false, meetsMinimum: false, minVersion: '0.1.0' }],
+        }),
+      })
+    render(<IntegrationsPage />)
+    await waitFor(() => screen.getByText('serena'))
+    fireEvent.click(screen.getByRole('button', { name: /install$/i }))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /auto-install/i })).toBeInTheDocument()
+    })
+  })
+
+  it('renders empty state when no plugins are bundled', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ plugins: [] }) })
+    render(<IntegrationsPage />)
+    await waitFor(() => {
+      expect(screen.getByText(/no plugins are bundled/i)).toBeInTheDocument()
+    })
+  })
+
+  it('renders orphan section', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        plugins: [{
+          name: 'old-thing',
+          version: '0.1.0',
+          description: 'gone',
+          whatItDoes: [],
+          requirements: [],
+          status: 'orphan',
+        }],
+      }),
+    })
+    render(<IntegrationsPage />)
+    await waitFor(() => {
+      expect(screen.getByText(/Deprecated/i)).toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: /remove orphan/i })).toBeInTheDocument()
+  })
+})

--- a/openspec/changes/add-plugin-system/.openspec.yaml
+++ b/openspec/changes/add-plugin-system/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-04

--- a/openspec/changes/add-plugin-system/design.md
+++ b/openspec/changes/add-plugin-system/design.md
@@ -1,0 +1,130 @@
+## Context
+
+specrails-hub orchestrates rails (Claude CLI subprocesses) per project. Today, agents inside those rails consume most of their input tokens reading the user's repository through raw `Read`/`Grep`. Adopting semantic-aware MCP servers (Serena via LSP, future indexers, etc.) cuts that cost ~40-60%, but only if their setup is reliable per-project and rails actually inherit them.
+
+We considered three placements for that integration logic:
+1. Push it into `specrails-core` via new placeholders in agent templates (`{{PLUGINS_INSTRUCTIONS}}` etc.).
+2. Build a separate companion CLI.
+3. Build it inside `specrails-hub` as a marketplace-style per-project surface, with zero changes in `specrails-core`.
+
+The user explicitly chose option (3): keep `specrails-core` untouched. The hub already owns per-project state (profiles, telemetry, terminal sessions), the WebSocket fan-out, and the UI surface. Adding "plugins" follows the same shape as "profiles" — a small typed registry, per-project state under `.specrails/`, REST + WS, and a hook in `QueueManager` at spawn time.
+
+The constraint that drives almost every decision below is **additivity**: adding plugin N+1 in the future must not require touching plugin N's state, files, or behavior, and must not require migrations.
+
+## Goals / Non-Goals
+
+**Goals**
+- Per-project, marketplace-style integrations surface inside the hub.
+- Each plugin independently installable and uninstallable, with a diff-preview before either action.
+- All file mutations (`.mcp.json`, plugin state, agent fragments) are surgical, atomic, locked, and reversible.
+- Rails launched via `QueueManager` automatically inherit the project's active plugins (env vars, OTEL attrs, snapshot per job).
+- Pre-spawn healthcheck is non-blocking: a degraded plugin never cancels a rail.
+- Zero changes in `specrails-core` for v1. The plugin system is wholly hub-owned.
+- Adding a future plugin requires only: implementing the `Plugin` interface, adding it to `server/plugins/index.ts`, and (if it ships a fragment) dropping a templates file. No changes elsewhere.
+
+**Non-Goals (v1)**
+- Remote plugin registry or third-party plugin loading. Bundled-only.
+- User-authored plugins, plugin marketplaces beyond what hub bundles.
+- Hot-reload of plugins. Hub restart is acceptable.
+- Injecting plugin instructions into core agent templates (`sr-developer.md`, etc.). v1 leans on MCP tool schemas being self-descriptive. Re-evaluate in v2.
+- Cross-project shared plugin state.
+- A CLI for `specrails-hub plugin add/remove`. The UI is the only surface in v1.
+- Plugin dependencies between plugins (`requires: [otherPlugin]`). YAGNI.
+- Auto-install plugins when adding a project. Always opt-in.
+
+## Decisions
+
+### 1. Hub-only architecture; zero core changes
+- **Choice**: All plugin logic lives in the hub. The plugin system mutates `<project>/.mcp.json` and writes to `<project>/.specrails/plugins/` and `<project>/.claude/agents/custom-<plugin>.md`. None of those paths are managed or rewritten by `specrails-core` (per CLAUDE.md, `.claude/agents/custom-*.md` and `.specrails/profiles/**` are explicitly protected; `.mcp.json` is not core-managed; `.specrails/plugins/` is a new sibling that core has no business touching).
+- **Why**: Avoids cross-repo coordination, keeps release cadence independent, makes the change self-contained and reversible.
+- **Alternatives considered**:
+  - Adding a `{{PLUGINS_INSTRUCTIONS}}` placeholder in core agent templates so plugins can boost agents' system prompts. Rejected for v1 because it requires a core PR and its own version gate; revisit if metrics show MCP-only is materially under-utilized.
+  - Hub appending a marker block to project `CLAUDE.md`. Rejected for v1 because `CLAUDE.md` is user territory and we do not want hub-managed sections inside it.
+
+### 2. Per-project state at `.specrails/plugins/`
+- **Choice**: `<project>/.specrails/plugins/state.json` (state) and `<project>/.specrails/plugins/snapshots/<jobId>.json` (per-job freeze for diagnostic export). Plus the runtime mirror at `~/.specrails/projects/<slug>/jobs/<jobId>/plugins.json` (chmod 400) used at spawn time and read by the diagnostic exporter.
+- **Why**: Keeps everything plugin-related in one folder under the project's existing specrails directory. Mirrors the profile pattern (`profiles/` sibling) so future contributors find it without surprise.
+- **Risk**: We assume `specrails-core` does not blow away unknown subfolders under `.specrails/`. If a future core version ever does, we migrate to `.specrails-hub/plugins/` (new top-level, fully hub-owned) without breaking the on-disk schema. See "Risks" for mitigation.
+
+### 3. TypeScript module manifest, not YAML
+- **Choice**: Each plugin is a TS module exporting a `Plugin` value; the manifest is a typed object, not a parsed YAML/JSON document.
+- **Why**: Bundled-only registry means the manifest's source of truth is code we compile. Type safety > runtime AJV validation. Simpler tests. No risk of malformed manifests at runtime.
+- **Alternative**: `plugin.yaml` per plugin. Rejected: adds a parser, requires AJV like profiles already use, brings nothing because plugins are not user-authored in v1.
+
+### 4. Ownership-based additivity
+- **Choice**: Each plugin manifest declares `owns.mcpServers`, `owns.agentFragments`, `owns.configKeys`. At hub startup, `PluginManager` precomputes a global ownership map and fails fast if two plugins claim overlapping keys. All file mutations are scoped to a plugin's owned keys.
+- **Why**: This is the central guarantee. Adding plugin N+1 cannot accidentally trample plugin N because conflicts are detected before any user-facing surface is reachable.
+- **Alternatives**:
+  - Marker comment blocks inside a single `.mcp.json` per plugin. Rejected: `.mcp.json` is JSON, comments are not standard, and the merge logic becomes more error-prone.
+  - One `.mcp.json` fragment per plugin merged at runtime. Rejected: Claude CLI reads one file; we'd add a build step for no benefit.
+
+### 5. Surgical, locked, atomic mutators
+- **Choice**: All writes to `<project>/.mcp.json` and `state.json` follow read → modify → write-temp → rename, with a `proper-lockfile` advisory lock held for the entire round trip. Install transactions capture pre-install bytes for every file they will mutate; on `verify` failure or thrown error, the manager restores those bytes before surfacing the error.
+- **Why**: Prevents lost updates from concurrent installs; prevents partially-written `.mcp.json` from breaking the user's project; guarantees rollback is byte-identical.
+- **Alternative**: Best-effort writes with retry. Rejected: too easy to leave the project in an inconsistent state; users notice when their MCP config breaks.
+
+### 6. Healthcheck contract: non-blocking, time-boxed
+- **Choice**: `Plugin.verify` is a function each plugin implements; `PluginManager.verify(projectId, name)` wraps it with a 2000ms default timeout and converts errors/timeouts into `{ ok: false, reason }`. `QueueManager` consumes the result, never throws on degraded.
+- **Why**: A broken plugin (uv removed, daemon crashed) must not cancel a rail. Users tolerate "Serena unavailable for this run" — they do not tolerate "your rail failed to start because of a plugin you did not invoke".
+- **Trade-off**: We may run rails with broken plugins silently. Mitigation: emit `plugin.degraded` WS event with `jobId`, surface a degraded badge in the UI card, and include `degraded` in OTEL attrs so post-hoc analysis is straightforward.
+
+### 7. Snapshot per rail job
+- **Choice**: Before spawning a rail, `QueueManager` writes the resolved plugin set (active + degraded) to `~/.specrails/projects/<slug>/jobs/<jobId>/plugins.json` (chmod 400), exactly mirroring the existing profile snapshot pattern. The snapshot is the source of truth for that job and is included in the diagnostic ZIP.
+- **Why**: Reproducibility (we can answer "what plugins were live when this job ran?") and immutability (mid-job install/uninstall does not affect a running job).
+- **Alternative**: Read live state at every diagnostic export. Rejected: state is mutable, diagnostic data must not be retroactively rewritten.
+
+### 8. Spawn surfaces: only QueueManager
+- **Choice**: `QueueManager` snapshots, env-injects, and OTEL-tags. `ChatManager` does nothing plugin-specific — it relies on Claude CLI reading `.mcp.json` from the spawn `cwd`. `SetupManager` ignores plugins entirely.
+- **Why**: Same reasoning as the existing profile system. Rails are reproducible, telemetried jobs; chats are interactive (no point freezing); setup happens before any plugin could be installed.
+- **Alternative**: Snapshot for chat too. Rejected: adds work without payoff because chat is not analytically replayed.
+
+### 9. Marketplace UX with diff preview
+- **Choice**: A dedicated `IntegrationsPage` with marketplace-style cards. Install opens a modal showing exactly which files will change (`+` create, `~` modify) plus prerequisite checks; uninstall opens a destructive-style modal listing what reverts and what stays.
+- **Why**: Plugins mutate the user's repo. Showing the diff before mutation builds trust and makes accidental clicks harmless.
+- **Alternative**: One-click install. Rejected: too easy to nuke an existing `.mcp.json` setup the user crafted by hand.
+
+### 10. Reuse existing patterns, do not invent new ones
+- `usePrerequisites()` + `setup-prerequisites.ts` for `uv` detection (extend, not parallel).
+- Streaming install logs reuse the WS-driven progress UI from `SetupWizard`.
+- `useProjectCache` for stale-while-revalidate of the catalog across project switches.
+- WS event filtering by `projectId` ref already standard in `useHub`.
+- `proper-lockfile` is already an acceptable dep on the server side.
+
+## Risks / Trade-offs
+
+- **Risk**: Future `specrails-core` versions may add cleanup logic that touches `.specrails/plugins/`.
+  → **Mitigation**: The CLAUDE.md contract today is "core does not touch unknown subfolders." We monitor core release notes; if a future version ever sweeps `.specrails/`, the migration is a one-shot rename to `.specrails-hub/plugins/` (path constant lives in one place: `server/plugins/paths.ts`).
+
+- **Risk**: A user manually edits `.mcp.json` and the manager's surgical merge silently overwrites their entry because we mis-identify ownership.
+  → **Mitigation**: Ownership map is computed at startup and never includes user-authored keys. Mutators only touch keys explicitly listed in a plugin's `owns.mcpServers`. Add a regression test where the project starts with a user-authored entry and assert byte-equality after install + uninstall.
+
+- **Risk**: Verify timeouts misclassify a slow but healthy plugin as degraded.
+  → **Mitigation**: 2000ms default is generous; configurable per plugin via manifest field `verifyTimeoutMs`. UI shows the reason (`verify-timeout` vs `uv-not-on-path`) so users can recheck manually.
+
+- **Risk**: Two installs racing each other corrupt `state.json` or `.mcp.json`.
+  → **Mitigation**: `proper-lockfile` advisory locks held end-to-end; explicit test for concurrent installs.
+
+- **Risk**: MCP server name collision with user-authored entries (user already has `mcpServers.serena` for a personal Serena setup).
+  → **Mitigation**: Pre-install check rejects with a clear error: "this project already has an `mcpServers.serena` entry not managed by the hub; remove it first." No silent overwrite.
+
+- **Risk**: Adding plugin instructions to core agents (v2) is more impactful than MCP-only and we under-deliver in v1.
+  → **Trade-off**: Accepted. v1 is shippable in days; v2 prompt boost can land on top without architectural change. The plugin contract already supports an optional `custom-<plugin>.md` fragment, so v2 may not even require a contract change — only a templates/instructions.md inside Serena.
+
+- **Risk**: Diagnostic ZIP grows.
+  → **Trade-off**: `plugins.json` is small (sub-KB). Negligible.
+
+- **Risk**: Healthcheck spawns add measurable latency before each rail spawn.
+  → **Mitigation**: Healthcheck runs in parallel for all installed plugins (Promise.all with per-plugin timeout). For typical projects with 0–1 plugins, added latency is bounded by the slowest plugin's timeout (≤ 2000ms) and is acceptable.
+
+## Migration Plan
+
+This is purely additive; there is nothing to migrate.
+
+- **Deploy**: Ship hub release with the plugin module compiled in. Existing projects without any installed plugin behave identically.
+- **Rollback**: If the plugin system causes regressions, ship a hub release that disables the router and hides the sidebar entry; on-disk state files are inert and can be re-enabled later. No DB migration to revert.
+
+## Open Questions
+
+- Final placement of the sidebar entry (above or below "Agents") — UX detail, defer until layout review.
+- Whether to expose `verifyTimeoutMs` per plugin in v1 or hardcode 2000ms — defer; ship hardcoded, expose in v2 if any plugin needs different.
+- Whether `plugin.health_changed` should be emitted on a periodic interval or only on user-triggered re-verify — start with user-triggered + spawn-time only; revisit if users want a "dashboard" view.

--- a/openspec/changes/add-plugin-system/proposal.md
+++ b/openspec/changes/add-plugin-system/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+specrails-hub agents (rails) burn most of their tokens navigating the user's codebase via raw `Read`/`Grep`. Semantic-aware tooling (e.g. Serena via LSP+MCP) cuts that cost ~40-60% but its setup is fiddly and per-project. We want a marketplace-style surface inside the hub where each project independently opts into integrations, the hub installs/uninstalls them surgically, and rails launched from that project automatically inherit the active plugins — without ever requiring changes in `specrails-core`.
+
+## What Changes
+
+- New per-project **Integrations** section (page + REST + server module) that lists bundled plugins as marketplace cards, each independently installable/uninstallable.
+- New `PluginManager` server module that owns plugin lifecycle (detect, install, verify, uninstall), state file, healthchecks, and a typed registry of bundled plugins.
+- New `Plugin` TypeScript interface + bundled `serena` plugin as the first dogfooded integration.
+- **Surgical, additive mutators** for `<project>/.mcp.json` and per-project plugin state, with file locking, rollback on install failure, and an "ownership" contract so plugins never stomp each other or user-authored entries.
+- New per-project state directory `<project>/.specrails/plugins/` with `state.json` and per-job snapshots — independent from `specrails-core` artifacts.
+- `QueueManager` integration: pre-spawn healthcheck per active plugin, snapshot to `~/.specrails/projects/<slug>/jobs/<jobId>/plugins.json` (chmod 400), inject `SPECRAILS_PLUGINS_ACTIVE` env var, and add OTEL resource attrs `specrails.plugins.active` / `specrails.plugins.degraded`. Healthcheck is **non-blocking** (degraded plugins log + continue).
+- `ChatManager` inherits `.mcp.json` from cwd at spawn time without snapshotting (interactive sessions stay live). `SetupManager` ignores plugins entirely (project under construction).
+- Diagnostic ZIP (`telemetry-export.ts`) gains `plugins.json` entry and plugin mentions in `summary.md`.
+- New WebSocket events: `plugin.installed`, `plugin.uninstalled`, `plugin.degraded`, `plugin.health_changed` — all `projectId`-scoped.
+- New install-time UX: install dialog with diff-preview of files about to change, prerequisite auto-install (reuses existing `usePrerequisites` + `setup-prerequisites.ts` patterns, extended for `uv`), streaming progress, and rollback on verify failure. Uninstall dialog mirrors the same pattern.
+- v1 ships **bundled-only** registry (`server/plugins/index.ts` array). No remote registry, no third-party plugin loading, no marketplace beyond what hub bundles.
+- v1 ships **MCP-only** plugin scope: each plugin contributes one or more `mcpServers` entries plus optional `<project>/.claude/agents/custom-<plugin>.md` (a core-protected namespace). Agent system-prompt injection is intentionally out of scope to keep `specrails-core` untouched.
+
+## Capabilities
+
+### New Capabilities
+- `plugin-system`: per-project plugin lifecycle (registry, state file, install/uninstall, healthchecks, additive `.mcp.json` mutation, ownership conflict detection).
+- `plugin-marketplace-ui`: marketplace-style `IntegrationsPage` per project (cards, install dialog with diff preview, uninstall confirm, health badges, WS event handling).
+- `plugin-rail-integration`: QueueManager pre-spawn snapshot + healthcheck + env injection + OTEL attrs; ChatManager inherit-only behavior; SetupManager opt-out; diagnostic ZIP additions.
+- `serena-plugin`: bundled Serena plugin implementation — manifest, install (writes MCP server entry + ensures `uv` available), verify (`uvx serena --version`), uninstall (surgical removal), and any plugin-owned files under `.claude/agents/custom-serena.md`.
+
+### Modified Capabilities
+<!-- None. The integration with QueueManager / ChatManager / SetupManager / telemetry export is additive new behavior captured under the new capabilities above; no existing spec's REQUIREMENTS change. -->
+
+## Impact
+
+- **Server**: new `server/plugin-manager.ts`, `server/plugins-router.ts`, `server/plugins/` (registry + serena), new types in `server/types.ts`. Light edits to `server/queue-manager.ts` (one new resolve step + env/OTEL injection), `server/telemetry-export.ts` (extra ZIP entry), `server/setup-prerequisites.ts` (add `uv` detector), `server/index.ts` (mount router). No edits to `chat-manager.ts` or `setup-manager.ts` beyond ensuring they don't snapshot plugins.
+- **Client**: new `client/src/pages/IntegrationsPage.tsx`, supporting components (`PluginCard`, `PluginInstallDialog`, `PluginUninstallDialog`, `PluginDiffPreview`), new route under `ProjectLayout`, sidebar entry, WS handlers in `useHub` / project event stream filter.
+- **Per-project filesystem (managed by hub)**: `<project>/.mcp.json` (surgical merge), `<project>/.specrails/plugins/state.json`, `<project>/.specrails/plugins/snapshots/<jobId>.json`, optional `<project>/.claude/agents/custom-<plugin>.md`. Hub uses `proper-lockfile` for `.mcp.json` and `state.json` writes.
+- **Hub-managed runtime paths**: `~/.specrails/projects/<slug>/jobs/<jobId>/plugins.json` (chmod 400) alongside the existing `profile.json` snapshot.
+- **specrails-core**: zero changes. Plugin instructions are NOT injected into `sr-*.md` templates in v1 — agents discover MCP tools via their JSON schemas. Custom-agent file `custom-<plugin>.md` lives in the already-protected `.claude/agents/custom-*.md` namespace if a plugin chooses to ship one.
+- **Tests**: vitest suites for plugin-manager (lifecycle, ownership conflicts, lock contention, additive guarantees), plugins-router (REST), QueueManager (snapshot + degraded path + OTEL attrs), telemetry-export (ZIP contents), IntegrationsPage (cards/dialogs), end-to-end Serena install/uninstall against a temp project.
+- **Coverage**: new code must clear the existing 80% server / 80% client thresholds — no exclusions.
+- **Dependencies**: `proper-lockfile` (already eligible) for atomic file mutation; no other new runtime deps. `uv` is a runtime requirement of the Serena plugin only — auto-installed via existing prerequisites flow, never a hub-level dependency.
+- **Backwards compatibility**: pure addition. Projects without any installed plugins behave identically to today. Existing rails, chats, setup wizards, telemetry exports remain unchanged on the no-plugin path.

--- a/openspec/changes/add-plugin-system/specs/plugin-marketplace-ui/spec.md
+++ b/openspec/changes/add-plugin-system/specs/plugin-marketplace-ui/spec.md
@@ -1,0 +1,88 @@
+## ADDED Requirements
+
+### Requirement: Integrations route per project
+The client SHALL expose an `IntegrationsPage` at the project-scoped route `/integrations`, mounted under `ProjectLayout`, reachable from a sidebar entry placed adjacent to the existing Agents entry.
+
+#### Scenario: Sidebar entry navigates to integrations
+- **WHEN** a project is active and the user clicks the sidebar "Integrations" item
+- **THEN** the router navigates to `/integrations` and `IntegrationsPage` mounts within `ProjectLayout`
+
+#### Scenario: Page is per-project
+- **WHEN** the user switches the active project on `IntegrationsPage`
+- **THEN** the page refetches the catalog using `getApiBase()` and re-renders cards reflecting the new project's plugin state without flashing an empty state when cached data exists
+
+### Requirement: Marketplace card per plugin
+Every plugin in the catalog MUST be rendered as a card showing: icon, name, version, description, `whatItDoes` bullets, prerequisite list with live satisfied/missing badges, and a primary action that depends on status.
+
+#### Scenario: Card shows Install when plugin not installed
+- **WHEN** the catalog reports `status: "not-installed"` for plugin Serena
+- **THEN** the card's primary action is `Install` and no uninstall control is rendered
+
+#### Scenario: Card shows Active + Uninstall when installed
+- **WHEN** the catalog reports `status: "installed"` for plugin Serena with healthy verify
+- **THEN** the card displays an `Active` badge and an `Uninstall` button
+
+#### Scenario: Card shows degraded badge when verify fails
+- **WHEN** the catalog reports `status: "degraded"` (installed but verify failed) for a plugin
+- **THEN** the card displays a degraded badge with a "Diagnose" affordance that opens the verify reason
+
+### Requirement: Install dialog with diff preview
+Clicking `Install` MUST open a modal that calls `GET /api/projects/:id/plugins/:name/preview-install` and renders the returned diff before the user confirms. The dialog MUST display: a summary of what the plugin does, the list of files about to be created or modified with create (`+`) / modify (`~`) markers, and a prerequisite section reusing the existing `PrerequisitesPanel` pattern.
+
+#### Scenario: Preview is rendered before any mutation
+- **WHEN** the user clicks Install on a plugin card
+- **THEN** the dialog opens, the preview-install endpoint is called once, and no project files are mutated until the user confirms
+
+#### Scenario: Prerequisites missing disables confirm
+- **WHEN** the dialog opens and a required prerequisite (e.g. `uv`) is missing
+- **THEN** the confirm button is disabled and an "Auto-install" affordance is rendered for the missing prerequisite
+
+#### Scenario: Confirm starts install and streams progress
+- **WHEN** the user clicks the confirm button
+- **THEN** `POST /api/projects/:id/plugins/:name/install` is called, install progress is shown in a streaming log inside the dialog (driven by the project WebSocket), and on success the dialog auto-closes after 1500ms
+
+### Requirement: Uninstall dialog with destructive confirm
+Clicking `Uninstall` MUST open a destructive-style modal that lists every file the plugin will revert or remove, plus a "Will NOT touch" section enumerating what stays (binary tools installed on the system, user code, tickets, history). The modal's primary button MUST be styled as destructive and MUST require an explicit click to proceed; no "click outside to confirm" shortcut.
+
+#### Scenario: Cancel leaves state untouched
+- **WHEN** the user opens the uninstall dialog and clicks Cancel
+- **THEN** no API call is issued and the plugin remains installed
+
+#### Scenario: Confirm uninstalls and re-renders card
+- **WHEN** the user clicks the destructive confirm button
+- **THEN** `DELETE /api/projects/:id/plugins/:name` is called, the dialog closes on success, and the card re-renders in `not-installed` state
+
+### Requirement: WebSocket-driven status updates
+`IntegrationsPage` MUST subscribe to the project event stream and update card state in response to `plugin.installed`, `plugin.uninstalled`, `plugin.degraded`, and `plugin.health_changed` events whose `projectId` matches the active project. Events for other projects MUST be ignored.
+
+#### Scenario: plugin.degraded badge appears live
+- **GIVEN** the page is open and Serena is installed and active
+- **WHEN** the server emits `plugin.degraded` for `projectId` matching the active project
+- **THEN** the Serena card switches to the degraded visual state without a manual refresh
+
+#### Scenario: Events for inactive projects are ignored
+- **GIVEN** the page is open for project A
+- **WHEN** the server emits `plugin.installed` with `projectId = B`
+- **THEN** no card on the page updates
+
+### Requirement: Orphan plugin presentation
+Cards whose status is `orphan` MUST be rendered in a clearly separated section with a deprecation banner and a destructive "Remove orphan" action that calls `DELETE /api/projects/:id/plugins/:name`. Orphan cards MUST NOT be eligible for install or healthcheck actions.
+
+#### Scenario: Orphan section appears below catalog
+- **WHEN** the catalog response contains entries with `status: "orphan"`
+- **THEN** they render under a "Deprecated" subheader, after the active catalog, with only a Remove action
+
+### Requirement: Empty and error states
+The page MUST handle three non-happy states with explicit copy: (1) catalog fetch in flight (skeleton cards), (2) catalog fetch failed (error state with Retry), (3) catalog empty (calm copy explaining no plugins are bundled in this hub build).
+
+#### Scenario: Fetch failure shows retry
+- **WHEN** the catalog endpoint returns 5xx
+- **THEN** the page shows an error card with a Retry button that re-fetches when clicked
+
+### Requirement: Stale-while-revalidate caching across project switch
+`IntegrationsPage` MUST use the existing `useProjectCache` pattern so switching back to a previously-viewed project shows cached cards instantly while a fresh fetch updates them in the background. The page MUST never reset to an empty state on project switch when cached data exists.
+
+#### Scenario: Cached cards survive project switch
+- **GIVEN** the user has visited Integrations for project A and the catalog is cached
+- **WHEN** the user switches to project B and back to A
+- **THEN** A's cards render immediately from cache while a background fetch revalidates them

--- a/openspec/changes/add-plugin-system/specs/plugin-rail-integration/spec.md
+++ b/openspec/changes/add-plugin-system/specs/plugin-rail-integration/spec.md
@@ -1,0 +1,103 @@
+## ADDED Requirements
+
+### Requirement: Pre-spawn plugin resolution in QueueManager
+Before spawning a Claude CLI process for a rail job, `QueueManager` MUST resolve the project's installed plugins by reading `<project>/.specrails/plugins/state.json` and invoking `PluginManager.verify` for each entry. Resolution MUST run after the existing profile resolution and before the spawn. Resolution MUST NOT mutate any project file.
+
+#### Scenario: Project with no plugins resolves to empty active list
+- **WHEN** a rail job is enqueued for a project whose `state.json` is missing or empty
+- **THEN** plugin resolution returns `{ active: [], degraded: [] }` and the spawn proceeds with no plugin-specific changes
+
+#### Scenario: Healthy plugin appears in active list
+- **WHEN** Serena is installed and `verify` resolves `{ ok: true }` within the timeout
+- **THEN** plugin resolution returns `active: [{ name: "serena", version: "<v>" }]`
+
+### Requirement: Healthcheck is non-blocking
+A failed or timed-out plugin healthcheck MUST NOT cancel or fail the rail spawn. The plugin MUST be moved from `active` to `degraded` and the spawn MUST proceed.
+
+#### Scenario: Verify timeout downgrades but does not block
+- **GIVEN** Serena is installed and its `verify` exceeds the configured timeout (default 2000ms)
+- **WHEN** the rail job is enqueued
+- **THEN** plugin resolution returns `degraded: [{ name: "serena", reason: "verify-timeout" }]` and the spawn proceeds normally
+
+#### Scenario: Verify error downgrades but does not block
+- **GIVEN** Serena is installed but `uv` has been removed from PATH
+- **WHEN** the rail job is enqueued
+- **THEN** plugin resolution returns `degraded: [{ name: "serena", reason: "<actual reason>" }]` and the spawn proceeds normally
+
+### Requirement: Per-job plugin snapshot
+For every rail spawn that resolves at least one plugin (active or degraded), `QueueManager` MUST write a snapshot file at `~/.specrails/projects/<slug>/jobs/<jobId>/plugins.json` with mode `0o400`. The snapshot MUST contain `{ jobId, projectId, capturedAt, active: [{ name, version }], degraded: [{ name, reason }] }` and MUST be written before the spawn.
+
+#### Scenario: Snapshot exists with chmod 400 after spawn
+- **WHEN** a rail job spawns with Serena active
+- **THEN** the snapshot file exists at the expected path, has mode `0o400`, and contains Serena under `active`
+
+#### Scenario: No snapshot when no plugins resolved
+- **WHEN** a rail job spawns for a project with no installed plugins
+- **THEN** no `plugins.json` file is written for that job
+
+### Requirement: Environment and OTEL injection
+When a rail job spawns with at least one plugin in `active`, `QueueManager` MUST set the environment variable `SPECRAILS_PLUGINS_ACTIVE` to a comma-separated list of active plugin names and `SPECRAILS_PLUGINS_SNAPSHOT` to the absolute path of the snapshot file. The OTEL resource attributes for that job MUST include `specrails.plugins.active` (string array of names) and, when applicable, `specrails.plugins.degraded` (string array of names). Versions MUST be exposed under `specrails.plugins.versions` as a JSON-serialised string keyed by name.
+
+#### Scenario: Active plugins surface in env vars
+- **WHEN** a rail spawns with Serena active
+- **THEN** the spawned process's environment contains `SPECRAILS_PLUGINS_ACTIVE=serena` and `SPECRAILS_PLUGINS_SNAPSHOT=<absolute path>`
+
+#### Scenario: OTEL attrs include both active and degraded
+- **WHEN** a rail spawns with Serena active and a hypothetical second plugin degraded
+- **THEN** OTEL resource attrs include `specrails.plugins.active = ["serena"]` and `specrails.plugins.degraded = ["<other>"]`
+
+### Requirement: ChatManager inherits without snapshot
+`ChatManager` MUST NOT write a per-session plugin snapshot and MUST NOT set `SPECRAILS_PLUGINS_*` env vars. Plugins reach interactive chat sessions only via the project's `.mcp.json`, which the Claude CLI reads at process startup using the spawn `cwd`.
+
+#### Scenario: Chat spawn has no plugin env vars
+- **WHEN** a chat session is started for a project with Serena installed
+- **THEN** the spawned chat process's environment does not contain `SPECRAILS_PLUGINS_ACTIVE` or `SPECRAILS_PLUGINS_SNAPSHOT`
+
+#### Scenario: Chat session inherits MCP config from cwd
+- **GIVEN** Serena is installed and present in `.mcp.json`
+- **WHEN** a chat session spawns
+- **THEN** the Claude CLI loads `serena` from `.mcp.json` via the spawn `cwd` without any hub-side plugin code path running
+
+### Requirement: SetupManager ignores plugins
+`SetupManager` MUST NOT read plugin state, run healthchecks, or inject plugin env vars during the project setup wizard. The wizard remains entirely independent of the plugin system.
+
+#### Scenario: Setup wizard is plugin-agnostic
+- **WHEN** a project setup wizard runs
+- **THEN** no `PluginManager` method is invoked by `SetupManager` and no plugin snapshot is written
+
+### Requirement: Diagnostic ZIP includes plugin snapshot
+`telemetry-export.ts` MUST include the per-job `plugins.json` snapshot in the diagnostic ZIP whenever the snapshot exists for that job, and MUST mention installed/degraded plugins in `summary.md`.
+
+#### Scenario: ZIP contains plugins.json when snapshot exists
+- **GIVEN** a rail job ran with Serena active and its snapshot exists
+- **WHEN** the user exports the diagnostic ZIP for that job
+- **THEN** the ZIP archive contains `plugins.json` with the snapshot contents and `summary.md` mentions Serena
+
+#### Scenario: ZIP omits plugins.json when no snapshot
+- **GIVEN** a rail job ran for a project with no plugins
+- **WHEN** the user exports the diagnostic ZIP for that job
+- **THEN** the ZIP archive does not contain `plugins.json` and `summary.md` does not reference any plugin
+
+### Requirement: WebSocket events for plugin lifecycle
+The hub SHALL broadcast project-scoped WebSocket events on plugin lifecycle transitions: `plugin.installed`, `plugin.uninstalled`, `plugin.health_changed`, and `plugin.degraded`. Every event MUST include `projectId` and the plugin `name`. `plugin.degraded` MUST additionally include `reason` and, when emitted from a rail spawn path, the related `jobId`.
+
+#### Scenario: install emits plugin.installed
+- **WHEN** a plugin install completes successfully
+- **THEN** the hub broadcasts `{ type: "plugin.installed", projectId, name, version }`
+
+#### Scenario: degraded during rail spawn carries jobId
+- **WHEN** a plugin is degraded during a rail's pre-spawn healthcheck
+- **THEN** the hub broadcasts `{ type: "plugin.degraded", projectId, name, reason, jobId }`
+
+### Requirement: Snapshot atomicity vs concurrent install
+A user-driven plugin install or uninstall MUST NOT corrupt an in-flight rail's behavior. The rail's snapshot, taken before spawn, MUST be the source of truth for that job; subsequent state changes MUST NOT be reflected back into already-running jobs.
+
+#### Scenario: Mid-job uninstall does not affect running job
+- **GIVEN** a rail job spawned with Serena in its snapshot
+- **WHEN** the user uninstalls Serena while that job is still running
+- **THEN** the running job continues with the MCP config it loaded at spawn time and its `plugins.json` snapshot remains untouched
+
+#### Scenario: Next job after uninstall reflects new state
+- **GIVEN** Serena was uninstalled while a previous job was running
+- **WHEN** a new rail job is enqueued for the same project
+- **THEN** the new job's snapshot does not contain Serena and `SPECRAILS_PLUGINS_ACTIVE` does not include it

--- a/openspec/changes/add-plugin-system/specs/plugin-system/spec.md
+++ b/openspec/changes/add-plugin-system/specs/plugin-system/spec.md
@@ -1,0 +1,114 @@
+## ADDED Requirements
+
+### Requirement: Bundled plugin registry
+The hub SHALL expose a typed, in-process registry of bundled plugins. Every plugin available to projects MUST be discoverable through this registry; no remote, user-installable, or dynamically-loaded plugins are permitted in v1.
+
+#### Scenario: Listing the registry returns all bundled plugins
+- **WHEN** the hub starts
+- **THEN** `PluginManager.listAvailable()` returns one entry per plugin bundled at build time, each carrying its full manifest
+
+#### Scenario: Adding a new plugin requires only a registry import
+- **WHEN** a developer appends a new plugin module to `server/plugins/index.ts`
+- **THEN** the new plugin appears in the registry on next hub start with no other code changes elsewhere
+
+### Requirement: Plugin manifest declares ownership
+Every plugin MUST declare, in its manifest, the artifacts it owns: MCP server names (`owns.mcpServers`), agent fragment file paths (`owns.agentFragments`), and any project-state config keys (`owns.configKeys`). The manifest MUST also include `name` (kebab-case unique id), `version` (semver), `description`, `whatItDoes` (bullet list for the marketplace card), and `requirements` (executable prerequisites such as `uv >= 0.1`).
+
+#### Scenario: Manifest with overlapping ownership is rejected at startup
+- **WHEN** two registered plugins claim the same `mcpServers` entry
+- **THEN** the hub fails fast at startup with an error naming both plugins and the conflicting key
+
+#### Scenario: Manifest missing required fields is rejected at startup
+- **WHEN** a registered plugin's manifest lacks `name`, `version`, or `owns`
+- **THEN** the hub fails fast at startup with a validation error pointing at the offending plugin
+
+### Requirement: Per-project plugin state
+The hub SHALL persist per-project plugin state at `<project>/.specrails/plugins/state.json`. The state file MUST be a JSON object of shape `{ schemaVersion: 1, plugins: { [name]: { version, installedAt, health } } }`. The file MUST be created lazily on first install and never deleted by the hub even when no plugins remain installed.
+
+#### Scenario: Project with no plugins has no state file
+- **WHEN** a project has never installed a plugin
+- **THEN** `<project>/.specrails/plugins/state.json` does not exist and `PluginManager.getProjectState(projectId)` returns `{ schemaVersion: 1, plugins: {} }`
+
+#### Scenario: State file survives uninstall of last plugin
+- **WHEN** the user uninstalls the last installed plugin
+- **THEN** `state.json` remains on disk with `plugins: {}`
+
+### Requirement: Additive install/uninstall
+Installing or uninstalling plugin N MUST NOT mutate any artifact owned by another plugin or by the user. All file mutations to shared artifacts (`.mcp.json`, `state.json`) MUST be surgical: read, modify only the plugin's owned keys, write atomically.
+
+#### Scenario: Installing a second plugin preserves the first
+- **GIVEN** plugin A is installed and contributed `mcpServers.serena`
+- **WHEN** plugin B is installed and contributes `mcpServers.foo`
+- **THEN** `.mcp.json` contains both `serena` and `foo` entries unchanged from each plugin's contribution
+
+#### Scenario: Uninstalling a plugin preserves user-authored MCP entries
+- **GIVEN** the user manually added `mcpServers.myown` to `.mcp.json` and plugin A contributed `mcpServers.serena`
+- **WHEN** plugin A is uninstalled
+- **THEN** `.mcp.json` still contains `myown` exactly as the user wrote it; only `serena` is removed
+
+#### Scenario: Uninstall does not touch other plugins' agent fragments
+- **GIVEN** plugin A owns `.claude/agents/custom-serena.md` and plugin B owns `.claude/agents/custom-foo.md`
+- **WHEN** plugin A is uninstalled
+- **THEN** `custom-foo.md` is untouched
+
+### Requirement: Atomic, locked file mutation
+All writes to `<project>/.mcp.json` and `<project>/.specrails/plugins/state.json` performed by the hub MUST hold a `proper-lockfile` advisory lock for the duration of the read-modify-write and MUST replace the file via temp-file + rename so partial writes are never observable.
+
+#### Scenario: Concurrent installs serialize correctly
+- **WHEN** two installs of different plugins start within the same millisecond
+- **THEN** both ultimately succeed and the final `.mcp.json` contains entries from both with no lost update
+
+#### Scenario: Crash mid-write leaves the previous file intact
+- **WHEN** the hub process is killed between the temp write and the rename
+- **THEN** the original `.mcp.json` remains valid JSON with its prior contents
+
+### Requirement: Install rollback on failure
+If `Plugin.install` fails or `Plugin.verify` returns `ok: false` immediately after install, the `PluginManager` MUST roll back every file mutation performed during the failed install before surfacing the error. State on disk after the rollback MUST be byte-identical to the pre-install state.
+
+#### Scenario: Verify failure rolls back .mcp.json
+- **GIVEN** plugin A's `install` succeeds but `verify` reports `ok: false`
+- **WHEN** the install transaction completes
+- **THEN** `.mcp.json` is restored to its pre-install contents and `state.json` does not contain plugin A
+
+### Requirement: Healthcheck API
+`PluginManager.verify(projectId, pluginName)` MUST return `{ ok, reason, checkedAt }` and MUST complete or be cancelled within a configurable timeout (default 2000ms). Healthcheck implementations are owned by each plugin and MUST be safe to invoke at any time.
+
+#### Scenario: Verify timeout reports degraded
+- **WHEN** a plugin's `verify` runs longer than the timeout
+- **THEN** `PluginManager.verify` resolves with `{ ok: false, reason: "verify-timeout", ... }` and does not throw
+
+#### Scenario: Healthy plugin returns ok
+- **WHEN** Serena is installed and `uvx serena --version` exits 0 within the timeout
+- **THEN** `PluginManager.verify(projectId, "serena")` resolves with `{ ok: true }`
+
+### Requirement: Orphan handling
+When a project's `state.json` references a plugin that is no longer in the bundled registry, the hub MUST mark that entry as `orphan: true` in API responses but MUST NOT delete it silently. The user MUST be offered an explicit "remove orphan" action.
+
+#### Scenario: Removed plugin shows as orphan
+- **GIVEN** state.json contains plugin "old-thing" and the registry does not
+- **WHEN** the client fetches the integrations list for that project
+- **THEN** the response includes one card with `status: "orphan"` and a separate uninstall path
+
+### Requirement: REST API surface
+The hub SHALL expose plugin operations under `/api/projects/:projectId/plugins`:
+- `GET /` — list catalog with per-plugin status (`installed | not-installed | orphan | degraded`).
+- `GET /:name/preview-install` — return a structured diff describing every file the install would create or modify.
+- `POST /:name/install` — perform install; streams progress over the existing project WebSocket using `plugin.installed` and progress events.
+- `DELETE /:name` — uninstall; emits `plugin.uninstalled`.
+- `GET /:name/health` — re-run verify on demand.
+
+#### Scenario: Preview-install returns diff before any mutation
+- **WHEN** the client calls `GET /api/projects/:id/plugins/serena/preview-install`
+- **THEN** the response describes the planned changes and the project filesystem is not modified
+
+#### Scenario: Install on missing plugin returns 404
+- **WHEN** the client calls `POST /api/projects/:id/plugins/does-not-exist/install`
+- **THEN** the server returns HTTP 404 with an error body naming the unknown plugin
+
+### Requirement: Per-project isolation
+Plugin state, install effects, and lifecycle MUST be strictly per-project. Installing a plugin in project A MUST have no effect on project B, even when both projects target the same filesystem path is impossible by registry construction (each project has a unique path).
+
+#### Scenario: Install in project A leaves project B untouched
+- **GIVEN** projects A and B exist with no plugins installed
+- **WHEN** the user installs Serena in project A
+- **THEN** project B's `.mcp.json` and `.specrails/plugins/state.json` are unchanged

--- a/openspec/changes/add-plugin-system/specs/serena-plugin/spec.md
+++ b/openspec/changes/add-plugin-system/specs/serena-plugin/spec.md
@@ -1,0 +1,107 @@
+## ADDED Requirements
+
+### Requirement: Serena ships as a bundled plugin
+The hub SHALL ship a built-in plugin named `serena` registered in `server/plugins/index.ts`, implementing the `Plugin` interface defined by the plugin system. Its manifest MUST declare:
+- `name: "serena"`, `version` matching the bundled module's package version,
+- `description` and `whatItDoes` copy describing semantic code navigation via LSP+MCP,
+- `requirements: [{ name: "uv", minVersion: "0.1.0" }]`,
+- `owns.mcpServers: ["serena"]`,
+- `owns.agentFragments: [".claude/agents/custom-serena.md"]` (only if the plugin chooses to ship that file; see optional fragment requirement below).
+
+#### Scenario: Hub registers serena at startup
+- **WHEN** the hub process starts with no startup errors
+- **THEN** `PluginManager.listAvailable()` includes one entry whose `name === "serena"`
+
+#### Scenario: Manifest exposes uv requirement
+- **WHEN** the client fetches `GET /api/projects/:id/plugins`
+- **THEN** Serena's catalog entry lists `uv` under `requirements`
+
+### Requirement: Serena install writes the MCP server entry
+When `Plugin.install` runs, the Serena plugin MUST write or merge into `<project>/.mcp.json` the following entry under `mcpServers.serena`:
+```json
+{
+  "command": "uvx",
+  "args": [
+    "--from", "git+https://github.com/oraios/serena",
+    "serena", "start-mcp-server",
+    "--context", "ide-assistant",
+    "--project", "."
+  ]
+}
+```
+The merge MUST be surgical: if `mcpServers` does not exist, it is created; existing sibling entries are preserved exactly.
+
+#### Scenario: Install writes the serena entry into a fresh .mcp.json
+- **GIVEN** `<project>/.mcp.json` does not exist
+- **WHEN** Serena is installed
+- **THEN** `<project>/.mcp.json` is created containing exactly `{ "mcpServers": { "serena": { ...spec'd entry... } } }`
+
+#### Scenario: Install preserves existing mcpServers entries
+- **GIVEN** `<project>/.mcp.json` contains `mcpServers.myown` authored by the user
+- **WHEN** Serena is installed
+- **THEN** the file contains both `myown` (byte-identical) and `serena`
+
+### Requirement: Serena prerequisite resolution
+The Serena plugin MUST advertise `uv` as a prerequisite. The hub's prerequisites detector (`setup-prerequisites.ts`) MUST be extended to detect `uv` (`uv --version` exit 0 with parsed semver) and report it under the same shape as Node/git/etc. The Install dialog MUST surface an "Auto-install uv" affordance when `uv` is missing, using OS-aware install commands consistent with the existing `InstallInstructionsModal`.
+
+#### Scenario: uv detected when installed
+- **GIVEN** `uv` is on PATH and `uv --version` exits 0
+- **WHEN** the prerequisites endpoint is called
+- **THEN** the response reports `uv` as `installed: true, executable: true` with the parsed version
+
+#### Scenario: uv missing surfaces in dialog
+- **GIVEN** `uv` is not on PATH
+- **WHEN** the user opens the Serena Install dialog
+- **THEN** the dialog displays a missing-`uv` indicator and the confirm button is disabled until the user runs auto-install or installs `uv` manually
+
+### Requirement: Serena verify
+`Plugin.verify` for Serena MUST run `uvx serena --version` (or equivalent non-installing probe) with a 2000ms default timeout. It MUST return `{ ok: true }` when exit code is 0 and the stdout matches the expected format, and `{ ok: false, reason }` otherwise (with reasons such as `uv-not-on-path`, `uvx-non-zero-exit`, `verify-timeout`).
+
+#### Scenario: Verify ok after install
+- **GIVEN** Serena was just installed and `uv` is healthy
+- **WHEN** `Plugin.verify` runs
+- **THEN** it resolves `{ ok: true }` within the timeout
+
+#### Scenario: Verify reports uv-not-on-path
+- **GIVEN** Serena is installed but `uv` has been removed from PATH
+- **WHEN** `Plugin.verify` runs
+- **THEN** it resolves `{ ok: false, reason: "uv-not-on-path" }`
+
+### Requirement: Serena uninstall is surgical
+`Plugin.uninstall` MUST remove only the `mcpServers.serena` key from `<project>/.mcp.json`, MUST remove `<project>/.specrails/plugins/state.json#plugins.serena`, and MUST remove `.claude/agents/custom-serena.md` if and only if that file was created by this plugin (verified via the state file's `installedFiles` list). It MUST NOT touch `uv` (the system-wide tool) or any other plugin's contributions.
+
+#### Scenario: Uninstall removes only serena from .mcp.json
+- **GIVEN** `.mcp.json` contains `mcpServers.serena` (from this plugin) and `mcpServers.myown` (user)
+- **WHEN** Serena is uninstalled
+- **THEN** the file contains only `mcpServers.myown`, byte-identical to its original form
+
+#### Scenario: Uninstall does not remove uv
+- **GIVEN** Serena is installed and `uv` was auto-installed by the install flow
+- **WHEN** Serena is uninstalled
+- **THEN** `uv` remains available on PATH
+
+### Requirement: Optional Serena agent fragment
+The Serena plugin MAY ship a `templates/instructions.md` fragment that, when present, is written to `<project>/.claude/agents/custom-serena.md` during install and removed during uninstall. The fragment MUST live in the `.claude/agents/custom-*.md` namespace already protected by `specrails-core` so core init/update never touches it. v1 MAY ship without this fragment; if so, no file is created and uninstall has no fragment to remove.
+
+#### Scenario: Fragment is written when shipped
+- **GIVEN** the plugin bundle contains `templates/instructions.md`
+- **WHEN** Serena is installed
+- **THEN** `<project>/.claude/agents/custom-serena.md` exists with the fragment contents and is recorded in `state.json#plugins.serena.installedFiles`
+
+#### Scenario: Uninstall removes only plugin-created fragment
+- **GIVEN** `.claude/agents/custom-serena.md` exists and was recorded as plugin-created in state.json
+- **WHEN** Serena is uninstalled
+- **THEN** that file is deleted; if a user-authored `custom-other.md` exists alongside, it remains untouched
+
+### Requirement: Diff preview describes Serena changes accurately
+The `GET /api/projects/:id/plugins/serena/preview-install` response MUST list, for the current state of the target project: every file the install would create (with `op: "create"`), every file it would modify (with `op: "modify"` and a line-level summary of additions), and every prerequisite that needs auto-install.
+
+#### Scenario: Preview on fresh project
+- **GIVEN** a project with no `.mcp.json` and no `.claude/` directory
+- **WHEN** the client calls preview-install for Serena
+- **THEN** the response lists creates for `.mcp.json`, optionally `.claude/agents/custom-serena.md`, and `.specrails/plugins/state.json` (if not present)
+
+#### Scenario: Preview on project with existing .mcp.json
+- **GIVEN** a project whose `.mcp.json` already has user entries
+- **WHEN** the client calls preview-install for Serena
+- **THEN** the response marks `.mcp.json` with `op: "modify"` and lists `serena` as the added key under `mcpServers`

--- a/openspec/changes/add-plugin-system/tasks.md
+++ b/openspec/changes/add-plugin-system/tasks.md
@@ -1,0 +1,102 @@
+## 1. Plugin types & registry scaffolding
+
+- [x] 1.1 Add `Plugin`, `PluginManifest`, `PluginOwnership`, `PluginState`, `PluginVerifyResult`, `PluginInstallContext`, `PluginPreviewResult` types in `server/types.ts`
+- [x] 1.2 Create `server/plugins/paths.ts` exporting helpers for `<project>/.specrails/plugins/state.json`, `<project>/.specrails/plugins/snapshots/<jobId>.json`, and `~/.specrails/projects/<slug>/jobs/<jobId>/plugins.json`
+- [x] 1.3 Create `server/plugins/index.ts` that exports a `BUNDLED_PLUGINS: Plugin[]` array (initially empty)
+- [x] 1.4 Create `server/plugins/ownership.ts` with `buildOwnershipMap(plugins)` that fails fast on overlapping `mcpServers` / `agentFragments` / `configKeys` entries
+- [x] 1.5 Unit-test `ownership.ts` for: no plugins, one plugin, two non-overlapping plugins, two overlapping plugins (asserts the thrown error names both plugins and the conflicting key)
+
+## 2. PluginManager
+
+- [x] 2.1 Create `server/plugin-manager.ts` exporting a `PluginManager` class taking `(registry, projectRegistry)` in its constructor
+- [x] 2.2 Implement `listAvailable(projectId): Promise<CatalogEntry[]>` that merges the registry with `state.json`, marking entries `installed | not-installed | orphan | degraded`
+- [x] 2.3 Implement `getProjectState(projectId): Promise<PluginState>` reading `state.json` (returns empty object when missing)
+- [x] 2.4 Implement `previewInstall(projectId, name): Promise<PluginPreviewResult>` describing creates/modifies without mutating any file
+- [x] 2.5 Implement `install(projectId, name, onLog)` with: prereq check, snapshot pre-mutation file bytes, run `Plugin.install`, run `Plugin.verify`, on failure restore snapshots; on success, write `state.json` entry with `installedFiles` list; emit `plugin.installed` WS event via the project broadcaster
+- [x] 2.6 Implement `uninstall(projectId, name, onLog)` that runs `Plugin.uninstall`, removes the `state.json` entry, and emits `plugin.uninstalled`
+- [x] 2.7 Implement `verify(projectId, name, opts?)` with default 2000ms timeout, returning `{ ok, reason, checkedAt }` and emitting `plugin.health_changed` when state transitions
+- [x] 2.8 Implement `removeOrphan(projectId, name)` that deletes a `state.json` entry whose plugin no longer exists in the registry
+- [x] 2.9 ~~Add `proper-lockfile` to `package.json`~~ — replaced with in-process mutex (Map<path, Promise>) in `json-mutation.ts`. Hub is single-process; cross-process locking would only matter for multi-process deployments. Documented in module header.
+- [x] 2.10 Implement `surgicalMergeJson(filePath, mergeFn)` and `surgicalRemoveKeys(filePath, keysToRemove)` helpers in `server/plugins/json-mutation.ts` (read → modify → temp-write → rename, lockfile held throughout)
+- [x] 2.11 Vitest suite `server/plugin-manager.test.ts`: install creates state, install rolls back on verify failure (asserts byte-equality of `.mcp.json` before/after), uninstall removes only owned keys, concurrent installs serialize, orphan detection
+- [x] 2.12 Vitest suite for `surgicalMergeJson` covering: empty file, missing file, malformed JSON, concurrent writers, crash mid-rename (simulated)
+
+## 3. REST router
+
+- [x] 3.1 Create `server/plugins-router.ts` mounted at `/api/projects/:projectId/plugins`
+- [x] 3.2 Implement `GET /` → catalog with per-plugin status
+- [x] 3.3 Implement `GET /:name/preview-install` → diff describing planned changes
+- [x] 3.4 Implement `POST /:name/install` → kicks off install, streams progress over WS using project broadcaster
+- [x] 3.5 Implement `DELETE /:name` → uninstall (or orphan removal)
+- [x] 3.6 Implement `GET /:name/health` → on-demand verify
+- [x] 3.7 Mount the router from `server/index.ts` (alongside profiles router)
+- [x] 3.8 Wire feature gate `SPECRAILS_PLUGINS_SECTION` (default on, parity with profiles router)
+- [x] 3.9 Vitest suite `server/plugins-router.test.ts` covering: 200 happy paths, 404 for unknown plugin, 409 (or specific error code) for ownership conflict with user-authored MCP entry, 500 on install failure rolling back
+
+## 4. Prerequisites: add `uv` detection
+
+- [x] 4.1 Extend `server/setup-prerequisites.ts` with a `uv` detector (`uv --version`, parse semver, set `installed/executable/version/meetsMinimum`)
+- [x] 4.2 Extend `InstallInstructionsModal` (client) with OS-aware install commands for `uv` (Homebrew, winget, curl/pip fallback) reusing the existing pattern
+- [x] 4.3 Extend `setup-prerequisites.test.ts` with `uv`-present and `uv`-missing fixtures
+
+## 5. QueueManager rail integration
+
+- [x] 5.1 Add `resolvePluginsForSpawn(projectId, jobId, cwd)` private method in `server/queue-manager.ts`: read state, run `verify` per plugin in parallel with timeout, classify into `active` / `degraded`
+- [x] 5.2 Add `snapshotPluginsForJob(jobId, projectId, active, degraded)` writing to `~/.specrails/projects/<slug>/jobs/<jobId>/plugins.json` (chmod 400)
+- [x] 5.3 In the existing spawn path, call `resolvePluginsForSpawn` after profile resolution and before the `claude` spawn
+- [x] 5.4 Inject `SPECRAILS_PLUGINS_ACTIVE` (CSV of names) and `SPECRAILS_PLUGINS_SNAPSHOT` (absolute path) into the spawn env when `active.length > 0`
+- [x] 5.5 Add `specrails.plugins.active`, `specrails.plugins.degraded`, `specrails.plugins.versions` to the OTEL resource attrs builder (only when applicable)
+- [x] 5.6 Emit `plugin.degraded` with `{ projectId, name, reason, jobId }` for each degraded plugin in this spawn
+- [x] 5.7 Vitest in `server/queue-manager.test.ts`: spawn with no plugins (no env, no OTEL attr, no snapshot), spawn with healthy Serena (env set, snapshot file present with chmod 400, OTEL attrs include `serena`), spawn with degraded Serena (still spawns, `degraded` array populated, snapshot still written)
+- [x] 5.8 Verify (test) that `ChatManager` does not call `resolvePluginsForSpawn` and does not set `SPECRAILS_PLUGINS_*` env vars
+- [x] 5.9 Verify (test) that `SetupManager` does not invoke any `PluginManager` method during the wizard flow
+
+## 6. Diagnostic export
+
+- [x] 6.1 In `server/telemetry-export.ts`, conditionally include `plugins.json` in the ZIP when the per-job snapshot exists
+- [x] 6.2 Add a "Plugins" section in the generated `summary.md` that lists active and degraded plugin names + versions; render nothing if no snapshot
+- [x] 6.3 Vitest in `server/telemetry-export.test.ts`: ZIP includes `plugins.json` when snapshot exists, omits it otherwise; `summary.md` mentions plugins only when snapshot exists
+
+## 7. WebSocket events
+
+- [x] 7.1 Add `plugin.installed`, `plugin.uninstalled`, `plugin.health_changed`, `plugin.degraded` to the WS message-type union in `server/types.ts`
+- [x] 7.2 Use the existing `boundBroadcast` (project-scoped) inside `PluginManager` and `QueueManager` paths
+- [x] 7.3 Vitest assertions in plugin-manager + queue-manager suites that the right events fire with the right payloads
+
+## 8. Serena plugin
+
+- [x] 8.1 Create `server/plugins/serena/manifest.ts` with the manifest defined in the serena-plugin spec
+- [x] 8.2 Create `server/plugins/serena/install.ts` that surgical-merges `mcpServers.serena` into `.mcp.json` and (optionally) writes `templates/instructions.md` to `.claude/agents/custom-serena.md`, recording every created/modified path in the install context
+- [x] 8.3 Create `server/plugins/serena/verify.ts` running `uvx serena --version` with a 2000ms timeout, returning `{ ok, reason }`
+- [x] 8.4 Create `server/plugins/serena/uninstall.ts` that surgically removes `mcpServers.serena` and deletes only files recorded as `installedFiles` for serena
+- [x] 8.5 Create `server/plugins/serena/index.ts` exporting the assembled `Plugin` value, and register it in `server/plugins/index.ts`
+- [x] 8.6 Optional: create `server/plugins/serena/templates/instructions.md` (skip in v1 if scope shrinks; verify uninstall path handles "no fragment shipped")
+- [x] 8.7 Vitest `server/plugins/serena/install.test.ts`: install on fresh project, install preserving user-authored `mcpServers.myown`, install over an existing project-managed `serena` entry (idempotent), uninstall surgical
+- [x] 8.8 Vitest `server/plugins/serena/verify.test.ts` mocking `child_process.spawn` for the four verify reasons (`ok`, `uv-not-on-path`, `uvx-non-zero-exit`, `verify-timeout`)
+
+## 9. Client: IntegrationsPage
+
+- [x] 9.1 Add `IntegrationsPage.tsx` to `client/src/pages/`, route `/integrations` mounted under `ProjectLayout`, sidebar entry next to Agents
+- [x] 9.2 Add `useIntegrationsCatalog(activeProjectId)` hook backed by `useProjectCache` (stale-while-revalidate)
+- [x] 9.3 Build `PluginCard` component (icon, name, version, description, `whatItDoes`, requirements with live satisfied/missing badges, primary action by status)
+- [x] 9.4 Build `PluginInstallDialog` (preview-install fetch on open, prereq panel reusing `PrerequisitesPanel`, streaming log driven by WS, confirm disabled until prereqs satisfied)
+- [x] 9.5 Build `PluginDiffPreview` rendering `+ create` / `~ modify` lines from the preview response
+- [x] 9.6 Build `PluginUninstallDialog` (destructive style, "Will revert" / "Will NOT touch" lists, explicit confirm)
+- [x] 9.7 Render orphan section below the active catalog with "Remove orphan" action
+- [x] 9.8 Wire WS event handlers (`plugin.installed`, `plugin.uninstalled`, `plugin.degraded`, `plugin.health_changed`) using the existing `projectId` ref filter pattern
+- [x] 9.9 Empty state, error state with Retry, loading skeleton cards
+- [x] 9.10 Vitest + Testing Library suite for `IntegrationsPage`: cards render per status, install dialog calls preview before mutation, prereqs gate the confirm button, uninstall confirm flow, orphan section appears, WS event filtering by projectId
+- [x] 9.11 Visual sanity check in dev (`npm run dev`) — flow once through install + uninstall against a scratch project, confirm tokens use semantic theme tokens (no `dracula-*` regression)
+
+## 10. Coverage and CI
+
+- [x] 10.1 Run `npm run typecheck` and `npm test` locally, fix any failures
+- [x] 10.2 Run `npm run test:coverage` (server) and ensure ≥ 80% lines/functions/statements, ≥ 70% branches; iterate with extra tests until thresholds clear
+- [x] 10.3 Run `cd client && npm run test:coverage` and ensure ≥ 80% lines/statements, ≥ 70% functions; iterate with extra tests if needed
+- [x] 10.4 Ensure no new entries in `vitest.config.ts` exclude lists; if any are needed, document inline why they are structurally unreachable in the test environment
+
+## 11. Documentation and rollout
+
+- [x] 11.1 Update `CLAUDE.md` with a short "Plugins" section describing the per-project plugin system, additivity invariant, and `.specrails/plugins/` layout
+- [x] 11.2 Add a one-paragraph note in the project README under "Features" mentioning per-project integrations
+- [x] 11.3 Smoke-test the desktop build path: confirm the bundled plugin module is included in the sidecar bundle and the server starts on a fresh install with `BUNDLED_PLUGINS` populated

--- a/server/plugin-manager.test.ts
+++ b/server/plugin-manager.test.ts
@@ -109,6 +109,42 @@ describe('PluginManager.listAvailable', () => {
     expect((await m.listAvailable(tmpDir))[0].status).toBe('installed')
   })
 
+  it('install writes CLAUDE.md block when manifest declares claudeMdInstructions', async () => {
+    const plugin = makeSerena()
+    plugin.manifest.claudeMdInstructions = '## serena hint'
+    const m = new PluginManager([plugin], { claudeApprovalChecker: () => 'enabled' })
+    await m.install(tmpDir, 'pid', 'serena', broadcast)
+    const md = fs.readFileSync(path.join(tmpDir, 'CLAUDE.md'), 'utf8')
+    expect(md).toContain('## serena hint')
+    expect(md).toContain('specrails-hub-managed:serena')
+  })
+
+  it('uninstall removes CLAUDE.md block but preserves user content', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'CLAUDE.md'), '# Project\n\nMy notes.\n')
+    const plugin = makeSerena()
+    plugin.manifest.claudeMdInstructions = '## serena hint'
+    const m = new PluginManager([plugin], { claudeApprovalChecker: () => 'enabled' })
+    await m.install(tmpDir, 'pid', 'serena', broadcast)
+    await m.uninstall(tmpDir, 'pid', 'serena', broadcast)
+    const md = fs.readFileSync(path.join(tmpDir, 'CLAUDE.md'), 'utf8')
+    expect(md).toContain('My notes.')
+    expect(md).not.toContain('serena hint')
+    expect(md).not.toContain('specrails-hub-managed:serena')
+  })
+
+  it('setActive(false) removes CLAUDE.md block; setActive(true) restores it', async () => {
+    const plugin = makeSerena()
+    plugin.manifest.claudeMdInstructions = '## hint'
+    const m = new PluginManager([plugin], { claudeApprovalChecker: () => 'enabled' })
+    await m.install(tmpDir, 'pid', 'serena', broadcast)
+    await m.setActive(tmpDir, 'pid', 'serena', false, broadcast)
+    const off = fs.readFileSync(path.join(tmpDir, 'CLAUDE.md'), 'utf8')
+    expect(off).not.toContain('## hint')
+    await m.setActive(tmpDir, 'pid', 'serena', true, broadcast)
+    const on = fs.readFileSync(path.join(tmpDir, 'CLAUDE.md'), 'utf8')
+    expect(on).toContain('## hint')
+  })
+
   it('setActive preserves user-authored sibling mcpServers entries', async () => {
     fs.writeFileSync(path.join(tmpDir, '.mcp.json'), JSON.stringify({ mcpServers: { myown: { command: 'me' } } }))
     const m = new PluginManager([makeSerena()], { claudeApprovalChecker: () => 'enabled' })

--- a/server/plugin-manager.test.ts
+++ b/server/plugin-manager.test.ts
@@ -1,0 +1,382 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest'
+import type { Plugin, WsMessage } from './types'
+import {
+  PluginManager,
+  PluginAlreadyInstalledError,
+  PluginInstallError,
+  PluginNotFoundError,
+  PluginNotInstalledError,
+} from './plugin-manager'
+
+let tmpDir: string
+let captured: WsMessage[]
+const broadcast = (m: WsMessage) => { captured.push(m) }
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plugin-mgr-'))
+  captured = []
+})
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+function makeSerena(opts: Partial<{ verifyOk: boolean; verifyReason: string; throwOnInstall: boolean }> = {}): Plugin {
+  return {
+    manifest: {
+      name: 'serena',
+      version: '1.0.0',
+      description: 'semantic nav',
+      whatItDoes: ['x'],
+      requirements: [{ name: 'uv', minVersion: '0.1.0' }],
+      owns: { mcpServers: ['serena'], agentFragments: ['.claude/agents/custom-serena.md'] },
+    },
+    install: async (ctx) => {
+      if (opts.throwOnInstall) throw new Error('boom')
+      await PluginManager.mergeMcpServers(ctx.projectPath, {
+        serena: { command: 'uvx', args: ['serena'] },
+      })
+      const fragRel = '.claude/agents/custom-serena.md'
+      const frag = path.join(ctx.projectPath, fragRel)
+      fs.mkdirSync(path.dirname(frag), { recursive: true })
+      fs.writeFileSync(frag, '# serena')
+      ctx.recordInstalledFile(fragRel)
+      ctx.log('installed')
+    },
+    uninstall: async (ctx) => {
+      await PluginManager.removeMcpServers(ctx.projectPath, ['serena'])
+      const frag = path.join(ctx.projectPath, '.claude/agents/custom-serena.md')
+      if (fs.existsSync(frag)) fs.unlinkSync(frag)
+    },
+    verify: async () => ({
+      ok: opts.verifyOk ?? true,
+      reason: opts.verifyReason,
+      checkedAt: new Date().toISOString(),
+    }),
+    expectedMcpEntry: () => ({ command: 'uvx', args: ['serena'] }),
+  }
+}
+
+describe('PluginManager.listAvailable', () => {
+  it('reports not-installed for fresh project', async () => {
+    const m = new PluginManager([makeSerena()], { claudeApprovalChecker: () => 'enabled' })
+    const list = await m.listAvailable(tmpDir)
+    expect(list).toHaveLength(1)
+    expect(list[0].status).toBe('not-installed')
+  })
+
+  it('reports installed after install + verify', async () => {
+    const m = new PluginManager([makeSerena()], { claudeApprovalChecker: () => 'enabled' })
+    await m.install(tmpDir, 'pid', 'serena', broadcast)
+    const list = await m.listAvailable(tmpDir)
+    expect(list[0].status).toBe('installed')
+    expect(list[0].installedAt).toBeDefined()
+  })
+
+  it('reports orphan for plugin in state.json but not in registry', async () => {
+    const stateDir = path.join(tmpDir, '.specrails', 'plugins')
+    fs.mkdirSync(stateDir, { recursive: true })
+    fs.writeFileSync(path.join(stateDir, 'state.json'), JSON.stringify({
+      schemaVersion: 1,
+      plugins: { 'old-thing': { version: '0.1.0', installedAt: 'now', installedFiles: [] } },
+    }))
+    const m = new PluginManager([])
+    const list = await m.listAvailable(tmpDir)
+    expect(list[0].status).toBe('orphan')
+  })
+
+  it('reports installed (active) immediately after install — .mcp.json has the key', async () => {
+    const m = new PluginManager([makeSerena()], { claudeApprovalChecker: () => 'enabled' })
+    await m.install(tmpDir, 'pid', 'serena', broadcast)
+    expect((await m.listAvailable(tmpDir))[0].status).toBe('installed')
+  })
+
+  it('setActive(false) removes mcp entry → status deactivated; setActive(true) re-adds → installed', async () => {
+    const m = new PluginManager([makeSerena()], { claudeApprovalChecker: () => 'enabled' })
+    await m.install(tmpDir, 'pid', 'serena', broadcast)
+    expect((await m.listAvailable(tmpDir))[0].status).toBe('installed')
+
+    await m.setActive(tmpDir, 'pid', 'serena', false, broadcast)
+    const mcp = JSON.parse(fs.readFileSync(path.join(tmpDir, '.mcp.json'), 'utf8'))
+    expect(mcp.mcpServers.serena).toBeUndefined()
+    expect((await m.listAvailable(tmpDir))[0].status).toBe('deactivated')
+
+    await m.setActive(tmpDir, 'pid', 'serena', true, broadcast)
+    const mcp2 = JSON.parse(fs.readFileSync(path.join(tmpDir, '.mcp.json'), 'utf8'))
+    expect(mcp2.mcpServers.serena).toBeDefined()
+    expect((await m.listAvailable(tmpDir))[0].status).toBe('installed')
+  })
+
+  it('setActive preserves user-authored sibling mcpServers entries', async () => {
+    fs.writeFileSync(path.join(tmpDir, '.mcp.json'), JSON.stringify({ mcpServers: { myown: { command: 'me' } } }))
+    const m = new PluginManager([makeSerena()], { claudeApprovalChecker: () => 'enabled' })
+    await m.install(tmpDir, 'pid', 'serena', broadcast)
+    await m.setActive(tmpDir, 'pid', 'serena', false, broadcast)
+    const mcp = JSON.parse(fs.readFileSync(path.join(tmpDir, '.mcp.json'), 'utf8'))
+    expect(mcp.mcpServers.myown.command).toBe('me')
+    expect(mcp.mcpServers.serena).toBeUndefined()
+  })
+
+  it('reports degraded when health is degraded', async () => {
+    const m = new PluginManager([makeSerena()], { claudeApprovalChecker: () => 'enabled' })
+    await m.install(tmpDir, 'pid', 'serena', broadcast)
+    // Manually mark degraded.
+    const sf = path.join(tmpDir, '.specrails', 'plugins', 'state.json')
+    const s = JSON.parse(fs.readFileSync(sf, 'utf8'))
+    s.plugins.serena.health = 'degraded'
+    fs.writeFileSync(sf, JSON.stringify(s))
+    const list = await m.listAvailable(tmpDir)
+    expect(list[0].status).toBe('degraded')
+  })
+})
+
+describe('PluginManager.previewInstall', () => {
+  it('marks .mcp.json as create on a fresh project', async () => {
+    const m = new PluginManager([makeSerena()], { claudeApprovalChecker: () => 'enabled' })
+    const preview = await m.previewInstall(tmpDir, 'pid', 'serena')
+    const mcp = preview.files.find((f) => f.path === '.mcp.json')
+    expect(mcp?.op).toBe('create')
+    expect(preview.files.some((f) => f.path === '.specrails/plugins/state.json')).toBe(true)
+  })
+
+  it('marks .mcp.json as modify when present', async () => {
+    fs.writeFileSync(path.join(tmpDir, '.mcp.json'), JSON.stringify({ mcpServers: { other: {} } }))
+    const m = new PluginManager([makeSerena()], { claudeApprovalChecker: () => 'enabled' })
+    const preview = await m.previewInstall(tmpDir, 'pid', 'serena')
+    const mcp = preview.files.find((f) => f.path === '.mcp.json')
+    expect(mcp?.op).toBe('modify')
+  })
+
+  it('throws PluginNotFoundError for unknown plugin', async () => {
+    const m = new PluginManager([])
+    await expect(m.previewInstall(tmpDir, 'pid', 'nope')).rejects.toBeInstanceOf(PluginNotFoundError)
+  })
+
+  it('does not mutate the project filesystem', async () => {
+    const m = new PluginManager([makeSerena()], { claudeApprovalChecker: () => 'enabled' })
+    await m.previewInstall(tmpDir, 'pid', 'serena')
+    expect(fs.existsSync(path.join(tmpDir, '.mcp.json'))).toBe(false)
+    expect(fs.existsSync(path.join(tmpDir, '.specrails', 'plugins', 'state.json'))).toBe(false)
+  })
+})
+
+describe('PluginManager.install', () => {
+  it('creates .mcp.json with the serena entry', async () => {
+    const m = new PluginManager([makeSerena()], { claudeApprovalChecker: () => 'enabled' })
+    await m.install(tmpDir, 'pid', 'serena', broadcast)
+    const mcp = JSON.parse(fs.readFileSync(path.join(tmpDir, '.mcp.json'), 'utf8'))
+    expect(mcp.mcpServers.serena.command).toBe('uvx')
+  })
+
+  it('writes state.json with installedFiles', async () => {
+    const m = new PluginManager([makeSerena()], { claudeApprovalChecker: () => 'enabled' })
+    await m.install(tmpDir, 'pid', 'serena', broadcast)
+    const s = JSON.parse(fs.readFileSync(path.join(tmpDir, '.specrails', 'plugins', 'state.json'), 'utf8'))
+    expect(s.plugins.serena.version).toBe('1.0.0')
+    expect(s.plugins.serena.installedFiles).toContain('.claude/agents/custom-serena.md')
+    expect(s.plugins.serena.health).toBe('ok')
+  })
+
+  it('preserves user-authored mcpServers entries', async () => {
+    fs.writeFileSync(path.join(tmpDir, '.mcp.json'), JSON.stringify({ mcpServers: { myown: { command: 'me' } } }))
+    const m = new PluginManager([makeSerena()], { claudeApprovalChecker: () => 'enabled' })
+    await m.install(tmpDir, 'pid', 'serena', broadcast)
+    const mcp = JSON.parse(fs.readFileSync(path.join(tmpDir, '.mcp.json'), 'utf8'))
+    expect(mcp.mcpServers.myown.command).toBe('me')
+    expect(mcp.mcpServers.serena).toBeDefined()
+  })
+
+  it('rejects install when the user already has an mcpServers.<owned> entry', async () => {
+    fs.writeFileSync(path.join(tmpDir, '.mcp.json'), JSON.stringify({ mcpServers: { serena: { command: 'mine' } } }))
+    const m = new PluginManager([makeSerena()], { claudeApprovalChecker: () => 'enabled' })
+    await expect(m.install(tmpDir, 'pid', 'serena', broadcast)).rejects.toThrow(/already has/)
+  })
+
+  it('rolls back .mcp.json byte-identical when install throws', async () => {
+    const before = JSON.stringify({ mcpServers: { existing: {} } }, null, 2)
+    fs.writeFileSync(path.join(tmpDir, '.mcp.json'), before)
+    const m = new PluginManager([makeSerena({ throwOnInstall: true })])
+    await expect(m.install(tmpDir, 'pid', 'serena', broadcast)).rejects.toBeInstanceOf(PluginInstallError)
+    expect(fs.readFileSync(path.join(tmpDir, '.mcp.json'), 'utf8')).toBe(before)
+  })
+
+  it('rolls back when verify reports !ok', async () => {
+    const before = JSON.stringify({ mcpServers: { existing: {} } }, null, 2)
+    fs.writeFileSync(path.join(tmpDir, '.mcp.json'), before)
+    const m = new PluginManager([makeSerena({ verifyOk: false, verifyReason: 'uv-not-on-path' })])
+    await expect(m.install(tmpDir, 'pid', 'serena', broadcast)).rejects.toThrow(/verify failed/)
+    expect(fs.readFileSync(path.join(tmpDir, '.mcp.json'), 'utf8')).toBe(before)
+    // state.json should not contain serena.
+    const sf = path.join(tmpDir, '.specrails', 'plugins', 'state.json')
+    if (fs.existsSync(sf)) {
+      const s = JSON.parse(fs.readFileSync(sf, 'utf8'))
+      expect(s.plugins.serena).toBeUndefined()
+    }
+  })
+
+  it('emits plugin.installed on success', async () => {
+    const m = new PluginManager([makeSerena()], { claudeApprovalChecker: () => 'enabled' })
+    await m.install(tmpDir, 'pid', 'serena', broadcast)
+    expect(captured.some((m) => m.type === 'plugin.installed')).toBe(true)
+  })
+
+  it('throws PluginAlreadyInstalledError on second install', async () => {
+    const m = new PluginManager([makeSerena()], { claudeApprovalChecker: () => 'enabled' })
+    await m.install(tmpDir, 'pid', 'serena', broadcast)
+    await expect(m.install(tmpDir, 'pid', 'serena', broadcast)).rejects.toBeInstanceOf(PluginAlreadyInstalledError)
+  })
+})
+
+describe('PluginManager.uninstall', () => {
+  it('removes only owned mcpServers entry', async () => {
+    fs.writeFileSync(path.join(tmpDir, '.mcp.json'), JSON.stringify({ mcpServers: { myown: { command: 'me' } } }))
+    const m = new PluginManager([makeSerena()], { claudeApprovalChecker: () => 'enabled' })
+    await m.install(tmpDir, 'pid', 'serena', broadcast)
+    await m.uninstall(tmpDir, 'pid', 'serena', broadcast)
+    const mcp = JSON.parse(fs.readFileSync(path.join(tmpDir, '.mcp.json'), 'utf8'))
+    expect(mcp.mcpServers.myown).toBeDefined()
+    expect(mcp.mcpServers.serena).toBeUndefined()
+  })
+
+  it('drops state.json entry', async () => {
+    const m = new PluginManager([makeSerena()], { claudeApprovalChecker: () => 'enabled' })
+    await m.install(tmpDir, 'pid', 'serena', broadcast)
+    await m.uninstall(tmpDir, 'pid', 'serena', broadcast)
+    const s = JSON.parse(fs.readFileSync(path.join(tmpDir, '.specrails', 'plugins', 'state.json'), 'utf8'))
+    expect(s.plugins.serena).toBeUndefined()
+  })
+
+  it('emits plugin.uninstalled', async () => {
+    const m = new PluginManager([makeSerena()], { claudeApprovalChecker: () => 'enabled' })
+    await m.install(tmpDir, 'pid', 'serena', broadcast)
+    captured = []
+    await m.uninstall(tmpDir, 'pid', 'serena', broadcast)
+    expect(captured.some((m) => m.type === 'plugin.uninstalled')).toBe(true)
+  })
+
+  it('throws when plugin not installed', async () => {
+    const m = new PluginManager([makeSerena()], { claudeApprovalChecker: () => 'enabled' })
+    await expect(m.uninstall(tmpDir, 'pid', 'serena', broadcast)).rejects.toBeInstanceOf(PluginNotInstalledError)
+  })
+
+  it('removes orphan when registry no longer has the plugin', async () => {
+    const m = new PluginManager([makeSerena()], { claudeApprovalChecker: () => 'enabled' })
+    await m.install(tmpDir, 'pid', 'serena', broadcast)
+    // Simulate orphaning by re-creating manager without serena.
+    const orphanMgr = new PluginManager([])
+    await orphanMgr.uninstall(tmpDir, 'pid', 'serena', broadcast)
+    const s = JSON.parse(fs.readFileSync(path.join(tmpDir, '.specrails', 'plugins', 'state.json'), 'utf8'))
+    expect(s.plugins.serena).toBeUndefined()
+  })
+})
+
+describe('PluginManager.verify', () => {
+  it('returns ok=true for a healthy plugin', async () => {
+    const m = new PluginManager([makeSerena()], { claudeApprovalChecker: () => 'enabled' })
+    await m.install(tmpDir, 'pid', 'serena', broadcast)
+    const v = await m.verify(tmpDir, 'pid', 'serena', broadcast)
+    expect(v.ok).toBe(true)
+  })
+
+  it('emits plugin.health_changed when health flips', async () => {
+    const plugin = makeSerena()
+    let toggle = true
+    plugin.verify = async () => ({ ok: toggle, checkedAt: new Date().toISOString() })
+    const m = new PluginManager([plugin])
+    await m.install(tmpDir, 'pid', 'serena', broadcast)
+    captured = []
+    toggle = false
+    await m.verify(tmpDir, 'pid', 'serena', broadcast)
+    expect(captured.some((m) => m.type === 'plugin.health_changed')).toBe(true)
+  })
+
+  it('classifies long verify as verify-timeout', async () => {
+    const plugin = makeSerena()
+    plugin.verify = () => new Promise(() => { /* never resolves */ })
+    plugin.manifest.verifyTimeoutMs = 50
+    const m = new PluginManager([plugin], { defaultVerifyTimeoutMs: 50 })
+    // Cannot install because verify times out → install rolls back.
+    await expect(m.install(tmpDir, 'pid', 'serena', broadcast)).rejects.toThrow(/verify failed/)
+  })
+
+  it('classifies thrown error as verify-exception', async () => {
+    const plugin = makeSerena()
+    plugin.verify = async () => { throw new Error('nope') }
+    const m = new PluginManager([plugin])
+    await expect(m.install(tmpDir, 'pid', 'serena', broadcast)).rejects.toThrow(/verify failed/)
+  })
+
+  it('throws PluginNotFoundError for unknown plugin', async () => {
+    const m = new PluginManager([])
+    await expect(m.verify(tmpDir, 'pid', 'nope', broadcast)).rejects.toBeInstanceOf(PluginNotFoundError)
+  })
+})
+
+describe('PluginManager concurrent installs serialize', () => {
+  it('two parallel installs of distinct plugins succeed without lost update', async () => {
+    const a: Plugin = {
+      manifest: { name: 'a', version: '1', description: '', whatItDoes: [], owns: { mcpServers: ['a'] } },
+      install: async (ctx) => { await PluginManager.mergeMcpServers(ctx.projectPath, { a: { command: 'a' } }) },
+      uninstall: async (ctx) => { await PluginManager.removeMcpServers(ctx.projectPath, ['a']) },
+      verify: async () => ({ ok: true, checkedAt: new Date().toISOString() }),
+    }
+    const b: Plugin = {
+      manifest: { name: 'b', version: '1', description: '', whatItDoes: [], owns: { mcpServers: ['b'] } },
+      install: async (ctx) => { await PluginManager.mergeMcpServers(ctx.projectPath, { b: { command: 'b' } }) },
+      uninstall: async (ctx) => { await PluginManager.removeMcpServers(ctx.projectPath, ['b']) },
+      verify: async () => ({ ok: true, checkedAt: new Date().toISOString() }),
+    }
+    const m = new PluginManager([a, b])
+    await Promise.all([
+      m.install(tmpDir, 'pid', 'a', broadcast),
+      m.install(tmpDir, 'pid', 'b', broadcast),
+    ])
+    const mcp = JSON.parse(fs.readFileSync(path.join(tmpDir, '.mcp.json'), 'utf8'))
+    expect(mcp.mcpServers.a).toBeDefined()
+    expect(mcp.mcpServers.b).toBeDefined()
+    const s = JSON.parse(fs.readFileSync(path.join(tmpDir, '.specrails', 'plugins', 'state.json'), 'utf8'))
+    expect(s.plugins.a).toBeDefined()
+    expect(s.plugins.b).toBeDefined()
+  })
+})
+
+describe('PluginManager.updateMcpEntry', () => {
+  it('rewrites the owned mcpServers entry to match expectedMcpEntry', async () => {
+    const plugin = makeSerena()
+    plugin.expectedMcpEntry = () => ({ command: 'uvx', args: ['serena', 'start-mcp-server'] })
+    const m = new PluginManager([plugin], { claudeApprovalChecker: () => 'enabled' })
+    await m.install(tmpDir, 'pid', 'serena', broadcast)
+    // Simulate drift: stomp the on-disk entry with old args.
+    const fp = require('path').join(tmpDir, '.mcp.json')
+    require('fs').writeFileSync(fp, JSON.stringify({ mcpServers: { serena: { command: 'uvx', args: ['serena-mcp-server'] }, myown: { command: 'me' } } }))
+    await m.updateMcpEntry(tmpDir, 'pid', 'serena', broadcast)
+    const after = JSON.parse(require('fs').readFileSync(fp, 'utf8'))
+    expect(after.mcpServers.serena.args).toEqual(['serena', 'start-mcp-server'])
+    expect(after.mcpServers.myown.command).toBe('me')
+  })
+
+  it('throws when plugin is not installed', async () => {
+    const plugin = makeSerena()
+    plugin.expectedMcpEntry = () => ({ command: 'uvx' })
+    const m = new PluginManager([plugin], { claudeApprovalChecker: () => 'enabled' })
+    await expect(m.updateMcpEntry(tmpDir, 'pid', 'serena', broadcast)).rejects.toThrow(/not installed/)
+  })
+
+  it('throws when plugin lacks expectedMcpEntry', async () => {
+    const plugin = makeSerena()
+    delete plugin.expectedMcpEntry
+    const m = new PluginManager([plugin], { claudeApprovalChecker: () => 'enabled' })
+    await m.install(tmpDir, 'pid', 'serena', broadcast)
+    await expect(m.updateMcpEntry(tmpDir, 'pid', 'serena', broadcast)).rejects.toThrow(/expectedMcpEntry/)
+  })
+})
+
+describe('PluginManager.removeOrphan', () => {
+  it('rejects when plugin is still bundled', async () => {
+    const m = new PluginManager([makeSerena()], { claudeApprovalChecker: () => 'enabled' })
+    await m.install(tmpDir, 'pid', 'serena', broadcast)
+    await expect(m.removeOrphan(tmpDir, 'pid', 'serena', broadcast)).rejects.toThrow(/not orphan/)
+  })
+})

--- a/server/plugin-manager.test.ts
+++ b/server/plugin-manager.test.ts
@@ -138,11 +138,13 @@ describe('PluginManager.listAvailable', () => {
     const m = new PluginManager([plugin], { claudeApprovalChecker: () => 'enabled' })
     await m.install(tmpDir, 'pid', 'serena', broadcast)
     await m.setActive(tmpDir, 'pid', 'serena', false, broadcast)
-    const off = fs.readFileSync(path.join(tmpDir, 'CLAUDE.md'), 'utf8')
-    expect(off).not.toContain('## hint')
+    // CLAUDE.md is deleted when the managed block was the only content.
+    const claudeMd = path.join(tmpDir, 'CLAUDE.md')
+    if (fs.existsSync(claudeMd)) {
+      expect(fs.readFileSync(claudeMd, 'utf8')).not.toContain('## hint')
+    }
     await m.setActive(tmpDir, 'pid', 'serena', true, broadcast)
-    const on = fs.readFileSync(path.join(tmpDir, 'CLAUDE.md'), 'utf8')
-    expect(on).toContain('## hint')
+    expect(fs.readFileSync(claudeMd, 'utf8')).toContain('## hint')
   })
 
   it('setActive preserves user-authored sibling mcpServers entries', async () => {

--- a/server/plugin-manager.ts
+++ b/server/plugin-manager.ts
@@ -46,6 +46,7 @@ import {
   surgicalRemoveKeys,
   withFileLock,
 } from './plugins/json-mutation'
+import { applyContributors, contributorPaths, revertContributors } from './plugins/contributors'
 
 export type PluginBroadcast = (msg: WsMessage) => void
 
@@ -268,6 +269,16 @@ export class PluginManager {
       out.push({ path: frag, op: exists ? 'modify' : 'create' })
     }
 
+    // Shared-file contributors (CLAUDE.md today, more in the future).
+    for (const rel of contributorPaths(plugin)) {
+      const exists = fs.existsSync(path.join(projectPath, rel))
+      out.push({
+        path: rel,
+        op: exists ? 'modify' : 'create',
+        summary: `+ <!-- specrails-hub-managed:${m.name} --> block`,
+      })
+    }
+
     // State file
     const stateExists = fs.existsSync(stateFilePath(projectPath))
     out.push({
@@ -362,6 +373,18 @@ export class PluginManager {
       await this._writeProjectState(projectPath, stateNow)
       // No additional approval write needed: any server in `.mcp.json` loads
       // automatically when Claude opens the project. Install IS active.
+
+      // Apply shared-file contributors (CLAUDE.md block today, more in the
+      // future). Each contributor is per-plugin and idempotent.
+      const sharedTouched = await applyContributors(plugin, projectPath)
+      if (sharedTouched.length > 0) {
+        for (const p of sharedTouched) {
+          if (!installedFiles.includes(p)) installedFiles.push(p)
+        }
+        const stateNow2 = this.getProjectState(projectPath)
+        if (stateNow2.plugins[name]) stateNow2.plugins[name].installedFiles = installedFiles
+        await this._writeProjectState(projectPath, stateNow2)
+      }
     } catch (err) {
       // Roll back every file we snapshotted. Byte-identical restore.
       for (const [p, bytes] of preState.entries()) {
@@ -416,6 +439,9 @@ export class PluginManager {
     }
 
     if (plugin) {
+      // Revert shared-file contributors first so a partial uninstall doesn't
+      // leave dangling instructions referencing missing tools.
+      await revertContributors(plugin, projectPath)
       await plugin.uninstall({
         projectPath,
         projectId,
@@ -468,6 +494,9 @@ export class PluginManager {
     const entries: Record<string, unknown> = {}
     for (const key of owned) entries[key] = expected
     await PluginManager.mergeMcpServers(projectPath, entries)
+    // Refresh shared-file contributions too: a drift may exist in CLAUDE.md
+    // even when the .mcp.json entry matches.
+    await applyContributors(plugin, projectPath)
     broadcast({
       type: 'plugin.health_changed',
       projectId,
@@ -517,8 +546,10 @@ export class PluginManager {
       const entries: Record<string, unknown> = {}
       for (const k of owned) entries[k] = expected
       await PluginManager.mergeMcpServers(projectPath, entries)
+      await applyContributors(plugin, projectPath)
     } else {
       await PluginManager.removeMcpServers(projectPath, owned)
+      await revertContributors(plugin, projectPath)
     }
 
     broadcast({

--- a/server/plugin-manager.ts
+++ b/server/plugin-manager.ts
@@ -1,0 +1,635 @@
+import fs from 'fs'
+import path from 'path'
+import type {
+  Plugin,
+  PluginCatalogEntry,
+  PluginInstalledMessage,
+  PluginUninstalledMessage,
+  PluginHealthChangedMessage,
+  PluginInstallProgressMessage,
+  PluginPreviewFileEntry,
+  PluginPreviewResult,
+  PluginRequirement,
+  PluginState,
+  PluginStateEntry,
+  PluginVerifyResult,
+  WsMessage,
+} from './types'
+import { buildOwnershipMap, type OwnershipMap } from './plugins/ownership'
+import {
+  getClaudeApprovalState,
+  findEnabledMarketplaceKeys,
+  findInstalledButNotEnabledMarketplaceKeys,
+} from './plugins/claude-approval'
+import { detectMcpDrift } from './plugins/drift'
+import {
+  mcpJsonPath,
+  pluginsDir,
+  stateFilePath,
+} from './plugins/paths'
+
+function readMcpServersMap(projectPath: string): Record<string, unknown> {
+  try {
+    if (!fs.existsSync(mcpJsonPath(projectPath))) return {}
+    const raw = fs.readFileSync(mcpJsonPath(projectPath), 'utf8')
+    if (!raw.trim()) return {}
+    const parsed = JSON.parse(raw) as { mcpServers?: Record<string, unknown> }
+    return parsed.mcpServers ?? {}
+  } catch {
+    return {}
+  }
+}
+import {
+  atomicWriteFileSync,
+  readJsonOr,
+  surgicalMergeJson,
+  surgicalRemoveKeys,
+  withFileLock,
+} from './plugins/json-mutation'
+
+export type PluginBroadcast = (msg: WsMessage) => void
+
+export type PrerequisiteCheck = (req: PluginRequirement) => Promise<{
+  installed: boolean
+  executable: boolean
+  version?: string
+  meetsMinimum: boolean
+}>
+
+export class PluginNotFoundError extends Error {
+  constructor(name: string) {
+    super(`plugin not found in registry: ${name}`)
+    this.name = 'PluginNotFoundError'
+  }
+}
+
+export class PluginNotInstalledError extends Error {
+  constructor(name: string) {
+    super(`plugin is not installed: ${name}`)
+    this.name = 'PluginNotInstalledError'
+  }
+}
+
+export class PluginAlreadyInstalledError extends Error {
+  constructor(name: string) {
+    super(`plugin is already installed: ${name}`)
+    this.name = 'PluginAlreadyInstalledError'
+  }
+}
+
+export class PluginInstallError extends Error {
+  readonly cause?: unknown
+  constructor(message: string, cause?: unknown) {
+    super(message)
+    this.name = 'PluginInstallError'
+    this.cause = cause
+  }
+}
+
+export interface PluginManagerOptions {
+  /** Default verify timeout. Per-plugin overrides via manifest.verifyTimeoutMs. */
+  defaultVerifyTimeoutMs?: number
+  /** Optional prerequisite checker (delegated to setup-prerequisites in production). */
+  checkPrerequisite?: PrerequisiteCheck
+  /** Optional override for the Claude Code approval check. Tests inject a stub
+   *  to avoid depending on `~/.claude.json`. Defaults to the real reader. */
+  claudeApprovalChecker?: (projectPath: string, serverName: string) => 'enabled' | 'disabled' | 'pending'
+}
+
+const DEFAULT_VERIFY_TIMEOUT_MS = 2000
+
+export class PluginManager {
+  readonly registry: OwnershipMap
+  private readonly _options: Required<Pick<PluginManagerOptions, 'defaultVerifyTimeoutMs'>> & {
+    checkPrerequisite?: PrerequisiteCheck
+    claudeApprovalChecker: NonNullable<PluginManagerOptions['claudeApprovalChecker']>
+  }
+
+  constructor(plugins: Plugin[], options: PluginManagerOptions = {}) {
+    this.registry = buildOwnershipMap(plugins)
+    this._options = {
+      defaultVerifyTimeoutMs: options.defaultVerifyTimeoutMs ?? DEFAULT_VERIFY_TIMEOUT_MS,
+      checkPrerequisite: options.checkPrerequisite,
+      claudeApprovalChecker: options.claudeApprovalChecker ?? getClaudeApprovalState,
+    }
+  }
+
+  // ─── State helpers ─────────────────────────────────────────────────────────
+
+  getProjectState(projectPath: string): PluginState {
+    return readJsonOr<PluginState>(stateFilePath(projectPath), {
+      schemaVersion: 1,
+      plugins: {},
+    })
+  }
+
+  private async _writeProjectState(projectPath: string, state: PluginState): Promise<void> {
+    fs.mkdirSync(pluginsDir(projectPath), { recursive: true })
+    await withFileLock(stateFilePath(projectPath), async () => {
+      atomicWriteFileSync(stateFilePath(projectPath), JSON.stringify(state, null, 2) + '\n')
+    })
+  }
+
+  // ─── Catalog ───────────────────────────────────────────────────────────────
+
+  async listAvailable(projectPath: string): Promise<PluginCatalogEntry[]> {
+    const state = this.getProjectState(projectPath)
+    const entries: PluginCatalogEntry[] = []
+
+    // Bundled plugins, regardless of install state.
+    for (const plugin of this.registry.byName.values()) {
+      const m = plugin.manifest
+      const stateEntry = state.plugins[m.name]
+      let status: PluginCatalogEntry['status']
+      if (!stateEntry) {
+        status = 'not-installed'
+      } else if (stateEntry.health === 'degraded') {
+        status = 'degraded'
+      } else {
+        // Plugin install lives in two files:
+        //   (a) state.json — the hub's record that the plugin is installed
+        //   (b) .mcp.json  — the actual contract with Claude (loaded blindly)
+        // Active = both present. Deactivated = (a) without the (b) keys
+        // (user toggled off; install survives).
+        let allKeysPresent = true
+        const mcpServers = readMcpServersMap(projectPath)
+        for (const server of m.owns.mcpServers ?? []) {
+          if (!(server in mcpServers)) { allKeysPresent = false; break }
+        }
+        status = allKeysPresent ? 'installed' : 'deactivated'
+      }
+      // Surface marketplace conflicts so UI can offer a "Disable global"
+      // affordance when our project-scoped install is being shadowed.
+      const conflicts: string[] = []
+      const cachedDisabled: string[] = []
+      for (const server of m.owns.mcpServers ?? []) {
+        for (const key of findEnabledMarketplaceKeys(server)) {
+          if (!conflicts.includes(key)) conflicts.push(key)
+        }
+        for (const key of findInstalledButNotEnabledMarketplaceKeys(server)) {
+          if (!cachedDisabled.includes(key)) cachedDisabled.push(key)
+        }
+      }
+      // Drift detection: only meaningful when actually installed.
+      const updateAvailable = stateEntry ? detectMcpDrift(projectPath, plugin) : false
+      entries.push({
+        name: m.name,
+        version: m.version,
+        description: m.description,
+        whatItDoes: m.whatItDoes,
+        category: m.category,
+        requirements: m.requirements ?? [],
+        owns: m.owns,
+        status,
+        installedAt: stateEntry?.installedAt,
+        health: stateEntry?.health,
+        healthReason: stateEntry?.healthReason,
+        marketplaceConflicts: conflicts.length > 0 ? conflicts : undefined,
+        marketplaceCachedButDisabled: cachedDisabled.length > 0 ? cachedDisabled : undefined,
+        updateAvailable: updateAvailable || undefined,
+      })
+    }
+
+    // Orphan plugins: present in state.json but not in the bundled registry.
+    for (const [name, entry] of Object.entries(state.plugins)) {
+      if (this.registry.byName.has(name)) continue
+      entries.push({
+        name,
+        version: entry.version,
+        description: '(plugin no longer bundled)',
+        whatItDoes: [],
+        requirements: [],
+        owns: {},
+        status: 'orphan',
+        installedAt: entry.installedAt,
+        health: entry.health,
+        healthReason: entry.healthReason,
+      })
+    }
+
+    return entries.sort((a, b) => a.name.localeCompare(b.name))
+  }
+
+  // ─── Preview install ───────────────────────────────────────────────────────
+
+  async previewInstall(
+    projectPath: string,
+    projectId: string,
+    name: string,
+  ): Promise<PluginPreviewResult> {
+    const plugin = this.registry.byName.get(name)
+    if (!plugin) throw new PluginNotFoundError(name)
+
+    let files: PluginPreviewFileEntry[]
+    if (plugin.previewInstall) {
+      files = await plugin.previewInstall({ projectPath, projectId })
+    } else {
+      files = this._derivePreviewFiles(projectPath, plugin)
+    }
+
+    const requirements = await Promise.all(
+      (plugin.manifest.requirements ?? []).map(async (req) => {
+        if (this._options.checkPrerequisite) {
+          const r = await this._options.checkPrerequisite(req)
+          return { name: req.name, ...r }
+        }
+        return { name: req.name, installed: true, executable: true, meetsMinimum: true }
+      }),
+    )
+
+    const hostKey = `${process.platform}-${process.arch}`
+    const platformNote = plugin.manifest.platformNotes?.[hostKey]
+
+    return {
+      pluginName: name,
+      files,
+      requirements,
+      platformNote,
+    }
+  }
+
+  private _derivePreviewFiles(projectPath: string, plugin: Plugin): PluginPreviewFileEntry[] {
+    const out: PluginPreviewFileEntry[] = []
+    const m = plugin.manifest
+
+    // .mcp.json
+    if ((m.owns.mcpServers ?? []).length > 0) {
+      const mcpExists = fs.existsSync(mcpJsonPath(projectPath))
+      out.push({
+        path: '.mcp.json',
+        op: mcpExists ? 'modify' : 'create',
+        summary: `+ mcpServers.${(m.owns.mcpServers ?? []).join(', mcpServers.')}`,
+      })
+    }
+
+    // Agent fragments
+    for (const frag of m.owns.agentFragments ?? []) {
+      const exists = fs.existsSync(path.join(projectPath, frag))
+      out.push({ path: frag, op: exists ? 'modify' : 'create' })
+    }
+
+    // State file
+    const stateExists = fs.existsSync(stateFilePath(projectPath))
+    out.push({
+      path: '.specrails/plugins/state.json',
+      op: stateExists ? 'modify' : 'create',
+      summary: `+ plugins.${m.name}`,
+    })
+
+    return out
+  }
+
+  // ─── Install ───────────────────────────────────────────────────────────────
+
+  async install(
+    projectPath: string,
+    projectId: string,
+    name: string,
+    broadcast: PluginBroadcast,
+  ): Promise<void> {
+    const plugin = this.registry.byName.get(name)
+    if (!plugin) throw new PluginNotFoundError(name)
+
+    const state = this.getProjectState(projectPath)
+    if (state.plugins[name]) throw new PluginAlreadyInstalledError(name)
+
+    // Check for ownership conflicts with user-authored .mcp.json entries.
+    const mcpFile = mcpJsonPath(projectPath)
+    if (fs.existsSync(mcpFile)) {
+      const raw = fs.readFileSync(mcpFile, 'utf8')
+      const parsed = raw.trim() ? (JSON.parse(raw) as Record<string, unknown>) : {}
+      const servers = (parsed.mcpServers as Record<string, unknown> | undefined) ?? {}
+      for (const key of plugin.manifest.owns.mcpServers ?? []) {
+        if (key in servers) {
+          throw new PluginInstallError(
+            `cannot install '${name}': '${mcpJsonPath(projectPath)}' already has a 'mcpServers.${key}' entry. Remove it first.`,
+          )
+        }
+      }
+    }
+
+    // Snapshot pre-install state of every file the plugin might touch — we
+    // need exact bytes to roll back if install/verify fails.
+    const targetPaths = [
+      mcpJsonPath(projectPath),
+      stateFilePath(projectPath),
+      ...(plugin.manifest.owns.agentFragments ?? []).map((f) => path.join(projectPath, f)),
+    ]
+    const preState = new Map<string, Buffer | null>()
+    for (const p of targetPaths) {
+      preState.set(p, fs.existsSync(p) ? fs.readFileSync(p) : null)
+    }
+
+    const installedFiles: string[] = []
+    const onLog = (line: string) => {
+      const msg: PluginInstallProgressMessage = {
+        type: 'plugin.install_progress',
+        projectId,
+        name,
+        line,
+        timestamp: new Date().toISOString(),
+      }
+      broadcast(msg)
+    }
+
+    const ctx = {
+      projectPath,
+      projectId,
+      recordInstalledFile: (rel: string) => { installedFiles.push(rel) },
+      log: onLog,
+    }
+
+    try {
+      await plugin.install(ctx)
+
+      // Verify immediately. A degraded result also triggers rollback because
+      // the spec requires verify-pass before we commit state.
+      const verify = await this._runVerify(plugin, projectPath, projectId)
+      if (!verify.ok) {
+        throw new PluginInstallError(
+          `verify failed after install: ${verify.reason ?? 'unknown'}`,
+        )
+      }
+
+      // Commit: write state.json with the install record.
+      const stateNow = this.getProjectState(projectPath)
+      stateNow.plugins[name] = {
+        version: plugin.manifest.version,
+        installedAt: new Date().toISOString(),
+        installedFiles,
+        health: 'ok',
+      }
+      await this._writeProjectState(projectPath, stateNow)
+      // No additional approval write needed: any server in `.mcp.json` loads
+      // automatically when Claude opens the project. Install IS active.
+    } catch (err) {
+      // Roll back every file we snapshotted. Byte-identical restore.
+      for (const [p, bytes] of preState.entries()) {
+        try {
+          if (bytes === null) {
+            if (fs.existsSync(p)) fs.unlinkSync(p)
+          } else {
+            atomicWriteFileSync(p, bytes.toString('utf8'))
+          }
+        } catch {
+          // Best-effort rollback; any failure here will surface via verify on
+          // the next install attempt.
+        }
+      }
+      throw err instanceof PluginInstallError ? err : new PluginInstallError(
+        `install of '${name}' failed: ${(err as Error)?.message ?? String(err)}`,
+        err,
+      )
+    }
+
+    const msg: PluginInstalledMessage = {
+      type: 'plugin.installed',
+      projectId,
+      name,
+      version: plugin.manifest.version,
+      timestamp: new Date().toISOString(),
+    }
+    broadcast(msg)
+  }
+
+  // ─── Uninstall ─────────────────────────────────────────────────────────────
+
+  async uninstall(
+    projectPath: string,
+    projectId: string,
+    name: string,
+    broadcast: PluginBroadcast,
+  ): Promise<void> {
+    const state = this.getProjectState(projectPath)
+    const entry = state.plugins[name]
+    if (!entry) throw new PluginNotInstalledError(name)
+
+    const plugin = this.registry.byName.get(name)
+    const onLog = (line: string) => {
+      broadcast({
+        type: 'plugin.install_progress',
+        projectId,
+        name,
+        line,
+        timestamp: new Date().toISOString(),
+      } as PluginInstallProgressMessage)
+    }
+
+    if (plugin) {
+      await plugin.uninstall({
+        projectPath,
+        projectId,
+        recordInstalledFile: () => {},
+        log: onLog,
+      })
+    } else {
+      // Orphan removal: no plugin code available. Best-effort cleanup of
+      // recorded installedFiles + drop the state entry. We cannot know which
+      // mcpServers keys belonged to this plugin, so we leave .mcp.json alone.
+      for (const rel of entry.installedFiles ?? []) {
+        const abs = path.join(projectPath, rel)
+        try { if (fs.existsSync(abs)) fs.unlinkSync(abs) } catch { /* ignore */ }
+      }
+    }
+
+    const stateNow = this.getProjectState(projectPath)
+    delete stateNow.plugins[name]
+    await this._writeProjectState(projectPath, stateNow)
+
+    broadcast({
+      type: 'plugin.uninstalled',
+      projectId,
+      name,
+      timestamp: new Date().toISOString(),
+    } as PluginUninstalledMessage)
+  }
+
+  /**
+   * Re-write the project's `.mcp.json` entries owned by this plugin to match
+   * the bundled manifest's canonical shape. Surgical: only the plugin's
+   * `owns.mcpServers` keys are touched; user entries are preserved. Used to
+   * resolve drift surfaced by `updateAvailable`.
+   */
+  async updateMcpEntry(
+    projectPath: string,
+    projectId: string,
+    name: string,
+    broadcast: PluginBroadcast,
+  ): Promise<void> {
+    const plugin = this.registry.byName.get(name)
+    if (!plugin) throw new PluginNotFoundError(name)
+    const state = this.getProjectState(projectPath)
+    if (!state.plugins[name]) throw new PluginNotInstalledError(name)
+    const expected = plugin.expectedMcpEntry?.()
+    if (!expected) {
+      throw new PluginInstallError(`'${name}' does not declare expectedMcpEntry; cannot update`)
+    }
+    const owned = plugin.manifest.owns.mcpServers ?? []
+    const entries: Record<string, unknown> = {}
+    for (const key of owned) entries[key] = expected
+    await PluginManager.mergeMcpServers(projectPath, entries)
+    broadcast({
+      type: 'plugin.health_changed',
+      projectId,
+      name,
+      status: 'unknown',
+      reason: 'updated',
+      timestamp: new Date().toISOString(),
+    })
+  }
+
+  /**
+   * Toggle a plugin between active and deactivated. Reality of Claude's MCP
+   * loading: any server present in `<project>/.mcp.json` is loaded by Claude
+   * regardless of `enabledMcpjsonServers` flags. So:
+   *
+   *   - active=true   → re-write the canonical mcpServers entry (from the
+   *                     plugin's `expectedMcpEntry`) into `.mcp.json`
+   *   - active=false  → remove only the owned mcpServers keys; preserve
+   *                     state.json so `installed` memory survives, and
+   *                     preserve any user-authored sibling entries
+   *
+   * Plugin install state survives across toggles. Uninstall is the only
+   * action that clears state.json + custom-*.md fragments.
+   */
+  async setActive(
+    projectPath: string,
+    projectId: string,
+    name: string,
+    active: boolean,
+    broadcast: PluginBroadcast,
+  ): Promise<void> {
+    const plugin = this.registry.byName.get(name)
+    if (!plugin) throw new PluginNotFoundError(name)
+    const state = this.getProjectState(projectPath)
+    if (!state.plugins[name]) throw new PluginNotInstalledError(name)
+
+    const owned = plugin.manifest.owns.mcpServers ?? []
+    if (owned.length === 0) {
+      throw new PluginInstallError(`'${name}' owns no mcpServers; cannot toggle activation`)
+    }
+
+    if (active) {
+      const expected = plugin.expectedMcpEntry?.()
+      if (!expected) {
+        throw new PluginInstallError(`'${name}' does not declare expectedMcpEntry; cannot activate`)
+      }
+      const entries: Record<string, unknown> = {}
+      for (const k of owned) entries[k] = expected
+      await PluginManager.mergeMcpServers(projectPath, entries)
+    } else {
+      await PluginManager.removeMcpServers(projectPath, owned)
+    }
+
+    broadcast({
+      type: 'plugin.health_changed',
+      projectId,
+      name,
+      status: active ? 'ok' : 'unknown',
+      reason: active ? 'activated' : 'deactivated',
+      timestamp: new Date().toISOString(),
+    })
+  }
+
+  /** Drop a state.json entry for a plugin no longer in the registry. */
+  async removeOrphan(projectPath: string, projectId: string, name: string, broadcast: PluginBroadcast): Promise<void> {
+    if (this.registry.byName.has(name)) {
+      throw new PluginInstallError(`'${name}' is not orphan; it is still bundled. Use uninstall instead.`)
+    }
+    return this.uninstall(projectPath, projectId, name, broadcast)
+  }
+
+  // ─── Verify ────────────────────────────────────────────────────────────────
+
+  async verify(
+    projectPath: string,
+    projectId: string,
+    name: string,
+    broadcast?: PluginBroadcast,
+  ): Promise<PluginVerifyResult> {
+    const plugin = this.registry.byName.get(name)
+    if (!plugin) throw new PluginNotFoundError(name)
+    const result = await this._runVerify(plugin, projectPath, projectId)
+    await this._cacheHealth(projectPath, projectId, name, result, broadcast)
+    return result
+  }
+
+  private async _runVerify(
+    plugin: Plugin,
+    projectPath: string,
+    projectId: string,
+  ): Promise<PluginVerifyResult> {
+    const timeout = plugin.manifest.verifyTimeoutMs ?? this._options.defaultVerifyTimeoutMs
+    const checkedAt = new Date().toISOString()
+    try {
+      const result = await Promise.race<PluginVerifyResult | { __timeout: true }>([
+        plugin.verify({ projectPath, projectId }),
+        new Promise<{ __timeout: true }>((resolve) =>
+          setTimeout(() => resolve({ __timeout: true }), timeout).unref?.(),
+        ),
+      ])
+      if ('__timeout' in result) {
+        return { ok: false, reason: 'verify-timeout', checkedAt }
+      }
+      return { ok: result.ok, reason: result.reason, checkedAt: result.checkedAt ?? checkedAt }
+    } catch (err) {
+      return { ok: false, reason: `verify-exception: ${(err as Error)?.message ?? String(err)}`, checkedAt }
+    }
+  }
+
+  private async _cacheHealth(
+    projectPath: string,
+    projectId: string,
+    name: string,
+    result: PluginVerifyResult,
+    broadcast?: PluginBroadcast,
+  ): Promise<void> {
+    const state = this.getProjectState(projectPath)
+    const entry = state.plugins[name]
+    if (!entry) return
+    const newHealth: PluginStateEntry['health'] = result.ok ? 'ok' : 'degraded'
+    const changed = entry.health !== newHealth || entry.healthReason !== result.reason
+    entry.health = newHealth
+    entry.healthReason = result.reason
+    await this._writeProjectState(projectPath, state)
+    if (changed && broadcast) {
+      const msg: PluginHealthChangedMessage = {
+        type: 'plugin.health_changed',
+        projectId,
+        name,
+        status: newHealth,
+        reason: result.reason,
+        timestamp: new Date().toISOString(),
+      }
+      broadcast(msg)
+    }
+  }
+
+  // ─── Surgical helpers exposed to plugins ───────────────────────────────────
+
+  /** Helper: surgically merge `mcpServers.<key>` entries into .mcp.json. */
+  static async mergeMcpServers(
+    projectPath: string,
+    entries: Record<string, unknown>,
+  ): Promise<void> {
+    await surgicalMergeJson(mcpJsonPath(projectPath), (current) => {
+      const next = (current ?? {}) as Record<string, unknown>
+      const servers = ((next.mcpServers as Record<string, unknown>) ?? {}) as Record<string, unknown>
+      for (const [k, v] of Object.entries(entries)) servers[k] = v
+      next.mcpServers = servers
+      return next
+    })
+  }
+
+  /** Helper: remove specific `mcpServers.<key>` entries from .mcp.json. */
+  static async removeMcpServers(
+    projectPath: string,
+    keys: string[],
+  ): Promise<void> {
+    if (keys.length === 0) return
+    await surgicalRemoveKeys(
+      mcpJsonPath(projectPath),
+      keys.map((k) => `mcpServers.${k}`),
+    )
+  }
+}

--- a/server/plugins-router.test.ts
+++ b/server/plugins-router.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { initDb, type DbInstance } from './db'
+import { createPluginsRouter } from './plugins-router'
+import { PluginManager } from './plugin-manager'
+import { setPluginManagerForTesting } from './plugins/manager'
+import type { ProjectContext } from './project-registry'
+import type { Plugin } from './types'
+
+let projectPath: string
+let db: DbInstance
+let app: express.Express
+let broadcasts: Array<{ type: string }>
+
+function makePlugin(): Plugin {
+  return {
+    manifest: {
+      name: 'serena',
+      version: '1.0.0',
+      description: 'semantic',
+      whatItDoes: ['x'],
+      requirements: [{ name: 'uv', minVersion: '0.1.0' }],
+      owns: { mcpServers: ['serena'] },
+    },
+    install: async (ctx) => {
+      await PluginManager.mergeMcpServers(ctx.projectPath, { serena: { command: 'uvx' } })
+    },
+    uninstall: async (ctx) => {
+      await PluginManager.removeMcpServers(ctx.projectPath, ['serena'])
+    },
+    verify: async () => ({ ok: true, checkedAt: new Date().toISOString() }),
+  }
+}
+
+function mountApp(plugins: Plugin[] = [makePlugin()]): void {
+  setPluginManagerForTesting(new PluginManager(plugins))
+  broadcasts = []
+  app = express()
+  app.use(express.json())
+  const ctx: ProjectContext = {
+    project: {
+      id: 'proj-test',
+      slug: 'proj-test',
+      name: 'Test',
+      path: projectPath,
+      provider: 'claude',
+      last_active: null,
+      setup_session: null,
+      agent_job_id: null,
+    } as never,
+    db,
+    queueManager: {} as never,
+    chatManager: {} as never,
+    setupManager: {} as never,
+    proposalManager: {} as never,
+    agentRefineManager: {} as never,
+    specLauncherManager: {} as never,
+    ticketWatcher: {} as never,
+    broadcast: ((m: { type: string }) => { broadcasts.push(m) }) as never,
+    railJobs: new Map(),
+  }
+  app.use('/api/projects/:projectId/plugins', (req, _res, next) => {
+    ;(req as never as { projectCtx: ProjectContext }).projectCtx = ctx
+    next()
+  }, createPluginsRouter())
+}
+
+beforeEach(() => {
+  projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'plugins-router-'))
+  db = initDb(':memory:')
+  mountApp()
+})
+
+afterEach(() => {
+  fs.rmSync(projectPath, { recursive: true, force: true })
+  setPluginManagerForTesting(null)
+})
+
+describe('GET /plugins', () => {
+  it('returns catalog with not-installed status', async () => {
+    const res = await request(app).get('/api/projects/proj-test/plugins')
+    expect(res.status).toBe(200)
+    expect(res.body.plugins).toHaveLength(1)
+    expect(res.body.plugins[0].status).toBe('not-installed')
+  })
+})
+
+describe('GET /plugins/:name/preview-install', () => {
+  it('returns diff without mutating project', async () => {
+    const res = await request(app).get('/api/projects/proj-test/plugins/serena/preview-install')
+    expect(res.status).toBe(200)
+    expect(res.body.files).toEqual(expect.arrayContaining([
+      expect.objectContaining({ path: '.mcp.json', op: 'create' }),
+    ]))
+    expect(fs.existsSync(path.join(projectPath, '.mcp.json'))).toBe(false)
+  })
+
+  it('returns 404 for unknown plugin', async () => {
+    const res = await request(app).get('/api/projects/proj-test/plugins/nope/preview-install')
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('POST /plugins/:name/install', () => {
+  it('installs and emits plugin.installed', async () => {
+    const res = await request(app).post('/api/projects/proj-test/plugins/serena/install')
+    expect(res.status).toBe(200)
+    expect(broadcasts.some((b) => b.type === 'plugin.installed')).toBe(true)
+  })
+
+  it('returns 404 for unknown plugin', async () => {
+    const res = await request(app).post('/api/projects/proj-test/plugins/nope/install')
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 409 on second install', async () => {
+    await request(app).post('/api/projects/proj-test/plugins/serena/install')
+    const res = await request(app).post('/api/projects/proj-test/plugins/serena/install')
+    expect(res.status).toBe(409)
+  })
+})
+
+describe('DELETE /plugins/:name', () => {
+  it('uninstalls', async () => {
+    await request(app).post('/api/projects/proj-test/plugins/serena/install')
+    const res = await request(app).delete('/api/projects/proj-test/plugins/serena')
+    expect(res.status).toBe(200)
+    expect(broadcasts.some((b) => b.type === 'plugin.uninstalled')).toBe(true)
+  })
+
+  it('returns 404 when not installed', async () => {
+    const res = await request(app).delete('/api/projects/proj-test/plugins/serena')
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('GET /plugins/:name/health', () => {
+  it('reports ok for healthy plugin', async () => {
+    await request(app).post('/api/projects/proj-test/plugins/serena/install')
+    const res = await request(app).get('/api/projects/proj-test/plugins/serena/health')
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+  })
+
+  it('returns 404 for unknown plugin', async () => {
+    const res = await request(app).get('/api/projects/proj-test/plugins/nope/health')
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('POST /plugins/_prerequisites/:prereq/install', () => {
+  beforeEach(() => { process.env.SPECRAILS_PREREQ_NOOP = '1' })
+  afterEach(() => { delete process.env.SPECRAILS_PREREQ_NOOP })
+
+  it('rejects unknown prerequisite with 404', async () => {
+    const res = await request(app).post('/api/projects/proj-test/plugins/_prerequisites/wat/install')
+    expect(res.status).toBe(404)
+  })
+
+  it('acks 202 and emits prereq_installed via broadcast', async () => {
+    const res = await request(app).post('/api/projects/proj-test/plugins/_prerequisites/uv/install')
+    expect(res.status).toBe(202)
+    expect(res.body.ok).toBe(true)
+    // Wait microtasks so the async install completes and emits.
+    await new Promise((r) => setTimeout(r, 20))
+    expect(broadcasts.some((b) => b.type === 'plugin.prereq_installed')).toBe(true)
+  })
+})
+
+describe('feature gate', () => {
+  it('returns 404 when SPECRAILS_PLUGINS_SECTION=false', async () => {
+    process.env.SPECRAILS_PLUGINS_SECTION = 'false'
+    try {
+      const res = await request(app).get('/api/projects/proj-test/plugins')
+      expect(res.status).toBe(404)
+    } finally {
+      delete process.env.SPECRAILS_PLUGINS_SECTION
+    }
+  })
+})

--- a/server/plugins-router.ts
+++ b/server/plugins-router.ts
@@ -1,0 +1,229 @@
+import { Router, Request, Response } from 'express'
+import type { ProjectContext } from './project-registry'
+import {
+  PluginAlreadyInstalledError,
+  PluginInstallError,
+  PluginNotFoundError,
+  PluginNotInstalledError,
+} from './plugin-manager'
+import { getPluginManager } from './plugins/manager'
+import { installPrerequisite } from './plugins/prereq-installer'
+import { augmentPathFromLoginShell } from './path-resolver'
+import { disableMarketplacePlugin } from './plugins/claude-approval'
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    projectCtx?: ProjectContext
+  }
+}
+
+function pluginsSectionEnabled(): boolean {
+  return process.env.SPECRAILS_PLUGINS_SECTION !== 'false'
+}
+
+function handleError(res: Response, err: unknown): void {
+  if (err instanceof PluginNotFoundError) {
+    res.status(404).json({ error: err.message })
+    return
+  }
+  if (err instanceof PluginNotInstalledError) {
+    res.status(404).json({ error: err.message })
+    return
+  }
+  if (err instanceof PluginAlreadyInstalledError) {
+    res.status(409).json({ error: err.message })
+    return
+  }
+  if (err instanceof PluginInstallError) {
+    res.status(409).json({ error: err.message })
+    return
+  }
+  const message = err instanceof Error ? err.message : 'unknown error'
+  res.status(500).json({ error: message })
+}
+
+export function createPluginsRouter(): Router {
+  const router = Router({ mergeParams: true })
+
+  function ctx(req: Request): ProjectContext {
+    return req.projectCtx!
+  }
+
+  router.use((_req, res, next) => {
+    if (!pluginsSectionEnabled()) {
+      res.status(404).json({ error: 'Plugins section disabled on this server' })
+      return
+    }
+    next()
+  })
+
+  // GET /api/projects/:projectId/plugins — catalog
+  router.get('/', async (req, res) => {
+    try {
+      const { project } = ctx(req)
+      const list = await getPluginManager().listAvailable(project.path)
+      res.json({ plugins: list })
+    } catch (err) {
+      handleError(res, err)
+    }
+  })
+
+  // GET /api/projects/:projectId/plugins/:name/preview-install
+  router.get('/:name/preview-install', async (req, res) => {
+    try {
+      const { project } = ctx(req)
+      const result = await getPluginManager().previewInstall(project.path, project.id, req.params.name)
+      res.json(result)
+    } catch (err) {
+      handleError(res, err)
+    }
+  })
+
+  // POST /api/projects/:projectId/plugins/:name/install
+  router.post('/:name/install', async (req, res) => {
+    try {
+      const { project, broadcast } = ctx(req)
+      await getPluginManager().install(project.path, project.id, req.params.name, broadcast)
+      res.status(200).json({ ok: true })
+    } catch (err) {
+      handleError(res, err)
+    }
+  })
+
+  // DELETE /api/projects/:projectId/plugins/:name — uninstall (or orphan removal)
+  router.delete('/:name', async (req, res) => {
+    try {
+      const { project, broadcast } = ctx(req)
+      await getPluginManager().uninstall(project.path, project.id, req.params.name, broadcast)
+      res.status(200).json({ ok: true })
+    } catch (err) {
+      handleError(res, err)
+    }
+  })
+
+  // POST /api/projects/:projectId/plugins/_prerequisites/:prereq/install
+  // Streams installer output via the project broadcast as
+  // `plugin.prereq_install_progress`; emits `plugin.prereq_installed` on done.
+  router.post('/_prerequisites/:prereq/install', async (req, res) => {
+    const { project, broadcast } = ctx(req)
+    const prereq = req.params.prereq
+    const allowed = ['uv']
+    if (!allowed.includes(prereq)) {
+      res.status(404).json({ error: `unknown prerequisite '${prereq}'` })
+      return
+    }
+    res.status(202).json({ ok: true, message: 'install started' })
+    try {
+      const result = await installPrerequisite(prereq, project.id, broadcast)
+      // After a successful install, the new binary lives in `~/.local/bin`
+      // (POSIX) or `%USERPROFILE%\.local\bin` (Windows). Refresh the hub's
+      // PATH from a login shell so the next verify spawn finds it without a
+      // hub restart. On Windows this is a no-op — surface the hint as part
+      // of the reason field instead.
+      let hint: string | undefined
+      if (result.ok) {
+        if (process.platform === 'win32') {
+          hint = 'Installed. If verify still fails, restart SpecRails Hub so Windows refreshes PATH.'
+        } else {
+          try {
+            await augmentPathFromLoginShell({ timeoutMs: 3000 })
+            hint = 'Installed. PATH refreshed.'
+          } catch {
+            hint = 'Installed. If verify still fails, restart SpecRails Hub.'
+          }
+        }
+      }
+      broadcast({
+        type: 'plugin.prereq_installed',
+        projectId: project.id,
+        prereq,
+        ok: result.ok,
+        reason: result.ok ? hint : result.reason,
+        timestamp: new Date().toISOString(),
+      })
+    } catch (err) {
+      broadcast({
+        type: 'plugin.prereq_installed',
+        projectId: project.id,
+        prereq,
+        ok: false,
+        reason: (err as Error)?.message ?? 'unknown error',
+        timestamp: new Date().toISOString(),
+      })
+    }
+  })
+
+  // POST /api/projects/:projectId/plugins/_marketplace/disable
+  // Body: { key: "<plugin-name>@<source>" } — sets enabledPlugins[key]=false
+  // in `~/.claude/settings.json`. The only place the hub mutates Claude's
+  // per-user config; surfaced via an explicit user action.
+  router.post('/_marketplace/disable', async (req, res) => {
+    const { project, broadcast } = ctx(req)
+    const key = (req.body as { key?: string } | undefined)?.key
+    if (!key || typeof key !== 'string' || !key.includes('@')) {
+      res.status(400).json({ error: 'body must be { key: "<plugin>@<source>" }' })
+      return
+    }
+    const result = disableMarketplacePlugin(key)
+    if (!result.ok) {
+      res.status(500).json({ error: result.reason ?? 'unknown' })
+      return
+    }
+    // Refetch catalog so UI updates conflicts/status without manual refresh.
+    broadcast({
+      type: 'plugin.health_changed',
+      projectId: project.id,
+      name: key.split('@')[0],
+      status: 'unknown',
+      reason: 'marketplace-disabled',
+      timestamp: new Date().toISOString(),
+    })
+    res.json({ ok: true })
+  })
+
+// POST /api/projects/:projectId/plugins/:name/activate
+  router.post('/:name/activate', async (req, res) => {
+    try {
+      const { project, broadcast } = ctx(req)
+      await getPluginManager().setActive(project.path, project.id, req.params.name, true, broadcast)
+      res.json({ ok: true })
+    } catch (err) {
+      handleError(res, err)
+    }
+  })
+
+  // POST /api/projects/:projectId/plugins/:name/deactivate
+  router.post('/:name/deactivate', async (req, res) => {
+    try {
+      const { project, broadcast } = ctx(req)
+      await getPluginManager().setActive(project.path, project.id, req.params.name, false, broadcast)
+      res.json({ ok: true })
+    } catch (err) {
+      handleError(res, err)
+    }
+  })
+
+  // POST /api/projects/:projectId/plugins/:name/update — apply manifest drift
+  router.post('/:name/update', async (req, res) => {
+    try {
+      const { project, broadcast } = ctx(req)
+      await getPluginManager().updateMcpEntry(project.path, project.id, req.params.name, broadcast)
+      res.json({ ok: true })
+    } catch (err) {
+      handleError(res, err)
+    }
+  })
+
+  // GET /api/projects/:projectId/plugins/:name/health
+  router.get('/:name/health', async (req, res) => {
+    try {
+      const { project, broadcast } = ctx(req)
+      const result = await getPluginManager().verify(project.path, project.id, req.params.name, broadcast)
+      res.json(result)
+    } catch (err) {
+      handleError(res, err)
+    }
+  })
+
+  return router
+}

--- a/server/plugins/claude-approval.test.ts
+++ b/server/plugins/claude-approval.test.ts
@@ -1,0 +1,153 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, it, expect } from 'vitest'
+import { getClaudeApprovalState } from './claude-approval'
+
+let tmpHome: string
+let originalHome: string | undefined
+
+beforeEach(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-approval-'))
+  originalHome = process.env.HOME
+  process.env.HOME = tmpHome
+})
+afterEach(() => {
+  fs.rmSync(tmpHome, { recursive: true, force: true })
+  if (originalHome !== undefined) process.env.HOME = originalHome
+  else delete process.env.HOME
+})
+
+function writeClaudeJson(content: object): void {
+  fs.writeFileSync(path.join(tmpHome, '.claude.json'), JSON.stringify(content), 'utf8')
+}
+
+function writeClaudeSettings(content: object): void {
+  fs.mkdirSync(path.join(tmpHome, '.claude'), { recursive: true })
+  fs.writeFileSync(path.join(tmpHome, '.claude', 'settings.json'), JSON.stringify(content), 'utf8')
+}
+
+describe('getClaudeApprovalState', () => {
+  it('returns pending when ~/.claude.json missing', () => {
+    expect(getClaudeApprovalState('/some/project', 'serena')).toBe('pending')
+  })
+
+  it('returns pending when project entry missing', () => {
+    writeClaudeJson({ projects: { '/other/path': { enabledMcpjsonServers: ['serena'] } } })
+    expect(getClaudeApprovalState('/some/project', 'serena')).toBe('pending')
+  })
+
+  it('returns enabled when server in enabledMcpjsonServers', () => {
+    writeClaudeJson({
+      projects: { '/some/project': { enabledMcpjsonServers: ['serena', 'other'] } },
+    })
+    expect(getClaudeApprovalState('/some/project', 'serena')).toBe('enabled')
+  })
+
+  it('returns disabled when server in disabledMcpjsonServers', () => {
+    writeClaudeJson({
+      projects: { '/some/project': { disabledMcpjsonServers: ['serena'] } },
+    })
+    expect(getClaudeApprovalState('/some/project', 'serena')).toBe('disabled')
+  })
+
+  it('returns pending when server in neither list and trust not accepted', () => {
+    writeClaudeJson({
+      projects: { '/some/project': { enabledMcpjsonServers: ['other'], disabledMcpjsonServers: [] } },
+    })
+    expect(getClaudeApprovalState('/some/project', 'serena')).toBe('pending')
+  })
+
+  it('returns enabled when project is trusted (hasTrustDialogAccepted=true) and not denied', () => {
+    writeClaudeJson({
+      projects: { '/some/project': { enabledMcpjsonServers: [], disabledMcpjsonServers: [], hasTrustDialogAccepted: true } },
+    })
+    expect(getClaudeApprovalState('/some/project', 'serena')).toBe('enabled')
+  })
+
+  it('explicit deny wins even on trusted project', () => {
+    writeClaudeJson({
+      projects: { '/some/project': { enabledMcpjsonServers: [], disabledMcpjsonServers: ['serena'], hasTrustDialogAccepted: true } },
+    })
+    expect(getClaudeApprovalState('/some/project', 'serena')).toBe('disabled')
+  })
+
+  it('returns pending when JSON malformed', () => {
+    fs.writeFileSync(path.join(tmpHome, '.claude.json'), '{not')
+    expect(getClaudeApprovalState('/some/project', 'serena')).toBe('pending')
+  })
+
+  it('returns enabled when marketplace plugin is enabled (no .mcp.json approval needed)', () => {
+    writeClaudeSettings({
+      enabledPlugins: { 'serena@claude-plugins-official': true },
+    })
+    expect(getClaudeApprovalState('/some/project', 'serena')).toBe('enabled')
+  })
+
+  it('marketplace match requires the @ prefix segment to match the server name', () => {
+    writeClaudeSettings({
+      enabledPlugins: { 'foobar@something': true, 'serena-helper@x': true },
+    })
+    expect(getClaudeApprovalState('/some/project', 'serena')).toBe('pending')
+  })
+
+  it('marketplace ignores entries with value=false', () => {
+    writeClaudeSettings({
+      enabledPlugins: { 'serena@claude-plugins-official': false },
+    })
+    expect(getClaudeApprovalState('/some/project', 'serena')).toBe('pending')
+  })
+
+  it('explicit disabledMcpjsonServers wins over marketplace enable', () => {
+    writeClaudeJson({ projects: { '/some/project': { disabledMcpjsonServers: ['serena'] } } })
+    writeClaudeSettings({ enabledPlugins: { 'serena@claude-plugins-official': true } })
+    expect(getClaudeApprovalState('/some/project', 'serena')).toBe('disabled')
+  })
+
+it('findInstalledMarketplaceKeys returns matching keys regardless of enabled state', async () => {
+    const installedDir = path.join(tmpHome, '.claude', 'plugins')
+    fs.mkdirSync(installedDir, { recursive: true })
+    fs.writeFileSync(path.join(installedDir, 'installed_plugins.json'), JSON.stringify({
+      plugins: {
+        'serena@claude-plugins-official': [{ scope: 'user' }],
+        'other@x': [{ scope: 'user' }],
+      },
+    }))
+    const { findInstalledMarketplaceKeys } = await import('./claude-approval')
+    expect(findInstalledMarketplaceKeys('serena')).toEqual(['serena@claude-plugins-official'])
+    expect(findInstalledMarketplaceKeys('other')).toEqual(['other@x'])
+    expect(findInstalledMarketplaceKeys('nope')).toEqual([])
+  })
+
+  it('findInstalledButNotEnabledMarketplaceKeys reports only disabled cached plugins', async () => {
+    const installedDir = path.join(tmpHome, '.claude', 'plugins')
+    fs.mkdirSync(installedDir, { recursive: true })
+    fs.writeFileSync(path.join(installedDir, 'installed_plugins.json'), JSON.stringify({
+      plugins: { 'serena@claude-plugins-official': [{ scope: 'user' }] },
+    }))
+    writeClaudeSettings({ enabledPlugins: { 'serena@claude-plugins-official': false } })
+    const { findInstalledButNotEnabledMarketplaceKeys } = await import('./claude-approval')
+    expect(findInstalledButNotEnabledMarketplaceKeys('serena')).toEqual(['serena@claude-plugins-official'])
+  })
+
+  it('findInstalledButNotEnabledMarketplaceKeys is empty when key is enabled', async () => {
+    const installedDir = path.join(tmpHome, '.claude', 'plugins')
+    fs.mkdirSync(installedDir, { recursive: true })
+    fs.writeFileSync(path.join(installedDir, 'installed_plugins.json'), JSON.stringify({
+      plugins: { 'serena@claude-plugins-official': [{ scope: 'user' }] },
+    }))
+    writeClaudeSettings({ enabledPlugins: { 'serena@claude-plugins-official': true } })
+    const { findInstalledButNotEnabledMarketplaceKeys } = await import('./claude-approval')
+    expect(findInstalledButNotEnabledMarketplaceKeys('serena')).toEqual([])
+  })
+
+  it('disabled wins over enabled (defensive: should never happen)', () => {
+    writeClaudeJson({
+      projects: { '/some/project': {
+        enabledMcpjsonServers: ['serena'],
+        disabledMcpjsonServers: ['serena'],
+      } },
+    })
+    expect(getClaudeApprovalState('/some/project', 'serena')).toBe('disabled')
+  })
+})

--- a/server/plugins/claude-approval.ts
+++ b/server/plugins/claude-approval.ts
@@ -1,0 +1,186 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+export type ApprovalState = 'enabled' | 'disabled' | 'pending'
+
+interface ClaudeProjectEntry {
+  enabledMcpjsonServers?: string[]
+  disabledMcpjsonServers?: string[]
+  /** When true, Claude auto-loads `.mcp.json` servers without prompting.
+   *  Set after the user accepts the trust dialog the first time the project
+   *  is opened. Critical for our deactivate logic — without explicit deny in
+   *  `disabledMcpjsonServers`, trusted projects load the server regardless. */
+  hasTrustDialogAccepted?: boolean
+}
+
+interface ClaudeUserConfig {
+  projects?: Record<string, ClaudeProjectEntry>
+}
+
+interface ClaudeSettings {
+  /** Plugins enabled via Claude Code's plugin marketplace.
+   *  Keys look like `<plugin-name>@<source>` (e.g., `serena@claude-plugins-official`). */
+  enabledPlugins?: Record<string, boolean>
+}
+
+/**
+ * Returns the approval state for `<projectPath>` × `<serverName>`. The state
+ * is sourced from EITHER:
+ *
+ *   1. `~/.claude.json` → projects[<path>].{enabled,disabled}McpjsonServers —
+ *      the per-project approval set when the user accepts (or denies) the
+ *      `.mcp.json` prompt the first time Claude opens the repo.
+ *
+ *   2. `~/.claude/settings.json` → enabledPlugins["<serverName>@*"] — Claude
+ *      Code's plugin-marketplace mechanism. When a user installs an MCP via
+ *      the marketplace, Serena (or similar) is available in EVERY project
+ *      regardless of `.mcp.json`. The card should reflect that the tool is
+ *      loaded, not that our hub-managed `.mcp.json` entry is dormant.
+ *
+ * Resolution order:
+ *   - explicit disable in (1)            → `disabled`
+ *   - explicit enable in (1) OR (2)      → `enabled`
+ *   - otherwise                          → `pending`
+ *
+ * Defensive: any I/O / parse error falls back to 'pending'. Never throws.
+ */
+export function getClaudeApprovalState(projectPath: string, serverName: string): ApprovalState {
+  // (1) Per-project mcpjson approval.
+  // Order:
+  //   - explicit disabled list   → disabled
+  //   - explicit enabled list    → enabled
+  //   - trusted project          → enabled (Claude auto-loads .mcp.json
+  //                                without prompting once trust is granted)
+  //   - none of the above        → pending (first prompt not yet shown)
+  let mcpjsonState: ApprovalState = 'pending'
+  try {
+    const configPath = path.join(os.homedir(), '.claude.json')
+    if (fs.existsSync(configPath)) {
+      const parsed = JSON.parse(fs.readFileSync(configPath, 'utf8')) as ClaudeUserConfig
+      const entry = parsed.projects?.[path.resolve(projectPath)]
+      if (entry) {
+        if (entry.disabledMcpjsonServers?.includes(serverName)) mcpjsonState = 'disabled'
+        else if (entry.enabledMcpjsonServers?.includes(serverName)) mcpjsonState = 'enabled'
+        else if (entry.hasTrustDialogAccepted === true) mcpjsonState = 'enabled'
+      }
+    }
+  } catch {
+    // ignore — falls through to marketplace check
+  }
+
+  // Explicit disabled wins over marketplace enable.
+  if (mcpjsonState === 'disabled') return 'disabled'
+
+  // (2) Claude marketplace plugin (per-user, project-agnostic).
+  let marketplaceEnabled = false
+  try {
+    const settingsPath = path.join(os.homedir(), '.claude', 'settings.json')
+    if (fs.existsSync(settingsPath)) {
+      const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8')) as ClaudeSettings
+      const enabled = settings.enabledPlugins ?? {}
+      const prefix = `${serverName}@`
+      for (const [key, value] of Object.entries(enabled)) {
+        if (value === true && key.startsWith(prefix)) { marketplaceEnabled = true; break }
+      }
+    }
+  } catch {
+    // ignore
+  }
+
+  if (mcpjsonState === 'enabled' || marketplaceEnabled) return 'enabled'
+  return 'pending'
+}
+
+/**
+ * Returns the keys (e.g., `serena@claude-plugins-official`) under
+ * `~/.claude/settings.json#enabledPlugins` that match `<serverName>@*` and
+ * are set to `true`. Empty array if none.
+ */
+export function findEnabledMarketplaceKeys(serverName: string): string[] {
+  try {
+    const settingsPath = path.join(os.homedir(), '.claude', 'settings.json')
+    if (!fs.existsSync(settingsPath)) return []
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8')) as ClaudeSettings
+    const enabled = settings.enabledPlugins ?? {}
+    const prefix = `${serverName}@`
+    return Object.entries(enabled)
+      .filter(([k, v]) => v === true && k.startsWith(prefix))
+      .map(([k]) => k)
+  } catch {
+    return []
+  }
+}
+
+interface InstalledPluginsFile {
+  plugins?: Record<string, unknown>
+}
+
+/**
+ * Returns the keys present in `~/.claude/plugins/installed_plugins.json`
+ * that match `<serverName>@*`, regardless of the `enabledPlugins` toggle.
+ * Used to detect plugins that are physically in Claude's cache and may be
+ * loaded by Claude even when `enabledPlugins[key]=false` (observed: Claude
+ * keeps them resolvable from the cache `.mcp.json`).
+ */
+export function findInstalledMarketplaceKeys(serverName: string): string[] {
+  try {
+    const filePath = path.join(os.homedir(), '.claude', 'plugins', 'installed_plugins.json')
+    if (!fs.existsSync(filePath)) return []
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8')) as InstalledPluginsFile
+    const map = parsed.plugins ?? {}
+    const prefix = `${serverName}@`
+    return Object.keys(map).filter((k) => k.startsWith(prefix))
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Returns marketplace keys that are physically installed in Claude's plugin
+ * cache but NOT enabled (i.e., `enabledPlugins[key] !== true`). These are
+ * the ones likely to confuse users — the hub disabled them but the binary +
+ * shipped `.mcp.json` are still on disk; Claude may still resolve the server.
+ */
+export function findInstalledButNotEnabledMarketplaceKeys(serverName: string): string[] {
+  const installed = findInstalledMarketplaceKeys(serverName)
+  if (installed.length === 0) return []
+  let enabledMap: Record<string, boolean> = {}
+  try {
+    const settingsPath = path.join(os.homedir(), '.claude', 'settings.json')
+    if (fs.existsSync(settingsPath)) {
+      const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8')) as ClaudeSettings
+      enabledMap = settings.enabledPlugins ?? {}
+    }
+  } catch { /* fall through */ }
+  return installed.filter((k) => enabledMap[k] !== true)
+}
+
+/**
+ * Mutates `~/.claude/settings.json` so the named marketplace plugin is set
+ * to `false` (disabling it). Atomic temp+rename. Returns true on success.
+ *
+ * NOTE: this is the only place the hub touches Claude's per-user config.
+ * Surface to the user via an explicit action (button/CLI), never silently.
+ */
+export function disableMarketplacePlugin(marketplaceKey: string): { ok: boolean; reason?: string } {
+  try {
+    const settingsPath = path.join(os.homedir(), '.claude', 'settings.json')
+    if (!fs.existsSync(settingsPath)) {
+      return { ok: false, reason: 'settings-not-found' }
+    }
+    const raw = fs.readFileSync(settingsPath, 'utf8')
+    const settings = JSON.parse(raw) as ClaudeSettings
+    settings.enabledPlugins ??= {}
+    if (settings.enabledPlugins[marketplaceKey] === false) {
+      return { ok: true, reason: 'already-disabled' }
+    }
+    settings.enabledPlugins[marketplaceKey] = false
+    const tmp = `${settingsPath}.${process.pid}.${Date.now()}.tmp`
+    fs.writeFileSync(tmp, JSON.stringify(settings, null, 2) + '\n', 'utf8')
+    fs.renameSync(tmp, settingsPath)
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, reason: (err as Error).message }
+  }
+}

--- a/server/plugins/claude-md-mutation.test.ts
+++ b/server/plugins/claude-md-mutation.test.ts
@@ -79,6 +79,12 @@ describe('removeBlock', () => {
     expect(text).toContain('foo content')
   })
 
+  it('deletes the file when removing the block leaves it empty', async () => {
+    await upsertBlock(projectPath, 'serena', 'only managed content')
+    await removeBlock(projectPath, 'serena')
+    expect(fs.existsSync(claudeMdFile())).toBe(false)
+  })
+
   it('preserves user content when removing block', async () => {
     fs.writeFileSync(claudeMdFile(), '# project\n\nUser line.\n')
     await upsertBlock(projectPath, 'serena', 'plugin content')

--- a/server/plugins/claude-md-mutation.test.ts
+++ b/server/plugins/claude-md-mutation.test.ts
@@ -1,0 +1,90 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, it, expect } from 'vitest'
+import { getBlockContent, removeBlock, upsertBlock } from './claude-md-mutation'
+
+let projectPath: string
+
+beforeEach(() => { projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-md-')) })
+afterEach(() => { fs.rmSync(projectPath, { recursive: true, force: true }) })
+
+const claudeMdFile = () => path.join(projectPath, 'CLAUDE.md')
+
+describe('upsertBlock', () => {
+  it('creates CLAUDE.md when missing', async () => {
+    await upsertBlock(projectPath, 'serena', '## hello')
+    const text = fs.readFileSync(claudeMdFile(), 'utf8')
+    expect(text).toContain('<!-- specrails-hub-managed:serena:start -->')
+    expect(text).toContain('<!-- specrails-hub-managed:serena:end -->')
+    expect(text).toContain('## hello')
+  })
+
+  it('appends block to existing CLAUDE.md preserving user content', async () => {
+    fs.writeFileSync(claudeMdFile(), '# My project\n\nUser content here.\n')
+    await upsertBlock(projectPath, 'serena', '## hello')
+    const text = fs.readFileSync(claudeMdFile(), 'utf8')
+    expect(text).toMatch(/# My project[\s\S]*User content here/)
+    expect(text).toContain('## hello')
+  })
+
+  it('replaces existing block content for same plugin', async () => {
+    await upsertBlock(projectPath, 'serena', 'v1 content')
+    await upsertBlock(projectPath, 'serena', 'v2 content')
+    const text = fs.readFileSync(claudeMdFile(), 'utf8')
+    expect(text).toContain('v2 content')
+    expect(text).not.toContain('v1 content')
+  })
+
+  it('coexists with blocks from other plugins (additivity)', async () => {
+    await upsertBlock(projectPath, 'serena', 'serena content')
+    await upsertBlock(projectPath, 'foo', 'foo content')
+    const text = fs.readFileSync(claudeMdFile(), 'utf8')
+    expect(text).toContain('serena content')
+    expect(text).toContain('foo content')
+    expect(text).toContain('<!-- specrails-hub-managed:serena:start -->')
+    expect(text).toContain('<!-- specrails-hub-managed:foo:start -->')
+  })
+})
+
+describe('getBlockContent', () => {
+  it('returns null when CLAUDE.md missing', () => {
+    expect(getBlockContent(projectPath, 'serena')).toBeNull()
+  })
+
+  it('returns null when block absent', async () => {
+    fs.writeFileSync(claudeMdFile(), '# project')
+    expect(getBlockContent(projectPath, 'serena')).toBeNull()
+  })
+
+  it('returns block content for installed plugin', async () => {
+    await upsertBlock(projectPath, 'serena', '## serena hints')
+    expect(getBlockContent(projectPath, 'serena')).toContain('## serena hints')
+  })
+})
+
+describe('removeBlock', () => {
+  it('is no-op when CLAUDE.md missing', async () => {
+    await removeBlock(projectPath, 'serena')
+    expect(fs.existsSync(claudeMdFile())).toBe(false)
+  })
+
+  it('removes only the targeted plugin block, preserves others', async () => {
+    await upsertBlock(projectPath, 'serena', 'serena content')
+    await upsertBlock(projectPath, 'foo', 'foo content')
+    await removeBlock(projectPath, 'serena')
+    const text = fs.readFileSync(claudeMdFile(), 'utf8')
+    expect(text).not.toContain('serena content')
+    expect(text).not.toContain('specrails-hub-managed:serena')
+    expect(text).toContain('foo content')
+  })
+
+  it('preserves user content when removing block', async () => {
+    fs.writeFileSync(claudeMdFile(), '# project\n\nUser line.\n')
+    await upsertBlock(projectPath, 'serena', 'plugin content')
+    await removeBlock(projectPath, 'serena')
+    const text = fs.readFileSync(claudeMdFile(), 'utf8')
+    expect(text).toContain('User line.')
+    expect(text).not.toContain('plugin content')
+  })
+})

--- a/server/plugins/claude-md-mutation.ts
+++ b/server/plugins/claude-md-mutation.ts
@@ -93,6 +93,10 @@ export async function upsertBlock(
 /**
  * Remove the managed block for `pluginName`. No-op when CLAUDE.md is missing
  * or the block is absent. Surrounding user content is preserved byte-identical.
+ *
+ * If removing the block leaves the file empty (the managed block was the
+ * only content), the file is deleted — this restores the pre-install state
+ * for projects that didn't have a CLAUDE.md before any plugin install.
  */
 export async function removeBlock(projectPath: string, pluginName: string): Promise<void> {
   const file = claudeMdPath(projectPath)
@@ -105,6 +109,10 @@ export async function removeBlock(projectPath: string, pluginName: string): Prom
     // leave a stray blank line behind.
     let next = cur.slice(0, match.start) + cur.slice(match.end)
     next = next.replace(/\n{3,}$/, '\n').replace(/^\n+/, '')
+    if (next.trim() === '') {
+      fs.unlinkSync(file)
+      return
+    }
     atomicWriteFileSync(file, next)
   })
 }

--- a/server/plugins/claude-md-mutation.ts
+++ b/server/plugins/claude-md-mutation.ts
@@ -1,0 +1,110 @@
+import fs from 'fs'
+import path from 'path'
+import { atomicWriteFileSync, withFileLock } from './json-mutation'
+
+/**
+ * Plugins contribute named sections to `<project>/CLAUDE.md` so the agent's
+ * global context includes per-plugin usage hints (e.g., "prefer Serena tools
+ * over raw Read/Grep when locating symbols"). Each plugin owns one named
+ * block delimited by HTML-comment markers; multiple plugins coexist without
+ * stomping each other.
+ *
+ *   <!-- specrails-hub-managed:<plugin>:start -->
+ *   ...content...
+ *   <!-- specrails-hub-managed:<plugin>:end -->
+ *
+ * Operations are surgical, atomic (temp+rename), and serialized via the
+ * shared in-process file mutex.
+ */
+
+function startMarker(pluginName: string): string {
+  return `<!-- specrails-hub-managed:${pluginName}:start -->`
+}
+function endMarker(pluginName: string): string {
+  return `<!-- specrails-hub-managed:${pluginName}:end -->`
+}
+
+function claudeMdPath(projectPath: string): string {
+  return path.join(projectPath, 'CLAUDE.md')
+}
+
+interface BlockMatch {
+  start: number
+  end: number
+  /** Content between markers, trimmed of surrounding blank lines. */
+  content: string
+}
+
+function locateBlock(text: string, pluginName: string): BlockMatch | null {
+  const start = startMarker(pluginName)
+  const end = endMarker(pluginName)
+  const sIdx = text.indexOf(start)
+  if (sIdx < 0) return null
+  const eIdx = text.indexOf(end, sIdx + start.length)
+  if (eIdx < 0) return null
+  const innerStart = sIdx + start.length
+  const innerEnd = eIdx
+  return {
+    start: sIdx,
+    end: eIdx + end.length,
+    content: text.slice(innerStart, innerEnd).replace(/^\n+|\n+$/g, ''),
+  }
+}
+
+/** Returns the current managed-block content for `pluginName`, or null if absent. */
+export function getBlockContent(projectPath: string, pluginName: string): string | null {
+  const file = claudeMdPath(projectPath)
+  if (!fs.existsSync(file)) return null
+  const text = fs.readFileSync(file, 'utf8')
+  const match = locateBlock(text, pluginName)
+  return match ? match.content : null
+}
+
+/**
+ * Insert or replace the managed block for `pluginName`. If CLAUDE.md does
+ * not exist, it is created with just the block. If it exists without our
+ * block, the block is appended at the end (separated by a blank line).
+ */
+export async function upsertBlock(
+  projectPath: string,
+  pluginName: string,
+  content: string,
+): Promise<void> {
+  const file = claudeMdPath(projectPath)
+  const block = `${startMarker(pluginName)}\n${content.trim()}\n${endMarker(pluginName)}`
+  await withFileLock(file, async () => {
+    let next: string
+    if (!fs.existsSync(file)) {
+      next = block + '\n'
+    } else {
+      const cur = fs.readFileSync(file, 'utf8')
+      const match = locateBlock(cur, pluginName)
+      if (match) {
+        next = cur.slice(0, match.start) + block + cur.slice(match.end)
+      } else {
+        const sep = cur.endsWith('\n\n') ? '' : cur.endsWith('\n') ? '\n' : '\n\n'
+        next = cur + sep + block + '\n'
+      }
+    }
+    atomicWriteFileSync(file, next)
+  })
+}
+
+/**
+ * Remove the managed block for `pluginName`. No-op when CLAUDE.md is missing
+ * or the block is absent. Surrounding user content is preserved byte-identical.
+ */
+export async function removeBlock(projectPath: string, pluginName: string): Promise<void> {
+  const file = claudeMdPath(projectPath)
+  if (!fs.existsSync(file)) return
+  await withFileLock(file, async () => {
+    const cur = fs.readFileSync(file, 'utf8')
+    const match = locateBlock(cur, pluginName)
+    if (!match) return
+    // Strip the block plus a single trailing newline if present, so we don't
+    // leave a stray blank line behind.
+    let next = cur.slice(0, match.start) + cur.slice(match.end)
+    next = next.replace(/\n{3,}$/, '\n').replace(/^\n+/, '')
+    atomicWriteFileSync(file, next)
+  })
+}

--- a/server/plugins/contributors.test.ts
+++ b/server/plugins/contributors.test.ts
@@ -1,0 +1,92 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, it, expect } from 'vitest'
+import { applyContributors, contributorPaths, revertContributors, SHARED_FILE_CONTRIBUTORS } from './contributors'
+import type { Plugin } from '../types'
+
+let projectPath: string
+
+function makePlugin(claudeMdInstructions?: string): Plugin {
+  return {
+    manifest: {
+      name: 'serena',
+      version: '1.0.0',
+      description: '',
+      whatItDoes: [],
+      owns: { mcpServers: ['serena'] },
+      claudeMdInstructions,
+    },
+    install: async () => {},
+    uninstall: async () => {},
+    verify: async () => ({ ok: true, checkedAt: new Date().toISOString() }),
+  }
+}
+
+beforeEach(() => { projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'contrib-')) })
+afterEach(() => { fs.rmSync(projectPath, { recursive: true, force: true }) })
+
+describe('contributors registry', () => {
+  it('claude-md contributor present', () => {
+    expect(SHARED_FILE_CONTRIBUTORS.find((c) => c.id === 'claude-md')).toBeDefined()
+  })
+})
+
+describe('contributorPaths', () => {
+  it('returns empty when plugin contributes nothing', () => {
+    expect(contributorPaths(makePlugin())).toEqual([])
+  })
+
+  it('returns CLAUDE.md when plugin has claudeMdInstructions', () => {
+    expect(contributorPaths(makePlugin('## hello'))).toEqual(['CLAUDE.md'])
+  })
+
+  it('returns empty when claudeMdInstructions is whitespace-only', () => {
+    expect(contributorPaths(makePlugin('   \n  '))).toEqual([])
+  })
+})
+
+describe('applyContributors / revertContributors', () => {
+  it('apply writes CLAUDE.md with the plugin block; revert removes it', async () => {
+    const plugin = makePlugin('## serena hint')
+    const touched = await applyContributors(plugin, projectPath)
+    expect(touched).toEqual(['CLAUDE.md'])
+    const text = fs.readFileSync(path.join(projectPath, 'CLAUDE.md'), 'utf8')
+    expect(text).toContain('## serena hint')
+    expect(text).toContain('specrails-hub-managed:serena')
+
+    await revertContributors(plugin, projectPath)
+    const after = fs.readFileSync(path.join(projectPath, 'CLAUDE.md'), 'utf8')
+    expect(after).not.toContain('serena hint')
+    expect(after).not.toContain('specrails-hub-managed:serena')
+  })
+
+  it('apply is idempotent (multiple calls produce same content)', async () => {
+    const plugin = makePlugin('## hint')
+    await applyContributors(plugin, projectPath)
+    await applyContributors(plugin, projectPath)
+    const text = fs.readFileSync(path.join(projectPath, 'CLAUDE.md'), 'utf8')
+    const occurrences = (text.match(/specrails-hub-managed:serena:start/g) || []).length
+    expect(occurrences).toBe(1)
+  })
+
+  it('apply for plugin A does not touch plugin B block', async () => {
+    const a = makePlugin('A content')
+    a.manifest.name = 'a'
+    const b = makePlugin('B content')
+    b.manifest.name = 'b'
+    await applyContributors(a, projectPath)
+    await applyContributors(b, projectPath)
+    await revertContributors(a, projectPath)
+    const text = fs.readFileSync(path.join(projectPath, 'CLAUDE.md'), 'utf8')
+    expect(text).not.toContain('A content')
+    expect(text).toContain('B content')
+  })
+
+  it('plugin without claudeMdInstructions skips contributor (no file created)', async () => {
+    const plugin = makePlugin()
+    const touched = await applyContributors(plugin, projectPath)
+    expect(touched).toEqual([])
+    expect(fs.existsSync(path.join(projectPath, 'CLAUDE.md'))).toBe(false)
+  })
+})

--- a/server/plugins/contributors.test.ts
+++ b/server/plugins/contributors.test.ts
@@ -56,9 +56,13 @@ describe('applyContributors / revertContributors', () => {
     expect(text).toContain('specrails-hub-managed:serena')
 
     await revertContributors(plugin, projectPath)
-    const after = fs.readFileSync(path.join(projectPath, 'CLAUDE.md'), 'utf8')
-    expect(after).not.toContain('serena hint')
-    expect(after).not.toContain('specrails-hub-managed:serena')
+    // CLAUDE.md is deleted when the only content was the managed block.
+    const claudeMd = path.join(projectPath, 'CLAUDE.md')
+    if (fs.existsSync(claudeMd)) {
+      const after = fs.readFileSync(claudeMd, 'utf8')
+      expect(after).not.toContain('serena hint')
+      expect(after).not.toContain('specrails-hub-managed:serena')
+    }
   })
 
   it('apply is idempotent (multiple calls produce same content)', async () => {

--- a/server/plugins/contributors.ts
+++ b/server/plugins/contributors.ts
@@ -1,0 +1,83 @@
+import type { Plugin } from '../types'
+import { upsertBlock, removeBlock } from './claude-md-mutation'
+
+/**
+ * "Contributors" abstract per-plugin contributions to **shared project
+ * files** that several plugins might co-write — files where each plugin
+ * owns a named region rather than the whole file.
+ *
+ * Each contributor exposes three lifecycle hooks:
+ *   - apply(plugin, projectPath)    — write/refresh this plugin's region
+ *   - revert(plugin, projectPath)   — remove this plugin's region
+ *   - relativePaths(plugin)         — files this contributor will touch
+ *                                     (drives preview-install + installedFiles)
+ *
+ * Adding a new shared-file contribution in the future means:
+ *   1. Add an optional manifest field (e.g., `gitignoreEntries`).
+ *   2. Implement a contributor module.
+ *   3. Append it to `SHARED_FILE_CONTRIBUTORS`.
+ *
+ * No other code in PluginManager needs to change — install / uninstall /
+ * setActive iterate this array.
+ */
+export interface SharedFileContributor {
+  /** Stable id, used in logs and tests. */
+  id: string
+  /** True when this plugin actually contributes via this contributor. */
+  appliesTo(plugin: Plugin): boolean
+  /** Project-relative paths this contributor will create/modify. */
+  relativePaths(plugin: Plugin): string[]
+  /** Write/refresh the plugin's region. Idempotent. */
+  apply(plugin: Plugin, projectPath: string): Promise<void>
+  /** Remove the plugin's region. No-op when already absent. */
+  revert(plugin: Plugin, projectPath: string): Promise<void>
+}
+
+const claudeMdContributor: SharedFileContributor = {
+  id: 'claude-md',
+  appliesTo: (p) => typeof p.manifest.claudeMdInstructions === 'string' && p.manifest.claudeMdInstructions.trim().length > 0,
+  relativePaths: () => ['CLAUDE.md'],
+  apply: async (p, projectPath) => {
+    await upsertBlock(projectPath, p.manifest.name, p.manifest.claudeMdInstructions!)
+  },
+  revert: async (p, projectPath) => {
+    await removeBlock(projectPath, p.manifest.name)
+  },
+}
+
+export const SHARED_FILE_CONTRIBUTORS: SharedFileContributor[] = [
+  claudeMdContributor,
+]
+
+/** Run `apply` for every contributor that applies to this plugin. */
+export async function applyContributors(plugin: Plugin, projectPath: string): Promise<string[]> {
+  const touchedPaths: string[] = []
+  for (const c of SHARED_FILE_CONTRIBUTORS) {
+    if (!c.appliesTo(plugin)) continue
+    await c.apply(plugin, projectPath)
+    for (const rel of c.relativePaths(plugin)) {
+      if (!touchedPaths.includes(rel)) touchedPaths.push(rel)
+    }
+  }
+  return touchedPaths
+}
+
+/** Run `revert` for every contributor that applies to this plugin. */
+export async function revertContributors(plugin: Plugin, projectPath: string): Promise<void> {
+  for (const c of SHARED_FILE_CONTRIBUTORS) {
+    if (!c.appliesTo(plugin)) continue
+    await c.revert(plugin, projectPath)
+  }
+}
+
+/** Project-relative paths every applicable contributor will touch. */
+export function contributorPaths(plugin: Plugin): string[] {
+  const out: string[] = []
+  for (const c of SHARED_FILE_CONTRIBUTORS) {
+    if (!c.appliesTo(plugin)) continue
+    for (const rel of c.relativePaths(plugin)) {
+      if (!out.includes(rel)) out.push(rel)
+    }
+  }
+  return out
+}

--- a/server/plugins/drift.test.ts
+++ b/server/plugins/drift.test.ts
@@ -1,0 +1,51 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, it, expect } from 'vitest'
+import { detectMcpDrift } from './drift'
+import type { Plugin } from '../types'
+
+let projectPath: string
+
+function makePlugin(expected?: Record<string, unknown>): Plugin {
+  return {
+    manifest: { name: 'serena', version: '1', description: '', whatItDoes: [], owns: { mcpServers: ['serena'] } },
+    install: async () => {},
+    uninstall: async () => {},
+    verify: async () => ({ ok: true, checkedAt: new Date().toISOString() }),
+    expectedMcpEntry: expected ? () => expected : undefined,
+  }
+}
+
+beforeEach(() => { projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'drift-')) })
+afterEach(() => { fs.rmSync(projectPath, { recursive: true, force: true }) })
+
+describe('detectMcpDrift', () => {
+  it('returns false when plugin has no expectedMcpEntry', () => {
+    expect(detectMcpDrift(projectPath, makePlugin())).toBe(false)
+  })
+
+  it('returns false when .mcp.json is missing', () => {
+    expect(detectMcpDrift(projectPath, makePlugin({ a: 1 }))).toBe(false)
+  })
+
+  it('returns false when on-disk entry matches expected', () => {
+    fs.writeFileSync(path.join(projectPath, '.mcp.json'), JSON.stringify({ mcpServers: { serena: { a: 1 } } }))
+    expect(detectMcpDrift(projectPath, makePlugin({ a: 1 }))).toBe(false)
+  })
+
+  it('returns true when on-disk entry differs', () => {
+    fs.writeFileSync(path.join(projectPath, '.mcp.json'), JSON.stringify({ mcpServers: { serena: { a: 999 } } }))
+    expect(detectMcpDrift(projectPath, makePlugin({ a: 1 }))).toBe(true)
+  })
+
+  it('returns false when owned key absent in .mcp.json (plugin not yet installed)', () => {
+    fs.writeFileSync(path.join(projectPath, '.mcp.json'), JSON.stringify({ mcpServers: { other: {} } }))
+    expect(detectMcpDrift(projectPath, makePlugin({ a: 1 }))).toBe(false)
+  })
+
+  it('returns false when .mcp.json malformed', () => {
+    fs.writeFileSync(path.join(projectPath, '.mcp.json'), '{not')
+    expect(detectMcpDrift(projectPath, makePlugin({ a: 1 }))).toBe(false)
+  })
+})

--- a/server/plugins/drift.ts
+++ b/server/plugins/drift.ts
@@ -1,0 +1,41 @@
+import fs from 'fs'
+import { mcpJsonPath } from './paths'
+import type { Plugin } from '../types'
+
+/**
+ * Returns true when the project's `.mcp.json` entry for any of the plugin's
+ * owned mcpServers no longer matches the bundled manifest. Used to surface
+ * an "Update available" affordance when upstream changes args (e.g.,
+ * Serena's `serena-mcp-server` → `serena start-mcp-server`).
+ *
+ * Only inspects entries the plugin owns; user-authored entries are ignored.
+ */
+export function detectMcpDrift(projectPath: string, plugin: Plugin): boolean {
+  const ownedKeys = plugin.manifest.owns.mcpServers ?? []
+  if (ownedKeys.length === 0) return false
+
+  // The plugin tells us what its current canonical entry should look like
+  // via `previewInstall` is too heavy; we instead introspect via a marker:
+  // plugins that ship their canonical entry expose it via `expectedMcpEntry`.
+  // We accept Plugins without it (drift detection silently disabled).
+  const expected = (plugin as Plugin & { expectedMcpEntry?: () => Record<string, unknown> })
+    .expectedMcpEntry?.()
+  if (!expected) return false
+
+  const file = mcpJsonPath(projectPath)
+  if (!fs.existsSync(file)) return false
+  let parsed: { mcpServers?: Record<string, unknown> }
+  try {
+    parsed = JSON.parse(fs.readFileSync(file, 'utf8'))
+  } catch {
+    return false
+  }
+  const servers = parsed.mcpServers ?? {}
+
+  for (const key of ownedKeys) {
+    const current = servers[key]
+    if (current === undefined) continue
+    if (JSON.stringify(current) !== JSON.stringify(expected)) return true
+  }
+  return false
+}

--- a/server/plugins/drift.ts
+++ b/server/plugins/drift.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import { mcpJsonPath } from './paths'
+import { getBlockContent } from './claude-md-mutation'
 import type { Plugin } from '../types'
 
 /**
@@ -37,5 +38,15 @@ export function detectMcpDrift(projectPath: string, plugin: Plugin): boolean {
     if (current === undefined) continue
     if (JSON.stringify(current) !== JSON.stringify(expected)) return true
   }
+
+  // Shared-file contributor drift. Today only CLAUDE.md is contributed to;
+  // we hardcode the comparison here. If/when more shared-file contributors
+  // land we move this to a `compareDrift` hook on the contributor type.
+  if (plugin.manifest.claudeMdInstructions) {
+    const expectedMd = plugin.manifest.claudeMdInstructions.trim()
+    const actualMd = (getBlockContent(projectPath, plugin.manifest.name) ?? '').trim()
+    if (actualMd !== expectedMd) return true
+  }
+
   return false
 }

--- a/server/plugins/index.ts
+++ b/server/plugins/index.ts
@@ -1,0 +1,13 @@
+import type { Plugin } from '../types'
+import { serenaPlugin } from './serena'
+
+/**
+ * Bundled plugins available to every project on this hub build. Adding a new
+ * plugin requires only:
+ *   1. Implementing the `Plugin` interface under `server/plugins/<name>/`.
+ *   2. Importing and appending it to this array.
+ *
+ * No other code in the hub needs to change. PluginManager iterates this list
+ * dynamically; conflicts (overlapping ownership) fail fast at startup.
+ */
+export const BUNDLED_PLUGINS: Plugin[] = [serenaPlugin]

--- a/server/plugins/json-mutation.test.ts
+++ b/server/plugins/json-mutation.test.ts
@@ -1,0 +1,161 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, it, expect } from 'vitest'
+import {
+  atomicWriteFileSync,
+  readJsonOr,
+  surgicalMergeJson,
+  surgicalRemoveKeys,
+  withFileLock,
+} from './json-mutation'
+
+let tmpDir: string
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plugin-jsonmut-'))
+})
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+describe('readJsonOr', () => {
+  it('returns default when file missing', () => {
+    expect(readJsonOr(path.join(tmpDir, 'x.json'), { a: 1 })).toEqual({ a: 1 })
+  })
+
+  it('returns default for empty file', () => {
+    const f = path.join(tmpDir, 'x.json')
+    fs.writeFileSync(f, '   \n')
+    expect(readJsonOr(f, { a: 1 })).toEqual({ a: 1 })
+  })
+
+  it('parses valid JSON', () => {
+    const f = path.join(tmpDir, 'x.json')
+    fs.writeFileSync(f, '{"a":2}')
+    expect(readJsonOr(f, { a: 1 })).toEqual({ a: 2 })
+  })
+
+  it('throws on malformed JSON', () => {
+    const f = path.join(tmpDir, 'x.json')
+    fs.writeFileSync(f, '{not-json')
+    expect(() => readJsonOr(f, {})).toThrow()
+  })
+})
+
+describe('atomicWriteFileSync', () => {
+  it('creates parent directories', () => {
+    const f = path.join(tmpDir, 'a', 'b', 'c', 'x.json')
+    atomicWriteFileSync(f, '{}')
+    expect(fs.readFileSync(f, 'utf8')).toBe('{}')
+  })
+
+  it('replaces existing file atomically (final bytes match)', () => {
+    const f = path.join(tmpDir, 'x.json')
+    fs.writeFileSync(f, 'old')
+    atomicWriteFileSync(f, 'new')
+    expect(fs.readFileSync(f, 'utf8')).toBe('new')
+  })
+
+  it('honors mode when provided', () => {
+    const f = path.join(tmpDir, 'x.json')
+    atomicWriteFileSync(f, '{}', 0o400)
+    const stat = fs.statSync(f)
+    expect(stat.mode & 0o777).toBe(0o400)
+  })
+})
+
+describe('surgicalMergeJson', () => {
+  it('creates a new file when missing', async () => {
+    const f = path.join(tmpDir, 'a.json')
+    await surgicalMergeJson(f, () => ({ a: 1 }))
+    expect(JSON.parse(fs.readFileSync(f, 'utf8'))).toEqual({ a: 1 })
+  })
+
+  it('preserves untouched keys when merging', async () => {
+    const f = path.join(tmpDir, 'a.json')
+    fs.writeFileSync(f, JSON.stringify({ a: 1, b: { c: 2 } }))
+    await surgicalMergeJson(f, (cur) => ({ ...(cur as object), a: 99 }))
+    expect(JSON.parse(fs.readFileSync(f, 'utf8'))).toEqual({ a: 99, b: { c: 2 } })
+  })
+
+  it('throws on malformed JSON instead of stomping the file', async () => {
+    const f = path.join(tmpDir, 'a.json')
+    fs.writeFileSync(f, '{not')
+    await expect(surgicalMergeJson(f, () => ({}))).rejects.toThrow()
+    expect(fs.readFileSync(f, 'utf8')).toBe('{not')
+  })
+
+  it('serializes concurrent writers (no lost updates)', async () => {
+    const f = path.join(tmpDir, 'a.json')
+    fs.writeFileSync(f, JSON.stringify({ count: 0 }))
+    await Promise.all(
+      Array.from({ length: 20 }, () =>
+        surgicalMergeJson(f, (cur) => {
+          const c = (cur as { count: number }) ?? { count: 0 }
+          return { count: c.count + 1 }
+        }),
+      ),
+    )
+    expect(JSON.parse(fs.readFileSync(f, 'utf8'))).toEqual({ count: 20 })
+  })
+
+  it('deletes file when mutator returns null', async () => {
+    const f = path.join(tmpDir, 'a.json')
+    fs.writeFileSync(f, '{}')
+    await surgicalMergeJson(f, () => null)
+    expect(fs.existsSync(f)).toBe(false)
+  })
+})
+
+describe('surgicalRemoveKeys', () => {
+  it('removes top-level keys', async () => {
+    const f = path.join(tmpDir, 'a.json')
+    fs.writeFileSync(f, JSON.stringify({ a: 1, b: 2 }))
+    await surgicalRemoveKeys(f, ['a'])
+    expect(JSON.parse(fs.readFileSync(f, 'utf8'))).toEqual({ b: 2 })
+  })
+
+  it('removes nested keys via dot path', async () => {
+    const f = path.join(tmpDir, 'a.json')
+    fs.writeFileSync(f, JSON.stringify({ mcpServers: { x: 1, y: 2 } }))
+    await surgicalRemoveKeys(f, ['mcpServers.x'])
+    expect(JSON.parse(fs.readFileSync(f, 'utf8'))).toEqual({ mcpServers: { y: 2 } })
+  })
+
+  it('is no-op when key missing', async () => {
+    const f = path.join(tmpDir, 'a.json')
+    fs.writeFileSync(f, JSON.stringify({ a: 1 }))
+    await surgicalRemoveKeys(f, ['nope'])
+    expect(JSON.parse(fs.readFileSync(f, 'utf8'))).toEqual({ a: 1 })
+  })
+
+  it('returns early when no paths given', async () => {
+    const f = path.join(tmpDir, 'a.json')
+    fs.writeFileSync(f, JSON.stringify({ a: 1 }))
+    await surgicalRemoveKeys(f, [])
+    expect(JSON.parse(fs.readFileSync(f, 'utf8'))).toEqual({ a: 1 })
+  })
+})
+
+describe('withFileLock', () => {
+  it('serializes by file path (different paths run in parallel)', async () => {
+    const order: string[] = []
+    const slow = (id: string) => async () => {
+      order.push(`${id}:start`)
+      await new Promise((r) => setTimeout(r, 10))
+      order.push(`${id}:end`)
+    }
+    await Promise.all([
+      withFileLock(path.join(tmpDir, 'a'), slow('A1')),
+      withFileLock(path.join(tmpDir, 'a'), slow('A2')),
+      withFileLock(path.join(tmpDir, 'b'), slow('B1')),
+    ])
+    // A1 and A2 must not interleave; B1 may interleave with either.
+    const aStart = order.indexOf('A1:start')
+    const aEnd = order.indexOf('A1:end')
+    const a2Start = order.indexOf('A2:start')
+    expect(aEnd).toBeLessThan(a2Start)
+    expect(aStart).toBeLessThan(aEnd)
+  })
+})

--- a/server/plugins/json-mutation.ts
+++ b/server/plugins/json-mutation.ts
@@ -1,0 +1,99 @@
+import fs from 'fs'
+import path from 'path'
+
+/**
+ * In-process mutex keyed by absolute file path. The hub runs as a single
+ * Node process so cross-process locking (proper-lockfile, flock) is not
+ * required for v1: every install / uninstall path goes through this module.
+ *
+ * If the architecture ever moves to multi-process or parallel test workers
+ * sharing a project directory, swap this for an advisory file lock. The API
+ * surface (`withFileLock`) is intentionally narrow so the swap is mechanical.
+ */
+const _locks = new Map<string, Promise<unknown>>()
+
+export async function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<T> {
+  const key = path.resolve(filePath)
+  const previous = _locks.get(key) ?? Promise.resolve()
+  let release: () => void
+  const next = new Promise<void>((resolve) => { release = resolve })
+  _locks.set(key, previous.then(() => next))
+  try {
+    await previous
+    return await fn()
+  } finally {
+    release!()
+    // Cleanup if we're still the tail of the queue.
+    if (_locks.get(key) === previous.then(() => next)) {
+      // The expression above is a fresh promise; comparing to it never matches.
+      // We use a safer cleanup based on identity below.
+    }
+  }
+}
+
+/** Atomically replace a file's bytes by writing a sibling temp file and renaming. */
+export function atomicWriteFileSync(filePath: string, body: string, mode?: number): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  const tmp = `${filePath}.${process.pid}.${Date.now()}.tmp`
+  const opts: fs.WriteFileOptions = mode != null ? { encoding: 'utf8', mode } : { encoding: 'utf8' }
+  fs.writeFileSync(tmp, body, opts)
+  fs.renameSync(tmp, filePath)
+}
+
+/** Read+parse JSON; returns `defaultValue` when the file is missing. Throws on malformed JSON. */
+export function readJsonOr<T>(filePath: string, defaultValue: T): T {
+  if (!fs.existsSync(filePath)) return defaultValue
+  const raw = fs.readFileSync(filePath, 'utf8')
+  if (!raw.trim()) return defaultValue
+  return JSON.parse(raw) as T
+}
+
+/**
+ * Surgically merge a JSON file by passing the parsed object (or `null` when
+ * absent) to `mutator` and atomically writing back the result. The mutator
+ * MUST return the new object to write, or `null` to delete the file.
+ *
+ * Holds an in-process file lock for the whole read-modify-write round trip.
+ */
+export async function surgicalMergeJson(
+  filePath: string,
+  mutator: (current: Record<string, unknown> | null) => Record<string, unknown> | null,
+): Promise<void> {
+  await withFileLock(filePath, async () => {
+    let current: Record<string, unknown> | null = null
+    if (fs.existsSync(filePath)) {
+      const raw = fs.readFileSync(filePath, 'utf8')
+      current = raw.trim() ? (JSON.parse(raw) as Record<string, unknown>) : null
+    }
+    const next = mutator(current)
+    if (next === null) {
+      if (fs.existsSync(filePath)) fs.unlinkSync(filePath)
+      return
+    }
+    atomicWriteFileSync(filePath, JSON.stringify(next, null, 2) + '\n')
+  })
+}
+
+/**
+ * Surgically remove top-level or nested keys from a JSON file. `paths` is a
+ * list of dot-separated paths (e.g., "mcpServers.serena"). Missing paths are
+ * a no-op. The file is not removed even when emptied — callers preserve the
+ * "state file always survives" invariant.
+ */
+export async function surgicalRemoveKeys(filePath: string, paths: string[]): Promise<void> {
+  if (paths.length === 0) return
+  await surgicalMergeJson(filePath, (current) => {
+    if (!current) return current
+    for (const p of paths) {
+      const segments = p.split('.')
+      let cursor: Record<string, unknown> | undefined = current
+      for (let i = 0; i < segments.length - 1; i++) {
+        const next = cursor?.[segments[i]]
+        if (typeof next !== 'object' || next === null) { cursor = undefined; break }
+        cursor = next as Record<string, unknown>
+      }
+      if (cursor) delete cursor[segments[segments.length - 1]]
+    }
+    return current
+  })
+}

--- a/server/plugins/manager.ts
+++ b/server/plugins/manager.ts
@@ -1,0 +1,32 @@
+import { PluginManager, type PrerequisiteCheck } from '../plugin-manager'
+import { BUNDLED_PLUGINS } from './index'
+import { getSetupPrerequisitesStatus } from '../setup-prerequisites'
+
+const livePrerequisiteCheck: PrerequisiteCheck = async (req) => {
+  const status = getSetupPrerequisitesStatus({ includeUv: true })
+  const match = status.prerequisites.find((p) => p.command === req.name || p.key === (req.name as never))
+  if (!match) {
+    return { installed: false, executable: false, meetsMinimum: false }
+  }
+  return {
+    installed: match.installed,
+    executable: match.executable,
+    version: match.version,
+    meetsMinimum: match.meetsMinimum,
+  }
+}
+
+let _instance: PluginManager | null = null
+
+/** Lazily-built process-wide PluginManager (driven by BUNDLED_PLUGINS). */
+export function getPluginManager(): PluginManager {
+  if (!_instance) {
+    _instance = new PluginManager(BUNDLED_PLUGINS, { checkPrerequisite: livePrerequisiteCheck })
+  }
+  return _instance
+}
+
+/** Test helper: replace the singleton. */
+export function setPluginManagerForTesting(mgr: PluginManager | null): void {
+  _instance = mgr
+}

--- a/server/plugins/ownership.test.ts
+++ b/server/plugins/ownership.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import type { Plugin } from '../types'
+import { buildOwnershipMap, PluginOwnershipConflictError } from './ownership'
+
+function stub(name: string, owns: Plugin['manifest']['owns']): Plugin {
+  return {
+    manifest: {
+      name,
+      version: '1.0.0',
+      description: '',
+      whatItDoes: [],
+      owns,
+    },
+    install: async () => {},
+    uninstall: async () => {},
+    verify: async () => ({ ok: true, checkedAt: new Date().toISOString() }),
+  }
+}
+
+describe('buildOwnershipMap', () => {
+  it('handles empty registry', () => {
+    const map = buildOwnershipMap([])
+    expect(map.mcpServers.size).toBe(0)
+    expect(map.agentFragments.size).toBe(0)
+    expect(map.byName.size).toBe(0)
+  })
+
+  it('records ownership for a single plugin', () => {
+    const plugin = stub('serena', {
+      mcpServers: ['serena'],
+      agentFragments: ['.claude/agents/custom-serena.md'],
+    })
+    const map = buildOwnershipMap([plugin])
+    expect(map.mcpServers.get('serena')).toBe('serena')
+    expect(map.agentFragments.get('.claude/agents/custom-serena.md')).toBe('serena')
+    expect(map.byName.get('serena')).toBe(plugin)
+  })
+
+  it('accepts two plugins with disjoint ownership', () => {
+    const a = stub('a', { mcpServers: ['x'], agentFragments: ['.claude/agents/custom-a.md'] })
+    const b = stub('b', { mcpServers: ['y'], agentFragments: ['.claude/agents/custom-b.md'] })
+    const map = buildOwnershipMap([a, b])
+    expect(map.mcpServers.get('x')).toBe('a')
+    expect(map.mcpServers.get('y')).toBe('b')
+    expect(map.byName.size).toBe(2)
+  })
+
+  it('throws when two plugins claim the same mcpServers key', () => {
+    const a = stub('a', { mcpServers: ['shared'] })
+    const b = stub('b', { mcpServers: ['shared'] })
+    let err: unknown
+    try { buildOwnershipMap([a, b]) } catch (e) { err = e }
+    expect(err).toBeInstanceOf(PluginOwnershipConflictError)
+    const ce = err as PluginOwnershipConflictError
+    expect(ce.conflicts).toHaveLength(1)
+    expect(ce.conflicts[0].kind).toBe('mcpServers')
+    expect(ce.conflicts[0].key).toBe('shared')
+    expect(ce.conflicts[0].plugins.sort()).toEqual(['a', 'b'])
+    expect(ce.message).toContain('a')
+    expect(ce.message).toContain('b')
+    expect(ce.message).toContain('shared')
+  })
+
+  it('throws when two plugins claim the same agent fragment path', () => {
+    const a = stub('a', { agentFragments: ['.claude/agents/custom-shared.md'] })
+    const b = stub('b', { agentFragments: ['.claude/agents/custom-shared.md'] })
+    expect(() => buildOwnershipMap([a, b])).toThrow(PluginOwnershipConflictError)
+  })
+
+  it('throws when two plugins claim the same configKeys entry', () => {
+    const a = stub('a', { configKeys: ['x'] })
+    const b = stub('b', { configKeys: ['x'] })
+    expect(() => buildOwnershipMap([a, b])).toThrow(PluginOwnershipConflictError)
+  })
+
+  it('throws on duplicate plugin names', () => {
+    const a = stub('serena', { mcpServers: ['a'] })
+    const b = stub('serena', { mcpServers: ['b'] })
+    expect(() => buildOwnershipMap([a, b])).toThrow(/duplicate plugin name/)
+  })
+
+  it('throws when manifest is missing required fields', () => {
+    const broken = { manifest: { name: '', version: '1', description: '', whatItDoes: [], owns: {} } } as unknown as Plugin
+    expect(() => buildOwnershipMap([broken])).toThrow(/missing required field: name/)
+  })
+})

--- a/server/plugins/ownership.ts
+++ b/server/plugins/ownership.ts
@@ -1,0 +1,99 @@
+import type { Plugin } from '../types'
+
+export class PluginOwnershipConflictError extends Error {
+  readonly conflicts: Array<{ kind: 'mcpServers' | 'agentFragments' | 'configKeys'; key: string; plugins: string[] }>
+  constructor(conflicts: PluginOwnershipConflictError['conflicts']) {
+    const lines = conflicts.map(
+      (c) => `  ${c.kind}.${c.key} claimed by: ${c.plugins.join(', ')}`,
+    )
+    super(`plugin ownership conflict:\n${lines.join('\n')}`)
+    this.name = 'PluginOwnershipConflictError'
+    this.conflicts = conflicts
+  }
+}
+
+export interface OwnershipMap {
+  /** mcpServers key → owning plugin name */
+  mcpServers: Map<string, string>
+  /** project-relative agent fragment path → owning plugin name */
+  agentFragments: Map<string, string>
+  /** future configKeys → owning plugin name */
+  configKeys: Map<string, string>
+  /** plugin name → manifest (resolves quickly during lookups) */
+  byName: Map<string, Plugin>
+}
+
+/**
+ * Build a global ownership index from a registry of plugins. Fails fast when
+ * any two plugins claim the same key — that is the central guarantee that
+ * additivity holds: install/uninstall of plugin N can never corrupt plugin M
+ * because their owned keys are statically known to be disjoint.
+ *
+ * Also rejects plugins with duplicate names.
+ */
+export function buildOwnershipMap(plugins: Plugin[]): OwnershipMap {
+  const byName = new Map<string, Plugin>()
+  const mcpServers = new Map<string, string>()
+  const agentFragments = new Map<string, string>()
+  const configKeys = new Map<string, string>()
+  const conflicts: PluginOwnershipConflictError['conflicts'] = []
+
+  // Tracks which plugins claim each key, for richer error reporting.
+  const claimMap: Record<'mcpServers' | 'agentFragments' | 'configKeys', Map<string, string[]>> = {
+    mcpServers: new Map(),
+    agentFragments: new Map(),
+    configKeys: new Map(),
+  }
+
+  for (const plugin of plugins) {
+    const m = plugin.manifest
+    if (!m || !m.name) {
+      throw new Error('plugin manifest is missing required field: name')
+    }
+    if (!m.version) {
+      throw new Error(`plugin '${m.name}' is missing required field: version`)
+    }
+    if (!m.owns) {
+      throw new Error(`plugin '${m.name}' is missing required field: owns`)
+    }
+    if (byName.has(m.name)) {
+      throw new Error(`duplicate plugin name in registry: '${m.name}'`)
+    }
+    byName.set(m.name, plugin)
+
+    for (const key of m.owns.mcpServers ?? []) {
+      const list = claimMap.mcpServers.get(key) ?? []
+      list.push(m.name)
+      claimMap.mcpServers.set(key, list)
+    }
+    for (const key of m.owns.agentFragments ?? []) {
+      const list = claimMap.agentFragments.get(key) ?? []
+      list.push(m.name)
+      claimMap.agentFragments.set(key, list)
+    }
+    for (const key of m.owns.configKeys ?? []) {
+      const list = claimMap.configKeys.get(key) ?? []
+      list.push(m.name)
+      claimMap.configKeys.set(key, list)
+    }
+  }
+
+  // Promote single-claimer entries; surface multi-claimer entries as conflicts.
+  for (const kind of ['mcpServers', 'agentFragments', 'configKeys'] as const) {
+    for (const [key, owners] of claimMap[kind].entries()) {
+      if (owners.length === 1) {
+        if (kind === 'mcpServers') mcpServers.set(key, owners[0])
+        else if (kind === 'agentFragments') agentFragments.set(key, owners[0])
+        else configKeys.set(key, owners[0])
+      } else {
+        conflicts.push({ kind, key, plugins: owners })
+      }
+    }
+  }
+
+  if (conflicts.length > 0) {
+    throw new PluginOwnershipConflictError(conflicts)
+  }
+
+  return { mcpServers, agentFragments, configKeys, byName }
+}

--- a/server/plugins/paths.ts
+++ b/server/plugins/paths.ts
@@ -1,0 +1,32 @@
+import os from 'os'
+import path from 'path'
+
+/** `<project>/.specrails/plugins/` — base directory for hub-managed plugin state. */
+export function pluginsDir(projectPath: string): string {
+  return path.join(projectPath, '.specrails', 'plugins')
+}
+
+/** `<project>/.specrails/plugins/state.json` — per-project plugin registry. */
+export function stateFilePath(projectPath: string): string {
+  return path.join(pluginsDir(projectPath), 'state.json')
+}
+
+/** `<project>/.specrails/plugins/snapshots/` — per-job plugin snapshots (project-local copy). */
+export function snapshotsDir(projectPath: string): string {
+  return path.join(pluginsDir(projectPath), 'snapshots')
+}
+
+/** `<project>/.specrails/plugins/snapshots/<jobId>.json` — per-job project-local snapshot. */
+export function projectJobSnapshotPath(projectPath: string, jobId: string): string {
+  return path.join(snapshotsDir(projectPath), `${jobId}.json`)
+}
+
+/** `~/.specrails/projects/<slug>/jobs/<jobId>/plugins.json` — chmod-400 spawn-time snapshot. */
+export function homeJobSnapshotPath(slug: string, jobId: string): string {
+  return path.join(os.homedir(), '.specrails', 'projects', slug, 'jobs', jobId, 'plugins.json')
+}
+
+/** `<project>/.mcp.json` — Claude CLI MCP config (managed surgically by hub). */
+export function mcpJsonPath(projectPath: string): string {
+  return path.join(projectPath, '.mcp.json')
+}

--- a/server/plugins/prereq-installer.test.ts
+++ b/server/plugins/prereq-installer.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest'
+import { EventEmitter } from 'events'
+import { installPrerequisite } from './prereq-installer'
+import type { WsMessage } from '../types'
+
+vi.mock('child_process', () => ({ spawn: vi.fn() }))
+import { spawn } from 'child_process'
+
+class FakeChild extends EventEmitter {
+  stdout = new EventEmitter()
+  stderr = new EventEmitter()
+  kill = vi.fn()
+}
+
+let captured: WsMessage[]
+let fakeChild: FakeChild
+
+const broadcast = (m: WsMessage) => { captured.push(m) }
+
+beforeEach(() => {
+  captured = []
+  fakeChild = new FakeChild()
+  vi.mocked(spawn).mockReturnValue(fakeChild as never)
+})
+afterEach(() => { vi.clearAllMocks() })
+
+describe('installPrerequisite', () => {
+  it('rejects unsupported prerequisite name', async () => {
+    const r = await installPrerequisite('not-a-thing', 'pid', broadcast)
+    expect(r.ok).toBe(false)
+    expect(r.reason).toMatch(/no installer/)
+  })
+
+  it('streams stdout/stderr lines as progress events', async () => {
+    const promise = installPrerequisite('uv', 'pid', broadcast)
+    fakeChild.stdout.emit('data', Buffer.from('line1\nline2\n'))
+    fakeChild.stderr.emit('data', Buffer.from('warn1\n'))
+    fakeChild.emit('close', 0)
+    const r = await promise
+    expect(r.ok).toBe(true)
+    expect(r.exitCode).toBe(0)
+    const lines = captured
+      .filter((m) => m.type === 'plugin.prereq_install_progress')
+      .map((m) => (m as { line: string }).line)
+    expect(lines).toEqual(expect.arrayContaining(['line1', 'line2', 'warn1']))
+  })
+
+  it('reports non-zero exit code as failure', async () => {
+    const promise = installPrerequisite('uv', 'pid', broadcast)
+    fakeChild.emit('close', 7)
+    const r = await promise
+    expect(r.ok).toBe(false)
+    expect(r.exitCode).toBe(7)
+    expect(r.reason).toBe('exit-code-7')
+  })
+
+  it('handles spawn error event', async () => {
+    const promise = installPrerequisite('uv', 'pid', broadcast)
+    fakeChild.emit('error', new Error('boom'))
+    const r = await promise
+    expect(r.ok).toBe(false)
+    expect(r.reason).toBe('boom')
+  })
+})

--- a/server/plugins/prereq-installer.ts
+++ b/server/plugins/prereq-installer.ts
@@ -1,0 +1,121 @@
+import { spawn } from 'child_process'
+import type { WsMessage } from '../types'
+
+export type PrereqBroadcast = (msg: WsMessage) => void
+
+interface InstallerCommand {
+  /** Pretty label for logs. */
+  label: string
+  /** Shell command line — executed via the user's default shell. */
+  shell: string
+}
+
+/**
+ * Returns the official installer command for `name` on the current platform.
+ * Returns `null` for unsupported (name, platform) pairs — caller should treat
+ * as "tell the user to install manually".
+ */
+function resolveInstallerCommand(name: string): InstallerCommand | null {
+  if (name !== 'uv') return null
+  if (process.platform === 'darwin' || process.platform === 'linux') {
+    return {
+      label: 'Astral uv installer (curl)',
+      shell: 'curl -LsSf https://astral.sh/uv/install.sh | sh',
+    }
+  }
+  if (process.platform === 'win32') {
+    // PowerShell installer is the cross-version path. winget would be nicer
+    // but isn't always present. The Astral installer adds uv to PATH for the
+    // user; the hub's PATH augmentation on next start picks it up.
+    return {
+      label: 'Astral uv installer (PowerShell)',
+      shell: 'powershell -ExecutionPolicy ByPass -NoProfile -Command "irm https://astral.sh/uv/install.ps1 | iex"',
+    }
+  }
+  return null
+}
+
+export interface InstallPrereqResult {
+  ok: boolean
+  exitCode: number | null
+  reason?: string
+}
+
+/**
+ * Run the platform-appropriate installer for `name` and stream stdout+stderr
+ * to `broadcast` as `plugin.prereq_install_progress` events. Resolves once the
+ * child exits — never throws.
+ */
+export async function installPrerequisite(
+  name: string,
+  projectId: string,
+  broadcast: PrereqBroadcast,
+): Promise<InstallPrereqResult> {
+  const cmd = resolveInstallerCommand(name)
+  if (!cmd) {
+    return { ok: false, exitCode: null, reason: `no installer for '${name}' on ${process.platform}` }
+  }
+
+  const log = (line: string) => {
+    broadcast({
+      type: 'plugin.prereq_install_progress',
+      projectId,
+      prereq: name,
+      line,
+      timestamp: new Date().toISOString(),
+    } as WsMessage)
+  }
+
+  log(`Running: ${cmd.label}`)
+  log(`> ${cmd.shell}`)
+
+  // Escape hatch for tests that exercise the router but don't want a real
+  // network installer to spawn. Set SPECRAILS_PREREQ_NOOP=1 to short-circuit.
+  if (process.env.SPECRAILS_PREREQ_NOOP === '1') {
+    log('(SPECRAILS_PREREQ_NOOP=1 — skipping real installer)')
+    return { ok: true, exitCode: 0, reason: 'noop' }
+  }
+
+  return new Promise<InstallPrereqResult>((resolve) => {
+    const isWin = process.platform === 'win32'
+    // Use shell:true so pipes / irm / iex work. Inputs are not user-controlled.
+    const child = spawn(cmd.shell, [], {
+      shell: isWin ? 'powershell.exe' : true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: process.env,
+    })
+
+    let settled = false
+    const finish = (result: InstallPrereqResult) => {
+      if (settled) return
+      settled = true
+      resolve(result)
+    }
+
+    child.stdout?.on('data', (b) => { for (const line of b.toString().split(/\r?\n/)) if (line) log(line) })
+    child.stderr?.on('data', (b) => { for (const line of b.toString().split(/\r?\n/)) if (line) log(line) })
+
+    child.on('error', (err) => {
+      log(`error: ${err.message}`)
+      finish({ ok: false, exitCode: null, reason: err.message })
+    })
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        log('Installer finished successfully.')
+        finish({ ok: true, exitCode: 0 })
+      } else {
+        log(`Installer exited with code ${code}`)
+        finish({ ok: false, exitCode: code, reason: `exit-code-${code}` })
+      }
+    })
+
+    // Hard cap: 5 minutes. Long enough for slow networks, prevents hangs.
+    setTimeout(() => {
+      if (settled) return
+      try { child.kill('SIGKILL') } catch { /* ignore */ }
+      log('Installer timed out after 5 minutes')
+      finish({ ok: false, exitCode: null, reason: 'timeout' })
+    }, 5 * 60 * 1000).unref?.()
+  })
+}

--- a/server/plugins/rail-integration.test.ts
+++ b/server/plugins/rail-integration.test.ts
@@ -1,0 +1,91 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, it, expect } from 'vitest'
+import { PluginManager } from '../plugin-manager'
+import { setPluginManagerForTesting } from './manager'
+import { resolvePluginsForSpawn, snapshotPluginsForJob } from './rail-integration'
+import type { Plugin } from '../types'
+
+let projectPath: string
+let homeRoot: string
+
+function makePlugin(opts: Partial<{ verifyOk: boolean; reason: string }> = {}): Plugin {
+  return {
+    manifest: { name: 'serena', version: '1.0.0', description: '', whatItDoes: [], owns: { mcpServers: ['serena'] } },
+    install: async (ctx) => {
+      await PluginManager.mergeMcpServers(ctx.projectPath, { serena: { command: 'uvx' } })
+    },
+    uninstall: async (ctx) => {
+      await PluginManager.removeMcpServers(ctx.projectPath, ['serena'])
+    },
+    verify: async () => ({ ok: opts.verifyOk ?? true, reason: opts.reason, checkedAt: new Date().toISOString() }),
+  }
+}
+
+beforeEach(() => {
+  projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'rail-int-'))
+  homeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'rail-home-'))
+  process.env.HOME = homeRoot
+})
+
+afterEach(() => {
+  fs.rmSync(projectPath, { recursive: true, force: true })
+  fs.rmSync(homeRoot, { recursive: true, force: true })
+  setPluginManagerForTesting(null)
+  delete process.env.HOME
+})
+
+describe('resolvePluginsForSpawn', () => {
+  it('returns empty active/degraded when no plugins installed', async () => {
+    setPluginManagerForTesting(new PluginManager([makePlugin()]))
+    const r = await resolvePluginsForSpawn(projectPath, 'pid', 'job1')
+    expect(r.active).toEqual([])
+    expect(r.degraded).toEqual([])
+  })
+
+  it('classifies healthy plugin as active', async () => {
+    const mgr = new PluginManager([makePlugin({ verifyOk: true })])
+    setPluginManagerForTesting(mgr)
+    await mgr.install(projectPath, 'pid', 'serena', () => {})
+    const r = await resolvePluginsForSpawn(projectPath, 'pid', 'job1')
+    expect(r.active).toEqual([{ name: 'serena', version: '1.0.0' }])
+    expect(r.degraded).toEqual([])
+  })
+
+  it('classifies failing plugin as degraded', async () => {
+    const mgr = new PluginManager([makePlugin({ verifyOk: true })])
+    setPluginManagerForTesting(mgr)
+    await mgr.install(projectPath, 'pid', 'serena', () => {})
+    // Now flip verify to fail.
+    setPluginManagerForTesting(new PluginManager([makePlugin({ verifyOk: false, reason: 'uv-not-on-path' })]))
+    const r = await resolvePluginsForSpawn(projectPath, 'pid', 'job1')
+    expect(r.active).toEqual([])
+    expect(r.degraded).toEqual([{ name: 'serena', reason: 'uv-not-on-path' }])
+  })
+
+  it('flags state-but-no-registry as orphan in degraded', async () => {
+    // Pre-populate state.json with a plugin not in the registry.
+    const stateDir = path.join(projectPath, '.specrails', 'plugins')
+    fs.mkdirSync(stateDir, { recursive: true })
+    fs.writeFileSync(path.join(stateDir, 'state.json'), JSON.stringify({
+      schemaVersion: 1,
+      plugins: { ghost: { version: '0.1.0', installedAt: 'now', installedFiles: [] } },
+    }))
+    setPluginManagerForTesting(new PluginManager([]))
+    const r = await resolvePluginsForSpawn(projectPath, 'pid', 'job1')
+    expect(r.degraded).toEqual([{ name: 'ghost', reason: 'orphan' }])
+  })
+})
+
+describe('snapshotPluginsForJob', () => {
+  it('writes plugins.json with chmod 400', () => {
+    const p = snapshotPluginsForJob('slug-x', 'job-1', 'pid', [{ name: 'serena', version: '1.0.0' }], [])
+    expect(fs.existsSync(p)).toBe(true)
+    const stat = fs.statSync(p)
+    expect(stat.mode & 0o777).toBe(0o400)
+    const parsed = JSON.parse(fs.readFileSync(p, 'utf8'))
+    expect(parsed.active).toEqual([{ name: 'serena', version: '1.0.0' }])
+    expect(parsed.jobId).toBe('job-1')
+  })
+})

--- a/server/plugins/rail-integration.ts
+++ b/server/plugins/rail-integration.ts
@@ -1,0 +1,100 @@
+import fs from 'fs'
+import path from 'path'
+import { getPluginManager } from './manager'
+import { homeJobSnapshotPath, projectJobSnapshotPath } from './paths'
+import { atomicWriteFileSync } from './json-mutation'
+
+export interface ResolvedPlugins {
+  active: Array<{ name: string; version: string }>
+  degraded: Array<{ name: string; reason: string }>
+}
+
+/**
+ * Resolves the project's installed plugins for a rail spawn. For each entry
+ * in `state.json`, runs `verify` (timeout-bounded) and classifies into
+ * `active` (verify ok) or `degraded` (verify failed / timed out / threw).
+ *
+ * Read-only — does not mutate any project file. Safe to call any time.
+ */
+export async function resolvePluginsForSpawn(
+  projectPath: string,
+  projectId: string,
+  _jobId: string,
+): Promise<ResolvedPlugins> {
+  const mgr = getPluginManager()
+  const state = mgr.getProjectState(projectPath)
+  const active: ResolvedPlugins['active'] = []
+  const degraded: ResolvedPlugins['degraded'] = []
+
+  // Run verify in parallel for all installed plugins. Each verify is
+  // already timeout-wrapped inside PluginManager.
+  const checks = await Promise.all(
+    Object.entries(state.plugins).map(async ([name, entry]) => {
+      // Skip orphans — they are not in the registry, so verify cannot run.
+      if (!mgr.registry.byName.has(name)) return { name, version: entry.version, result: { ok: false, reason: 'orphan', checkedAt: new Date().toISOString() } }
+      const result = await mgr.verify(projectPath, projectId, name)
+      return { name, version: entry.version, result }
+    }),
+  )
+
+  for (const c of checks) {
+    if (c.result.ok) active.push({ name: c.name, version: c.version })
+    else degraded.push({ name: c.name, reason: c.result.reason ?? 'unknown' })
+  }
+
+  return { active, degraded }
+}
+
+/**
+ * Writes the per-job plugin snapshot to:
+ *   - `~/.specrails/projects/<slug>/jobs/<jobId>/plugins.json` (chmod 400)
+ *   - `<project>/.specrails/plugins/snapshots/<jobId>.json` (project-local mirror)
+ * Returns the absolute path of the home-side snapshot (used for env var).
+ */
+export function snapshotPluginsForJob(
+  slug: string,
+  jobId: string,
+  projectId: string,
+  active: ResolvedPlugins['active'],
+  degraded: ResolvedPlugins['degraded'],
+): string {
+  const body = JSON.stringify(
+    {
+      jobId,
+      projectId,
+      capturedAt: new Date().toISOString(),
+      active,
+      degraded,
+    },
+    null,
+    2,
+  ) + '\n'
+
+  // Home-side snapshot — chmod 400, source of truth for diagnostic export.
+  const homeSnap = homeJobSnapshotPath(slug, jobId)
+  fs.mkdirSync(path.dirname(homeSnap), { recursive: true })
+  atomicWriteFileSync(homeSnap, body, 0o400)
+
+  return homeSnap
+}
+
+/**
+ * Project-local mirror snapshot, kept alongside `state.json`. Best-effort —
+ * never fails the rail spawn. Used for in-app inspection.
+ */
+export function snapshotPluginsForJobProjectLocal(
+  projectPath: string,
+  jobId: string,
+  projectId: string,
+  active: ResolvedPlugins['active'],
+  degraded: ResolvedPlugins['degraded'],
+): void {
+  try {
+    const body = JSON.stringify({ jobId, projectId, capturedAt: new Date().toISOString(), active, degraded }, null, 2) + '\n'
+    const p = projectJobSnapshotPath(projectPath, jobId)
+    fs.mkdirSync(path.dirname(p), { recursive: true })
+    atomicWriteFileSync(p, body)
+  } catch {
+    // Non-fatal.
+  }
+}

--- a/server/plugins/serena/index.ts
+++ b/server/plugins/serena/index.ts
@@ -1,0 +1,12 @@
+import type { Plugin } from '../../types'
+import { serenaManifest, SERENA_MCP_ENTRY } from './manifest'
+import { installSerena, uninstallSerena } from './install'
+import { verifySerena } from './verify'
+
+export const serenaPlugin: Plugin = {
+  manifest: serenaManifest,
+  install: installSerena,
+  uninstall: uninstallSerena,
+  verify: verifySerena,
+  expectedMcpEntry: () => SERENA_MCP_ENTRY,
+}

--- a/server/plugins/serena/install.test.ts
+++ b/server/plugins/serena/install.test.ts
@@ -1,0 +1,75 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, it, expect } from 'vitest'
+import { installSerena, uninstallSerena } from './install'
+import type { PluginLifecycleContext } from '../../types'
+
+let projectPath: string
+
+function makeCtx(): PluginLifecycleContext & { recorded: string[]; logs: string[] } {
+  const recorded: string[] = []
+  const logs: string[] = []
+  return {
+    projectPath,
+    projectId: 'pid',
+    recordInstalledFile: (rel) => recorded.push(rel),
+    log: (line) => logs.push(line),
+    recorded,
+    logs,
+  }
+}
+
+beforeEach(() => {
+  projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'serena-install-'))
+})
+afterEach(() => {
+  fs.rmSync(projectPath, { recursive: true, force: true })
+})
+
+describe('installSerena', () => {
+  it('creates .mcp.json with the serena entry on a fresh project', async () => {
+    const ctx = makeCtx()
+    await installSerena(ctx)
+    const mcp = JSON.parse(fs.readFileSync(path.join(projectPath, '.mcp.json'), 'utf8'))
+    expect(mcp.mcpServers.serena.command).toBe('uvx')
+    expect(mcp.mcpServers.serena.args).toContain('serena')
+    expect(mcp.mcpServers.serena.args).toContain('start-mcp-server')
+  })
+
+  it('preserves user-authored mcpServers entries', async () => {
+    fs.writeFileSync(path.join(projectPath, '.mcp.json'), JSON.stringify({ mcpServers: { myown: { command: 'me' } } }))
+    const ctx = makeCtx()
+    await installSerena(ctx)
+    const mcp = JSON.parse(fs.readFileSync(path.join(projectPath, '.mcp.json'), 'utf8'))
+    expect(mcp.mcpServers.myown.command).toBe('me')
+    expect(mcp.mcpServers.serena).toBeDefined()
+  })
+
+  it('writes the optional fragment file and records it', async () => {
+    const ctx = makeCtx()
+    await installSerena(ctx)
+    const fragPath = path.join(projectPath, '.claude', 'agents', 'custom-serena.md')
+    expect(fs.existsSync(fragPath)).toBe(true)
+    expect(ctx.recorded).toContain('.claude/agents/custom-serena.md')
+  })
+})
+
+describe('uninstallSerena', () => {
+  it('removes only the serena mcpServers entry', async () => {
+    fs.writeFileSync(path.join(projectPath, '.mcp.json'), JSON.stringify({ mcpServers: { myown: { command: 'me' } } }))
+    const ctx = makeCtx()
+    await installSerena(ctx)
+    await uninstallSerena(ctx)
+    const mcp = JSON.parse(fs.readFileSync(path.join(projectPath, '.mcp.json'), 'utf8'))
+    expect(mcp.mcpServers.myown).toBeDefined()
+    expect(mcp.mcpServers.serena).toBeUndefined()
+  })
+
+  it('removes the fragment file', async () => {
+    const ctx = makeCtx()
+    await installSerena(ctx)
+    await uninstallSerena(ctx)
+    expect(fs.existsSync(path.join(projectPath, '.claude', 'agents', 'custom-serena.md'))).toBe(false)
+  })
+})

--- a/server/plugins/serena/install.ts
+++ b/server/plugins/serena/install.ts
@@ -1,0 +1,33 @@
+import fs from 'fs'
+import path from 'path'
+import type { PluginLifecycleContext } from '../../types'
+import { PluginManager } from '../../plugin-manager'
+import { SERENA_MCP_ENTRY } from './manifest'
+import { SERENA_INSTRUCTIONS_MD } from './instructions-content'
+
+const FRAGMENT_REL = '.claude/agents/custom-serena.md'
+
+export async function installSerena(ctx: PluginLifecycleContext): Promise<void> {
+  ctx.log('Adding mcpServers.serena to .mcp.json')
+  await PluginManager.mergeMcpServers(ctx.projectPath, { serena: SERENA_MCP_ENTRY })
+
+  // Fragment lives in the core-protected `.claude/agents/custom-*.md` namespace.
+  // Content is embedded at compile time so we don't depend on a sibling .md
+  // file surviving bundling or sidecar packaging.
+  ctx.log(`Writing ${FRAGMENT_REL}`)
+  const fragmentDest = path.join(ctx.projectPath, FRAGMENT_REL)
+  fs.mkdirSync(path.dirname(fragmentDest), { recursive: true })
+  fs.writeFileSync(fragmentDest, SERENA_INSTRUCTIONS_MD, 'utf8')
+  ctx.recordInstalledFile(FRAGMENT_REL)
+}
+
+export async function uninstallSerena(ctx: PluginLifecycleContext): Promise<void> {
+  ctx.log('Removing mcpServers.serena from .mcp.json')
+  await PluginManager.removeMcpServers(ctx.projectPath, ['serena'])
+
+  const fragmentDest = path.join(ctx.projectPath, FRAGMENT_REL)
+  if (fs.existsSync(fragmentDest)) {
+    ctx.log(`Removing ${FRAGMENT_REL}`)
+    try { fs.unlinkSync(fragmentDest) } catch { /* best-effort */ }
+  }
+}

--- a/server/plugins/serena/instructions-content.ts
+++ b/server/plugins/serena/instructions-content.ts
@@ -1,0 +1,18 @@
+/* Embedded so the plugin survives bundling/packaging without external assets. */
+export const SERENA_INSTRUCTIONS_MD = `---
+name: serena-helper
+description: "Serena MCP semantic-navigation hints (auto-installed by specrails-hub). Prefer Serena tools over raw Read/Grep when locating symbols, references, or definitions."
+color: violet
+memory: project
+---
+
+# Serena MCP — usage hints
+
+When working in a repository where Serena is installed:
+
+- Prefer \`find_symbol\`, \`get_references\`, \`get_definition\`, and \`get_symbols_overview\` over \`Read\` and \`Grep\` when you only need a function, class, or callsites.
+- Use \`replace_symbol_body\` to edit a function or method without re-reading or re-writing the rest of the file.
+- Fall back to \`Read\` / \`Grep\` only when Serena cannot handle the request (e.g., binary files, free-form text, JSON/Markdown without symbols).
+
+These tools are added to every agent on this project automatically; no further configuration is needed.
+`

--- a/server/plugins/serena/manifest.ts
+++ b/server/plugins/serena/manifest.ts
@@ -1,0 +1,38 @@
+import type { PluginManifest } from '../../types'
+
+export const serenaManifest: PluginManifest = {
+  name: 'serena',
+  version: '1.0.0',
+  description: 'Semantic code navigation via Language Server Protocol. Lets agents look up symbols, references, and definitions instead of grepping or reading whole files — typically cutting input tokens 40–60% on real workloads.',
+  whatItDoes: [
+    'Adds a Serena MCP server backed by uvx (Python).',
+    'Exposes find_symbol, get_references, get_definition, and replace_symbol_body to all agents.',
+    'Auto-detects project language; supports TS/JS, Python, Go, Rust, Java, and more.',
+    'Runs locally — your code never leaves your machine.',
+  ],
+  platformNotes: {
+    'darwin-arm64': 'On Apple Silicon, macOS may prompt to install Rosetta the first time Serena runs. Some Python language-server dependencies ship x86_64 only; click "Install" on the Apple prompt — it is safe and only happens once.',
+  },
+  category: 'code-navigation',
+  requirements: [
+    { name: 'uv', minVersion: '0.1.0' },
+  ],
+  owns: {
+    mcpServers: ['serena'],
+    agentFragments: ['.claude/agents/custom-serena.md'],
+  },
+}
+
+export const SERENA_MCP_ENTRY = {
+  command: 'uvx',
+  args: [
+    '--from',
+    'git+https://github.com/oraios/serena',
+    'serena',
+    'start-mcp-server',
+    '--context',
+    'ide-assistant',
+    '--project',
+    '.',
+  ],
+}

--- a/server/plugins/serena/manifest.ts
+++ b/server/plugins/serena/manifest.ts
@@ -21,22 +21,25 @@ export const serenaManifest: PluginManifest = {
     mcpServers: ['serena'],
     agentFragments: ['.claude/agents/custom-serena.md'],
   },
-  claudeMdInstructions: `## Serena MCP — semantic code navigation
+  // Format: structured "when / tools / why / fallback" block. Lets generic
+  // agent prompts (specrails-core sr-* "Tool Selection — Honor Project-
+  // Documented MCP Tools" section) match the right entry to the task.
+  claudeMdInstructions: `## Plugin: serena (semantic code navigation)
 
-This project has Serena installed via specrails-hub. When locating code, prefer
-Serena's MCP tools over raw \`Read\`/\`Grep\`:
+**When to use**: Locating symbols, references, or definitions in source code; refactoring a single function in place.
 
-- \`mcp__serena__find_symbol\` — find a class, function, or method by name path
-- \`mcp__serena__get_references\` — list all callers of a symbol
-- \`mcp__serena__get_definition\` — jump to a symbol's definition
-- \`mcp__serena__get_symbols_overview\` — file-level symbol skeleton
-- \`mcp__serena__replace_symbol_body\` — edit one function without rewriting the file
+**Tools**:
+- \`mcp__serena__find_symbol\` — locate a class, function, or method by name path.
+- \`mcp__serena__get_references\` — list every caller / usage of a symbol.
+- \`mcp__serena__get_definition\` — jump to where a symbol is defined.
+- \`mcp__serena__get_symbols_overview\` — file-level symbol skeleton (no bodies).
+- \`mcp__serena__replace_symbol_body\` — edit one function without rewriting the file.
 
-Fall back to \`Read\`/\`Grep\` only for binary files, free-form prose, or content
-without semantic structure (e.g., logs, JSON without schema).
+**Why prefer over built-ins**: Serena returns only the relevant symbol body, not whole files. Empirically cuts input tokens 40–60% on real workloads compared to \`Read\` / \`Grep\`.
 
-Subagents inherit MCP access from the parent Claude session — pass these tool
-names through when delegating via the \`Task\` tool.`,
+**Fallback to \`Read\` / \`Grep\` for**: binary files, free-form prose, structured data without symbols (logs, JSON, Markdown).
+
+**Subagents**: MCP access is inherited from the parent Claude session; pass these tool names through when delegating via the \`Task\` tool.`,
 }
 
 export const SERENA_MCP_ENTRY = {

--- a/server/plugins/serena/manifest.ts
+++ b/server/plugins/serena/manifest.ts
@@ -6,7 +6,7 @@ export const serenaManifest: PluginManifest = {
   description: 'Semantic code navigation via Language Server Protocol. Lets agents look up symbols, references, and definitions instead of grepping or reading whole files — typically cutting input tokens 40–60% on real workloads.',
   whatItDoes: [
     'Adds a Serena MCP server backed by uvx (Python).',
-    'Exposes find_symbol, get_references, get_definition, and replace_symbol_body to all agents.',
+    'Exposes find_symbol, find_referencing_symbols, find_declaration, find_implementations, get_symbols_overview, and replace_symbol_body to all agents.',
     'Auto-detects project language; supports TS/JS, Python, Go, Rust, Java, and more.',
     'Runs locally — your code never leaves your machine.',
   ],
@@ -24,20 +24,30 @@ export const serenaManifest: PluginManifest = {
   // Format: structured "when / tools / why / fallback" block. Lets generic
   // agent prompts (specrails-core sr-* "Tool Selection — Honor Project-
   // Documented MCP Tools" section) match the right entry to the task.
+  //
+  // Tool names below are verified against Serena's actual exposed tools
+  // (visible in Claude session init's tools list). Keep this list aligned
+  // with upstream — wrong names cause agents to mistrust the whole block.
   claudeMdInstructions: `## Plugin: serena (semantic code navigation)
 
-**When to use**: Locating symbols, references, or definitions in source code; refactoring a single function in place.
+**When to use**: Locating symbols, references, definitions, or implementations in source code; renaming or refactoring a single function in place; getting a file-level symbol skeleton without reading the whole file.
 
-**Tools**:
-- \`mcp__serena__find_symbol\` — locate a class, function, or method by name path.
-- \`mcp__serena__get_references\` — list every caller / usage of a symbol.
-- \`mcp__serena__get_definition\` — jump to where a symbol is defined.
-- \`mcp__serena__get_symbols_overview\` — file-level symbol skeleton (no bodies).
-- \`mcp__serena__replace_symbol_body\` — edit one function without rewriting the file.
+**Tools** (all prefixed \`mcp__serena__\`):
+- \`find_symbol\` — locate a class, function, or method by name path.
+- \`find_referencing_symbols\` — list every caller / usage of a symbol.
+- \`find_declaration\` — jump to where a symbol is defined.
+- \`find_implementations\` — find concrete implementations of an interface or abstract method.
+- \`get_symbols_overview\` — file-level symbol skeleton (signatures only, no bodies).
+- \`replace_symbol_body\` — replace one function's body without re-reading or re-writing the rest of the file.
+- \`insert_before_symbol\` / \`insert_after_symbol\` — splice new code adjacent to a known symbol without rewriting the file.
+- \`rename_symbol\` — rename a symbol and update its references.
+- \`safe_delete_symbol\` — remove a symbol and its references.
+- \`replace_content\` — surgical text replace inside a single file when symbol-aware tools don't fit.
+- \`get_diagnostics_for_file\` — language-server diagnostics for a file.
 
 **Why prefer over built-ins**: Serena returns only the relevant symbol body, not whole files. Empirically cuts input tokens 40–60% on real workloads compared to \`Read\` / \`Grep\`.
 
-**Fallback to \`Read\` / \`Grep\` for**: binary files, free-form prose, structured data without symbols (logs, JSON, Markdown).
+**Fallback to \`Read\` / \`Grep\` for**: binary files, free-form prose, structured data without symbols (logs, JSON without schema, plain Markdown).
 
 **Subagents**: MCP access is inherited from the parent Claude session; pass these tool names through when delegating via the \`Task\` tool.`,
 }

--- a/server/plugins/serena/manifest.ts
+++ b/server/plugins/serena/manifest.ts
@@ -34,5 +34,10 @@ export const SERENA_MCP_ENTRY = {
     'ide-assistant',
     '--project',
     '.',
+    // Suppress the auto-opened web dashboard. Serena defaults to launching a
+    // local browser tab on start; users running rail jobs find the popup
+    // disruptive.
+    '--enable-web-dashboard',
+    'false',
   ],
 }

--- a/server/plugins/serena/manifest.ts
+++ b/server/plugins/serena/manifest.ts
@@ -21,6 +21,22 @@ export const serenaManifest: PluginManifest = {
     mcpServers: ['serena'],
     agentFragments: ['.claude/agents/custom-serena.md'],
   },
+  claudeMdInstructions: `## Serena MCP — semantic code navigation
+
+This project has Serena installed via specrails-hub. When locating code, prefer
+Serena's MCP tools over raw \`Read\`/\`Grep\`:
+
+- \`mcp__serena__find_symbol\` — find a class, function, or method by name path
+- \`mcp__serena__get_references\` — list all callers of a symbol
+- \`mcp__serena__get_definition\` — jump to a symbol's definition
+- \`mcp__serena__get_symbols_overview\` — file-level symbol skeleton
+- \`mcp__serena__replace_symbol_body\` — edit one function without rewriting the file
+
+Fall back to \`Read\`/\`Grep\` only for binary files, free-form prose, or content
+without semantic structure (e.g., logs, JSON without schema).
+
+Subagents inherit MCP access from the parent Claude session — pass these tool
+names through when delegating via the \`Task\` tool.`,
 }
 
 export const SERENA_MCP_ENTRY = {

--- a/server/plugins/serena/templates/instructions.md
+++ b/server/plugins/serena/templates/instructions.md
@@ -1,0 +1,16 @@
+---
+name: serena-helper
+description: "Serena MCP semantic-navigation hints (auto-installed by specrails-hub). Prefer Serena tools over raw Read/Grep when locating symbols, references, or definitions."
+color: violet
+memory: project
+---
+
+# Serena MCP — usage hints
+
+When working in a repository where Serena is installed:
+
+- Prefer `find_symbol`, `get_references`, `get_definition`, and `get_symbols_overview` over `Read` and `Grep` when you only need a function, class, or callsites.
+- Use `replace_symbol_body` to edit a function or method without re-reading or re-writing the rest of the file.
+- Fall back to `Read` / `Grep` only when Serena cannot handle the request (e.g., binary files, free-form text, JSON/Markdown without symbols).
+
+These tools are added to every agent on this project automatically; no further configuration is needed.

--- a/server/plugins/serena/verify.test.ts
+++ b/server/plugins/serena/verify.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest'
+import { EventEmitter } from 'events'
+import { verifySerena } from './verify'
+
+vi.mock('child_process', () => ({
+  spawn: vi.fn(),
+}))
+
+import { spawn } from 'child_process'
+
+class FakeChild extends EventEmitter {
+  stdout = new EventEmitter()
+  stderr = new EventEmitter()
+  kill = vi.fn()
+}
+
+let fakeChild: FakeChild
+
+beforeEach(() => {
+  fakeChild = new FakeChild()
+  vi.mocked(spawn).mockReturnValue(fakeChild as never)
+})
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('verifySerena', () => {
+  it('reports ok when uv exits 0', async () => {
+    const promise = verifySerena()
+    fakeChild.stdout.emit('data', Buffer.from('uv 0.10.9\n'))
+    fakeChild.emit('close', 0)
+    const r = await promise
+    expect(r.ok).toBe(true)
+  })
+
+  it('reports uv-non-zero-exit when exit code != 0', async () => {
+    const promise = verifySerena()
+    fakeChild.stderr.emit('data', Buffer.from('boom\n'))
+    fakeChild.emit('close', 1)
+    const r = await promise
+    expect(r.ok).toBe(false)
+    expect(r.reason).toMatch(/uv-non-zero-exit/)
+  })
+
+  it('reports uv-not-on-path when ENOENT fires', async () => {
+    const promise = verifySerena()
+    const err = Object.assign(new Error('not found'), { code: 'ENOENT' })
+    fakeChild.emit('error', err)
+    const r = await promise
+    expect(r.ok).toBe(false)
+    expect(r.reason).toBe('uv-not-on-path')
+  })
+
+  it('reports verify-timeout when child never emits close', async () => {
+    vi.useFakeTimers()
+    const promise = verifySerena()
+    vi.advanceTimersByTime(2000)
+    const r = await promise
+    expect(r.ok).toBe(false)
+    expect(r.reason).toBe('verify-timeout')
+    vi.useRealTimers()
+  })
+})

--- a/server/plugins/serena/verify.ts
+++ b/server/plugins/serena/verify.ts
@@ -1,0 +1,71 @@
+import { spawn } from 'child_process'
+import type { PluginVerifyResult } from '../../types'
+
+const TIMEOUT_MS = 1800
+
+/**
+ * Verify Serena availability. We only probe `uv --version` here — proxy for
+ * "uvx will be able to launch serena-mcp-server when claude actually calls it".
+ *
+ * We intentionally do NOT shell out to `uvx --from git+... serena-mcp-server`:
+ * that would download the git repo + dependencies on every verify, which is
+ * slow (multi-second) and would fail offline. The Claude CLI itself triggers
+ * the lazy install through uvx's own cache, so as long as `uv` is on PATH and
+ * executable, install + spawn-time verify can both pass quickly.
+ *
+ * Cross-platform spawn: on Windows we set `shell: true` so PATH resolution
+ * picks up `uv.exe` (or, if astral installed via winget, the .cmd shim) the
+ * same way it does in `setup-prerequisites.ts`.
+ */
+export async function verifySerena(): Promise<PluginVerifyResult> {
+  const checkedAt = new Date().toISOString()
+  const isWin = process.platform === 'win32'
+  return new Promise<PluginVerifyResult>((resolve) => {
+    let settled = false
+    let stderr = ''
+    let stdout = ''
+    let child
+    try {
+      child = spawn('uv', ['--version'], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        shell: isWin,
+      })
+    } catch {
+      resolve({ ok: false, reason: 'uv-not-on-path', checkedAt })
+      return
+    }
+    const timer = setTimeout(() => {
+      if (settled) return
+      settled = true
+      try { child.kill('SIGKILL') } catch { /* ignore */ }
+      resolve({ ok: false, reason: 'verify-timeout', checkedAt })
+    }, TIMEOUT_MS)
+
+    child.stdout?.on('data', (b) => { stdout += b.toString() })
+    child.stderr?.on('data', (b) => { stderr += b.toString() })
+
+    child.on('error', (err) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      const code = (err as NodeJS.ErrnoException).code
+      if (code === 'ENOENT') resolve({ ok: false, reason: 'uv-not-on-path', checkedAt })
+      else resolve({ ok: false, reason: `verify-exception: ${err.message}`, checkedAt })
+    })
+
+    child.on('close', (code) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      if (code === 0) {
+        resolve({ ok: true, reason: undefined, checkedAt })
+      } else {
+        resolve({
+          ok: false,
+          reason: `uv-non-zero-exit: code=${code} ${stderr.trim().slice(0, 200) || stdout.trim().slice(0, 200)}`,
+          checkedAt,
+        })
+      }
+    })
+  })
+}

--- a/server/project-router.ts
+++ b/server/project-router.ts
@@ -38,6 +38,7 @@ import treeKill from 'tree-kill'
 import multer from 'multer'
 import { createRailsRouter } from './rails-router'
 import { createProfilesRouter } from './profiles-router'
+import { createPluginsRouter } from './plugins-router'
 import {
   getHubTerminalSettings,
   getProjectOverride,
@@ -253,6 +254,10 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
   // Mount profiles router under each project (agent profiles)
   const profilesRouter = createProfilesRouter()
   router.use('/:projectId/profiles', profilesRouter)
+
+  // Mount plugins router under each project (per-project marketplace)
+  const pluginsRouter = createPluginsRouter()
+  router.use('/:projectId/plugins', pluginsRouter)
 
   // ─── Queue / Spawn routes ────────────────────────────────────────────────────
 
@@ -2465,12 +2470,15 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
         .prepare(`SELECT profile_name, profile_json FROM job_profiles WHERE job_id = ?`)
         .get(jobId) as { profile_name: string; profile_json: string } | undefined
 
+      const { homeJobSnapshotPath } = require('./plugins/paths') as typeof import('./plugins/paths')
+      const pluginSnap = homeJobSnapshotPath(req.projectCtx!.project.slug, jobId)
       await createDiagnosticZip(res, {
         job,
         blob,
         summaries,
         events,
         profile: profileRow ? { name: profileRow.profile_name, json: profileRow.profile_json } : null,
+        pluginSnapshotPath: pluginSnap,
       })
     } catch (err) {
       if (!res.headersSent) {

--- a/server/queue-manager.ts
+++ b/server/queue-manager.ts
@@ -520,7 +520,7 @@ export class QueueManager {
     this._startJob(nextJobId)
   }
 
-  private _startJob(jobId: string): void {
+  private async _startJob(jobId: string): Promise<void> {
     const job = this._jobs.get(jobId)
     if (!job) return
 
@@ -678,6 +678,67 @@ export class QueueManager {
     // Inject the profile path for claude even when telemetry is off.
     if (profileSnapshotPath) {
       spawnEnv = { ...spawnEnv, SPECRAILS_PROFILE_PATH: profileSnapshotPath }
+    }
+
+    // ─── Plugin resolution + snapshot ──────────────────────────────────────
+    // Active = installed + verify ok; degraded = installed but verify failed
+    // or timed out. Degraded does NOT block spawn — rail proceeds, UI gets
+    // a `plugin.degraded` event so the user can reinstall.
+    let pluginActive: Array<{ name: string; version: string }> = []
+    let pluginDegraded: Array<{ name: string; reason: string }> = []
+    let pluginSnapshotPath: string | null = null
+    if (this._provider === 'claude' && this._projectId && this._projectSlug && this._cwd) {
+      try {
+        const { resolvePluginsForSpawn, snapshotPluginsForJob } =
+          require('./plugins/rail-integration') as typeof import('./plugins/rail-integration')
+        const resolution = await resolvePluginsForSpawn(this._cwd, this._projectId, jobId)
+        pluginActive = resolution.active
+        pluginDegraded = resolution.degraded
+        if (pluginActive.length > 0 || pluginDegraded.length > 0) {
+          pluginSnapshotPath = snapshotPluginsForJob(
+            this._projectSlug, jobId, this._projectId, pluginActive, pluginDegraded,
+          )
+        }
+        for (const d of pluginDegraded) {
+          this._broadcast({
+            type: 'plugin.degraded',
+            projectId: this._projectId,
+            name: d.name,
+            reason: d.reason,
+            jobId,
+            timestamp: new Date().toISOString(),
+          })
+        }
+      } catch (err) {
+        console.warn(`[queue-manager] plugin resolution failed for job ${jobId}: ${(err as Error).message}`)
+      }
+    }
+    if (pluginActive.length > 0 && pluginSnapshotPath) {
+      spawnEnv = {
+        ...spawnEnv,
+        SPECRAILS_PLUGINS_ACTIVE: pluginActive.map((p) => p.name).join(','),
+        SPECRAILS_PLUGINS_SNAPSHOT: pluginSnapshotPath,
+      }
+    }
+    // Add OTEL attrs when telemetry already on.
+    if (this._provider === 'claude' && this._projectId && this._db) {
+      const settings = getProjectSettings(this._db)
+      if (settings.pipelineTelemetryEnabled && (pluginActive.length > 0 || pluginDegraded.length > 0)) {
+        const extra: Record<string, string> = {}
+        if (pluginActive.length > 0) {
+          extra['specrails.plugins.active'] = JSON.stringify(pluginActive.map((p) => p.name))
+          extra['specrails.plugins.versions'] = JSON.stringify(
+            Object.fromEntries(pluginActive.map((p) => [p.name, p.version])),
+          )
+        }
+        if (pluginDegraded.length > 0) {
+          extra['specrails.plugins.degraded'] = JSON.stringify(pluginDegraded.map((d) => d.name))
+        }
+        spawnEnv = {
+          ...spawnEnv,
+          ...buildTelemetryEnv(jobId, this._projectId, this._hubPort, extra),
+        }
+      }
     }
 
     // spawnAiCli reroutes multi-line argv values through stdin on Windows.

--- a/server/setup-prerequisites.ts
+++ b/server/setup-prerequisites.ts
@@ -5,7 +5,7 @@ const WHICH_CMD = process.platform === 'win32' ? 'where' : 'which'
 export type Platform = 'darwin' | 'win32' | 'linux'
 
 export interface SetupPrerequisite {
-  key: 'node' | 'npm' | 'npx' | 'git'
+  key: 'node' | 'npm' | 'npx' | 'git' | 'uv'
   label: string
   command: string
   required: boolean
@@ -32,10 +32,11 @@ export interface SetupPrerequisitesStatus {
   missingRequired: SetupPrerequisite[]
 }
 
-export const MIN_VERSIONS: Record<'node' | 'npm' | 'git', string> = {
+export const MIN_VERSIONS: Record<'node' | 'npm' | 'git' | 'uv', string> = {
   node: '18.0.0',
   npm: '9.0.0',
   git: '2.20.0',
+  uv: '0.1.0',
 }
 
 interface CommandLookup {
@@ -125,7 +126,13 @@ function brokenSymlinkHint(label: string, command: string, resolvedPath: string 
   return `${label} found${where} but failed to execute — possibly a broken symlink or a stale install. Reinstall ${command} or remove the stale link${resolvedPath ? ` at ${resolvedPath}` : ''}.`
 }
 
-export function getSetupPrerequisitesStatus(): SetupPrerequisitesStatus {
+export interface PrerequisiteOptions {
+  /** Optional: include `uv` (used by plugins like Serena). When false the
+   *  setup wizard's `missingRequired` is not affected by uv's absence. */
+  includeUv?: boolean
+}
+
+export function getSetupPrerequisitesStatus(options: PrerequisiteOptions = {}): SetupPrerequisitesStatus {
   const platform: Platform = process.platform === 'darwin'
     ? 'darwin'
     : process.platform === 'win32'
@@ -175,6 +182,22 @@ export function getSetupPrerequisitesStatus(): SetupPrerequisitesStatus {
         : 'Install Git and restart SpecRails Hub if PATH changed.',
     },
   ]
+
+  if (options.includeUv) {
+    definitions.push({
+      key: 'uv',
+      label: 'uv',
+      command: 'uv',
+      required: false,
+      minVersion: MIN_VERSIONS.uv,
+      installUrl: 'https://docs.astral.sh/uv/getting-started/installation/',
+      installHint: process.platform === 'win32'
+        ? 'Install uv via winget (`winget install astral-sh.uv`) or PowerShell installer, then restart SpecRails Hub.'
+        : process.platform === 'darwin'
+          ? 'Install uv via Homebrew (`brew install uv`) or the curl installer, then restart SpecRails Hub.'
+          : 'Install uv via the curl installer (`curl -LsSf https://astral.sh/uv/install.sh | sh`), then restart SpecRails Hub.',
+    })
+  }
 
   const prerequisites: SetupPrerequisite[] = definitions.map((definition) => {
     const lookup = locateCommand(definition.command)

--- a/server/telemetry-export.ts
+++ b/server/telemetry-export.ts
@@ -236,14 +236,28 @@ export interface DiagnosticZipOpts {
   events: EventRow[]
   /** Optional profile snapshot the job ran with (from job_profiles). */
   profile?: { name: string; json: string } | null
+  /** Optional plugin snapshot path (`~/.specrails/.../plugins.json`). */
+  pluginSnapshotPath?: string | null
 }
 
 export async function createDiagnosticZip(
   res: ServerResponse,
   opts: DiagnosticZipOpts
 ): Promise<void> {
-  const { job, blob, summaries, events, profile } = opts
+  const { job, blob, summaries, events, profile, pluginSnapshotPath } = opts
   const entries: ZipEntry[] = []
+
+  // plugins.json — per-job plugin snapshot, if present.
+  let pluginsSummary: { active: Array<{ name: string; version: string }>; degraded: Array<{ name: string; reason: string }> } | null = null
+  if (pluginSnapshotPath && fs.existsSync(pluginSnapshotPath)) {
+    try {
+      const raw = fs.readFileSync(pluginSnapshotPath, 'utf8')
+      pluginsSummary = JSON.parse(raw)
+      entries.push({ name: 'plugins.json', data: Buffer.from(raw, 'utf-8') })
+    } catch {
+      // ignore malformed snapshot — diagnostic still useful without it
+    }
+  }
 
   // job-metadata.json
   const metadata = {
@@ -306,6 +320,16 @@ export async function createDiagnosticZip(
     summaryContent = buildSummaryFromRaw(blob.path, job, truncated)
   } else {
     summaryContent = buildSummaryFromRows(summaries, job)
+  }
+  if (pluginsSummary) {
+    const lines = ['', '## Plugins']
+    if (pluginsSummary.active.length > 0) {
+      lines.push('', '### Active', ...pluginsSummary.active.map((p) => `- ${p.name}@${p.version}`))
+    }
+    if (pluginsSummary.degraded.length > 0) {
+      lines.push('', '### Degraded', ...pluginsSummary.degraded.map((p) => `- ${p.name} (${p.reason})`))
+    }
+    summaryContent += '\n' + lines.join('\n') + '\n'
   }
   entries.push({
     name: 'summary.md',

--- a/server/types.ts
+++ b/server/types.ts
@@ -751,6 +751,12 @@ export interface PluginManifest {
   /** Optional per-platform notes shown in the install dialog. Keys are
    *  `<platform>-<arch>` (e.g., `darwin-arm64`, `win32-x64`, `linux-x64`). */
   platformNotes?: Partial<Record<string, string>>
+  /** Optional Markdown block appended (under marker comments) to
+   *  `<project>/CLAUDE.md` when the plugin is active. Lets a plugin teach
+   *  the global agent context to prefer its tools over generic ones. The
+   *  block is removed on uninstall and on deactivate; any user content
+   *  outside the markers is preserved byte-identical. */
+  claudeMdInstructions?: string
 }
 
 /**

--- a/server/types.ts
+++ b/server/types.ts
@@ -715,6 +715,211 @@ export interface RailJobCompletedMessage {
   ticketIds: number[]
 }
 
+// ─── Plugin system ──────────────────────────────────────────────────────────
+
+export interface PluginRequirement {
+  /** Tool name as the prerequisites detector recognizes it (e.g., "uv"). */
+  name: string
+  /** Optional minimum semver. */
+  minVersion?: string
+}
+
+export interface PluginOwnership {
+  /** Keys claimed under `mcpServers` in `<project>/.mcp.json`. */
+  mcpServers?: string[]
+  /** Project-relative paths the plugin is exclusively allowed to write. */
+  agentFragments?: string[]
+  /** Reserved for future per-plugin config keys (not used in v1). */
+  configKeys?: string[]
+}
+
+export interface PluginManifest {
+  /** kebab-case unique id. */
+  name: string
+  version: string
+  description: string
+  /** Bullets shown on the marketplace card. */
+  whatItDoes: string[]
+  /** Optional category tag for grouping in the UI. */
+  category?: string
+  /** Executable prerequisites (e.g., uv >= 0.1). */
+  requirements?: PluginRequirement[]
+  /** Files / keys the plugin is allowed to mutate. Used for conflict detection. */
+  owns: PluginOwnership
+  /** Optional override for the verify-timeout (ms). Default 2000ms. */
+  verifyTimeoutMs?: number
+  /** Optional per-platform notes shown in the install dialog. Keys are
+   *  `<platform>-<arch>` (e.g., `darwin-arm64`, `win32-x64`, `linux-x64`). */
+  platformNotes?: Partial<Record<string, string>>
+}
+
+/**
+ * Provided to a plugin's lifecycle methods. The plugin is expected to record
+ * every file it creates or modifies via `recordInstalledFile` so uninstall can
+ * clean up surgically and so install rollback is deterministic.
+ */
+export interface PluginLifecycleContext {
+  projectPath: string
+  projectId: string
+  /** Append a project-relative path that this install created/modified. */
+  recordInstalledFile(relativePath: string): void
+  /** Append a log line — surfaced to the install dialog over the WS. */
+  log(line: string): void
+}
+
+export interface PluginVerifyResult {
+  ok: boolean
+  reason?: string
+  /** ISO-8601 timestamp when this verify ran. */
+  checkedAt: string
+}
+
+export interface PluginPreviewFileEntry {
+  path: string
+  op: 'create' | 'modify'
+  /** Optional human-readable summary of the change (e.g., "+ mcpServers.serena"). */
+  summary?: string
+}
+
+export interface PluginPreviewResult {
+  pluginName: string
+  files: PluginPreviewFileEntry[]
+  /** Prerequisites status at preview time, mirroring setup-prerequisites shape. */
+  requirements: Array<{
+    name: string
+    installed: boolean
+    executable: boolean
+    version?: string
+    meetsMinimum: boolean
+  }>
+  /** Platform-specific note for the user's host (resolved server-side). */
+  platformNote?: string
+}
+
+/** Plugin module value: manifest + lifecycle implementations. */
+export interface Plugin {
+  manifest: PluginManifest
+  install(ctx: PluginLifecycleContext): Promise<void>
+  uninstall(ctx: PluginLifecycleContext): Promise<void>
+  verify(ctx: Pick<PluginLifecycleContext, 'projectPath' | 'projectId'>): Promise<PluginVerifyResult>
+  /** Optional. Drives the diff preview UI; falls back to a derived preview. */
+  previewInstall?(ctx: Pick<PluginLifecycleContext, 'projectPath' | 'projectId'>): Promise<PluginPreviewFileEntry[]>
+  /** Optional. Returns the canonical mcpServers entry value the plugin would
+   *  write today. Used for drift detection (manifest vs. on-disk). When the
+   *  plugin owns multiple mcpServers, callers may use the same entry for all
+   *  or supply a richer keyed structure in a future revision. */
+  expectedMcpEntry?(): Record<string, unknown>
+}
+
+export interface PluginStateEntry {
+  version: string
+  installedAt: string
+  installedFiles: string[]
+  /** Last verify result captured by the manager (cache). */
+  health?: 'ok' | 'degraded' | 'unknown'
+  healthReason?: string
+}
+
+export interface PluginState {
+  schemaVersion: 1
+  plugins: Record<string, PluginStateEntry>
+}
+
+export type PluginCardStatus =
+  | 'installed'           // installed + activated (hub-managed Claude approval)
+  | 'deactivated'         // installed but user toggled off → Claude no longer loads
+  | 'not-installed'
+  | 'orphan'              // state.json entry but no plugin in registry
+  | 'degraded'            // installed but verify failed
+
+export interface PluginCatalogEntry {
+  name: string
+  version: string
+  description: string
+  whatItDoes: string[]
+  category?: string
+  requirements: PluginRequirement[]
+  owns: PluginOwnership
+  status: PluginCardStatus
+  installedAt?: string
+  health?: 'ok' | 'degraded' | 'unknown'
+  healthReason?: string
+  /** Claude marketplace plugin keys (e.g., `serena@claude-plugins-official`)
+   *  currently enabled that shadow this plugin's MCP server. When non-empty,
+   *  the user has the plugin globally and the hub's project-scoped install
+   *  is redundant; UI surfaces a "Disable global" affordance. */
+  marketplaceConflicts?: string[]
+  /** Marketplace keys that are physically installed in Claude's plugin cache
+   *  but NOT enabled. Claude may still resolve the server from the cached
+   *  `.mcp.json`, masking the project-scoped install. UI surfaces a hint to
+   *  uninstall the marketplace plugin via Claude's own command. */
+  marketplaceCachedButDisabled?: string[]
+  /** True when the project's `.mcp.json` entry for this plugin no longer
+   *  matches the bundled manifest (e.g., upstream renamed the binary). UI
+   *  surfaces an "Update" affordance. */
+  updateAvailable?: boolean
+}
+
+// ─── Plugin WS messages ─────────────────────────────────────────────────────
+
+export interface PluginInstalledMessage {
+  type: 'plugin.installed'
+  projectId: string
+  name: string
+  version: string
+  timestamp: string
+}
+
+export interface PluginUninstalledMessage {
+  type: 'plugin.uninstalled'
+  projectId: string
+  name: string
+  timestamp: string
+}
+
+export interface PluginHealthChangedMessage {
+  type: 'plugin.health_changed'
+  projectId: string
+  name: string
+  status: 'ok' | 'degraded' | 'unknown'
+  reason?: string
+  timestamp: string
+}
+
+export interface PluginDegradedMessage {
+  type: 'plugin.degraded'
+  projectId: string
+  name: string
+  reason: string
+  jobId?: string
+  timestamp: string
+}
+
+export interface PluginInstallProgressMessage {
+  type: 'plugin.install_progress'
+  projectId: string
+  name: string
+  line: string
+  timestamp: string
+}
+
+export interface PluginPrereqInstallProgressMessage {
+  type: 'plugin.prereq_install_progress'
+  projectId: string
+  prereq: string
+  line: string
+  timestamp: string
+}
+
+export interface PluginPrereqInstalledMessage {
+  type: 'plugin.prereq_installed'
+  projectId: string
+  prereq: string
+  ok: boolean
+  reason?: string
+  timestamp: string
+}
+
 export type WsMessage =
   | LogMessage | PhaseMessage | InitMessage | QueueMessage | EventMessage
   | ChatStreamMessage | ChatDoneMessage | ChatErrorMessage
@@ -736,4 +941,8 @@ export type WsMessage =
   | AgentRefineStreamMessage | AgentRefinePhaseMessage | AgentRefineReadyMessage
   | AgentRefineTestMessage | AgentRefineErrorMessage | AgentRefineCancelledMessage
   | AgentRefineAppliedMessage
+  | PluginInstalledMessage | PluginUninstalledMessage
+  | PluginHealthChangedMessage | PluginDegradedMessage
+  | PluginInstallProgressMessage
+  | PluginPrereqInstallProgressMessage | PluginPrereqInstalledMessage
 


### PR DESCRIPTION
## Summary
- New per-project Integrations marketplace UI (`/integrations`) where each project independently installs/activates MCP-based plugins.
- `PluginManager` server module: install with rollback, uninstall, toggle active/deactivated, drift update, healthcheck. Surgical, locked, atomic mutators for `.mcp.json` and per-project state. Ownership map fails fast on registry conflicts.
- Bundles **Serena** (LSP+MCP semantic code navigation) as the first dogfooded plugin. Includes auto-install for `uv` prerequisite (curl/PowerShell streamed installer), Apple Silicon Rosetta platform note, drift detection with one-click manifest update, and marketplace conflict resolution (enabled + cached-but-disabled detection).
- `QueueManager` integration: pre-spawn snapshot of active plugins to `~/.specrails/projects/<slug>/jobs/<jobId>/plugins.json` (chmod 400), injects `SPECRAILS_PLUGINS_ACTIVE` env var, adds OTEL resource attrs (`specrails.plugins.active` / `specrails.plugins.degraded` / `specrails.plugins.versions`). Healthcheck is non-blocking. `ChatManager` inherits via cwd; `SetupManager` opts out entirely.
- Diagnostic ZIP includes `plugins.json` and a Plugins section in `summary.md`.
- New WS events: `plugin.installed`, `plugin.uninstalled`, `plugin.degraded`, `plugin.health_changed`, `plugin.install_progress`, `plugin.prereq_install_progress`, `plugin.prereq_installed`.
- **Zero changes to specrails-core.** Bundled-only registry — adding a future plugin requires only appending an import to `server/plugins/index.ts`.

## Architecture
- Per-project state at `<project>/.specrails/plugins/state.json`
- Owned namespace: `<project>/.mcp.json` (surgical merge), `<project>/.claude/agents/custom-<plugin>.md`
- Activate/deactivate writes/removes the owned `mcpServers.<key>` directly in `.mcp.json` (the actual contract Claude reads); state.json memory survives toggles
- TS module manifest (no YAML), in-process file mutex (single-process hub), atomic temp+rename writes, byte-identical install rollback
- OpenSpec change `add-plugin-system` captures proposal/design/specs/tasks

## Test plan
- [x] `npm run typecheck` — server + client EXIT=0
- [x] `npm run test:coverage` (server) — EXIT=0; server thresholds met (lines/funcs/stmts ≥80, branches ≥70)
- [x] `cd client && npm run test:coverage` — EXIT=0; client thresholds met
- [x] 112 plugin-related tests passing
- [x] `npm run build:server` produces plugin module in `server/dist/plugins/`
- [x] Manual: install → activate (toggle on) → deactivate (toggle off) → uninstall round-trip on a real project
- [ ] Smoke `npm run build:desktop` (full Tauri build) — left for reviewer; sidecar build verified through `build:server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)