### PR TITLE
fix: stabilize ExploreSpecShell Create Spec test (flake on CI)

### DIFF
--- a/client/src/components/explore-spec/__tests__/ExploreSpecShell.test.tsx
+++ b/client/src/components/explore-spec/__tests__/ExploreSpecShell.test.tsx
@@ -233,6 +233,10 @@ describe('ExploreSpecShell', () => {
     })
 
     const createBtn = await screen.findByRole('button', { name: /create spec from current draft/i })
+    // Wait for the spec_draft.update to propagate through useSpecDraftStream
+    // and unset disabled — otherwise on slower CI runners the click fires
+    // while `!draft.title.trim()` still holds and the click is a no-op.
+    await waitFor(() => expect(createBtn).not.toBeDisabled())
     fireEvent.click(createBtn)
     await waitFor(() => {
       expect(fakeFetch).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

- **Why**: PR #294 (release-please 1.49.0) failed CI on `ExploreSpecShell.test.tsx > calls onTicketCreated and onClose after a successful Create Spec POST`.
- **Root cause**: The test emits a \`spec_draft.update\` WS event then immediately fires \`fireEvent.click\` on Create. On slower CI runners the WS update hadn't propagated through \`useSpecDraftStream\` yet, so \`draft.title.trim()\` was still empty, the button was still \`disabled\`, the click was a no-op, and the expected \`/tickets/from-draft\` fetch never fired.
- **Fix**: Wait for the button to be enabled before clicking.

## Test plan
- [x] Local stress test: 5 consecutive runs of the suite, all green
- [x] Targeted run of the previously failing test
- [ ] Verify CI green on this PR
- [ ] Once merged, re-run CI on PR #294 to unblock the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)