### PR TITLE
fix(desktop): allow wasm-unsafe-eval in CSP for Monaco

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' http://localhost:4200 http://127.0.0.1:4200 ws://localhost:4200 ws://127.0.0.1:4200; img-src 'self' blob: data: http://localhost:4200 http://127.0.0.1:4200; media-src 'self' blob:; frame-src 'self' blob:; style-src 'self' 'unsafe-inline'; script-src 'self'",
+      "csp": "default-src 'self'; connect-src 'self' http://localhost:4200 http://127.0.0.1:4200 ws://localhost:4200 ws://127.0.0.1:4200; img-src 'self' blob: data: http://localhost:4200 http://127.0.0.1:4200; media-src 'self' blob:; frame-src 'self' blob:; style-src 'self' 'unsafe-inline'; script-src 'self' 'wasm-unsafe-eval'",
       "dangerousDisableAssetCspModification": ["style-src"]
     }
   },


### PR DESCRIPTION
## Summary
- Add `'wasm-unsafe-eval'` to `script-src` CSP in `src-tauri/tauri.conf.json` so Monaco WebAssembly workers load in the Tauri webview.

## Test plan
- [ ] Open Code section in packaged desktop build, confirm Monaco viewer mounts without CSP violation in devtools.