### PR TITLE
feat(theme): add specrails brand theme as new default

### DIFF
--- a/client/src/components/settings/__tests__/AppearanceSection.test.tsx
+++ b/client/src/components/settings/__tests__/AppearanceSection.test.tsx
@@ -23,13 +23,14 @@ describe('AppearanceSection', () => {
     vi.restoreAllMocks()
   })
 
-  it('renders all four theme cards', () => {
+  it('renders all five theme cards', () => {
     vi.spyOn(global, 'fetch').mockResolvedValue(ok({ theme: 'dracula' }))
     render(<ThemeProvider><AppearanceSection /></ThemeProvider>)
     expect(screen.getByTestId('theme-card-dracula')).toBeInTheDocument()
     expect(screen.getByTestId('theme-card-aurora-light')).toBeInTheDocument()
     expect(screen.getByTestId('theme-card-obsidian-dark')).toBeInTheDocument()
     expect(screen.getByTestId('theme-card-matrix')).toBeInTheDocument()
+    expect(screen.getByTestId('theme-card-specrails')).toBeInTheDocument()
   })
 
   it('matrix card is selectable and updates the active theme', async () => {
@@ -100,6 +101,6 @@ describe('AppearanceSection', () => {
     render(<ThemeProvider><AppearanceSection /></ThemeProvider>)
     const group = screen.getByRole('radiogroup', { name: /theme/i })
     expect(group).toBeInTheDocument()
-    expect(screen.getAllByRole('radio')).toHaveLength(4)
+    expect(screen.getAllByRole('radio')).toHaveLength(5)
   })
 })

--- a/client/src/context/__tests__/ThemeContext.test.tsx
+++ b/client/src/context/__tests__/ThemeContext.test.tsx
@@ -52,10 +52,10 @@ describe('ThemeContext', () => {
     expect(screen.getByTestId('current').textContent).toBe('obsidian-dark')
   })
 
-  it('falls back to dracula when both attribute and storage are absent', () => {
-    vi.spyOn(global, 'fetch').mockResolvedValue(okJson({ theme: 'dracula' }))
+  it('falls back to specrails (DEFAULT_THEME) when both attribute and storage are absent', () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue(okJson({ theme: 'specrails' }))
     render(<ThemeProvider><Probe /></ThemeProvider>)
-    expect(screen.getByTestId('current').textContent).toBe('dracula')
+    expect(screen.getByTestId('current').textContent).toBe('specrails')
   })
 
   it('reconciles to server value when it differs from boot', async () => {

--- a/client/src/globals.css
+++ b/client/src/globals.css
@@ -207,6 +207,45 @@
   --glass-card-opacity:          30%;
 }
 
+/* ─── SpecRails (brand theme — deep navy-indigo, saturated cyan) ─── */
+[data-theme="specrails"] {
+  --color-background:             hsl(240 35% 4%);    /* deep navy-indigo */
+  --color-foreground:             hsl(240 20% 94%);
+  --color-card:                   hsl(238 30% 9%);
+  --color-card-foreground:        hsl(240 20% 94%);
+  --color-popover:                hsl(240 35% 4%);
+  --color-popover-foreground:     hsl(240 20% 94%);
+  --color-primary:                hsl(187 100% 41%);  /* saturated cyan */
+  --color-primary-foreground:     hsl(240 35% 4%);
+  --color-secondary:              hsl(238 26% 13%);
+  --color-secondary-foreground:   hsl(240 20% 94%);
+  --color-muted:                  hsl(238 26% 13%);
+  --color-muted-foreground:       hsl(240 12% 58%);
+  --color-accent:                 hsl(238 26% 13%);
+  --color-accent-foreground:      hsl(240 20% 94%);
+  --color-destructive:            hsl(12 78% 52%);
+  --color-destructive-foreground: hsl(240 35% 4%);
+  --color-border:                 hsl(240 20% 100% / 0.08);
+  --color-input:                  hsl(238 26% 13%);
+  --color-ring:                   hsl(187 100% 41%);
+
+  --color-accent-primary:    hsl(187 100% 41%);  /* cyan */
+  --color-accent-info:       hsl(191 97% 50%);   /* electric cyan */
+  --color-accent-success:    hsl(152 80% 44%);   /* emerald */
+  --color-accent-secondary:  hsl(280 38% 57%);   /* violet */
+  --color-accent-warning:    hsl(42 90% 56%);    /* amber */
+  --color-accent-highlight:  hsl(248 70% 63%);   /* indigo */
+  --color-surface:           hsl(238 30% 9%);
+  --color-background-deep:   hsl(240 38% 2%);
+
+  --color-scrollbar-thumb:       hsl(240 20% 50% / 0.35);
+  --color-scrollbar-thumb-hover: hsl(240 20% 60% / 0.55);
+  --color-prose-table-stripe:    hsl(238 30% 9% / 0.5);
+  --color-prose-table-header:    hsl(238 30% 9% / 0.8);
+  --color-toast-shadow:          hsl(240 38% 1% / 0.65);
+  --glass-card-opacity:          28%;
+}
+
 @layer base {
   *,
   *::before,

--- a/client/src/lib/__tests__/themes.test.ts
+++ b/client/src/lib/__tests__/themes.test.ts
@@ -11,8 +11,8 @@ import {
 
 describe('themes', () => {
   describe('THEME_IDS allow-list', () => {
-    it('contains the four documented built-in themes', () => {
-      expect([...THEME_IDS]).toEqual(['dracula', 'aurora-light', 'obsidian-dark', 'matrix'])
+    it('contains the five documented built-in themes', () => {
+      expect([...THEME_IDS]).toEqual(['dracula', 'aurora-light', 'obsidian-dark', 'matrix', 'specrails'])
     })
 
     it('THEMES has an entry for every ThemeId', () => {
@@ -42,8 +42,8 @@ describe('themes', () => {
   })
 
   describe('DEFAULT_THEME', () => {
-    it('is dracula', () => {
-      expect(DEFAULT_THEME).toBe('dracula')
+    it('is specrails', () => {
+      expect(DEFAULT_THEME).toBe('specrails')
     })
 
     it('is in the allow-list', () => {

--- a/client/src/lib/themes.ts
+++ b/client/src/lib/themes.ts
@@ -12,7 +12,7 @@
  * No component code changes required (OCP).
  */
 
-export const THEME_IDS = ['dracula', 'aurora-light', 'obsidian-dark', 'matrix'] as const
+export const THEME_IDS = ['dracula', 'aurora-light', 'obsidian-dark', 'matrix', 'specrails'] as const
 export type ThemeId = (typeof THEME_IDS)[number]
 
 /**
@@ -25,7 +25,7 @@ export function isThemeId(v: unknown): v is ThemeId {
   return typeof v === 'string' && (THEME_IDS as readonly string[]).includes(v)
 }
 
-export const DEFAULT_THEME: ThemeId = 'dracula'
+export const DEFAULT_THEME: ThemeId = 'specrails'
 
 /**
  * Full xterm.js theme. Mirrors `ITheme` from xterm — duplicated to avoid a
@@ -327,6 +327,66 @@ const MATRIX: ThemeDescriptor = {
   },
 }
 
+// ─── SpecRails ─────────────────────────────────────────────────────────────
+
+const SPECRAILS_PALETTE = {
+  bg:          'hsl(240 35% 4%)',
+  card:        'hsl(238 30% 9%)',
+  bgDeep:      'hsl(240 38% 2%)',
+  fg:          'hsl(240 20% 94%)',
+  muted:       'hsl(240 12% 58%)',
+  primary:     'hsl(187 100% 41%)',   // cyan
+  secondary:   'hsl(280 38% 57%)',    // violet
+  success:     'hsl(152 80% 44%)',    // emerald
+  info:        'hsl(191 97% 50%)',    // electric cyan
+  warning:     'hsl(42 90% 56%)',     // amber
+  highlight:   'hsl(248 70% 63%)',    // indigo
+  destructive: 'hsl(12 78% 52%)',     // tomato-red
+} as const
+
+const SPECRAILS: ThemeDescriptor = {
+  id: 'specrails',
+  displayName: 'SpecRails',
+  tagline: 'Brand theme — deep navy-indigo with saturated cyan accents',
+  scheme: 'dark',
+  previewSwatches: {
+    background: SPECRAILS_PALETTE.bg,
+    foreground: SPECRAILS_PALETTE.fg,
+    accents: [SPECRAILS_PALETTE.primary, SPECRAILS_PALETTE.highlight, SPECRAILS_PALETTE.secondary, SPECRAILS_PALETTE.success],
+  },
+  xterm: {
+    background:          SPECRAILS_PALETTE.bg,
+    foreground:          SPECRAILS_PALETTE.fg,
+    cursor:              SPECRAILS_PALETTE.primary,
+    cursorAccent:        SPECRAILS_PALETTE.bg,
+    selectionBackground: 'hsl(240 30% 22%)',
+    black:               'hsl(240 35% 8%)',
+    red:                 SPECRAILS_PALETTE.destructive,
+    green:               SPECRAILS_PALETTE.success,
+    yellow:              SPECRAILS_PALETTE.warning,
+    blue:                SPECRAILS_PALETTE.highlight,
+    magenta:             SPECRAILS_PALETTE.secondary,
+    cyan:                SPECRAILS_PALETTE.primary,
+    white:               SPECRAILS_PALETTE.fg,
+    brightBlack:         SPECRAILS_PALETTE.muted,
+    brightRed:           'hsl(12 78% 66%)',
+    brightGreen:         'hsl(152 80% 58%)',
+    brightYellow:        'hsl(42 90% 70%)',
+    brightBlue:          'hsl(248 70% 76%)',
+    brightMagenta:       'hsl(280 38% 70%)',
+    brightCyan:          'hsl(191 97% 65%)',
+    brightWhite:         'hsl(240 20% 100%)',
+  },
+  chart: [SPECRAILS_PALETTE.primary, SPECRAILS_PALETTE.info, SPECRAILS_PALETTE.success, SPECRAILS_PALETTE.secondary, SPECRAILS_PALETTE.warning],
+  status: {
+    completed: SPECRAILS_PALETTE.primary,
+    failed:    SPECRAILS_PALETTE.destructive,
+    canceled:  SPECRAILS_PALETTE.warning,
+    running:   SPECRAILS_PALETTE.info,
+    queued:    SPECRAILS_PALETTE.muted,
+  },
+}
+
 // ─── Public registry ───────────────────────────────────────────────────────
 
 export const THEMES: Record<ThemeId, ThemeDescriptor> = {
@@ -334,6 +394,7 @@ export const THEMES: Record<ThemeId, ThemeDescriptor> = {
   'aurora-light':  AURORA_LIGHT,
   'obsidian-dark': OBSIDIAN_DARK,
   'matrix':        MATRIX,
+  'specrails':     SPECRAILS,
 }
 
 export function getTheme(id: ThemeId): ThemeDescriptor {

--- a/server/hub-router.ts
+++ b/server/hub-router.ts
@@ -27,7 +27,7 @@ function slugify(name: string): string {
 
 // Theme allow-list. Mirror of THEME_IDS in `client/src/lib/themes.ts` —
 // kept duplicated to avoid pulling client code into the server bundle.
-const THEME_ID_ALLOWLIST = new Set<string>(['dracula', 'aurora-light', 'obsidian-dark', 'matrix'])
+const THEME_ID_ALLOWLIST = new Set<string>(['dracula', 'aurora-light', 'obsidian-dark', 'matrix', 'specrails'])
 
 // LOW-04: Deny registration of system-critical directory paths.
 const DENIED_PATH_PREFIXES = [


### PR DESCRIPTION
## Summary

- Adds `specrails` as a fifth hub theme derived from `design_handoff_specrails_web/` design system
- Cyan-forward dark palette: near-black background (`hsl(240 35% 4%)`), saturated cyan primary (`hsl(187 100% 41%)`), soft violet secondary
- Sets `DEFAULT_THEME = 'specrails'` for fresh installs (users with stored localStorage preference unaffected)
- Purely additive — three files, zero component changes

## Changes

| File | Change |
|------|--------|
| `client/src/lib/themes.ts` | SPECRAILS_PALETTE + ThemeDescriptor + THEME_IDS + DEFAULT_THEME |
| `client/src/globals.css` | `[data-theme="specrails"]` CSS token block (35 lines) |
| `server/hub-router.ts` | Added `'specrails'` to THEME_ID_ALLOWLIST |
| `*.test.ts/tsx` | Updated 3 test files to reflect new theme count and DEFAULT_THEME |

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm test` — 2301 tests pass
- [ ] `npm run test:coverage` — server thresholds met
- [ ] `cd client && npm run test:coverage` — client thresholds met
- [ ] Open app, GlobalSettingsPage shows 5 themes including 'specrails'
- [ ] Fresh load (no localStorage) renders specrails theme
- [ ] Switching to Dracula persists across refresh
- [ ] `PATCH /api/hub/theme {"theme":"specrails"}` returns 200
- [ ] `grep -r 'dracula-'` finds 0 matches in new CSS block

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)