### PR TITLE
fix(desktop): Windows arm64 smoke test git config (NUL → NOSYSTEM)

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -362,7 +362,11 @@ jobs:
           # Functional git check: init + commit + log exercises git-core helpers/templates.
           $tmp = Join-Path $env:TEMP ("smokegit-" + [guid]::NewGuid())
           New-Item -ItemType Directory -Path $tmp | Out-Null
-          $env:GIT_CONFIG_GLOBAL = "NUL"; $env:GIT_CONFIG_SYSTEM = "NUL"
+          # Hermetic git config without the "NUL" device: GIT_CONFIG_SYSTEM=NUL throws
+          # "fatal: unable to access 'NUL': Invalid argument" on the Windows arm64
+          # PortableGit build. Disable system config via NOSYSTEM and point the global
+          # config at a path that doesn't exist (git treats a missing global config as empty).
+          $env:GIT_CONFIG_NOSYSTEM = "1"; $env:GIT_CONFIG_GLOBAL = (Join-Path $tmp ".gitconfig-absent")
           & $git -C $tmp init -q;  if ($LASTEXITCODE -ne 0) { Write-Error "git init failed"; exit 1 }
           & $git -C $tmp -c user.email=ci@specrails.dev -c user.name=ci commit -q --allow-empty -m smoke; if ($LASTEXITCODE -ne 0) { Write-Error "git commit failed"; exit 1 }
           & $git -C $tmp log --oneline; if ($LASTEXITCODE -ne 0) { Write-Error "git log failed"; exit 1 }
@@ -490,7 +494,11 @@ jobs:
           }
           $tmp = Join-Path $env:TEMP ("smokegit-" + [guid]::NewGuid())
           New-Item -ItemType Directory -Path $tmp | Out-Null
-          $env:GIT_CONFIG_GLOBAL = "NUL"; $env:GIT_CONFIG_SYSTEM = "NUL"
+          # Hermetic git config without the "NUL" device: GIT_CONFIG_SYSTEM=NUL throws
+          # "fatal: unable to access 'NUL': Invalid argument" on the Windows arm64
+          # PortableGit build. Disable system config via NOSYSTEM and point the global
+          # config at a path that doesn't exist (git treats a missing global config as empty).
+          $env:GIT_CONFIG_NOSYSTEM = "1"; $env:GIT_CONFIG_GLOBAL = (Join-Path $tmp ".gitconfig-absent")
           & $git -C $tmp init -q;  if ($LASTEXITCODE -ne 0) { Write-Error "git init failed"; exit 1 }
           & $git -C $tmp -c user.email=ci@specrails.dev -c user.name=ci commit -q --allow-empty -m smoke; if ($LASTEXITCODE -ne 0) { Write-Error "git commit failed"; exit 1 }
           & $git -C $tmp log --oneline; if ($LASTEXITCODE -ne 0) { Write-Error "git log failed"; exit 1 }


### PR DESCRIPTION
## Problem

The `v1.58.0` Desktop Release failed on **build-windows-arm64** at the bundled-runtimes smoke test:

```
git version 2.49.0.windows.1
fatal: unable to access 'NUL': Invalid argument
git init failed
```

`node`/`npm`/`npx`/`git --version` all pass; only `git init` fails. The smoke step sets `GIT_CONFIG_SYSTEM=NUL` / `GIT_CONFIG_GLOBAL=NUL` to isolate config. The x64 PortableGit resolves `NUL` to the null device, but the **arm64** PortableGit build rejects it with `Invalid argument`. Because one build job failed, the `deploy` job was **skipped** — so no installers (macOS/x64 included) were uploaded to Hostinger and `manifest.json` was not refreshed for v1.58.0.

## Fix

Replace the `NUL` device trick (in **both** the x64 and arm64 smoke steps) with a cross-arch hermetic config:

- `GIT_CONFIG_NOSYSTEM=1` — disables system config cleanly
- `GIT_CONFIG_GLOBAL=<non-existent path under $tmp>` — git treats a missing global config as empty, no device access

## Release impact

This is a `fix:` → release-please will cut **v1.58.1**; the tagged Desktop Release then rebuilds all three targets (now incl. arm64) and runs `deploy`. Alternatively, trigger `workflow_dispatch` on `main` once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)