### PR TITLE
fix(hub): isolate spawned claude from user global config + harden spec-gen turns

### DIFF
--- a/server/project-router.ts
+++ b/server/project-router.ts
@@ -1841,7 +1841,11 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
     // by the codex adapter (it doesn't read extraArgs that don't apply).
     const adapter = getAdapter(provider)
     const toolFlags = provider === 'claude' ? toolFlagsForScope(quickScope) : { args: [] }
-    const claudeMaxTurns = quickScope.full ? 6 : (hasAttachments ? 3 : 1)
+    // Full scope grants Read/Grep/Glob. The model spends turns exploring the
+    // repo before it writes the spec; 6 was too tight (a few tool calls on a
+    // sparse/empty repo hit error_max_turns → exit 1 → opaque failure). 15
+    // leaves comfortable headroom while --max-turns still bounds runaway loops.
+    const claudeMaxTurns = quickScope.full ? 15 : (hasAttachments ? 3 : 1)
     const args = adapter.buildArgs('spec-gen', {
       prompt: userPrompt,
       systemPrompt,
@@ -1972,7 +1976,21 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
       clearSpecGenWatchdog()
       let createdTicketId: number | null = null
 
-      if (code === 0 && buffer.trim()) {
+      // When claude burns its whole --max-turns budget it exits non-zero with
+      // a result event of subtype:error_max_turns — but it may already have
+      // emitted a complete spec. Salvage that usable output instead of failing
+      // the whole request on an exit code.
+      const resultSubtype = (lastResultEvent?.subtype as string | undefined) ?? null
+      const hasUsableSpec = buffer.trim().length > 0 && /##\s*Spec Title/i.test(buffer)
+      const salvageMaxTurns = code !== 0 && resultSubtype === 'error_max_turns' && hasUsableSpec
+
+      if ((code === 0 && buffer.trim()) || salvageMaxTurns) {
+        if (salvageMaxTurns) {
+          console.warn(
+            `[project-router] spec-gen salvaged partial output after error_max_turns (${requestId}); ` +
+              `consider raising --max-turns if this recurs`,
+          )
+        }
         // Extract title from generated spec
         const titleMatch = buffer.match(/##\s*Spec Title\s*\n+(.+)/)
         const specTitle = titleMatch ? titleMatch[1].trim() : idea.trim().slice(0, 80)
@@ -2107,7 +2125,11 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
           broadcast(errMsg)
         }
       } else {
-        const reason = code === 0 ? 'Empty response from AI' : `Process exited with code ${code}`
+        const reason = code === 0
+          ? 'Empty response from AI'
+          : resultSubtype === 'error_max_turns'
+            ? 'AI hit its turn limit before finishing the spec. Try again, or narrow the idea / turn off full-codebase context.'
+            : `Process exited with code ${code}`
         console.error(
           `[project-router] spec-gen failed (${requestId}): ${reason}` +
             (stderrBuf.trim() ? `\n  stderr: ${stderrBuf.trim()}` : '') +

--- a/server/providers/claude-adapter.test.ts
+++ b/server/providers/claude-adapter.test.ts
@@ -95,6 +95,7 @@ describe('claudeAdapter.buildArgs', () => {
       '--tools', 'default',
       '--output-format', 'stream-json',
       '--verbose',
+      '--setting-sources', 'project,local',
       '--system-prompt', 'be brief',
       '-p', 'hello',
     ])

--- a/server/providers/claude-adapter.ts
+++ b/server/providers/claude-adapter.ts
@@ -53,6 +53,14 @@ const COMMON_FLAGS = [
   '--tools', 'default',
   '--output-format', 'stream-json',
   '--verbose',
+  // Isolate hub-spawned claude from the *user's* global Claude config. Without
+  // this, the child loads ~/.claude (user CLAUDE.md memory, plugins like
+  // claude-mem, SessionStart hooks). That bled cross-project memory into
+  // Explore turns (e.g. an unrelated "fighting game" surfaced for a fresh
+  // project) and inflated spec-gen tool usage past --max-turns. `project,local`
+  // still loads the target repo's own .claude settings + CLAUDE.md, which is
+  // exactly the context a hub run should see.
+  '--setting-sources', 'project,local',
 ] as const
 
 function buildClaudeArgs(action: SpawnAction, opts: SpawnOptions): string[] {


### PR DESCRIPTION
## Problem

Two coupled bugs surfaced from Explore Spec and Quick "add spec", with **one root cause**: hub-spawned `claude` inherited the *user's* global Claude config (`~/.claude` CLAUDE.md memory, plugins like claude-mem, SessionStart hooks).

1. **Explore Spec leaked cross-project memory** — claude-mem's SessionStart hook injected an unrelated project's context (a "fighting game") into a brand-new, empty project's conversation. The explore-cwd's own `CLAUDE.md` was correct; the user-global config bled in on top.
2. **Quick "add spec" (full scope) failed with opaque `Process exited with code 1`** — with `Read,Grep,Glob` granted, the model burned its whole `--max-turns 6` budget exploring and exited non-zero (`subtype: error_max_turns`). The hub surfaced only the exit code, no stderr.

Both reproduced end-to-end against a fresh project.

## Fix

- **`claude-adapter` `COMMON_FLAGS`:** add `--setting-sources project,local` so every hub-spawned `claude` loads only the **target repo's** `.claude` config — never the user's global memory/plugins/hooks. Kills the cross-project leak and the noise that inflated tool usage.
- **spec-gen `--max-turns` 6 → 15** for full scope (comfortable headroom; the bound still guards runaway loops).
- **spec-gen close handler:** salvage a complete spec emitted before `error_max_turns` instead of failing, and report a human-readable reason instead of the bare exit code.

## Verification

- Reproduced original failure: `--max-turns 6` + tools → `error_max_turns` → exit 1.
- After fix, faithful spec-gen invocation against a fresh repo: **succeeds, 8/15 turns**.
- `tsc` clean; adapter + project-router + chat-manager + manager tests green (360+).

## Follow-up (not in this PR)

`proposal-manager.ts` and `spec-launcher-manager.ts` also spawn `claude`; if they build args without the adapter they may share the same global-config leak. Worth a separate audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)