### PR TITLE
fix(desktop): use NOSYSTEM + absent global config in Windows arm64 smoke test

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -362,7 +362,11 @@ jobs:
           # Functional git check: init + commit + log exercises git-core helpers/templates.
           $tmp = Join-Path $env:TEMP ("smokegit-" + [guid]::NewGuid())
           New-Item -ItemType Directory -Path $tmp | Out-Null
-          $env:GIT_CONFIG_GLOBAL = "NUL"; $env:GIT_CONFIG_SYSTEM = "NUL"
+          # Hermetic git config without the "NUL" device: GIT_CONFIG_SYSTEM=NUL throws
+          # "fatal: unable to access 'NUL': Invalid argument" on the Windows arm64
+          # PortableGit build. Disable system config via NOSYSTEM and point the global
+          # config at a path that doesn't exist (git treats a missing global config as empty).
+          $env:GIT_CONFIG_NOSYSTEM = "1"; $env:GIT_CONFIG_GLOBAL = (Join-Path $tmp ".gitconfig-absent")
           & $git -C $tmp init -q;  if ($LASTEXITCODE -ne 0) { Write-Error "git init failed"; exit 1 }
           & $git -C $tmp -c user.email=ci@specrails.dev -c user.name=ci commit -q --allow-empty -m smoke; if ($LASTEXITCODE -ne 0) { Write-Error "git commit failed"; exit 1 }
           & $git -C $tmp log --oneline; if ($LASTEXITCODE -ne 0) { Write-Error "git log failed"; exit 1 }
@@ -490,7 +494,11 @@ jobs:
           }
           $tmp = Join-Path $env:TEMP ("smokegit-" + [guid]::NewGuid())
           New-Item -ItemType Directory -Path $tmp | Out-Null
-          $env:GIT_CONFIG_GLOBAL = "NUL"; $env:GIT_CONFIG_SYSTEM = "NUL"
+          # Hermetic git config without the "NUL" device: GIT_CONFIG_SYSTEM=NUL throws
+          # "fatal: unable to access 'NUL': Invalid argument" on the Windows arm64
+          # PortableGit build. Disable system config via NOSYSTEM and point the global
+          # config at a path that doesn't exist (git treats a missing global config as empty).
+          $env:GIT_CONFIG_NOSYSTEM = "1"; $env:GIT_CONFIG_GLOBAL = (Join-Path $tmp ".gitconfig-absent")
           & $git -C $tmp init -q;  if ($LASTEXITCODE -ne 0) { Write-Error "git init failed"; exit 1 }
           & $git -C $tmp -c user.email=ci@specrails.dev -c user.name=ci commit -q --allow-empty -m smoke; if ($LASTEXITCODE -ne 0) { Write-Error "git commit failed"; exit 1 }
           & $git -C $tmp log --oneline; if ($LASTEXITCODE -ne 0) { Write-Error "git log failed"; exit 1 }


### PR DESCRIPTION
## Problem

`GIT_CONFIG_SYSTEM=NUL` throws `fatal: unable to access NUL: Invalid argument` on the Windows **arm64** PortableGit build. That fails the bundled-runtimes smoke test (`git init`) and skips the deploy job for the **whole release**.

## Fix

Replace the `NUL` device trick with `GIT_CONFIG_NOSYSTEM=1` plus a non-existent `GIT_CONFIG_GLOBAL` path (git treats a missing global config as empty), in both the x64 and arm64 smoke steps.

- `.github/workflows/desktop-release.yml` (+10 / −2)

Single-purpose CI fix; unblocks the desktop deploy/release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)