### PR TITLE
fix(desktop): reliable self-update restart + premium update toast

### DIFF
--- a/client/src/globals.css
+++ b/client/src/globals.css
@@ -642,3 +642,119 @@
   }
 }
 
+/* ─────────────────────────────────────────────────────────────────────────────
+ * Premium desktop self-update toast (see hooks/useDesktopUpdateNotifier.tsx).
+ * Fixed-height, accent-driven card with CSS-only motion. `--u-accent` is set
+ * per-state inline on `.u-update-card`. All motion degrades to a static state
+ * under prefers-reduced-motion.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+/* Top accent hairline — the "alive" cue. */
+.u-update-card .u-glow {
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--u-accent), transparent);
+  opacity: 0.45;
+  pointer-events: none;
+}
+.u-update-card[data-state='downloading'] .u-glow,
+.u-update-card[data-state='installing'] .u-glow {
+  animation: u-glow-pulse 2.2s ease-in-out infinite;
+}
+.u-update-card[data-state='ready'] .u-glow {
+  animation: u-glow-flash 0.6s ease-out;
+  opacity: 0.6;
+}
+.u-update-card[data-state='error'] .u-glow {
+  opacity: 0.15;
+}
+@keyframes u-glow-pulse {
+  0%, 100% { opacity: 0.3; }
+  50% { opacity: 0.85; }
+}
+@keyframes u-glow-flash {
+  0% { opacity: 0.4; }
+  40% { opacity: 1; }
+  100% { opacity: 0.6; }
+}
+
+/* Determinate progress shimmer (sweeps only the filled portion). */
+.u-update-card .u-shimmer {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    color-mix(in srgb, var(--color-foreground) 26%, transparent),
+    transparent
+  );
+  transform: translateX(-130%);
+  animation: u-shimmer 1.15s linear infinite;
+  pointer-events: none;
+}
+@keyframes u-shimmer {
+  0% { transform: translateX(-130%); }
+  100% { transform: translateX(230%); }
+}
+
+/* Indeterminate sweep (installing, or downloading with unknown total). */
+.u-update-card .u-indeterminate {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -35%;
+  width: 35%;
+  border-radius: 9999px;
+  background: linear-gradient(90deg, transparent, var(--u-accent), transparent);
+  animation: u-indeterminate 1.1s ease-in-out infinite;
+  pointer-events: none;
+}
+@keyframes u-indeterminate {
+  0% { left: -35%; }
+  100% { left: 100%; }
+}
+
+/* Slow cog rotation while installing. */
+.u-update-card .u-spin {
+  animation: u-spin 2.4s linear infinite;
+  transform-origin: center;
+}
+@keyframes u-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Success checkmark draw-in + badge pop on ready. */
+.u-update-card .u-check path {
+  stroke-dasharray: 24;
+  stroke-dashoffset: 24;
+  animation: u-check-draw 0.42s ease-out forwards;
+}
+@keyframes u-check-draw {
+  to { stroke-dashoffset: 0; }
+}
+.u-update-card[data-state='ready'] .u-badge {
+  animation: u-pop 0.3s ease-out;
+}
+@keyframes u-pop {
+  0% { transform: scale(0.7); opacity: 0.5; }
+  60% { transform: scale(1.08); }
+  100% { transform: scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .u-update-card .u-glow,
+  .u-update-card[data-state='downloading'] .u-glow,
+  .u-update-card[data-state='installing'] .u-glow,
+  .u-update-card[data-state='ready'] .u-glow,
+  .u-update-card .u-shimmer,
+  .u-update-card .u-indeterminate,
+  .u-update-card .u-spin,
+  .u-update-card[data-state='ready'] .u-badge {
+    animation: none;
+  }
+  .u-update-card .u-shimmer { display: none; }
+  .u-update-card .u-indeterminate { left: 0; width: 100%; opacity: 0.5; }
+  .u-update-card .u-check path { stroke-dashoffset: 0; }
+}
+

--- a/client/src/hooks/__tests__/useDesktopUpdateNotifier.test.tsx
+++ b/client/src/hooks/__tests__/useDesktopUpdateNotifier.test.tsx
@@ -1,14 +1,18 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { renderHook, waitFor } from '../../test-utils'
+import { renderHook, waitFor, render, screen, fireEvent } from '../../test-utils'
 
 const customMock = vi.fn()
 const dismissMock = vi.fn()
+const successMock = vi.fn()
 const checkMock = vi.fn()
+const relaunchMock = vi.fn()
+const invokeMock = vi.fn()
 
 vi.mock('sonner', () => ({
   toast: {
     custom: (...args: unknown[]) => customMock(...args),
     dismiss: (...args: unknown[]) => dismissMock(...args),
+    success: (...args: unknown[]) => successMock(...args),
   },
 }))
 
@@ -17,12 +21,19 @@ vi.mock('@tauri-apps/plugin-updater', () => ({
 }))
 
 vi.mock('@tauri-apps/plugin-process', () => ({
-  relaunch: vi.fn(),
+  relaunch: (...args: unknown[]) => relaunchMock(...args),
 }))
 
-import { useDesktopUpdateNotifier } from '../useDesktopUpdateNotifier'
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}))
 
-function createTauriUpdate() {
+import { useDesktopUpdateNotifier, DesktopUpdateToast } from '../useDesktopUpdateNotifier'
+
+type ToastUpdate = Parameters<typeof DesktopUpdateToast>[0]['update']
+type DownloadEventArg = Parameters<Parameters<ToastUpdate['downloadAndInstall']>[0]>[0]
+
+function createTauriUpdate(): ToastUpdate {
   return {
     currentVersion: '1.50.0',
     version: '99.0.0-test',
@@ -34,7 +45,10 @@ describe('useDesktopUpdateNotifier', () => {
   beforeEach(() => {
     customMock.mockReset()
     dismissMock.mockReset()
+    successMock.mockReset()
     checkMock.mockReset()
+    relaunchMock.mockReset()
+    invokeMock.mockReset()
     localStorage.clear()
     ;(window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {}
     checkMock.mockResolvedValue(createTauriUpdate())
@@ -57,6 +71,7 @@ describe('useDesktopUpdateNotifier', () => {
       duration: Infinity,
       dismissible: false,
       unstyled: true,
+      closeButton: false,
     })
   })
 
@@ -66,5 +81,190 @@ describe('useDesktopUpdateNotifier', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 30))
     expect(customMock).not.toHaveBeenCalled()
+  })
+
+  it('does nothing outside a Tauri runtime when mock mode is off', async () => {
+    delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__
+    renderHook(() => useDesktopUpdateNotifier())
+
+    await new Promise((resolve) => setTimeout(resolve, 30))
+    expect(checkMock).not.toHaveBeenCalled()
+    expect(customMock).not.toHaveBeenCalled()
+  })
+
+  it('swallows a failed update check without surfacing a toast', async () => {
+    checkMock.mockRejectedValue(new Error('network down'))
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    renderHook(() => useDesktopUpdateNotifier())
+
+    await waitFor(() => {
+      expect(warnSpy).toHaveBeenCalled()
+    })
+    expect(customMock).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+})
+
+describe('DesktopUpdateToast', () => {
+  beforeEach(() => {
+    dismissMock.mockReset()
+    successMock.mockReset()
+    relaunchMock.mockReset()
+    invokeMock.mockReset()
+    invokeMock.mockResolvedValue(undefined)
+    localStorage.clear()
+  })
+
+  it('renders the available state with a version delta pill', () => {
+    render(<DesktopUpdateToast update={createTauriUpdate()} />)
+    expect(screen.getByText('Update available')).toBeInTheDocument()
+    expect(screen.getByText('1.50.0 → 99.0.0-test')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Update' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Dismiss' })).toBeInTheDocument()
+  })
+
+  it('shows determinate progress with a progressbar role while downloading', async () => {
+    let resolveInstall: (() => void) | undefined
+    const update: ToastUpdate = {
+      currentVersion: '1.50.0',
+      version: '99.0.0-test',
+      downloadAndInstall: vi.fn(
+        (onEvent: (e: DownloadEventArg) => void) =>
+          new Promise<void>((resolve) => {
+            onEvent({ event: 'Started', data: { contentLength: 1000 } } as DownloadEventArg)
+            onEvent({ event: 'Progress', data: { chunkLength: 500 } } as DownloadEventArg)
+            resolveInstall = resolve
+          }),
+      ),
+    }
+    render(<DesktopUpdateToast update={update} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+    const bar = await screen.findByRole('progressbar')
+    expect(bar).toHaveAttribute('aria-valuenow', '50')
+    expect(screen.getByText(/50% ·/)).toBeInTheDocument()
+
+    resolveInstall?.()
+    await screen.findByRole('button', { name: 'Restart' })
+  })
+
+  it('renders an indeterminate installing state with a disabled button', async () => {
+    const update: ToastUpdate = {
+      currentVersion: '1.50.0',
+      version: '99.0.0-test',
+      downloadAndInstall: vi.fn(
+        (onEvent: (e: DownloadEventArg) => void) =>
+          new Promise<void>(() => {
+            onEvent({ event: 'Started', data: { contentLength: 1000 } } as DownloadEventArg)
+            onEvent({ event: 'Progress', data: { chunkLength: 1000 } } as DownloadEventArg)
+            onEvent({ event: 'Finished' } as DownloadEventArg)
+          }),
+      ),
+    }
+    render(<DesktopUpdateToast update={update} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+    expect(await screen.findByText('Installing update')).toBeInTheDocument()
+    const btn = screen.getByRole('button', { name: 'Installing…' })
+    expect(btn).toBeDisabled()
+  })
+
+  it('reaches the ready state and restarts via the restart_app command', async () => {
+    const update: ToastUpdate = {
+      currentVersion: '1.50.0',
+      version: '99.0.0-test',
+      downloadAndInstall: vi.fn(async (onEvent: (e: DownloadEventArg) => void) => {
+        onEvent({ event: 'Started', data: { contentLength: 1000 } } as DownloadEventArg)
+        onEvent({ event: 'Progress', data: { chunkLength: 1000 } } as DownloadEventArg)
+        onEvent({ event: 'Finished' } as DownloadEventArg)
+      }),
+    }
+    render(<DesktopUpdateToast update={update} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+    const restart = await screen.findByRole('button', { name: 'Restart' })
+    expect(screen.getByText('Update ready')).toBeInTheDocument()
+    fireEvent.click(restart)
+    expect(invokeMock).toHaveBeenCalledWith('restart_app')
+    expect(relaunchMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to relaunch() when the restart command is unavailable', async () => {
+    invokeMock.mockRejectedValue(new Error('command not found'))
+    const update: ToastUpdate = {
+      currentVersion: '1.50.0',
+      version: '99.0.0-test',
+      downloadAndInstall: vi.fn(async (onEvent: (e: DownloadEventArg) => void) => {
+        onEvent({ event: 'Finished' } as DownloadEventArg)
+      }),
+    }
+    render(<DesktopUpdateToast update={update} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Update' }))
+    const restart = await screen.findByRole('button', { name: 'Restart' })
+    fireEvent.click(restart)
+    await waitFor(() => expect(relaunchMock).toHaveBeenCalled())
+  })
+
+  it('mock updates confirm with a success toast instead of restarting', async () => {
+    const update: ToastUpdate = {
+      currentVersion: '1.40.1',
+      version: '99.0.0-test',
+      isMock: true,
+      downloadAndInstall: vi.fn(async (onEvent: (e: DownloadEventArg) => void) => {
+        onEvent({ event: 'Finished' } as DownloadEventArg)
+      }),
+    }
+    render(<DesktopUpdateToast update={update} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Update' }))
+    const restart = await screen.findByRole('button', { name: 'Restart' })
+    fireEvent.click(restart)
+    expect(successMock).toHaveBeenCalled()
+    expect(dismissMock).toHaveBeenCalledWith('specrails-hub-desktop-update')
+    expect(invokeMock).not.toHaveBeenCalled()
+  })
+
+  it('surfaces an error state with a Try again action and alert role', async () => {
+    const update: ToastUpdate = {
+      currentVersion: '1.50.0',
+      version: '99.0.0-test',
+      downloadAndInstall: vi.fn(async () => {
+        throw new Error('signature mismatch')
+      }),
+    }
+    render(<DesktopUpdateToast update={update} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+    expect(await screen.findByText('Update failed')).toBeInTheDocument()
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
+  })
+
+  it('persists the dismissed version and closes the toast on Dismiss', () => {
+    const onClose = vi.fn()
+    render(<DesktopUpdateToast update={createTauriUpdate()} onClose={onClose} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }))
+
+    expect(localStorage.getItem('specrails-hub:dismissedDesktopUpdateVersion')).toBe('99.0.0-test')
+    expect(dismissMock).toHaveBeenCalledWith('specrails-hub-desktop-update')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('closes without persisting when choosing Later from the ready state', async () => {
+    const onClose = vi.fn()
+    const update: ToastUpdate = {
+      currentVersion: '1.50.0',
+      version: '99.0.0-test',
+      downloadAndInstall: vi.fn(async (onEvent: (e: DownloadEventArg) => void) => {
+        onEvent({ event: 'Finished' } as DownloadEventArg)
+      }),
+    }
+    render(<DesktopUpdateToast update={update} onClose={onClose} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Update' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Later' }))
+
+    expect(dismissMock).toHaveBeenCalledWith('specrails-hub-desktop-update')
+    expect(localStorage.getItem('specrails-hub:dismissedDesktopUpdateVersion')).toBeNull()
+    expect(onClose).toHaveBeenCalled()
   })
 })

--- a/client/src/hooks/useDesktopUpdateNotifier.tsx
+++ b/client/src/hooks/useDesktopUpdateNotifier.tsx
@@ -1,10 +1,13 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { check, type DownloadEvent, type Update } from '@tauri-apps/plugin-updater'
 import { relaunch } from '@tauri-apps/plugin-process'
+import { invoke } from '@tauri-apps/api/core'
 import { toast } from 'sonner'
+import { DownloadCloud, Cog, Check, AlertTriangle } from 'lucide-react'
 
 const DISMISSED_UPDATE_KEY = 'specrails-hub:dismissedDesktopUpdateVersion'
 const UPDATE_TOAST_ID = 'specrails-hub-desktop-update'
+const RECHECK_INTERVAL_MS = 6 * 60 * 60 * 1000 // 6h — surface releases published mid-session
 
 type UpdateToastState = 'available' | 'downloading' | 'installing' | 'ready' | 'error'
 
@@ -72,7 +75,70 @@ function dismissVersion(version: string): void {
   toast.dismiss(UPDATE_TOAST_ID)
 }
 
-function DesktopUpdateToast({ update }: { update: DesktopUpdate }) {
+// Per-state accent token (semantic theme tokens only — never brand-named).
+// `error` keeps the primary accent for chrome and conveys failure via icon + copy,
+// honouring the theme token contract (no destructive token in the allow-list).
+function accentFor(state: UpdateToastState): string {
+  switch (state) {
+    case 'downloading':
+      return 'var(--color-accent-info)'
+    case 'ready':
+      return 'var(--color-accent-success)'
+    default:
+      return 'var(--color-accent-primary)'
+  }
+}
+
+function StateIcon({ state }: { state: UpdateToastState }) {
+  const cls = 'h-[15px] w-[15px]'
+  if (state === 'installing') return <Cog className={`${cls} u-spin`} aria-hidden />
+  if (state === 'ready') return <Check className={`${cls} u-check`} aria-hidden />
+  if (state === 'error') return <AlertTriangle className={cls} aria-hidden />
+  return <DownloadCloud className={cls} aria-hidden />
+}
+
+/** Always-mounted progress track. Its inner fill/animation differs per state, but
+ * the row itself never unmounts — keeping the card height invariant so sonner's
+ * once-on-mount height measurement stays valid (no stacking jank / clipping). */
+function ProgressTrack({
+  state,
+  progress,
+}: {
+  state: UpdateToastState
+  progress: number | null
+}) {
+  const determinate = state === 'downloading' && progress != null
+  const indeterminate = state === 'installing' || (state === 'downloading' && progress == null)
+  const full = state === 'ready'
+
+  return (
+    <div className="relative h-1.5 w-full overflow-hidden rounded-full border border-border/30 bg-background/70">
+      {determinate && (
+        <div
+          className="relative h-full overflow-hidden rounded-full bg-[color:var(--u-accent)] transition-[width] duration-300 ease-out"
+          style={{ width: `${progress}%` }}
+          role="progressbar"
+          aria-valuenow={progress ?? 0}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        >
+          <span className="u-shimmer" aria-hidden />
+        </div>
+      )}
+      {indeterminate && <span className="u-indeterminate" aria-hidden />}
+      {full && <div className="h-full w-full rounded-full bg-[color:var(--u-accent)]/80" aria-hidden />}
+      {/* available / error → empty dim track (nothing rendered) */}
+    </div>
+  )
+}
+
+export function DesktopUpdateToast({
+  update,
+  onClose,
+}: {
+  update: DesktopUpdate
+  onClose?: () => void
+}) {
   const [state, setState] = useState<UpdateToastState>('available')
   const [downloaded, setDownloaded] = useState(0)
   const [total, setTotal] = useState<number | null>(null)
@@ -105,99 +171,188 @@ function DesktopUpdateToast({ update }: { update: DesktopUpdate }) {
     }
   }
 
+  function handleRestart() {
+    if (update.isMock) {
+      toast.success('Mock update ready — restart skipped', { duration: 2500 })
+      toast.dismiss(UPDATE_TOAST_ID)
+      onClose?.()
+      return
+    }
+    // Use the Rust `restart_app` command (not plugin-process relaunch directly):
+    // it terminates the sidecar and waits for port 4200 to free BEFORE restarting,
+    // so the relaunched instance never hits a port conflict (no second restart).
+    void invoke('restart_app').catch(() => {
+      // Fallback for older hosts without the command registered.
+      void relaunch()
+    })
+  }
+
   const progress = total && total > 0 ? Math.min(100, Math.round((downloaded / total) * 100)) : null
+
+  const accent = accentFor(state)
+  const busy = state === 'downloading' || state === 'installing'
+
+  const title =
+    state === 'downloading'
+      ? 'Downloading update'
+      : state === 'installing'
+        ? 'Installing update'
+        : state === 'ready'
+          ? 'Update ready'
+          : state === 'error'
+            ? 'Update failed'
+            : 'Update available'
+
   const description =
     state === 'available'
-      ? `Current ${update.currentVersion} -> ${update.version}`
+      ? 'A new version of SpecRails Hub is ready to install.'
       : state === 'downloading'
         ? progress == null
-          ? `Downloading ${formatBytes(downloaded)}`
-          : `Downloading ${progress}% (${formatBytes(downloaded)} of ${formatBytes(total ?? 0)})`
+          ? `Fetching ${formatBytes(downloaded)}…`
+          : `${progress}% · ${formatBytes(downloaded)} of ${formatBytes(total ?? 0)}`
         : state === 'installing'
-          ? 'Verifying signature and installing...'
+          ? 'Verifying signature and finishing up…'
           : state === 'ready'
-            ? 'Restart to finish installing the update.'
-            : error ?? 'Update failed'
+            ? `Restart to launch version ${update.version}.`
+            : (error && error.length <= 80 ? error : 'Couldn’t complete the update. Please try again.')
+
+  // Right-hand pill: version delta when idle, status word while working, hidden on error.
+  const pill =
+    state === 'available'
+      ? `${update.currentVersion} → ${update.version}`
+      : state === 'downloading'
+        ? 'Downloading'
+        : state === 'installing'
+          ? 'Installing'
+          : state === 'ready'
+            ? 'Ready'
+            : null
 
   return (
-    <div className="w-[372px] rounded-lg border border-accent-primary/35 bg-surface/95 p-3 shadow-2xl shadow-black/40">
-      <div className="flex items-start gap-3">
-        <div className="mt-0.5 h-2.5 w-2.5 rounded-full bg-accent-primary shadow-[0_0_16px_hsl(265_89%_78%)]" />
-        <div className="min-w-0 flex-1">
-          <p className="text-xs font-semibold text-foreground">SpecRails Hub {update.version} is available</p>
-          <p className="mt-1 text-[11px] leading-4 text-muted-foreground">{description}</p>
-          {state === 'downloading' && progress != null && (
-            <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-background">
-              <div
-                className="h-full rounded-full bg-accent-primary transition-[width]"
-                style={{ width: `${progress}%` }}
-              />
-            </div>
-          )}
-          <div className="mt-3 flex items-center gap-2">
-            {state === 'ready' ? (
-              <button
-                type="button"
-                className="rounded-md border border-accent-primary/40 bg-accent-primary/20 px-3 py-1.5 text-[11px] font-medium text-foreground hover:bg-accent-primary/30"
-                onClick={() => {
-                  if (update.isMock) {
-                    toast.dismiss(UPDATE_TOAST_ID)
-                    return
-                  }
-                  void relaunch()
-                }}
-              >
-                Restart
-              </button>
-            ) : (
-              <button
-                type="button"
-                className="rounded-md border border-accent-primary/40 bg-accent-primary/20 px-3 py-1.5 text-[11px] font-medium text-foreground hover:bg-accent-primary/30 disabled:cursor-not-allowed disabled:opacity-60"
-                disabled={state === 'downloading' || state === 'installing'}
-                onClick={() => void installUpdate()}
-              >
-                Update
-              </button>
-            )}
+    <div
+      className="u-update-card relative flex w-full flex-col gap-2 overflow-hidden"
+      style={{ ['--u-accent' as string]: accent }}
+      role={state === 'error' ? 'alert' : 'status'}
+      aria-live={state === 'error' ? 'assertive' : 'polite'}
+      data-state={state}
+    >
+      {/* Top accent hairline — static at rest, pulsing while working, flash on ready */}
+      <span className="u-glow" aria-hidden />
+
+      <div className="flex items-center gap-2.5">
+        <span
+          className="u-badge grid h-7 w-7 shrink-0 place-items-center rounded-lg border border-border/50 bg-background/60 text-[color:var(--u-accent)]"
+          aria-hidden
+        >
+          <StateIcon state={state} />
+        </span>
+        <span className="min-w-0 flex-1 truncate text-[13px] font-semibold leading-tight text-foreground">
+          {title}
+        </span>
+        {pill != null && (
+          <span
+            className="shrink-0 whitespace-nowrap rounded-md border border-border/40 bg-background/60 px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-muted-foreground"
+            style={state !== 'available' ? { color: 'var(--u-accent)' } : undefined}
+          >
+            {pill}
+          </span>
+        )}
+      </div>
+
+      <p className="h-4 truncate text-[11px] leading-4 text-muted-foreground" data-testid="update-description">
+        {description}
+      </p>
+
+      <ProgressTrack state={state} progress={progress} />
+
+      <div className="flex items-center justify-end gap-1.5">
+        {state === 'ready' ? (
+          <>
             <button
               type="button"
-              className="rounded-md px-3 py-1.5 text-[11px] font-medium text-muted-foreground hover:bg-background/70 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
-              disabled={state === 'downloading' || state === 'installing'}
-              onClick={() => dismissVersion(update.version)}
+              className="inline-grid h-7 min-w-[64px] place-items-center rounded-lg border border-[color:var(--u-accent)]/45 bg-[color:var(--u-accent)]/15 px-3 text-[11px] font-semibold leading-none text-foreground transition-colors hover:bg-[color:var(--u-accent)]/25"
+              onClick={handleRestart}
+            >
+              Restart
+            </button>
+            <button
+              type="button"
+              className="h-7 rounded-lg px-2.5 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-background/70 hover:text-foreground"
+              onClick={() => {
+                toast.dismiss(UPDATE_TOAST_ID)
+                onClose?.()
+              }}
+            >
+              Later
+            </button>
+          </>
+        ) : (
+          <>
+            <button
+              type="button"
+              className="inline-grid h-7 min-w-[64px] place-items-center rounded-lg border border-[color:var(--u-accent)]/45 bg-[color:var(--u-accent)]/15 px-3 text-[11px] font-semibold leading-none text-foreground transition-colors hover:bg-[color:var(--u-accent)]/25 disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={busy}
+              onClick={() => void installUpdate()}
+            >
+              {state === 'installing' ? 'Installing…' : state === 'error' ? 'Try again' : 'Update'}
+            </button>
+            <button
+              type="button"
+              className="h-7 rounded-lg px-2.5 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-background/70 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
+              disabled={busy}
+              onClick={() => {
+                dismissVersion(update.version)
+                onClose?.()
+              }}
             >
               Dismiss
             </button>
-          </div>
-        </div>
+          </>
+        )}
       </div>
     </div>
   )
 }
 
 export function useDesktopUpdateNotifier() {
-  const didCheck = useRef(false)
-
   useEffect(() => {
     const useMockUpdate = isMockUpdateEnabled()
-    if (didCheck.current || (!useMockUpdate && !isTauriRuntime())) return
-    didCheck.current = true
+    if (!useMockUpdate && !isTauriRuntime()) return
+
+    let cancelled = false
+    const shown = { current: false }
 
     async function checkForUpdate() {
+      if (cancelled || shown.current) return
       try {
         const update = useMockUpdate ? createMockUpdate() : await check()
-        if (!update || readDismissedVersion() === update.version) return
-
-        toast.custom(() => <DesktopUpdateToast update={update} />, {
+        if (cancelled || !update || readDismissedVersion() === update.version) return
+        shown.current = true
+        toast.custom(() => <DesktopUpdateToast update={update} onClose={() => { shown.current = false }} />, {
           id: UPDATE_TOAST_ID,
           duration: Infinity,
           dismissible: false,
           unstyled: true,
+          closeButton: false,
+          onDismiss: () => { shown.current = false },
+          onAutoClose: () => { shown.current = false },
         })
       } catch (err) {
         console.warn('[desktop-update] update check failed:', err)
+        // leave shown=false so the next interval tick retries
       }
     }
 
     void checkForUpdate()
+    // Periodic re-check: recovers from a transient failure at launch and surfaces
+    // releases published while the app stays open. The fixed toast id + the
+    // dismissed-version gate keep this idempotent; `shown` avoids disrupting an
+    // in-progress download.
+    const interval = setInterval(() => void checkForUpdate(), RECHECK_INTERVAL_MS)
+
+    return () => {
+      cancelled = true
+      clearInterval(interval)
+    }
   }, [])
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -52,15 +52,22 @@ const parentPidArg = process.argv.find((a) => a.startsWith('--parent-pid='))
 if (parentPidArg) {
   const parentPid = parseInt(parentPidArg.split('=')[1], 10)
   if (!isNaN(parentPid)) {
-    setInterval(() => {
+    // Poll at 1s (not 3s): on a self-update relaunch the Tauri host exits and the
+    // freshly-launched instance needs port 4200 freed fast. The old 3s latency
+    // raced the new instance's startup port check and produced "port already in
+    // use". Faster detection + a graceful exit shrinks that window.
+    const watchdog = setInterval(() => {
       try {
         // signal 0 = existence check only, does not actually send a signal
         process.kill(parentPid, 0)
       } catch {
-        // Parent process is gone — terminate cleanly
-        process.exit(0)
+        // Parent process is gone — shut down GRACEFULLY (tree-kill child rails,
+        // PTYs, remove the PID file, release the port) instead of a bare
+        // process.exit(0) that orphans children and leaks the PID file.
+        clearInterval(watchdog)
+        void shutdown()
       }
-    }, 3000)
+    }, 1000)
   }
 }
 
@@ -414,7 +421,11 @@ server.listen(port, '127.0.0.1', () => {
 
 // ─── Clean shutdown ───────────────────────────────────────────────────────────
 
+let shuttingDown = false
 async function shutdown(): Promise<void> {
+  // Idempotent: the watchdog, SIGTERM and SIGINT can all race into here.
+  if (shuttingDown) return
+  shuttingDown = true
   removePidFile()
   try {
     _registry?.shutdown()
@@ -424,10 +435,26 @@ async function shutdown(): Promise<void> {
   } catch { /* ignore */ }
   try { wss.close() } catch { /* ignore */ }
   try { terminalWss.close() } catch { /* ignore */ }
+  // Force-close lingering keep-alive / WebSocket sockets so server.close()'s
+  // callback actually fires. The persistent /ws client connection and terminal
+  // sockets would otherwise hold the server open, stalling the port release that
+  // a relaunching desktop instance is waiting on. (Node 18.2+.)
+  try {
+    ;(server as unknown as { closeAllConnections?: () => void }).closeAllConnections?.()
+  } catch { /* ignore */ }
+  // Hard-exit fallback in case server.close() still hangs.
+  const forceExit = setTimeout(() => process.exit(0), 3000)
+  forceExit.unref?.()
   server.close(() => {
+    clearTimeout(forceExit)
     process.exit(0)
   })
 }
 
 process.on('SIGTERM', () => { void shutdown() })
 process.on('SIGINT', () => { void shutdown() })
+// Last-resort PID-file cleanup for paths that bypass shutdown() (hard crash,
+// uncaught exception). 'exit' handlers must be synchronous.
+process.on('exit', () => {
+  try { fs.unlinkSync(PID_FILE) } catch { /* best effort */ }
+})

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -66,18 +66,65 @@ fn terminate_process(pid: u32) {
 #[cfg(windows)]
 fn terminate_process(pid: u32) {
     use std::process::Command;
-    // Try graceful HTTP shutdown first
-    let _ = reqwest::blocking::Client::new()
-        .post("http://localhost:4200/shutdown")
-        .timeout(Duration::from_secs(2))
-        .send();
-
-    std::thread::sleep(Duration::from_secs(2));
-
-    // Forceful kill as fallback
+    // Windows Node cannot catch a graceful termination signal (taskkill /F issues
+    // a non-catchable TerminateProcess), so there is no point POSTing to a
+    // shutdown route. Kill the whole process tree (/T) so the node sidecar AND its
+    // children (claude/codex rails, node-pty shells) are reaped — without /T the
+    // node process dies but its children are orphaned and keep file/DB locks.
     let _ = Command::new("taskkill")
-        .args(["/PID", &pid.to_string(), "/F"])
+        .args(["/PID", &pid.to_string(), "/T", "/F"])
         .output();
+
+    // Best-effort wait so the caller can rely on port 4200 having been released.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let alive = Command::new("tasklist")
+            .args(["/FI", &format!("PID eq {}", pid), "/NH"])
+            .output()
+            .map(|o| String::from_utf8_lossy(&o.stdout).contains(&pid.to_string()))
+            .unwrap_or(false);
+        if !alive || Instant::now() >= deadline {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(150));
+    }
+}
+
+/// Shared handle to the spawned sidecar PID, exposed to commands via managed state.
+struct SidecarState {
+    pid: Arc<Mutex<Option<u32>>>,
+}
+
+/// Cleanly restart the desktop app after a self-update.
+///
+/// The naive path — calling plugin-process `relaunch()` from the frontend —
+/// races: Tauri's `restart()` exits the host WITHOUT firing `CloseRequested`
+/// (so the sidecar is never terminated by us) and relaunches immediately, while
+/// the old Node sidecar is still listening on port 4200. The freshly-launched
+/// instance then fails its startup port check and the user has to restart a
+/// second time. This command closes that race: it terminates the current
+/// sidecar (and its process tree), waits until port 4200 is actually free, and
+/// only THEN restarts — so the new instance always finds a clean port.
+#[tauri::command]
+fn restart_app(app: tauri::AppHandle, sidecar: tauri::State<'_, SidecarState>) {
+    let pid = *sidecar.pid.lock().unwrap();
+    // Run off the command thread so the `invoke` resolves immediately and the UI
+    // stays responsive while the (up to several second) teardown happens.
+    std::thread::spawn(move || {
+        if let Some(pid) = pid {
+            terminate_process(pid);
+        }
+        // The Node server holds the port; it may take a moment to release after
+        // SIGTERM/taskkill. Wait until the bind succeeds, then restart regardless.
+        let deadline = Instant::now() + Duration::from_secs(8);
+        while Instant::now() < deadline {
+            if check_port_available(SERVER_PORT) {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        app.restart();
+    });
 }
 
 pub fn run() {
@@ -90,8 +137,35 @@ pub fn run() {
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_clipboard_manager::init())
+        .invoke_handler(tauri::generate_handler![restart_app])
         .setup(move |app| {
             let app_handle = app.handle().clone();
+
+            // Expose the sidecar PID to the `restart_app` command.
+            app.manage(SidecarState {
+                pid: Arc::clone(&sidecar_pid_clone),
+            });
+
+            // --- Port conflict check (with a grace window) ---
+            // Run this BEFORE showing/maximizing the window so a conflict bails
+            // out cleanly. During a self-update relaunch (or a quick quit→reopen)
+            // the previous sidecar may still be releasing port 4200 for a second
+            // or two; retry for a grace window instead of an immediate fatal
+            // failure that would force the user to restart a second time.
+            let port_deadline = Instant::now() + Duration::from_secs(10);
+            let mut port_free = check_port_available(SERVER_PORT);
+            while !port_free && Instant::now() < port_deadline {
+                std::thread::sleep(Duration::from_millis(250));
+                port_free = check_port_available(SERVER_PORT);
+            }
+            if !port_free {
+                app_handle
+                    .dialog()
+                    .message("Port 4200 is already in use by another process. Close it and reopen SpecRails Hub.")
+                    .title("SpecRails Hub — Port Conflict")
+                    .blocking_show();
+                std::process::exit(1);
+            }
 
             // --- Force the main window to open maximized ---
             // tauri.conf.json sets `maximized: true`, but macOS's window-state
@@ -99,16 +173,6 @@ pub fn run() {
             // call guarantees the window fills the screen every time.
             if let Some(win) = app.get_webview_window("main") {
                 let _ = win.maximize();
-            }
-
-            // --- Port conflict check ---
-            if !check_port_available(SERVER_PORT) {
-                app_handle
-                    .dialog()
-                    .message("Port 4200 is already in use. Close the conflicting process and try again.")
-                    .title("SpecRails Hub — Port Conflict")
-                    .blocking_show();
-                std::process::exit(1);
             }
 
             // --- Spawn sidecar ---


### PR DESCRIPTION
## Problema

Tres fallos reportados en la funcionalidad de **update** del desktop app:

1. **Tras actualizar y reiniciarse solo, hay que reiniciar otra vez.**
2. **A veces el reinicio falla con "ya existe una ejecución del servidor en background" / puerto en uso.**
3. **El toast de update se ve entrecortado** (cortado por el borde + saltos al cambiar de estado).

Root causes verificadas (búsqueda en docs/issues de Tauri + verificación adversarial sobre el código):

- `relaunch()` → `restart()` de Tauri sale del host **sin** disparar `CloseRequested`, así que el sidecar Node viejo (escuchando en el 4200) **nunca se mata**. La nueva instancia arranca al instante, el puerto sigue ocupado → el check de puerto hace `exit(1)` → el usuario tiene que reabrir.
- El watchdog parent-pid hacía `process.exit(0)` directo → saltaba `shutdown()` → huérfanos (rails/PTYs) + PID file stale.
- El toast custom era `w-[372px]` dentro del contenedor de 356px de sonner → **clip** en el borde derecho; sonner mide la altura **una sola vez**, y los cambios de estado crecían/encogían la tarjeta → **jank**.

## Cambios

### Restart / puerto (síntomas 1 + 2)
- **`src-tauri/src/lib.rs`**: nuevo comando Rust `restart_app` que mata el árbol del sidecar → **espera a que el puerto 4200 quede libre** → entonces reinicia. El frontend lo invoca en vez de `relaunch()` directo (relaunch queda como fallback).
- Check de puerto al arrancar: **reintenta 10s** (ventana de gracia) en vez de `exit(1)` inmediato.
- **`server/index.ts`**: watchdog ahora hace `shutdown()` **graceful** (antes `process.exit(0)` → huérfanos + PID stale); intervalo 3s→**1s**. `shutdown()` idempotente + `closeAllConnections()` (no se cuelga con el socket `/ws` abierto). Handler `'exit'` para limpiar el PID file en crashes.
- Windows `terminate_process`: se elimina el `POST /shutdown` muerto (la ruta nunca existió, siempre 404) y se añade `taskkill /T` (mata el árbol de hijos en vez de dejarlos huérfanos).

### Toast premium (síntoma 3)
- **`useDesktopUpdateNotifier.tsx`** + **`globals.css`**: rebuild completo. `w-full` (encaja en el contenedor), **layout de altura fija** (track de progreso siempre montado, copy en una línea con truncate) → sin clip, sin jank. Motion 100% CSS (shimmer determinado, sweep indeterminado al instalar, cog girando, checkmark dibujándose, glow de acento), solo tokens semánticos de tema, a11y (`role`/`aria-live`/`progressbar`), botón **"Try again"** real en error, re-check periódico (6h) y feedback en mock-restart.

### Rechazado (verificación adversarial)
"Hacer `terminate_process` síncrono en `CloseRequested`" → congelaría la UI 5s en cada cierre y el flujo de update ni siquiera pasa por ahí. Descartado.

## Verificación

- ✅ Typecheck client + server
- ✅ `cargo check` limpio (sin warnings/errores)
- ✅ Client: **2194 tests pass**, coverage 80.73% lines / 71.71% func (gate 80/70)
- ✅ Server: **2379 tests pass**, coverage 82.67% lines / 86.31% func / 71.06% branch (gate 80/80/70)
- 11 tests nuevos para el toast (estados available/downloading/installing/ready/error, restart vía comando + fallback, mock, dismiss).

⚠️ Los cambios de Rust requieren un **rebuild del desktop** (`npm run build:desktop`) para verse en la app empaquetada — no se pueden ejercitar desde el repo. TS/CSS/tests verificados al 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)