### PR TITLE
fix(code-explorer): repair provenance, summaries, security and viewer bugs

### DIFF
--- a/client/src/components/code-explorer/TicketFilesTouched.tsx
+++ b/client/src/components/code-explorer/TicketFilesTouched.tsx
@@ -17,12 +17,13 @@ interface Props {
 }
 
 export function TicketFilesTouched({ ticketId, onClose }: Props) {
-  if (!FEATURE_CODE_EXPLORER) return null
-
+  // Hooks must run unconditionally and in a stable order — declare them before
+  // any early return (Rules of Hooks). The feature gate is applied below.
   const navigate = useNavigate()
   const [rows, setRows] = useState<ProvenanceRow[] | null>(null)
 
   useEffect(() => {
+    if (!FEATURE_CODE_EXPLORER) return
     let cancelled = false
     fetch(`${getApiBase()}/code/provenance?ticketId=${ticketId}`)
       .then((r) => (r.ok ? r.json() : []))
@@ -31,6 +32,7 @@ export function TicketFilesTouched({ ticketId, onClose }: Props) {
     return () => { cancelled = true }
   }, [ticketId])
 
+  if (!FEATURE_CODE_EXPLORER) return null
   if (!rows || rows.length === 0) return null
 
   return (

--- a/server/code-explorer-router.test.ts
+++ b/server/code-explorer-router.test.ts
@@ -6,6 +6,20 @@ import os from 'os'
 import path from 'path'
 import { initDb, type DbInstance } from './db'
 import { createCodeExplorerRouter } from './code-explorer-router'
+import { writeSummary, computeFileHash } from './file-summary-manager'
+
+async function storeSummary(rel: string, fileHash: string): Promise<void> {
+  writeSummary(projectPath, rel, {
+    schemaVersion: 1,
+    path: rel,
+    fileHash,
+    summary: 'A summary.',
+    language: 'en',
+    generatedAt: '2026-05-22T00:00:00.000Z',
+    generatedBy: { model: 'claude-haiku-4-5', promptVersion: 1 },
+    triggeredBy: { kind: 'user', id: 'manual', ticketId: null },
+  })
+}
 
 let projectPath: string
 let db: DbInstance
@@ -301,5 +315,131 @@ describe('GET /summary', () => {
     const res = await request(app).get('/api/projects/proj-test/code/summary?path=foo.ts')
     expect(res.status).toBe(200)
     expect(res.body).toEqual({ summary: null })
+  })
+})
+
+describe('summary staleness', () => {
+  it('reports summaryStale=false for a matching hash and true after the file changes', async () => {
+    fs.writeFileSync(path.join(projectPath, 'hello.ts'), 'export const x = 1\n', 'utf8')
+    const hash = await computeFileHash(path.join(projectPath, 'hello.ts'))
+    await storeSummary('hello.ts', hash)
+
+    const fresh = await request(app).get('/api/projects/proj-test/code/summary?path=hello.ts')
+    expect(fresh.status).toBe(200)
+    expect(fresh.body.summary).not.toBeNull()
+    expect(fresh.body.summaryStale).toBe(false)
+
+    // GET /file should agree.
+    const file = await request(app).get('/api/projects/proj-test/code/file?path=hello.ts')
+    expect(file.body.summaryStale).toBe(false)
+
+    // Mutate the file → the stored summary is now stale.
+    fs.writeFileSync(path.join(projectPath, 'hello.ts'), 'export const x = 2\n', 'utf8')
+    const stale = await request(app).get('/api/projects/proj-test/code/summary?path=hello.ts')
+    expect(stale.body.summaryStale).toBe(true)
+  })
+})
+
+describe('Monaco language ids', () => {
+  it('maps .tsx and .jsx to registered Monaco ids (typescript/javascript)', async () => {
+    fs.writeFileSync(path.join(projectPath, 'C.tsx'), 'export const C = () => null\n', 'utf8')
+    fs.writeFileSync(path.join(projectPath, 'd.jsx'), 'export const D = () => null\n', 'utf8')
+    const tsx = await request(app).get('/api/projects/proj-test/code/file?path=C.tsx')
+    expect(tsx.body.language).toBe('typescript')
+    const jsx = await request(app).get('/api/projects/proj-test/code/file?path=d.jsx')
+    expect(jsx.body.language).toBe('javascript')
+  })
+})
+
+describe('deny-list enforcement on content endpoints', () => {
+  it('GET /file returns 403 for denied files (.env, lockfiles)', async () => {
+    fs.writeFileSync(path.join(projectPath, '.env'), 'AWS_SECRET=topsecret', 'utf8')
+    fs.writeFileSync(path.join(projectPath, 'package-lock.json'), '{}', 'utf8')
+    const env = await request(app).get('/api/projects/proj-test/code/file?path=.env')
+    expect(env.status).toBe(403)
+    const lock = await request(app).get('/api/projects/proj-test/code/file?path=package-lock.json')
+    expect(lock.status).toBe(403)
+  })
+
+  it('GET /summary returns 403 for denied files', async () => {
+    fs.writeFileSync(path.join(projectPath, '.env'), 'X=1', 'utf8')
+    const res = await request(app).get('/api/projects/proj-test/code/summary?path=.env')
+    expect(res.status).toBe(403)
+  })
+
+  it('POST /file/regenerate-summary returns 403 for denied files and does not enqueue', async () => {
+    fs.writeFileSync(path.join(projectPath, 'secrets.log'), 'noise', 'utf8')
+    const res = await request(app)
+      .post('/api/projects/proj-test/code/file/regenerate-summary?path=secrets.log')
+      .send({})
+    expect(res.status).toBe(403)
+    expect(enqueueSpy).not.toHaveBeenCalled()
+  })
+
+  it('touched-by-ai tree omits denied files so it matches the all-tree', async () => {
+    fs.writeFileSync(path.join(projectPath, '.env'), 'X=1', 'utf8')
+    db.prepare(
+      `INSERT INTO file_provenance (file_path, ticket_id, job_id, kind, at) VALUES (?, ?, ?, ?, ?)`,
+    ).run('.env', 1, 'job-a', 'modified', Date.now())
+    const r = await request(app).get('/api/projects/proj-test/code/tree?filter=touched-by-ai&withProvenance=1')
+    const paths = (r.body.entries as Array<{ path: string }>).map((e) => e.path)
+    expect(paths).not.toContain('.env')
+  })
+})
+
+describe('symlink path-escape hardening', () => {
+  it('rejects a symlink whose target is outside the project root', async () => {
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'ce-outside-'))
+    fs.writeFileSync(path.join(outside, 'secret.txt'), 'TOP SECRET', 'utf8')
+    let linked = false
+    try {
+      fs.symlinkSync(path.join(outside, 'secret.txt'), path.join(projectPath, 'link.txt'))
+      linked = true
+    } catch {
+      // Platforms without symlink privileges (e.g. Windows non-admin) — skip.
+    }
+    try {
+      if (!linked) return
+      const res = await request(app).get('/api/projects/proj-test/code/file?path=link.txt')
+      expect(res.status).toBe(400)
+    } finally {
+      fs.rmSync(outside, { recursive: true, force: true })
+    }
+  })
+
+  it('still serves a legitimate in-project file (no false rejection)', async () => {
+    fs.writeFileSync(path.join(projectPath, 'real.ts'), 'export const r = 1\n', 'utf8')
+    const res = await request(app).get('/api/projects/proj-test/code/file?path=real.ts')
+    expect(res.status).toBe(200)
+    expect(res.body.content).toBe('export const r = 1\n')
+  })
+})
+
+describe('POST /file/regenerate-summary result surfacing', () => {
+  it('passes force:true so an explicit regenerate bypasses the hash gate', async () => {
+    fs.writeFileSync(path.join(projectPath, 'foo.ts'), 'x', 'utf8')
+    await request(app)
+      .post('/api/projects/proj-test/code/file/regenerate-summary?path=foo.ts')
+      .send({})
+    expect(enqueueSpy.mock.calls[0][0]).toMatchObject({ force: true })
+  })
+
+  it('surfaces skipped:budget as 200 { skipped: "budget" } so the client prompt is reachable', async () => {
+    fs.writeFileSync(path.join(projectPath, 'foo.ts'), 'x', 'utf8')
+    enqueueSpy.mockResolvedValueOnce('skipped:budget')
+    const res = await request(app)
+      .post('/api/projects/proj-test/code/file/regenerate-summary?path=foo.ts')
+      .send({})
+    expect(res.status).toBe(200)
+    expect(res.body.skipped).toBe('budget')
+  })
+
+  it('surfaces a failed enqueue as 500', async () => {
+    fs.writeFileSync(path.join(projectPath, 'foo.ts'), 'x', 'utf8')
+    enqueueSpy.mockResolvedValueOnce('failed')
+    const res = await request(app)
+      .post('/api/projects/proj-test/code/file/regenerate-summary?path=foo.ts')
+      .send({})
+    expect(res.status).toBe(500)
   })
 })

--- a/server/code-explorer-router.ts
+++ b/server/code-explorer-router.ts
@@ -14,6 +14,8 @@ import {
 import {
   readSummary,
   computeFileHash,
+  pathHash,
+  summariesDir,
   type FileSummaryManager,
   type SummaryPayload,
 } from './file-summary-manager'
@@ -45,13 +47,24 @@ function isDenied(entryName: string): boolean {
   return false
 }
 
+// Apply the deny-list to ANY segment of a relative path so the policy is the
+// single source of truth across every surface (tree walk, touched-by-ai list,
+// and the content endpoints) — not just the top-level `all` walk.
+function isDeniedRelPath(rel: string): boolean {
+  return rel.split(/[\\/]/).filter(Boolean).some(isDenied)
+}
+
 function languageForExt(ext: string): string {
   const e = ext.toLowerCase()
   switch (e) {
-    case '.ts': return 'typescript'
-    case '.tsx': return 'typescriptreact'
-    case '.js': return 'javascript'
-    case '.jsx': return 'javascriptreact'
+    case '.ts':
+    case '.tsx':
+    case '.cts':
+    case '.mts': return 'typescript'
+    case '.js':
+    case '.jsx':
+    case '.mjs':
+    case '.cjs': return 'javascript'
     case '.json': return 'json'
     case '.md': return 'markdown'
     case '.py': return 'python'
@@ -252,6 +265,9 @@ function listTouchedEntries(
   const out: Array<{ rel: string; isDir: boolean; size: number | null; mtime: number | null }> = []
 
   for (const filePath of rowsByPath.keys()) {
+    // Keep touched-by-ai consistent with the `all` tree (and never surface
+    // secrets like .env that an AI job happened to touch).
+    if (isDeniedRelPath(filePath)) continue
     const parts = filePath.split('/').filter(Boolean)
     for (let i = 1; i < parts.length; i += 1) {
       const dirRel = parts.slice(0, i).join('/')
@@ -282,6 +298,23 @@ function listTouchedEntries(
     return Number(b.isDir) - Number(a.isDir)
   })
   return out
+}
+
+// Set of summary file basenames (without `.json`), i.e. the path-hash of every
+// file that currently has a summary on disk. One readdir replaces a per-entry
+// readSummary disk hit during the tree walk.
+function readSummaryHashSet(projectPath: string): Set<string> {
+  const set = new Set<string>()
+  let files: string[]
+  try {
+    files = fs.readdirSync(summariesDir(projectPath))
+  } catch {
+    return set
+  }
+  for (const f of files) {
+    if (f.endsWith('.json')) set.add(f.slice(0, -'.json'.length))
+  }
+  return set
 }
 
 export interface CodeExplorerDeps {
@@ -322,7 +355,7 @@ export function createCodeExplorerRouter(deps: CodeExplorerDeps): Router {
     const jobId = parseNonEmptyString(req.query.jobId)
 
     let entries: Array<{ rel: string; isDir: boolean; size: number | null; mtime: number | null }>
-    let touchedRowsByPath = new Map<string, ProvenanceRow[]>()
+    const touchedRowsByPath = new Map<string, ProvenanceRow[]>()
     if (filter === 'touched-by-ai') {
       const rows = listTouchedRows(deps.db, { ticketId, jobId })
       for (const row of rows) {
@@ -333,26 +366,34 @@ export function createCodeExplorerRouter(deps: CodeExplorerDeps): Router {
       entries = listTouchedEntries(deps.projectPath, touchedRowsByPath)
     } else {
       entries = listAllEntries(deps.projectPath)
+      // Batch-load ALL provenance once instead of a per-entry SQL query (N+1).
+      if (withProvenance) {
+        for (const row of listTouchedRows(deps.db, {})) {
+          const existing = touchedRowsByPath.get(row.file_path)
+          if (existing) existing.push(row)
+          else touchedRowsByPath.set(row.file_path, [row])
+        }
+      }
     }
 
     const page = entries.slice(skip, skip + MAX_TREE_PAGE)
     const nextCursor = skip + page.length < entries.length ? encodeCursor(skip + page.length) : null
 
+    // Read the summaries dir ONCE into a Set of path-hashes instead of opening +
+    // parsing a JSON file per entry just to test existence.
+    const summaryHashes = readSummaryHashSet(deps.projectPath)
+
     const out: TreeEntry[] = page.map((e) => {
-      const rawRows = withProvenance
-        ? (filter === 'touched-by-ai' && e.isDir
-            ? []
-            : (touchedRowsByPath.get(e.rel) ?? listByPath(deps.db, deps.projectId, e.rel)))
-        : []
-      const summary = readSummary(deps.projectPath, e.rel)
-      const provenance = withProvenance && filter === 'touched-by-ai' && e.isDir
+      const isTouchedDir = filter === 'touched-by-ai' && e.isDir
+      const rawRows = withProvenance && !isTouchedDir ? (touchedRowsByPath.get(e.rel) ?? []) : []
+      const provenance = withProvenance && isTouchedDir
         ? rollupDirectoryProvenance(touchedRowsByPath, e.rel)
         : rollupProvenance(rawRows)
       return {
         path: e.rel,
         kind: e.isDir ? 'dir' : 'file',
         sizeBytes: e.size,
-        hasSummary: summary != null,
+        hasSummary: !e.isDir && summaryHashes.has(pathHash(e.rel)),
         provenance,
         lastModifiedAt: e.mtime,
       }
@@ -377,6 +418,10 @@ export function createCodeExplorerRouter(deps: CodeExplorerDeps): Router {
     const guard = resolveSafePath(deps.projectPath, relRaw)
     if (!guard) {
       res.status(400).json({ error: 'path traversal not allowed' })
+      return
+    }
+    if (isDeniedRelPath(relRaw)) {
+      res.status(403).json({ error: 'path is excluded by the code-explorer deny-list' })
       return
     }
     const abs = guard
@@ -476,6 +521,10 @@ export function createCodeExplorerRouter(deps: CodeExplorerDeps): Router {
       res.status(400).json({ error: 'path traversal not allowed' })
       return
     }
+    if (isDeniedRelPath(relRaw)) {
+      res.status(403).json({ error: 'path is excluded by the code-explorer deny-list' })
+      return
+    }
     const summary = readSummary(deps.projectPath, relRaw)
     if (!summary) {
       res.json({ summary: null })
@@ -499,6 +548,10 @@ export function createCodeExplorerRouter(deps: CodeExplorerDeps): Router {
     const guard = resolveSafePath(deps.projectPath, relRaw)
     if (!guard) {
       res.status(400).json({ error: 'path traversal not allowed' })
+      return
+    }
+    if (isDeniedRelPath(relRaw)) {
+      res.status(403).json({ error: 'path is excluded by the code-explorer deny-list' })
       return
     }
     let stat: fs.Stats
@@ -534,14 +587,31 @@ export function createCodeExplorerRouter(deps: CodeExplorerDeps): Router {
     }
     const body = (req.body ?? {}) as { overrideBudget?: boolean }
     try {
-      await deps.fileSummaryManager.enqueue({
+      // force: true — an explicit "Regenerate" click should re-summarise even if
+      // the content hash is unchanged (e.g. after a hub language switch).
+      const result = await deps.fileSummaryManager.enqueue({
         projectPath: deps.projectPath,
         projectId: deps.projectId,
         projectSlug: deps.projectId,
         relPath: relRaw,
         triggeredBy: { kind: 'user', id: 'manual', ticketId: null },
         overrideBudget: body.overrideBudget === true,
+        force: true,
       })
+      // Surface the enqueue outcome so the client's budget-override prompt is
+      // reachable. 200 (not 4xx) keeps res.ok true so the client reads `skipped`.
+      if (result === 'skipped:budget') {
+        res.status(200).json({ skipped: 'budget' })
+        return
+      }
+      if (result === 'skipped:per-job-cap') {
+        res.status(200).json({ skipped: 'per-job-cap' })
+        return
+      }
+      if (result === 'failed') {
+        res.status(500).json({ error: 'summary generation failed' })
+        return
+      }
       res.status(202).json({ enqueued: true })
     } catch (err) {
       console.error('[code-explorer-router] enqueue failed:', err)
@@ -607,7 +677,39 @@ function resolveSafePath(projectPath: string, relPath: string): string | null {
   const resolved = path.resolve(projectPath, relPath)
   const root = projectPath.endsWith(path.sep) ? projectPath : projectPath + path.sep
   if (resolved !== projectPath && !resolved.startsWith(root)) return null
-  return resolved
+
+  // Symlink hardening: the lexical check above is defeated by an in-tree symlink
+  // whose target escapes the project (e.g. `link -> /etc/passwd`). Verify the
+  // REAL path stays under the REAL project root. Walk up to the nearest existing
+  // ancestor (so not-yet-created paths — used by the not-found banner and the
+  // regenerate endpoint — still validate), realpath it, then re-append the
+  // missing suffix.
+  let realRoot: string
+  try {
+    realRoot = fs.realpathSync.native(projectPath)
+  } catch {
+    // Project root itself is unreadable — fall back to the lexical result.
+    return resolved
+  }
+  const realRootWithSep = realRoot.endsWith(path.sep) ? realRoot : realRoot + path.sep
+  let probe = resolved
+  const suffix: string[] = []
+  for (;;) {
+    try {
+      const realProbe = fs.realpathSync.native(probe)
+      const realFull = suffix.length > 0
+        ? path.join(realProbe, ...suffix.slice().reverse())
+        : realProbe
+      if (realFull !== realRoot && !realFull.startsWith(realRootWithSep)) return null
+      return resolved
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') return null
+      const parent = path.dirname(probe)
+      if (parent === probe) return null // hit filesystem root without resolving
+      suffix.push(path.basename(probe))
+      probe = parent
+    }
+  }
 }
 
 async function computeStaleness(abs: string, summary: SummaryPayload | null): Promise<boolean> {

--- a/server/file-provenance.test.ts
+++ b/server/file-provenance.test.ts
@@ -13,6 +13,7 @@ import {
   getProvenanceDiff,
   listProvenanceByTicket,
   listProvenanceByPath,
+  listUntracked,
   broadcastProvenanceUpdated,
   type DiffEntry,
   type ProvenanceRow,
@@ -54,23 +55,25 @@ function initGitRepo(): string {
 }
 
 describe('snapshotWorkingTree', () => {
-  it('returns a sha for a dirty repo', () => {
+  it('returns a sha for a dirty repo and captures untracked files', () => {
     const dir = initGitRepo()
     try {
       appendFileSync(join(dir, 'a.txt'), 'change\n')
       writeFileSync(join(dir, 'b.txt'), 'new\n')
-      const sha = snapshotWorkingTree(dir)
-      expect(sha).toMatch(/^[0-9a-f]{40}$/)
+      const snap = snapshotWorkingTree(dir)
+      expect(snap.ref).toMatch(/^[0-9a-f]{40}$/)
+      expect(snap.untracked).toContain('b.txt')
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }
   })
 
-  it('returns empty string for a clean repo', () => {
+  it('returns empty ref and empty untracked for a clean repo', () => {
     const dir = initGitRepo()
     try {
-      const sha = snapshotWorkingTree(dir)
-      expect(sha).toBe('')
+      const snap = snapshotWorkingTree(dir)
+      expect(snap.ref).toBe('')
+      expect(snap.untracked).toEqual([])
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }
@@ -135,6 +138,86 @@ describe('diffAgainstSnapshot', () => {
       rmSync(dir, { recursive: true, force: true })
     }
   })
+
+  it('records rail-created untracked files even when the tree was DIRTY at snapshot time', () => {
+    // Regression: a dirty tree yields a non-empty stash ref; the old code only
+    // ran `git ls-files --others` when the ref was empty, so new untracked files
+    // a rail created were silently lost. Pre-existing untracked files must NOT be
+    // mis-recorded as created.
+    const dir = initGitRepo()
+    try {
+      // Dirty the tree: modify a tracked file AND leave a pre-existing untracked file.
+      appendFileSync(join(dir, 'a.txt'), 'dirty\n')
+      writeFileSync(join(dir, 'preexisting.txt'), 'was here before\n')
+      const snap = snapshotWorkingTree(dir)
+      expect(snap.ref).toMatch(/^[0-9a-f]{40}$/) // dirty → real ref
+      expect(snap.untracked).toContain('preexisting.txt')
+
+      // The "rail" runs: creates a brand-new untracked file + edits the tracked file again.
+      writeFileSync(join(dir, 'rail-new.txt'), 'created by rail\n')
+      appendFileSync(join(dir, 'a.txt'), 'rail edit\n')
+
+      const entries = diffAgainstSnapshot(dir, snap.ref, snap.untracked)
+      const byPath = new Map(entries.map((e) => [e.path, e]))
+      expect(byPath.get('rail-new.txt')?.status).toBe('A') // recorded as created
+      expect(byPath.get('a.txt')?.status).toBe('M')
+      expect(byPath.has('preexisting.txt')).toBe(false) // not the rail's creation
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('maps a typechange (T) status to modified and never desyncs the parser', () => {
+    // Replace a regular file with a symlink → git reports `T`. The next changed
+    // file must still be parsed correctly (no off-by-one corruption).
+    const dir = initGitRepo()
+    try {
+      writeFileSync(join(dir, 'sib.txt'), 'sibling\n')
+      execSync('git add -A', { cwd: dir })
+      execSync('git commit -q -m "add sib"', { cwd: dir })
+      const baselineRef = execSync('git rev-parse HEAD', { cwd: dir, encoding: 'utf8' }).trim()
+
+      unlinkSync(join(dir, 'a.txt'))
+      execSync('ln -s sib.txt a.txt', { cwd: dir }) // a.txt: regular → symlink = typechange
+      appendFileSync(join(dir, 'sib.txt'), 'more\n')
+      execSync('git add -A', { cwd: dir })
+
+      const entries = diffAgainstSnapshot(dir, baselineRef)
+      const byPath = new Map(entries.map((e) => [e.path, e]))
+      expect(byPath.get('a.txt')?.status).toBe('M') // T → M
+      expect(byPath.get('sib.txt')?.status).toBe('M')
+      // No phantom path named after a status letter leaked in.
+      expect(entries.every((e) => e.path === 'a.txt' || e.path === 'sib.txt')).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('listUntracked', () => {
+  it('lists untracked non-ignored files and excludes ignored ones', () => {
+    const dir = initGitRepo()
+    try {
+      writeFileSync(join(dir, '.gitignore'), 'ignored.txt\n')
+      writeFileSync(join(dir, 'untracked.txt'), 'x\n')
+      writeFileSync(join(dir, 'ignored.txt'), 'y\n')
+      const list = listUntracked(dir)
+      expect(list).toContain('untracked.txt')
+      expect(list).toContain('.gitignore')
+      expect(list).not.toContain('ignored.txt')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('returns [] outside a git repo', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fp-nogit-'))
+    try {
+      expect(listUntracked(dir)).toEqual([])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('collectDiffPatches', () => {
@@ -146,6 +229,25 @@ describe('collectDiffPatches', () => {
       const diff = diffAgainstSnapshot(dir, baselineRef)
       const patches = collectDiffPatches(dir, baselineRef, diff)
       expect(patches.get('a.txt')?.patch).toContain('+change')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('synthesizes an added-file patch with the no-newline marker for untracked files', () => {
+    const dir = initGitRepo()
+    try {
+      // Clean tree → empty snapshot ref → untracked files surface as 'A'.
+      writeFileSync(join(dir, 'no-eol.txt'), 'line1\nline2') // no trailing newline
+      writeFileSync(join(dir, 'eol.txt'), 'a\nb\n') // trailing newline
+      const diff = diffAgainstSnapshot(dir, '')
+      const patches = collectDiffPatches(dir, '', diff)
+      const noEol = patches.get('no-eol.txt')?.patch ?? ''
+      const eol = patches.get('eol.txt')?.patch ?? ''
+      expect(noEol).toContain('+line2')
+      expect(noEol).toContain('\\ No newline at end of file')
+      expect(eol).toContain('+b')
+      expect(eol).not.toContain('No newline at end of file')
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }

--- a/server/file-provenance.ts
+++ b/server/file-provenance.ts
@@ -2,7 +2,7 @@ import { execFileSync, execSync } from 'child_process'
 import fs from 'fs'
 import path from 'path'
 import type { DbInstance } from './db'
-import type { WsMessage } from './types'
+import type { WsMessage, FileProvenanceUpdatedMessage } from './types'
 
 export type DiffStatus = 'A' | 'M' | 'D' | 'R'
 
@@ -32,14 +32,56 @@ const MAX_PATCH_BYTES = 512 * 1024
 // in each function degrades a timeout to empty provenance. Mirrors metrics.ts.
 const GIT_TIMEOUT_MS = 15_000
 const GIT_MAX_BUFFER = 16 * 1024 * 1024
-const GIT_EXEC_ENV = {
-  ...process.env,
-  GIT_TERMINAL_PROMPT: '0',
-  GIT_ASKPASS: 'echo',
-  GCM_INTERACTIVE: 'never',
+// Bound on how many per-file patches we collect after a job. Each is a synchronous
+// git spawn on the event loop, so a job touching hundreds of files would otherwise
+// block the whole hub. Provenance ROWS are recorded for every path regardless; only
+// the on-demand diff patches beyond this cap are skipped (the UI shows "diff
+// unavailable" for them). Mirrors the existing large-job warn threshold (50).
+const MAX_PATCH_FILES = 50
+const GIT_EXEC_ENV = (() => {
+  // Inherit the parent env but STRIP git-location vars. If the hub process (or a
+  // parent) ever exports GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE, every cwd-scoped
+  // git call below would silently operate on that repo instead of the project —
+  // corrupting provenance. Always pin git to the cwd we pass.
+  const env: NodeJS.ProcessEnv = { ...process.env }
+  delete env.GIT_DIR
+  delete env.GIT_WORK_TREE
+  delete env.GIT_INDEX_FILE
+  delete env.GIT_COMMON_DIR
+  delete env.GIT_OBJECT_DIRECTORY
+  env.GIT_TERMINAL_PROMPT = '0'
+  env.GIT_ASKPASS = 'echo'
+  env.GCM_INTERACTIVE = 'never'
+  return env
+})()
+
+export interface WorkingTreeSnapshot {
+  /** `git stash create` ref, or '' when the tree was clean / git failed. */
+  ref: string
+  /** Untracked paths present at snapshot time (excluded from "created" later). */
+  untracked: string[]
 }
 
-export function snapshotWorkingTree(cwd: string): string {
+/** List untracked, non-ignored paths in the working tree. Best-effort: any git
+ *  failure (no git, no repo, timeout) degrades to []. */
+export function listUntracked(cwd: string): string[] {
+  try {
+    const out = execSync('git ls-files --others --exclude-standard -z', {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: GIT_TIMEOUT_MS,
+      maxBuffer: GIT_MAX_BUFFER,
+      env: GIT_EXEC_ENV,
+    })
+    return out.split('\0').filter((p) => p.length > 0)
+  } catch {
+    return []
+  }
+}
+
+export function snapshotWorkingTree(cwd: string): WorkingTreeSnapshot {
+  let ref = ''
   try {
     const out = execSync('git stash create --include-untracked', {
       cwd,
@@ -49,22 +91,31 @@ export function snapshotWorkingTree(cwd: string): string {
       maxBuffer: GIT_MAX_BUFFER,
       env: GIT_EXEC_ENV,
     })
-    return out.trim()
+    ref = out.trim()
   } catch (err) {
     const msg = (err as { message?: string }).message ?? ''
     if (/ENOENT|not found|command not found/i.test(msg)) {
       throw err
     }
-    return ''
+    ref = ''
   }
+  // Capture the untracked set NOW so the post-job diff can tell rail-created
+  // files apart from files that were already untracked before the job ran.
+  return { ref, untracked: listUntracked(cwd) }
 }
 
-export function diffAgainstSnapshot(cwd: string, snapshotRef: string): DiffEntry[] {
+export function diffAgainstSnapshot(
+  cwd: string,
+  snapshotRef: string,
+  untrackedBefore?: string[],
+): DiffEntry[] {
   const hasSnap = snapshotRef && snapshotRef.length > 0
   const ref = hasSnap ? snapshotRef : 'HEAD'
   let out = ''
   try {
-    out = execSync(`git diff --name-status -z ${ref} --`, {
+    // --find-renames so rename detection is deterministic regardless of the
+    // user's global `diff.renames` config (matches collectDiffPatches).
+    out = execSync(`git diff --name-status --find-renames -z ${ref} --`, {
       cwd,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -85,11 +136,16 @@ export function diffAgainstSnapshot(cwd: string, snapshotRef: string): DiffEntry
     while (i < tokens.length) {
       const raw = tokens[i]
       const code = raw[0]
-      if (code === 'R') {
+      if (code === 'R' || code === 'C') {
+        // Rename/copy: `<status>\0<old>\0<new>\0`.
         const oldPath = tokens[i + 1]
         const newPath = tokens[i + 2]
         if (oldPath !== undefined && newPath !== undefined && !seen.has(newPath)) {
-          entries.push({ path: newPath, status: 'R', renamedFrom: oldPath })
+          entries.push(
+            code === 'R'
+              ? { path: newPath, status: 'R', renamedFrom: oldPath }
+              : { path: newPath, status: 'A' },
+          )
           seen.add(newPath)
         }
         i += 3
@@ -104,35 +160,33 @@ export function diffAgainstSnapshot(cwd: string, snapshotRef: string): DiffEntry
         i += 2
         continue
       }
-      i += 1
+      if (code === 'T') {
+        // Typechange (file⇄symlink, regular⇄submodule). Record as modified.
+        const p = tokens[i + 1]
+        if (p !== undefined && !seen.has(p)) {
+          entries.push({ path: p, status: 'M' })
+          seen.add(p)
+        }
+        i += 2
+        continue
+      }
+      // Unknown single-letter status: `<status>\0<path>\0`. Consume the pair so
+      // the path token is never re-read as a status (which would corrupt the
+      // rest of the stream).
+      i += 2
     }
   }
 
-  // `git diff HEAD` only reports tracked-file changes. When the pre-spawn
-  // snapshot was empty (clean working tree) the diff above misses every NEW
-  // file the rail created. `git ls-files --others` surfaces untracked paths;
-  // we record them as 'A' (created) since they did not exist at snapshot time.
-  if (!hasSnap) {
-    let others = ''
-    try {
-      others = execSync('git ls-files --others --exclude-standard -z', {
-        cwd,
-        encoding: 'utf8',
-        stdio: ['ignore', 'pipe', 'pipe'],
-        timeout: GIT_TIMEOUT_MS,
-        maxBuffer: GIT_MAX_BUFFER,
-        env: GIT_EXEC_ENV,
-      })
-    } catch {
-      others = ''
-    }
-    if (others) {
-      for (const p of others.split('\0')) {
-        if (p && !seen.has(p)) {
-          entries.push({ path: p, status: 'A' })
-          seen.add(p)
-        }
-      }
+  // `git diff <ref>` only reports TRACKED-file deltas — it never lists untracked
+  // files. New files a rail creates are untracked, so without this pass they are
+  // silently lost whenever the tree was dirty at snapshot time (the common case).
+  // Always surface currently-untracked paths, minus those already untracked at
+  // snapshot time (which the rail did not create), as 'A' (created).
+  const before = new Set(untrackedBefore ?? [])
+  for (const p of listUntracked(cwd)) {
+    if (!seen.has(p) && !before.has(p)) {
+      entries.push({ path: p, status: 'A' })
+      seen.add(p)
     }
   }
 
@@ -165,8 +219,12 @@ function addedFilePatch(cwd: string, relPath: string): string {
   } catch {
     return ''
   }
+  const noTrailingNewline = content.length > 0 && !content.endsWith('\n')
   const lines = content.split('\n')
   if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop()
+  const body = lines.map((line) => `+${line}`)
+  // Mirror git's own unified-diff output for a file with no terminating newline.
+  if (noTrailingNewline) body.push('\\ No newline at end of file')
   return [
     `diff --git a/${relPath} b/${relPath}`,
     'new file mode 100644',
@@ -174,7 +232,7 @@ function addedFilePatch(cwd: string, relPath: string): string {
     '--- /dev/null',
     `+++ b/${relPath}`,
     `@@ -0,0 +1,${lines.length} @@`,
-    ...lines.map((line) => `+${line}`),
+    ...body,
     '',
   ].join('\n')
 }
@@ -184,10 +242,19 @@ export function collectDiffPatches(cwd: string, snapshotRef: string, diff: DiffE
   if (diff.length === 0) return patches
 
   const ref = snapshotRef && snapshotRef.length > 0 ? snapshotRef : 'HEAD'
-  for (const entry of diff) {
+  // Cap the number of per-file git spawns: each runs synchronously on the event
+  // loop. Beyond the cap, provenance rows are still recorded (by the caller) but
+  // patches are skipped — the UI renders "diff unavailable" for them.
+  const capped = diff.slice(0, MAX_PATCH_FILES)
+  for (const entry of capped) {
+    // For a rename, scope the diff to BOTH paths so git can pair them and emit a
+    // proper `rename from`/`rename to` patch instead of a delete + 100%-add.
+    const pathspec = entry.status === 'R' && entry.renamedFrom !== undefined
+      ? [entry.renamedFrom, entry.path]
+      : [entry.path]
     let patch = ''
     try {
-      patch = execFileSync('git', ['diff', '--no-ext-diff', '--find-renames', '--unified=80', ref, '--', entry.path], {
+      patch = execFileSync('git', ['diff', '--no-ext-diff', '--find-renames', '--unified=80', ref, '--', ...pathspec], {
         cwd,
         encoding: 'utf8',
         stdio: ['ignore', 'pipe', 'pipe'],
@@ -321,8 +388,8 @@ export function broadcastProvenanceUpdated(
   projectId: string,
   row: ProvenanceRow,
 ): void {
-  const msg = {
-    type: 'file.provenance_updated' as const,
+  const msg: FileProvenanceUpdatedMessage = {
+    type: 'file.provenance_updated',
     projectId,
     path: row.file_path,
     kind: row.kind,
@@ -330,6 +397,5 @@ export function broadcastProvenanceUpdated(
     jobId: row.job_id,
     at: row.at,
   }
-  // TODO: extend WsMessage union in server/types.ts with the 'file.provenance_updated' variant
-  ;(broadcast as (msg: unknown) => void)(msg)
+  broadcast(msg)
 }

--- a/server/file-summary-manager.test.ts
+++ b/server/file-summary-manager.test.ts
@@ -367,6 +367,114 @@ describe('FileSummaryManager.enqueue', () => {
     ).toBe(true)
   })
 
+  it('regenerates when the hub language changed even if the content hash matches', async () => {
+    writeFile(projectPath, 'src/foo.ts', 'console.log("hi")\n')
+    const hash = await computeFileHash(path.join(projectPath, 'src/foo.ts'))
+    writeSummary(projectPath, 'src/foo.ts', {
+      schemaVersion: 1,
+      path: 'src/foo.ts',
+      fileHash: hash,
+      summary: 'old english summary',
+      language: 'en',
+      generatedAt: '2026-05-22T00:00:00.000Z',
+      generatedBy: { model: 'claude-haiku-4-5', promptVersion: 1 },
+      triggeredBy: { kind: 'job', id: 'job_old', ticketId: 1 },
+    })
+    let observedLang: string | undefined
+    const gen = vi.fn(async (input: GenerateInput): Promise<GenerateOutput> => {
+      observedLang = input.language
+      return { summary: 'resumen', model: 'claude-haiku-4-5', provider: 'claude', costUsd: 0, tokensIn: 0, tokensOut: 0, durationMs: 0 }
+    })
+    const { deps } = makeDeps(db, { language: () => 'es', generate: gen })
+    const mgr = new FileSummaryManager(deps)
+    const result = await mgr.enqueue({
+      projectPath, projectId: 'p1', projectSlug: 'p1', relPath: 'src/foo.ts',
+      triggeredBy: { kind: 'job', id: 'job_new', ticketId: 1 }, jobId: 'job_new',
+    })
+    await mgr.flush()
+    expect(result).toBe('enqueued')
+    expect(gen).toHaveBeenCalledTimes(1)
+    expect(observedLang).toBe('es')
+    expect(readSummary(projectPath, 'src/foo.ts')?.language).toBe('es')
+  })
+
+  it('force bypasses the content-hash gate (explicit Regenerate of an unchanged file)', async () => {
+    writeFile(projectPath, 'src/foo.ts', 'console.log("hi")\n')
+    const hash = await computeFileHash(path.join(projectPath, 'src/foo.ts'))
+    writeSummary(projectPath, 'src/foo.ts', {
+      schemaVersion: 1,
+      path: 'src/foo.ts',
+      fileHash: hash,
+      summary: 'unchanged',
+      language: 'en',
+      generatedAt: '2026-05-22T00:00:00.000Z',
+      generatedBy: { model: 'claude-haiku-4-5', promptVersion: 1 },
+      triggeredBy: { kind: 'user', id: 'manual', ticketId: null },
+    })
+    const { deps, generate } = makeDeps(db)
+    const mgr = new FileSummaryManager(deps)
+    const result = await mgr.enqueue({
+      projectPath, projectId: 'p1', projectSlug: 'p1', relPath: 'src/foo.ts',
+      triggeredBy: { kind: 'user', id: 'manual', ticketId: null }, force: true,
+    })
+    await mgr.flush()
+    expect(result).toBe('enqueued')
+    expect(generate).toHaveBeenCalledTimes(1)
+  })
+
+  it('budget cap also applies to USER-triggered (manual) regenerate', async () => {
+    writeFile(projectPath, 'src/foo.ts', 'a\n')
+    const { deps, generate, broadcasts } = makeDeps(db, {
+      monthToDateSpend: () => 10,
+      monthlyBudgetUsd: () => 5,
+    })
+    const mgr = new FileSummaryManager(deps)
+    const result = await mgr.enqueue({
+      projectPath, projectId: 'p1', projectSlug: 'p1', relPath: 'src/foo.ts',
+      triggeredBy: { kind: 'user', id: 'manual', ticketId: null },
+    })
+    expect(result).toBe('skipped:budget')
+    expect(generate).not.toHaveBeenCalled()
+    expect(broadcasts.some((b) => b.type === 'file.summary_skipped' && b.reason === 'budget')).toBe(true)
+  })
+
+  it('attributes a failed invocation to the configured provider, not always claude', async () => {
+    writeFile(projectPath, 'src/foo.ts', 'x\n')
+    const { deps } = makeDeps(db, {
+      providerId: () => 'codex',
+      generate: vi.fn(async () => { throw new Error('boom') }),
+    })
+    const mgr = new FileSummaryManager(deps)
+    await mgr.enqueue({
+      projectPath, projectId: 'p1', projectSlug: 'p1', relPath: 'src/foo.ts',
+      triggeredBy: { kind: 'user', id: 'manual', ticketId: null },
+    })
+    await mgr.flush()
+    const rows = db.prepare(`SELECT provider, status FROM ai_invocations`).all() as Array<{ provider: string; status: string }>
+    expect(rows).toHaveLength(1)
+    expect(rows[0].status).toBe('failed')
+    expect(rows[0].provider).toBe('codex')
+  })
+
+  it('bounds the per-job counter map (evicts oldest beyond maxJobCounters)', async () => {
+    writeFile(projectPath, 'a.ts', '// a\n')
+    writeFile(projectPath, 'b.ts', '// b\n')
+    const { deps, generate } = makeDeps(db)
+    const mgr = new FileSummaryManager(deps, { maxJobCounters: 1, perProjectConcurrency: 8, hubConcurrency: 8 })
+    const r1 = await mgr.enqueue({
+      projectPath, projectId: 'p1', projectSlug: 'p1', relPath: 'a.ts',
+      triggeredBy: { kind: 'job', id: 'jA', ticketId: null }, jobId: 'jA',
+    })
+    const r2 = await mgr.enqueue({
+      projectPath, projectId: 'p1', projectSlug: 'p1', relPath: 'b.ts',
+      triggeredBy: { kind: 'job', id: 'jB', ticketId: null }, jobId: 'jB',
+    })
+    await mgr.flush()
+    expect(r1).toBe('enqueued')
+    expect(r2).toBe('enqueued')
+    expect(generate).toHaveBeenCalledTimes(2)
+  })
+
   it('failure path records a failed ai_invocations row and broadcasts file.summary_failed', async () => {
     writeFile(projectPath, 'src/foo.ts', 'x\n')
     const { deps, broadcasts } = makeDeps(db, {

--- a/server/file-summary-manager.ts
+++ b/server/file-summary-manager.ts
@@ -4,7 +4,12 @@ import * as path from 'path'
 import chokidar, { type FSWatcher } from 'chokidar'
 import { isInBuildDir } from './build-dirs'
 import type { DbInstance } from './db'
-import type { WsMessage } from './types'
+import type {
+  WsMessage,
+  FileSummaryUpdatedMessage,
+  FileSummaryFailedMessage,
+  FileSummarySkippedMessage,
+} from './types'
 import { recordInvocation, type Surface } from './ai-invocations'
 
 export type SummaryLanguage = 'en' | 'es'
@@ -28,6 +33,9 @@ export interface EnqueueRequest {
   triggeredBy: SummaryPayload['triggeredBy']
   jobId?: string
   overrideBudget?: boolean
+  /** Bypass the content-hash gate. Set on explicit user "Regenerate" so an
+   *  unchanged file is re-summarised anyway (e.g. after a language switch). */
+  force?: boolean
 }
 
 export interface GenerateInput {
@@ -60,6 +68,9 @@ export interface FileSummaryDeps {
   monthlyBudgetUsd: () => number
   /** Hub-wide summary language. Defaults to 'en' when omitted. */
   language?: () => SummaryLanguage
+  /** Provider id for the project ('claude' | 'codex' | …). Used to attribute the
+   *  failure-path ai_invocations row correctly. Defaults to 'claude'. */
+  providerId?: () => string
   now?: () => number
 }
 
@@ -68,6 +79,8 @@ export interface FileSummaryOpts {
   hubConcurrency?: number
   perJobCap?: number
   queueTtlMs?: number
+  /** Upper bound on distinct jobId counters retained (defensive anti-leak). */
+  maxJobCounters?: number
 }
 
 type EnqueueResult =
@@ -78,6 +91,12 @@ type EnqueueResult =
   | 'skipped:per-job-cap'
 
 const SUMMARIES_REL = path.join('.specrails', 'file-summaries')
+// Current summary prompt version. Bump when buildSystemPrompt changes materially
+// so existing summaries are treated as stale and regenerated on next request.
+const CURRENT_PROMPT_VERSION = 1
+// Defensive bound on the per-job counter map so it cannot grow without limit
+// across a long-lived hub session (the per-job cap is best-effort).
+const MAX_JOB_COUNTERS = 2000
 const TOKEN_CHARS_PER_TOKEN = 4
 const TOKEN_LIMIT = 8000
 const TRUNCATE_HEAD_CHARS = 16000
@@ -193,6 +212,9 @@ export function sweepOrphans(
 interface QueueEntry {
   req: EnqueueRequest
   enqueuedAt: number
+  /** Content hash computed at enqueue time, carried on the entry so the worker
+   *  never has to recompute it — and never picks up another entry's hash. */
+  newHash: string
   resolve: (r: EnqueueResult) => void
   reject: (err: Error) => void
 }
@@ -208,6 +230,7 @@ export class FileSummaryManager {
   private readonly hubConcurrency: number
   private readonly perJobCap: number
   private readonly queueTtlMs: number
+  private readonly maxJobCounters: number
 
   // Per-project queue, per-project in-flight count, hub-wide in-flight count.
   private readonly queues = new Map<string, QueueEntry[]>()
@@ -230,6 +253,7 @@ export class FileSummaryManager {
     this.hubConcurrency = opts.hubConcurrency ?? 8
     this.perJobCap = opts.perJobCap ?? 50
     this.queueTtlMs = opts.queueTtlMs ?? 5 * 60 * 1000
+    this.maxJobCounters = opts.maxJobCounters ?? MAX_JOB_COUNTERS
   }
 
   async enqueue(req: EnqueueRequest): Promise<EnqueueResult> {
@@ -249,9 +273,20 @@ export class FileSummaryManager {
       return 'skipped:hash'
     }
 
-    // Step 2: hash gate.
+    // Step 2: hash gate. Skip regeneration only when content, language AND prompt
+    // version all match — and never when the caller forced it. Without the
+    // language check a hub language switch (en↔es) would never refresh existing
+    // summaries; without `force` an explicit "Regenerate" of an unchanged file
+    // would be a silent no-op.
+    const currentLang: SummaryLanguage = this.deps.language?.() ?? 'en'
     const existing = readSummary(req.projectPath, req.relPath)
-    if (existing && existing.fileHash === newHash) {
+    if (
+      !req.force &&
+      existing &&
+      existing.fileHash === newHash &&
+      existing.language === currentLang &&
+      existing.generatedBy?.promptVersion === CURRENT_PROMPT_VERSION
+    ) {
       this.deps.broadcast(buildSummaryUpdated(req.projectId, existing, false))
       return 'skipped:hash'
     }
@@ -263,11 +298,20 @@ export class FileSummaryManager {
         this.emitSkipped(req, 'per-job-cap')
         return 'skipped:per-job-cap'
       }
+      // Bound the map: drop the oldest counters if it grows unreasonably large
+      // over a long hub session (the cap is best-effort, so a reset is harmless).
+      if (!this.jobCounter.has(req.jobId) && this.jobCounter.size >= this.maxJobCounters) {
+        const oldest = this.jobCounter.keys().next().value
+        if (oldest !== undefined) this.jobCounter.delete(oldest)
+      }
       this.jobCounter.set(req.jobId, count + 1)
     }
 
-    // Step 4: budget cap (job-triggered only, unless overrideBudget).
-    if (req.triggeredBy.kind === 'job' && !req.overrideBudget) {
+    // Step 4: budget cap. Applies to job- AND user-triggered requests; the only
+    // bypass is an explicit overrideBudget (the "Override the budget cap?"
+    // confirmation in the UI). Previously only job-triggered requests were
+    // gated, which left the manual-regenerate budget prompt unreachable.
+    if (!req.overrideBudget) {
       const spend = this.deps.monthToDateSpend(req.projectId)
       const budget = this.deps.monthlyBudgetUsd()
       if (spend >= budget) {
@@ -281,18 +325,19 @@ export class FileSummaryManager {
       const entry: QueueEntry = {
         req: { ...req },
         enqueuedAt: (this.deps.now ?? Date.now)(),
+        newHash,
         resolve,
         reject,
       }
       const queue = this.queues.get(req.projectId) ?? []
       queue.push(entry)
       this.queues.set(req.projectId, queue)
-      this.pump(req.projectId, newHash)
+      this.pump(req.projectId)
     })
     return result
   }
 
-  private pump(projectId: string, hashHint?: string): void {
+  private pump(projectId: string): void {
     const queue = this.queues.get(projectId) ?? []
     while (queue.length > 0) {
       if (this.hubInFlight >= this.hubConcurrency) break
@@ -308,7 +353,7 @@ export class FileSummaryManager {
       }
       this.inFlightPerProject.set(projectId, perProject + 1)
       this.hubInFlight += 1
-      const p = this.runOne(entry, hashHint)
+      const p = this.runOne(entry)
         .catch((err) => entry.reject(err))
         .finally(() => {
           this.inFlightPerProject.set(
@@ -325,7 +370,7 @@ export class FileSummaryManager {
     else this.queues.set(projectId, queue)
   }
 
-  private async runOne(entry: QueueEntry, hashHint?: string): Promise<void> {
+  private async runOne(entry: QueueEntry): Promise<void> {
     const { req } = entry
     const absolutePath = path.join(req.projectPath, req.relPath)
     const startedIso = new Date((this.deps.now ?? Date.now)()).toISOString()
@@ -334,7 +379,9 @@ export class FileSummaryManager {
     let fileHash: string
     try {
       contents = fs.readFileSync(absolutePath, 'utf8')
-      fileHash = hashHint ?? (await computeFileHash(absolutePath))
+      // Use the hash captured for THIS entry at enqueue time (never another
+      // entry's). Fall back to a recompute only if it was somehow not set.
+      fileHash = entry.newHash || (await computeFileHash(absolutePath))
     } catch {
       this.emitSkipped(req, 'not-found')
       entry.resolve('skipped:hash')
@@ -394,10 +441,11 @@ export class FileSummaryManager {
           num_turns: 1,
           total_cost_usd_estimated: !!out.costEstimated,
         })
-      } catch {
-        // The 'file-summary' surface is introduced by a sibling change; if the
-        // ALLOWED_SURFACES set has not yet been extended at install time the
-        // insert is silently dropped rather than crashing the queue.
+      } catch (err) {
+        // An ai_invocations write failure must never crash the summary queue,
+        // but it should not be silent either — a swallowed failure here means
+        // spending under-counts with no trace.
+        console.error('[file-summary] recordInvocation (success) failed:', err)
       }
       this.deps.broadcast(buildSummaryUpdated(req.projectId, payload, false))
       this.deps.broadcast({ type: 'spending.invalidated', projectId: req.projectId })
@@ -408,7 +456,7 @@ export class FileSummaryManager {
         recordInvocation(this.deps.db, {
           id: randomUUID(),
           project_id: req.projectId,
-          provider: 'claude',
+          provider: this.deps.providerId?.() ?? 'claude',
           surface: 'file-summary' as Surface,
           surface_ref_id: req.jobId ?? null,
           ticket_id: req.triggeredBy.ticketId,
@@ -423,15 +471,18 @@ export class FileSummaryManager {
           num_turns: 1,
           total_cost_usd_estimated: false,
         })
-      } catch {
-        // ai_invocations write failures must not crash the manager.
+      } catch (recErr) {
+        // ai_invocations write failures must not crash the manager, but log so
+        // a persistent DB problem is visible.
+        console.error('[file-summary] recordInvocation (failure) failed:', recErr)
       }
-      this.deps.broadcast({
+      const failedMsg: FileSummaryFailedMessage = {
         type: 'file.summary_failed',
         projectId: req.projectId,
         path: req.relPath,
         reason,
-      } as unknown as WsMessage)
+      }
+      this.deps.broadcast(failedMsg)
       // Resolve with 'failed' (not 'enqueued') so a caller awaiting enqueue()
       // can distinguish a failed generation from a successful one.
       entry.resolve('failed')
@@ -520,13 +571,14 @@ export class FileSummaryManager {
     return false
   }
 
-  private emitSkipped(req: EnqueueRequest, reason: string): void {
-    this.deps.broadcast({
+  private emitSkipped(req: EnqueueRequest, reason: FileSummarySkippedMessage['reason']): void {
+    const msg: FileSummarySkippedMessage = {
       type: 'file.summary_skipped',
       projectId: req.projectId,
       path: req.relPath,
       reason,
-    } as unknown as WsMessage)
+    }
+    this.deps.broadcast(msg)
   }
 }
 
@@ -535,12 +587,13 @@ function buildSummaryUpdated(
   payload: SummaryPayload,
   stale: boolean,
 ): WsMessage {
-  return {
+  const msg: FileSummaryUpdatedMessage = {
     type: 'file.summary_updated',
     projectId,
     path: payload.path,
     summaryAvailable: true,
     stale,
     generatedAt: payload.generatedAt,
-  } as unknown as WsMessage
+  }
+  return msg
 }

--- a/server/project-registry.ts
+++ b/server/project-registry.ts
@@ -353,6 +353,7 @@ export class ProjectRegistry {
         const raw = getHubSetting(this._hubDb, 'summary_language')
         return raw === 'es' ? 'es' : 'en'
       },
+      providerId: () => fileSummaryAdapter.id,
     })
     // NOTE: the chokidar watcher is NOT attached here. It is only needed to mark
     // already-generated summaries stale, which is irrelevant until the user opens

--- a/server/project-router.ts
+++ b/server/project-router.ts
@@ -392,15 +392,23 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
   router.use('/:projectId/plugins', pluginsRouter)
 
   // Mount Code-Explorer router. FileSummaryManager comes from ProjectContext.
+  // Memoize per ProjectContext (keyed on the object so a removed+re-added
+  // project gets a fresh router) instead of rebuilding the router on every
+  // /code/* request.
+  const codeRouterByCtx = new WeakMap<object, Router>()
   router.use('/:projectId/code', (req: Request, res: Response, next: NextFunction) => {
     const projectCtx = ctx(req)
-    const codeRouter = createCodeExplorerRouter({
-      db: projectCtx.db,
-      projectPath: projectCtx.project.path,
-      projectId: projectCtx.project.id,
-      broadcast: projectCtx.broadcast,
-      fileSummaryManager: projectCtx.fileSummaryManager,
-    })
+    let codeRouter = codeRouterByCtx.get(projectCtx)
+    if (!codeRouter) {
+      codeRouter = createCodeExplorerRouter({
+        db: projectCtx.db,
+        projectPath: projectCtx.project.path,
+        projectId: projectCtx.project.id,
+        broadcast: projectCtx.broadcast,
+        fileSummaryManager: projectCtx.fileSummaryManager,
+      })
+      codeRouterByCtx.set(projectCtx, codeRouter)
+    }
     codeRouter(req, res, next)
   })
 

--- a/server/queue-manager.ts
+++ b/server/queue-manager.ts
@@ -17,6 +17,7 @@ import {
   collectDiffPatches,
   recordProvenanceForJob,
   broadcastProvenanceUpdated,
+  type WorkingTreeSnapshot,
 } from './file-provenance'
 import { finaliseInvocationResult } from './result-event'
 import { randomUUID } from 'crypto'
@@ -240,7 +241,7 @@ export class QueueManager {
   private _jobProfileSelection: Map<string, string | null>
   /** Pre-spawn working-tree snapshot refs keyed by jobId — read at exit time
    *  by the Code-Explorer provenance hook. Cleared on job exit. */
-  private _snapshotRefs: Map<string, string>
+  private _snapshotRefs: Map<string, WorkingTreeSnapshot>
 
   constructor(
     broadcast: (msg: WsMessage) => void,
@@ -350,6 +351,8 @@ export class QueueManager {
 
     this._activeProcess = null
     this._activeJobId = null
+    // Release any per-job provenance snapshots so teardown leaves no map entries.
+    this._snapshotRefs.clear()
     // Drop the DB reference last so any in-flight 'close' callback sees null
     // and skips all DB work via the existing `if (this._db)` guards.
     this._db = null
@@ -853,8 +856,8 @@ export class QueueManager {
     // against it. Gated by SPECRAILS_CODE_EXPLORER — when off, no-op.
     if (isCodeExplorerEnabled() && this._cwd) {
       try {
-        const ref = snapshotWorkingTree(this._cwd)
-        this._snapshotRefs.set(jobId, ref)
+        const snap = snapshotWorkingTree(this._cwd)
+        this._snapshotRefs.set(jobId, snap)
       } catch (err) {
         console.warn(`[queue-manager] provenance snapshot failed: ${(err as Error).message}`)
       }
@@ -1065,6 +1068,12 @@ export class QueueManager {
       this._killTimer = null
     }
 
+    // Reclaim the pre-spawn snapshot unconditionally, BEFORE any early return,
+    // so a disposed/unknown job can't leak its entry in _snapshotRefs (the git
+    // stash commit it references is dangling and git-GC'd on its own).
+    const snapshot = this._snapshotRefs.get(jobId)
+    this._snapshotRefs.delete(jobId)
+
     // The manager was torn down (e.g. project removed) while the child was
     // still running. The DB may be closed; skip all bookkeeping to avoid an
     // uncaught throw inside this EventEmitter 'close' listener.
@@ -1168,10 +1177,9 @@ export class QueueManager {
       // SPECRAILS_CODE_EXPLORER (re-checked at each completion so the flag can
       // be flipped off mid-session without leaving partial writes).
       if (isCodeExplorerEnabled() && this._cwd && this._projectId) {
-        const ref = this._snapshotRefs.get(jobId) ?? ''
-        this._snapshotRefs.delete(jobId)
+        const ref = snapshot?.ref ?? ''
         try {
-          const diff = diffAgainstSnapshot(this._cwd, ref)
+          const diff = diffAgainstSnapshot(this._cwd, ref, snapshot?.untracked)
           const patches = collectDiffPatches(this._cwd, ref, diff)
           if (diff.length > 50) {
             console.warn(`[provenance.large_job] job=${jobId} files=${diff.length}`)


### PR DESCRIPTION
## Resumen

Repaso a fondo del **explorador de código**. Un workflow multi-agente (7 revisores → verificación adversarial → síntesis) destapó **78 hallazgos crudos → 34 confirmados → 16 defectos distintos**. Todos arreglados, con tests y cobertura.

## HIGH — pérdida de datos / seguridad
- **Archivos creados por IA se perdían**: con el árbol sucio en el snapshot, `git stash create` daba ref no-vacío y el fallback `ls-files --others` solo corría con ref vacío → todo archivo nuevo untracked del rail desaparecía de provenance (caso común). `snapshotWorkingTree` ahora devuelve `{ref, untracked}` y `diffAgainstSnapshot` siempre lista untracked menos el set previo. *(Confirmado con experimento git.)*
- **Symlink escapaba el root**: `resolveSafePath` solo hacía chequeo léxico; un symlink in-repo dejaba `/file` leer fuera del proyecto. Endurecido con validación realpath (único chokepoint de los 5 endpoints).

## MEDIUM
- `.tsx`/`.jsx` se mostraban como **plaintext** (Monaco no registra `typescriptreact`/`javascriptreact`) → mapeo a `typescript`/`javascript`.
- **Budget de regenerar manual muerto**: el gate solo aplicaba a `kind==='job'` → el prompt de override del cliente era inalcanzable. Ahora aplica a ambos (bypass solo con `overrideBudget`) y la ruta devuelve `200 {skipped:'budget'}`.
- **Hash gate ignoraba el idioma**: cambiar idioma o regenerar no surtía efecto. Gate ahora compara contenido+idioma+promptVersion; nuevo flag `force` para regenerar explícito.
- **Deny-list inconsistente**: `.env`/lockfiles/`.log` servibles vía `/file` y visibles en touched-by-ai → deny-list uniforme (403 + omisión en árbol).
- **`/tree?filter=all` bloqueaba el event loop** (walk síncrono + `readSummary` por entrada + N+1 SQL) → 1 query batch + 1 readdir.
- Typechange `T` corrompía el parser `-z` → manejado (+ consumo defensivo de estados desconocidos).
- Fallos de file-summary se atribuían siempre a `claude` → `providerId`.

## LOW
hashHint cruzado entre entradas de la cola; leak de `_snapshotRefs` + stash colgante; `jobCounter` sin tope; patches de rename como add-100%; `diff.renames=false` no-determinista; `GIT_DIR/WORK_TREE/INDEX` heredados; marcador `\ No newline`; router reconstruido por request; orden de hooks en `TicketFilesTouched`; casts `as unknown as WsMessage` y TODO obsoletos; catch silencioso de `recordInvocation`.

## Verificación (CI mirror, todo verde)
- typecheck server + client: 0 / 0
- server coverage **EXIT 0** — 81.6% stmts / 71.7% branch / 86.5% funcs / 83.1% lines
- client coverage **EXIT 0** — 80.8% lines/stmts / 71.8% funcs
- suite completa pasa. **+44 tests** nuevos.

## Diferido a propósito (no bugs)
- Paginación cursor de `/tree` (el cliente hace fetch de página única; árboles >2000 truncan).
- Banner "stale" por idioma en `/file`.
- Doc de `CLAUDE.md` dice que `/tree` respeta `.gitignore` pero solo hay deny-list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)