### PR TITLE
fix(desktop): drop unsigned fsevents from bundled Playwright (notarization)

### DIFF
--- a/scripts/build-sidecar.mjs
+++ b/scripts/build-sidecar.mjs
@@ -192,6 +192,31 @@ function copyDirSync(src, dest) {
   fs.cpSync(src, dest, { recursive: true, dereference: false })
 }
 
+/** Recursively delete every directory named `name` under `root`. */
+function removeDirsByName(root, name) {
+  let entries
+  try { entries = fs.readdirSync(root, { withFileTypes: true }) } catch { return }
+  for (const e of entries) {
+    if (!e.isDirectory()) continue
+    const p = path.join(root, e.name)
+    if (e.name === name) fs.rmSync(p, { recursive: true, force: true })
+    else removeDirsByName(p, name)
+  }
+}
+
+/** Collect every `*.node` file under `root` (transitive native addons). */
+function findNodeAddons(root) {
+  const out = []
+  let entries
+  try { entries = fs.readdirSync(root, { withFileTypes: true }) } catch { return out }
+  for (const e of entries) {
+    const p = path.join(root, e.name)
+    if (e.isDirectory()) out.push(...findNodeAddons(p))
+    else if (e.name.endsWith('.node')) out.push(p)
+  }
+  return out
+}
+
 function ensureSpawnHelperExecutable(nodePtyDir) {
   if (process.platform === 'win32') return
   const prebuildsDir = path.join(nodePtyDir, 'prebuilds')
@@ -418,10 +443,10 @@ async function main() {
   }
 
   // Step 3c: Copy Playwright (browser-capture feature) externally so require()
-  // resolves on the real fs inside the packaged sidecar (mirrors node-pty). Pure
-  // JS — no Mach-O, so no codesigning needed. The Chromium *browser binary* is
-  // shipped separately under runtimes/chromium (when BUNDLE_CHROMIUM=true) or
-  // downloaded by Playwright on first use; this only ships the JS driver.
+  // resolves on the real fs inside the packaged sidecar (mirrors node-pty). The
+  // Chromium *browser binary* is shipped separately under runtimes/chromium (when
+  // BUNDLE_CHROMIUM=true) or downloaded by Playwright on first use; this only
+  // ships the JS driver.
   console.log('\n[3c] Copying Playwright packages...')
   const pwNodeModulesDest = path.join(BINARIES_DIR, 'node_modules')
   ensureDir(pwNodeModulesDest)
@@ -435,8 +460,15 @@ async function main() {
     copyDirSync(src, dest)
     // Defensive: drop any in-package browser cache (browsers live in ~/.cache).
     fs.rmSync(path.join(dest, '.local-browsers'), { recursive: true, force: true })
+    // Drop `fsevents` — a transitive, optional macOS-only native addon. Its
+    // unsigned fsevents.node fails Apple notarization, and the browser-capture
+    // path (launch + screencast + screenshot/DOM) never needs file watching.
+    fs.rmSync(path.join(dest, 'node_modules', 'fsevents'), { recursive: true, force: true })
     console.log(`  ${src} → ${dest}`)
   }
+  // Belt-and-suspenders: remove any remaining nested fsevents anywhere under the
+  // copied node_modules (npm layout can vary across versions).
+  removeDirsByName(pwNodeModulesDest, 'fsevents')
 
   // Step 4: Codesign sidecar + .node addons (macOS only, requires APPLE_SIGNING_IDENTITY)
   // Apple notarization rejects bundles with unsigned binaries or binaries missing
@@ -479,6 +511,14 @@ async function main() {
           console.log(`  Signed: ${helper}`)
         }
       }
+    }
+
+    // Sign any remaining native addons under binaries/node_modules (e.g. a
+    // transitive `*.node` pulled in by Playwright). fsevents is trimmed above,
+    // but this future-proofs notarization against any other native dep.
+    for (const addon of findNodeAddons(path.join(BINARIES_DIR, 'node_modules'))) {
+      run(`codesign --force --sign "${signingIdentity}" --timestamp "${addon}"`)
+      console.log(`  Signed: ${addon}`)
     }
   } else if (process.platform === 'darwin') {
     console.log('\n[4/4] Skipping codesign (APPLE_SIGNING_IDENTITY not set — local build)')


### PR DESCRIPTION
## Problem
The v1.61.0 **Desktop Release** failed at macOS notarization:
> Archive contains critical validation errors — `…/binaries/node_modules/playwright/node_modules/fsevents/fsevents.node` — "The binary is not signed."

Bundling the Playwright JS driver (added in #341) also pulled in `fsevents`, an **optional, macOS-only native addon** (`fsevents.node`, an unsigned Mach-O). Tauri ships `bundle.resources` unsigned, so notarization rejects it.

## Fix
- `scripts/build-sidecar.mjs`: trim any `fsevents` directory from the copied `playwright` / `playwright-core` (file-watching is never used by the browser-capture path — launch + screencast + screenshot/DOM).
- Defensively codesign any remaining `*.node` under `binaries/node_modules` (future-proofs notarization against other transitive native deps).

## Validation
Simulated the CI nested layout locally (`playwright/node_modules/fsevents/fsevents.node`) → after `npm run build:sidecar` the bundle contains **no** `fsevents`/`.node`. `build:server` + `build:sidecar` pass.

After merge: re-run **Desktop Release** (workflow_dispatch on `main`) to backfill the v1.61.0 desktop installers with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)