### PR TITLE
fix(desktop): bundle + notarize Chromium for browser-capture

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -15,10 +15,10 @@ env:
   # from browser"). Default OFF: when unset/false the desktop app falls back to a
   # Playwright-managed Chromium downloaded on first use (server/chromium-resolver.ts
   # returns null → Playwright's default). Flip to "true" to ship Chromium inside the
-  # app for an offline-first experience — but VALIDATE macOS notarization first: the
-  # nested Chromium.app frameworks/helpers may need inside-out codesigning beyond the
-  # existing per-Mach-O loop, and a notarization failure fails the whole macOS release.
-  BUNDLE_CHROMIUM: "false"
+  # app for an offline-first experience. macOS notarization of Chromium's nested
+  # frameworks/helpers is handled by scripts/sign-chromium-macos.sh (inside-out
+  # codesigning with hardened runtime + JIT entitlements), run before tauri build.
+  BUNDLE_CHROMIUM: "true"
 
 jobs:
   build-macos:
@@ -171,12 +171,18 @@ jobs:
           # runtime (candidate: chromium/chrome-mac/Chromium.app/Contents/MacOS/Chromium).
           npx playwright install chromium
           EXE=$(node -e "process.stdout.write(require('playwright').chromium.executablePath())")
-          PLATDIR="$EXE"; for _ in 1 2 3 4; do PLATDIR=$(dirname "$PLATDIR"); done   # → chrome-mac
+          # Walk up to Playwright's platform folder (chrome-mac-arm64 / chrome-mac / …
+          # depending on version) — the dir directly under chromium-<rev>.
+          PLATDIR="$EXE"
+          while [[ "$(basename "$(dirname "$PLATDIR")")" != chromium-* && "$PLATDIR" != "/" ]]; do PLATDIR=$(dirname "$PLATDIR"); done
           rm -rf src-tauri/runtimes/chromium
           mkdir -p src-tauri/runtimes/chromium
           cp -R "$PLATDIR" "src-tauri/runtimes/chromium/$(basename "$PLATDIR")"
-          test -e "src-tauri/runtimes/chromium/chrome-mac/Chromium.app/Contents/MacOS/Chromium"
-          echo "Bundled Chromium from ${PLATDIR}"
+          # Verify a *.app with a MacOS binary landed (name varies: "Google Chrome for
+          # Testing.app" in current Playwright). The resolver discovers it at runtime.
+          APP=$(find src-tauri/runtimes/chromium -maxdepth 2 -name "*.app" -type d | head -1)
+          test -n "${APP}" && test -n "$(find "${APP}/Contents/MacOS" -type f | head -1)"
+          echo "Bundled Chromium from ${PLATDIR} (app: ${APP})"
 
       - name: Import codesign certificate
         uses: apple-actions/import-codesign-certs@v3
@@ -205,6 +211,8 @@ jobs:
           # Mach-O under runtimes/ with hardened runtime + the JIT/library-validation
           # entitlements node's V8 needs. Signatures embed in the Mach-O and survive
           # Tauri's copy into the .app, so the assembled bundle notarizes cleanly.
+          # Chromium is excluded here — it is a deep app bundle that must be signed
+          # inside-out as bundles (see the dedicated step below), not as loose files.
           count=0
           while IFS= read -r f; do
             if file "$f" | grep -q "Mach-O"; then
@@ -212,10 +220,24 @@ jobs:
                 --sign "$APPLE_SIGNING_IDENTITY" "$f"
               count=$((count+1))
             fi
-          done < <(find src-tauri/runtimes -type f)
-          echo "Signed ${count} Mach-O binaries under src-tauri/runtimes/"
+          done < <(find src-tauri/runtimes -type f -not -path '*/chromium/*')
+          echo "Signed ${count} Mach-O binaries under src-tauri/runtimes/ (excluding chromium)"
           codesign --verify --strict --verbose=2 src-tauri/runtimes/node/bin/node
           codesign --verify --strict --verbose=2 src-tauri/runtimes/git/bin/git
+
+      - name: Sign bundled Chromium (macOS arm64)
+        if: ${{ env.BUNDLE_CHROMIUM == 'true' }}
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${APPLE_SIGNING_IDENTITY:-}" ]]; then
+            echo "APPLE_SIGNING_IDENTITY not set — skipping Chromium signing."
+            exit 0
+          fi
+          APP=$(find "$PWD/src-tauri/runtimes/chromium" -maxdepth 2 -name "*.app" -type d | head -1)
+          if [[ -z "${APP}" ]]; then echo "No Chromium .app found to sign"; exit 1; fi
+          bash scripts/sign-chromium-macos.sh "$APP" "$APPLE_SIGNING_IDENTITY" "$PWD/src-tauri/entitlements.plist"
 
       - name: Build desktop app
         run: npm run build:desktop
@@ -365,7 +387,7 @@ jobs:
           rm -rf src-tauri/runtimes/chromium
           mkdir -p src-tauri/runtimes/chromium
           cp -R "$PLATDIR" "src-tauri/runtimes/chromium/$(basename "$PLATDIR")"
-          test -e "src-tauri/runtimes/chromium/chrome-win/chrome.exe"
+          test -n "$(find src-tauri/runtimes/chromium -name 'chrome.exe' | head -1)"
           echo "Bundled Chromium from ${PLATDIR}"
 
       - name: Build desktop app
@@ -518,7 +540,7 @@ jobs:
           rm -rf src-tauri/runtimes/chromium
           mkdir -p src-tauri/runtimes/chromium
           cp -R "$PLATDIR" "src-tauri/runtimes/chromium/$(basename "$PLATDIR")"
-          test -e "src-tauri/runtimes/chromium/chrome-win/chrome.exe"
+          test -n "$(find src-tauri/runtimes/chromium -name 'chrome.exe' | head -1)"
           echo "Bundled Chromium from ${PLATDIR}"
 
       - name: Build desktop app

--- a/scripts/assemble-runtimes-local.mjs
+++ b/scripts/assemble-runtimes-local.mjs
@@ -142,12 +142,14 @@ if (process.env.BUNDLE_CHROMIUM === 'true') {
   bash('Bundle Chromium (macOS arm64)', `
     npx playwright install chromium
     EXE=$(node -e "process.stdout.write(require('playwright').chromium.executablePath())")
-    PLATDIR="\${EXE}"; for _ in 1 2 3 4; do PLATDIR=$(dirname "\${PLATDIR}"); done
+    PLATDIR="\${EXE}"
+    while [[ "$(basename "$(dirname "\${PLATDIR}")")" != chromium-* && "\${PLATDIR}" != "/" ]]; do PLATDIR=$(dirname "\${PLATDIR}"); done
     rm -rf src-tauri/runtimes/chromium
     mkdir -p src-tauri/runtimes/chromium
     cp -R "\${PLATDIR}" "src-tauri/runtimes/chromium/$(basename "\${PLATDIR}")"
-    test -e "src-tauri/runtimes/chromium/chrome-mac/Chromium.app/Contents/MacOS/Chromium"
-    echo "Bundled Chromium from \${PLATDIR}"
+    APP=$(find src-tauri/runtimes/chromium -maxdepth 2 -name "*.app" -type d | head -1)
+    test -n "\${APP}" && test -n "$(find "\${APP}/Contents/MacOS" -type f | head -1)"
+    echo "Bundled Chromium from \${PLATDIR} (app: \${APP})"
   `);
 }
 

--- a/scripts/sign-chromium-macos.sh
+++ b/scripts/sign-chromium-macos.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# sign-chromium-macos.sh <Chromium.app> <signing-identity> <entitlements.plist>
+#
+# Codesign a bundled Chromium.app for Apple notarization. Unlike the bundled
+# node/git (single relocatable Mach-O files), Chromium.app is a deep app bundle:
+# a main executable, a versioned framework, and several helper .app bundles
+# (GPU/Renderer/Plugin/…). Notarization requires EVERY nested Mach-O AND every
+# nested bundle (.app/.framework) to be signed with a Developer ID + hardened
+# runtime + a secure timestamp, signed INSIDE-OUT (deepest first), with the JIT /
+# unsigned-memory / library-validation entitlements Chromium's V8 + sandbox need
+# on the main app and the helpers.
+#
+# We can't use a single `--deep` pass: --deep does not propagate entitlements to
+# nested bundles, so the helper processes would be killed at runtime. So we sign
+# each Mach-O file, then each nested bundle deepest-first, applying the
+# entitlements to every code object.
+set -euo pipefail
+
+APP="${1:?usage: sign-chromium-macos.sh <Chromium.app> <identity> <entitlements>}"
+ID="${2:?missing signing identity}"
+ENT="${3:?missing entitlements plist}"
+
+if [[ ! -d "${APP}" ]]; then
+  echo "ERROR: app bundle not found: ${APP}"
+  exit 1
+fi
+
+sign() {
+  codesign --force --timestamp --options runtime --entitlements "${ENT}" --sign "${ID}" "$1"
+}
+
+echo "=== Signing Chromium: ${APP} ==="
+
+# 1. Every nested Mach-O file (dylibs, .so, framework binaries, helper execs),
+#    deepest-first so a parent is never signed before its children.
+file_count=0
+while IFS= read -r f; do
+  if file "$f" | grep -q "Mach-O"; then
+    sign "$f"
+    file_count=$((file_count + 1))
+  fi
+done < <(find "${APP}" -depth -type f)
+echo "Signed ${file_count} nested Mach-O files"
+
+# 2. Every nested bundle (.app / .framework) deepest-first. `find -depth` lists
+#    the top Chromium.app LAST, so the whole tree is sealed inside-out in one pass.
+bundle_count=0
+while IFS= read -r b; do
+  sign "$b"
+  bundle_count=$((bundle_count + 1))
+done < <(find "${APP}" -depth \( -name "*.app" -o -name "*.framework" \) -type d)
+echo "Signed ${bundle_count} nested bundles (helpers + frameworks + main app)"
+
+# 3. Verify the seal.
+codesign --verify --deep --strict --verbose=2 "${APP}"
+echo "Chromium signed + verified OK"

--- a/scripts/smoke-bundled-runtimes.sh
+++ b/scripts/smoke-bundled-runtimes.sh
@@ -53,14 +53,14 @@ rm -rf "${T}"
 # present (it is bundled solely when BUNDLE_CHROMIUM=true in the release workflow);
 # otherwise the feature falls back to a Playwright-managed Chromium at runtime.
 CHROMIUM=""
-for c in \
-  "${RT}/chromium/chrome-mac/Chromium.app/Contents/MacOS/Chromium" \
-  "${RT}/chromium/chrome-linux/chrome" \
-  "${RT}/chromium/chrome-win/chrome.exe" \
-  "${RT}/chromium/bin/chromium" \
-  "${RT}/chromium/bin/chromium.exe"; do
-  if [[ -e "${c}" ]]; then CHROMIUM="${c}"; break; fi
-done
+if [[ -d "${RT}/chromium" ]]; then
+  # Discover the executable (Playwright's name/layout varies: a macOS *.app binary,
+  # or chrome.exe / chrome on Windows / Linux).
+  CHROMIUM=$(find "${RT}/chromium" -path "*.app/Contents/MacOS/*" -type f 2>/dev/null | head -1)
+  if [[ -z "${CHROMIUM}" ]]; then
+    CHROMIUM=$(find "${RT}/chromium" -type f \( -name "chrome.exe" -o -name "chrome" -o -name "chromium" \) 2>/dev/null | head -1)
+  fi
+fi
 if [[ -n "${CHROMIUM}" ]]; then
   echo "chromium: $("${CHROMIUM}" --version 2>&1 | head -n1)"
   "${CHROMIUM}" --headless=new --dump-dom about:blank >/dev/null 2>&1 \

--- a/server/chromium-resolver.test.ts
+++ b/server/chromium-resolver.test.ts
@@ -2,17 +2,41 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { bundledChromiumCandidates, resolveBundledChromiumPath } from './chromium-resolver'
+import { discoverChromiumExecutable, resolveBundledChromiumPath } from './chromium-resolver'
 
 describe('chromium-resolver', () => {
   const savedDesktop = process.env.SPECRAILS_IS_DESKTOP
   const savedRuntimes = process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH
   let tmp: string
 
+  // Build a fake Playwright-style chromium tree for the current platform and
+  // return [chromiumRoot, expectedExecutablePath].
+  function makeChromiumTree(root: string): string {
+    fs.mkdirSync(root, { recursive: true })
+    if (process.platform === 'win32') {
+      const dir = path.join(root, 'chrome-win')
+      fs.mkdirSync(dir, { recursive: true })
+      const exe = path.join(dir, 'chrome.exe')
+      fs.writeFileSync(exe, 'x')
+      return exe
+    }
+    if (process.platform === 'darwin') {
+      const macos = path.join(root, 'chrome-mac-arm64', 'Google Chrome for Testing.app', 'Contents', 'MacOS')
+      fs.mkdirSync(macos, { recursive: true })
+      const exe = path.join(macos, 'Google Chrome for Testing')
+      fs.writeFileSync(exe, 'x')
+      return exe
+    }
+    const dir = path.join(root, 'chrome-linux')
+    fs.mkdirSync(dir, { recursive: true })
+    const exe = path.join(dir, 'chrome')
+    fs.writeFileSync(exe, 'x')
+    return exe
+  }
+
   beforeEach(() => {
     tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'chromium-resolver-'))
   })
-
   afterEach(() => {
     if (savedDesktop === undefined) delete process.env.SPECRAILS_IS_DESKTOP
     else process.env.SPECRAILS_IS_DESKTOP = savedDesktop
@@ -21,22 +45,22 @@ describe('chromium-resolver', () => {
     fs.rmSync(tmp, { recursive: true, force: true })
   })
 
-  it('returns platform-appropriate candidate paths under chromium/', () => {
-    const c = bundledChromiumCandidates('/runtimes')
-    expect(c.length).toBeGreaterThan(0)
-    expect(c.every((p) => p.includes(path.join('/runtimes', 'chromium')))).toBe(true)
-    if (process.platform === 'darwin') {
-      expect(c.some((p) => p.includes('Chromium.app'))).toBe(true)
-    } else if (process.platform === 'win32') {
-      expect(c.some((p) => p.endsWith('.exe'))).toBe(true)
-    } else {
-      expect(c.some((p) => p.includes('chrome-linux'))).toBe(true)
-    }
+  it('discovers the bundled chromium executable for the current platform', () => {
+    const root = path.join(tmp, 'chromium')
+    const exe = makeChromiumTree(root)
+    expect(discoverChromiumExecutable(root)).toBe(exe)
+  })
+
+  it('discoverChromiumExecutable returns null for an empty/missing tree', () => {
+    expect(discoverChromiumExecutable(path.join(tmp, 'nope'))).toBeNull()
+    fs.mkdirSync(path.join(tmp, 'empty'))
+    expect(discoverChromiumExecutable(path.join(tmp, 'empty'))).toBeNull()
   })
 
   it('returns null when not in desktop mode', () => {
     delete process.env.SPECRAILS_IS_DESKTOP
     process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH = tmp
+    makeChromiumTree(path.join(tmp, 'chromium'))
     expect(resolveBundledChromiumPath()).toBeNull()
   })
 
@@ -46,19 +70,16 @@ describe('chromium-resolver', () => {
     expect(resolveBundledChromiumPath()).toBeNull()
   })
 
-  it('returns null when no bundled chromium file exists', () => {
+  it('returns null when no bundled chromium exists', () => {
     process.env.SPECRAILS_IS_DESKTOP = '1'
     process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH = tmp
     expect(resolveBundledChromiumPath()).toBeNull()
   })
 
-  it('resolves the bundled chromium when a candidate file exists', () => {
+  it('resolves the bundled chromium when present (desktop mode)', () => {
     process.env.SPECRAILS_IS_DESKTOP = '1'
     process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH = tmp
-    // Create the first candidate file for the current platform.
-    const candidate = bundledChromiumCandidates(tmp)[0]
-    fs.mkdirSync(path.dirname(candidate), { recursive: true })
-    fs.writeFileSync(candidate, 'binary')
-    expect(resolveBundledChromiumPath()).toBe(candidate)
+    const exe = makeChromiumTree(path.join(tmp, 'chromium'))
+    expect(resolveBundledChromiumPath()).toBe(exe)
   })
 })

--- a/server/chromium-resolver.ts
+++ b/server/chromium-resolver.ts
@@ -5,52 +5,85 @@ import path from 'path'
  * Resolve the Chromium executable the browser-capture feature should launch.
  *
  * Mirrors the bundled-runtime resolution used by `path-resolver.ts` for node/git:
- * in desktop mode (`SPECRAILS_IS_DESKTOP=1`) we existence-gate a bundled Chromium
- * shipped under `<runtimes>/chromium/` (declared in tauri.conf.json via the
- * `runtimes/**` glob, codesigned in CI before `tauri build`). When the bundled
- * binary is absent (dev, a runtimes-less build, or a partial extraction) we return
- * `null` so Playwright falls back to its own managed Chromium download — never
- * dead-ending the feature.
+ * in desktop mode (`SPECRAILS_IS_DESKTOP=1`) we DISCOVER a bundled Chromium shipped
+ * under `<runtimes>/chromium/` (declared in tauri.conf.json via the `runtimes/**`
+ * glob, codesigned in CI before `tauri build`). When no bundle is present (dev, a
+ * runtimes-less build, or a partial extraction) we return `null` so Playwright
+ * falls back to its own managed browser — never dead-ending the feature.
  *
- * Layout (matches the CI assembly + smoke test):
- *   macOS/Linux: runtimes/chromium/chrome-<plat>/Chromium.app/Contents/MacOS/Chromium
- *                or runtimes/chromium/bin/chromium
- *   Windows:     runtimes/chromium/chrome-win/chrome.exe
- *                or runtimes/chromium/bin/chromium.exe
- *
- * Multiple candidate paths are probed so the exact Playwright tarball layout
- * (which nests under chrome-<platform>/) and a flattened bin/ layout both work.
+ * We DISCOVER rather than hard-code the path because Playwright's layout changes
+ * across versions (e.g. `chrome-mac/Chromium.app` → `chrome-mac-arm64/Google Chrome
+ * for Testing.app`, `chrome-win/chrome.exe`, `chrome-linux/chrome`). The CI assembly
+ * copies Playwright's platform folder verbatim under `<runtimes>/chromium/`; this
+ * walks that tree to find the real executable.
  */
-function fileExists(p: string): boolean {
-  try {
-    return fs.statSync(p).isFile()
-  } catch {
-    return false
-  }
+
+const MAX_DEPTH = 6
+
+function isFile(p: string): boolean {
+  try { return fs.statSync(p).isFile() } catch { return false }
 }
 
-export function bundledChromiumCandidates(runtimesPath: string): string[] {
-  const root = path.join(runtimesPath, 'chromium')
+/** Depth-bounded search for the first file whose basename satisfies `match`. */
+function findFirstFile(root: string, match: (name: string) => boolean, depth = 0): string | null {
+  if (depth > MAX_DEPTH) return null
+  let entries: fs.Dirent[]
+  try { entries = fs.readdirSync(root, { withFileTypes: true }) } catch { return null }
+  // Files first (cheap), then recurse into dirs.
+  for (const e of entries) {
+    if (e.isFile() && match(e.name)) return path.join(root, e.name)
+  }
+  for (const e of entries) {
+    if (e.isDirectory()) {
+      const hit = findFirstFile(path.join(root, e.name), match, depth + 1)
+      if (hit) return hit
+    }
+  }
+  return null
+}
+
+/** On macOS: locate the main executable inside the first `*.app` under `root`. */
+function findMacAppExecutable(root: string, depth = 0): string | null {
+  if (depth > MAX_DEPTH) return null
+  let entries: fs.Dirent[]
+  try { entries = fs.readdirSync(root, { withFileTypes: true }) } catch { return null }
+  for (const e of entries) {
+    if (e.isDirectory() && e.name.endsWith('.app')) {
+      const macosDir = path.join(root, e.name, 'Contents', 'MacOS')
+      // The main binary is conventionally named like the app (sans ".app");
+      // fall back to the first regular file in MacOS/.
+      const preferred = path.join(macosDir, e.name.slice(0, -'.app'.length))
+      if (isFile(preferred)) return preferred
+      try {
+        for (const inner of fs.readdirSync(macosDir, { withFileTypes: true })) {
+          if (inner.isFile()) return path.join(macosDir, inner.name)
+        }
+      } catch { /* keep searching */ }
+    }
+  }
+  for (const e of entries) {
+    if (e.isDirectory() && !e.name.endsWith('.app')) {
+      const hit = findMacAppExecutable(path.join(root, e.name), depth + 1)
+      if (hit) return hit
+    }
+  }
+  return null
+}
+
+/** Find the bundled Chromium executable under `<chromiumRoot>`, or null. */
+export function discoverChromiumExecutable(chromiumRoot: string): string | null {
+  if (!fs.existsSync(chromiumRoot)) return null
   if (process.platform === 'win32') {
-    return [
-      path.join(root, 'bin', 'chromium.exe'),
-      path.join(root, 'chrome-win', 'chrome.exe'),
-      path.join(root, 'chrome.exe'),
-    ]
+    return findFirstFile(chromiumRoot, (n) => n === 'chrome.exe' || n === 'chromium.exe')
   }
   if (process.platform === 'darwin') {
-    return [
-      path.join(root, 'bin', 'chromium'),
-      path.join(root, 'chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium'),
-      path.join(root, 'Chromium.app', 'Contents', 'MacOS', 'Chromium'),
-    ]
+    return (
+      findMacAppExecutable(chromiumRoot) ??
+      findFirstFile(chromiumRoot, (n) => n === 'Chromium' || n === 'chromium' || n === 'chrome')
+    )
   }
   // linux
-  return [
-    path.join(root, 'bin', 'chromium'),
-    path.join(root, 'chrome-linux', 'chrome'),
-    path.join(root, 'chrome'),
-  ]
+  return findFirstFile(chromiumRoot, (n) => n === 'chrome' || n === 'chromium' || n === 'chrome-wrapper')
 }
 
 /**
@@ -61,8 +94,9 @@ export function resolveBundledChromiumPath(): string | null {
   if (process.env.SPECRAILS_IS_DESKTOP !== '1') return null
   const runtimesPath = process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH
   if (!runtimesPath) return null
-  for (const candidate of bundledChromiumCandidates(runtimesPath)) {
-    if (fileExists(candidate)) return candidate
+  try {
+    return discoverChromiumExecutable(path.join(runtimesPath, 'chromium'))
+  } catch {
+    return null
   }
-  return null
 }


### PR DESCRIPTION
## Why
The **"From a website"** feature is **non-functional in the packaged desktop app** without a bundled Chromium: Playwright's `launch()` does **not** auto-download a browser — it throws *"Executable doesn't exist"*. (It only worked in dev because `npx playwright install chromium` was run there.) So we ship Chromium inside the app and notarize it.

## Changes
- **`scripts/sign-chromium-macos.sh`** (new): signs `Chromium.app` **inside-out** for notarization — every nested Mach-O, then every nested bundle (`.framework` + helper `.app`) deepest-first, with hardened runtime + the JIT / unsigned-memory / library-validation entitlements V8 + the sandbox require. A single `codesign --deep` is insufficient (doesn't propagate entitlements to helper apps → they'd be killed at runtime).
- **`desktop-release.yml`**: `BUNDLE_CHROMIUM=true`; exclude chromium from the generic per-file sign loop; dedicated Chromium-signing step (macOS); discover the app/exe instead of hard-coding paths (mac + win).
- **`server/chromium-resolver.ts`**: **discover** the bundled executable by walking `<runtimes>/chromium/`. Playwright's layout changed (`chrome-mac/Chromium.app` → `chrome-mac-arm64/"Google Chrome for Testing.app"`; `chrome-win/chrome.exe`; `chrome-linux/chrome`) — the previous hard-coded candidates were wrong.
- **smoke script + local assembler**: discover the executable too.

## Validation (local, real Playwright app)
- Discovery finds `chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing`.
- `sign-chromium-macos.sh` (ad-hoc) signs all nested helpers/frameworks inside-out; `codesign --verify --deep --strict` → **valid**.
- typecheck ✓, resolver tests ✓, server coverage ✓, workflow YAML valid.

Developer-ID signing + Apple notarization happen in CI. macOS Chromium notarization is the unvalidatable-until-CI part; the signing flow is structurally validated.

After merge: release-please cuts **v1.61.2** → Desktop Release builds with bundled, signed Chromium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)