### PR TITLE
feat(browser-capture): design tokens, network capture, multi-breakpoint, annotations + clipboard & toolbar fixes

### DIFF
--- a/client/src/components/ProposeSpecModal.tsx
+++ b/client/src/components/ProposeSpecModal.tsx
@@ -182,6 +182,12 @@ export function ProposeSpecModal({ open, onClose, tickets, onExploreLaunch }: Pr
     // are tracked here and merged into the submit payload; the screenshot renders
     // as a visual chip and the DOM in a collapsible panel. They are NOT inserted
     // as editor pills so removeCapture can cleanly drop both.
+    // If the user annotated, the flattened image is `screenshot`; drop the raw one
+    // it replaced so only the annotated image + DOM ride into the spec.
+    if (result.rawScreenshot && result.rawScreenshot.id !== result.screenshot.id) {
+      const pid = activeProjectIdRef.current
+      fetch(`${API_ORIGIN}/api/projects/${pid}/tickets/${pendingSpecId}/attachments/${result.rawScreenshot.id}`, { method: 'DELETE' }).catch(() => {})
+    }
     const breakpoints = result.breakpoints
       ? Object.entries(result.breakpoints).map(([key, b]) => ({ key, attachmentId: b.attachment.id, dataUrl: b.dataUrl, width: b.viewport.width }))
       : undefined
@@ -195,7 +201,7 @@ export function ProposeSpecModal({ open, onClose, tickets, onExploreLaunch }: Pr
     }])
     // One DOM attachment + N screenshots (N=1 for a normal capture).
     setAttachmentCount((c) => c + 1 + (breakpoints ? breakpoints.length : 1))
-  }, [])
+  }, [pendingSpecId])
 
   const removeCapture = useCallback((entry: BrowserCaptureEntry) => {
     setCaptures((c) => c.filter((e) => e.domAttachmentId !== entry.domAttachmentId))

--- a/client/src/components/ProposeSpecModal.tsx
+++ b/client/src/components/ProposeSpecModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useCallback, useMemo, useRef, useState } from 'react'
-import { Sparkles, Send, Zap, MessagesSquare, Globe } from 'lucide-react'
+import { Sparkles, Send, Zap, MessagesSquare, Globe, Ratio } from 'lucide-react'
 import { toast } from 'sonner'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from './ui/dialog'
 import { Button } from './ui/button'
@@ -23,12 +23,21 @@ import { BrowserCaptureModal } from './browser-capture/BrowserCaptureModal'
 import { CapturedDomPanel } from './browser-capture/CapturedDomPanel'
 import { isBrowserCaptureEnabled, type CaptureResult, type CapturedDom } from '../lib/browser-capture'
 
+interface BrowserCaptureBreakpoint {
+  key: string
+  attachmentId: string
+  dataUrl: string
+  width: number
+}
+
 interface BrowserCaptureEntry {
   screenshotId: string
   screenshotName: string
   screenshotDataUrl: string
   domAttachmentId: string
   dom: CapturedDom
+  /** Present for a multi-breakpoint capture: one screenshot per device size. */
+  breakpoints?: BrowserCaptureBreakpoint[]
 }
 
 type SpecMode = 'quick' | 'explore'
@@ -173,34 +182,50 @@ export function ProposeSpecModal({ open, onClose, tickets, onExploreLaunch }: Pr
     // are tracked here and merged into the submit payload; the screenshot renders
     // as a visual chip and the DOM in a collapsible panel. They are NOT inserted
     // as editor pills so removeCapture can cleanly drop both.
+    const breakpoints = result.breakpoints
+      ? Object.entries(result.breakpoints).map(([key, b]) => ({ key, attachmentId: b.attachment.id, dataUrl: b.dataUrl, width: b.viewport.width }))
+      : undefined
     setCaptures((c) => [...c, {
       screenshotId: result.screenshot.id,
       screenshotName: result.screenshot.filename,
       screenshotDataUrl: result.screenshotDataUrl,
       domAttachmentId: result.domAttachment.id,
       dom: result.dom,
+      breakpoints,
     }])
-    setAttachmentCount((c) => c + 2)
+    // One DOM attachment + N screenshots (N=1 for a normal capture).
+    setAttachmentCount((c) => c + 1 + (breakpoints ? breakpoints.length : 1))
   }, [])
 
   const removeCapture = useCallback((entry: BrowserCaptureEntry) => {
     setCaptures((c) => c.filter((e) => e.domAttachmentId !== entry.domAttachmentId))
-    setAttachmentCount((c) => Math.max(0, c - 2))
+    const ids = new Set<string>([entry.screenshotId, entry.domAttachmentId, ...(entry.breakpoints?.map((b) => b.attachmentId) ?? [])])
+    setAttachmentCount((c) => Math.max(0, c - ids.size))
     const pid = activeProjectIdRef.current
-    for (const id of [entry.screenshotId, entry.domAttachmentId]) {
+    for (const id of ids) {
       fetch(`${API_ORIGIN}/api/projects/${pid}/tickets/${pendingSpecId}/attachments/${id}`, { method: 'DELETE' }).catch(() => {})
     }
   }, [pendingSpecId])
 
   const handleSubmit = useCallback(async () => {
     const typed = editorRef.current?.getPlainText().trim() ?? ''
-    const idea = typed || (captures.length > 0
+    let idea = typed || (captures.length > 0
       ? 'Create a spec based on the captured browser selection (a screenshot and the page DOM are attached for reference).'
       : '')
     if (!idea) return
+    // When any capture is multi-breakpoint, tell the spec generator it must be
+    // responsive and which reference sizes are attached.
+    const responsive = captures.find((c) => c.breakpoints && c.breakpoints.length > 1)
+    if (responsive) {
+      const widths = responsive.breakpoints!.map((b) => `${b.width}px`).join(', ')
+      idea += `${idea ? '\n\n' : ''}This element must be responsive: reference screenshots are attached at ${widths}.`
+    }
     const attachmentIds = [
       ...(editorRef.current?.getAttachmentIds() ?? []),
-      ...captures.flatMap((c) => [c.screenshotId, c.domAttachmentId]),
+      ...captures.flatMap((c) => [
+        ...(c.breakpoints ? c.breakpoints.map((b) => b.attachmentId) : [c.screenshotId]),
+        c.domAttachmentId,
+      ]),
     ]
 
     const projectId = activeProjectIdRef.current
@@ -376,11 +401,32 @@ export function ProposeSpecModal({ open, onClose, tickets, onExploreLaunch }: Pr
                 {captures.map((c) => (
                   <div key={c.domAttachmentId} className="space-y-1.5">
                     <div className="rounded-lg border border-accent-secondary/40 bg-accent-secondary/5 p-2 space-y-1.5">
-                      <img
-                        src={c.screenshotDataUrl}
-                        alt={c.screenshotName}
-                        className="max-h-44 w-auto max-w-full object-contain rounded border border-border/60 bg-background-deep mx-auto block"
-                      />
+                      {c.breakpoints ? (
+                        <div className="space-y-1.5" data-testid="capture-breakpoints">
+                          <div className="flex items-center gap-1 text-[10px] font-medium text-accent-highlight">
+                            <Ratio className="w-3 h-3 shrink-0" />
+                            Responsive · {c.breakpoints.length} sizes
+                          </div>
+                          <div className="flex items-end justify-center gap-2 flex-wrap">
+                            {c.breakpoints.map((b) => (
+                              <div key={b.key} className="flex flex-col items-center gap-1">
+                                <img
+                                  src={b.dataUrl}
+                                  alt={`${b.key} (${b.width}px)`}
+                                  className="max-h-36 w-auto max-w-[10rem] object-contain rounded border border-border/60 bg-background-deep block"
+                                />
+                                <span className="text-[10px] text-muted-foreground tabular-nums">{b.key} · {b.width}px</span>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      ) : (
+                        <img
+                          src={c.screenshotDataUrl}
+                          alt={c.screenshotName}
+                          className="max-h-44 w-auto max-w-full object-contain rounded border border-border/60 bg-background-deep mx-auto block"
+                        />
+                      )}
                       {c.dom.url && c.dom.url !== 'about:blank' && (
                         <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground" title={c.dom.url}>
                           <Globe className="w-3 h-3 shrink-0" />

--- a/client/src/components/browser-capture/AnnotationEditor.tsx
+++ b/client/src/components/browser-capture/AnnotationEditor.tsx
@@ -1,0 +1,360 @@
+import { useCallback, useEffect, useReducer, useRef, useState } from 'react'
+import { ArrowUpRight, Square, Type, Droplet, Hash, Undo2, Redo2, Check, ArrowLeft, X, Loader2 } from 'lucide-react'
+import { Button } from '../ui/button'
+import { uploadCaptureImage, type CaptureResult } from '../../lib/browser-capture'
+import {
+  annotationReducer,
+  initialEditorState,
+  nextStepNumber,
+  normalizeBox,
+  arrowHead,
+  isUsableDrag,
+  clamp01,
+  toAnnotationSet,
+  type AnnotationTool,
+  type Pt,
+} from '../../lib/annotations'
+
+interface AnnotationEditorProps {
+  result: CaptureResult
+  pendingSpecId: string
+  /** Reserve the macOS traffic-light gutter on the floating toolbar. */
+  macOverlay?: boolean
+  /** Flattens + uploads, then hands back an augmented CaptureResult. */
+  onConfirm: (augmented: CaptureResult) => void
+  /** Discard markup, return to the rubber-band selection step. */
+  onReselect: () => void
+  /** Discard markup + close (confirm-if-dirty handled by the caller chain). */
+  onCancel: () => void
+}
+
+// A tight, high-contrast palette (concrete hex — canvas fillStyle can't read CSS
+// vars). Red default = the universal "attention/this is wrong" convention.
+const PALETTE = ['#ef4444', '#f59e0b', '#3b82f6', '#22c55e', '#ffffff']
+
+const TOOLS: Array<{ tool: AnnotationTool; icon: typeof Square; label: string; key: string }> = [
+  { tool: 'arrow', icon: ArrowUpRight, label: 'Arrow (A)', key: 'a' },
+  { tool: 'box', icon: Square, label: 'Box (R)', key: 'r' },
+  { tool: 'text', icon: Type, label: 'Text (T)', key: 't' },
+  { tool: 'blur', icon: Droplet, label: 'Blur / redact (B)', key: 'b' },
+  { tool: 'step', icon: Hash, label: 'Step number (N)', key: 'n' },
+]
+
+let idSeq = 0
+const newId = () => `a${++idSeq}-${Date.now().toString(36)}`
+
+/**
+ * In-place markup editor over a FROZEN capture bitmap. Tools: arrow, box, text,
+ * blur (real pixel-destroying redaction at flatten time), and step badges.
+ * Add-only with undo/redo + tool persistence (move/resize deferred). On confirm
+ * the objects are flattened onto the bitmap at natural resolution, uploaded, and
+ * the annotated image becomes the screenshot the spec uses. Excluded from
+ * coverage — canvas + pointer drag is not exercisable under jsdom; the model and
+ * geometry live in `lib/annotations.ts` and are unit-tested.
+ */
+export function AnnotationEditor({ result, pendingSpecId, macOverlay, onConfirm, onReselect, onCancel }: AnnotationEditorProps) {
+  const [state, dispatch] = useReducer(annotationReducer, initialEditorState)
+  const [tool, setTool] = useState<AnnotationTool>('arrow')
+  const [color, setColor] = useState(PALETTE[0])
+  const [draft, setDraft] = useState<{ start: Pt; cur: Pt } | null>(null)
+  const [disp, setDisp] = useState({ w: 1, h: 1 })
+  const [busy, setBusy] = useState(false)
+
+  const imgRef = useRef<HTMLImageElement | null>(null)
+  const objects = state.objects
+
+  const measure = useCallback(() => {
+    const img = imgRef.current
+    if (!img) return
+    const r = img.getBoundingClientRect()
+    if (r.width > 0 && r.height > 0) setDisp({ w: r.width, h: r.height })
+  }, [])
+
+  useEffect(() => {
+    measure()
+    window.addEventListener('resize', measure)
+    return () => window.removeEventListener('resize', measure)
+  }, [measure])
+
+  const toNorm = useCallback((clientX: number, clientY: number): Pt => {
+    const img = imgRef.current
+    if (!img) return { x: 0, y: 0 }
+    const r = img.getBoundingClientRect()
+    return clamp01({ x: r.width > 0 ? (clientX - r.left) / r.width : 0, y: r.height > 0 ? (clientY - r.top) / r.height : 0 })
+  }, [])
+
+  // ─── Pointer drawing ────────────────────────────────────────────────────────
+
+  const onDown = useCallback((e: React.PointerEvent) => {
+    if (busy) return
+    ;(e.target as HTMLElement).setPointerCapture?.(e.pointerId)
+    const p = toNorm(e.clientX, e.clientY)
+    if (tool === 'text') {
+      const text = window.prompt('Note text:')?.trim()
+      if (text) dispatch({ type: 'add', obj: { id: newId(), kind: 'text', x: p.x, y: p.y, text, color } })
+      return
+    }
+    if (tool === 'step') {
+      dispatch({ type: 'add', obj: { id: newId(), kind: 'step', x: p.x, y: p.y, n: nextStepNumber(objects), color } })
+      return
+    }
+    setDraft({ start: p, cur: p })
+  }, [busy, tool, color, objects, toNorm])
+
+  const onMove = useCallback((e: React.PointerEvent) => {
+    if (!draft) return
+    setDraft((d) => (d ? { ...d, cur: toNorm(e.clientX, e.clientY) } : d))
+  }, [draft, toNorm])
+
+  const onUp = useCallback(() => {
+    if (!draft) return
+    const { start, cur } = draft
+    setDraft(null)
+    if (!isUsableDrag(start, cur)) return
+    if (tool === 'arrow') {
+      dispatch({ type: 'add', obj: { id: newId(), kind: 'arrow', from: start, to: cur, color } })
+    } else if (tool === 'box') {
+      const b = normalizeBox(start, cur)
+      dispatch({ type: 'add', obj: { id: newId(), kind: 'box', ...b, color } })
+    } else if (tool === 'blur') {
+      const b = normalizeBox(start, cur)
+      dispatch({ type: 'add', obj: { id: newId(), kind: 'blur', ...b } })
+    }
+  }, [draft, tool, color])
+
+  // ─── Keyboard shortcuts ─────────────────────────────────────────────────────
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (busy) return
+      const meta = e.metaKey || e.ctrlKey
+      if (meta && e.key.toLowerCase() === 'z') { e.preventDefault(); dispatch({ type: e.shiftKey ? 'redo' : 'undo' }); return }
+      if (meta && e.key === 'Enter') { e.preventDefault(); void handleConfirm(); return }
+      if (meta) return
+      const t = TOOLS.find((x) => x.key === e.key.toLowerCase())
+      if (t) { setTool(t.tool); return }
+      if (e.key === 'Escape') { e.preventDefault(); handleCancel() }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [busy, objects, color, tool])
+
+  // ─── Flatten + confirm ──────────────────────────────────────────────────────
+
+  const flatten = useCallback(async (): Promise<{ blob: Blob; dataUrl: string } | null> => {
+    const img = imgRef.current
+    if (!img || !img.naturalWidth) return null
+    const nw = img.naturalWidth
+    const nh = img.naturalHeight
+    const canvas = document.createElement('canvas')
+    canvas.width = nw
+    canvas.height = nh
+    const cx = canvas.getContext('2d')
+    if (!cx) return null
+    cx.drawImage(img, 0, 0, nw, nh)
+    // Blur regions FIRST so they sit over the sharp base and under the marks. Real
+    // pixel destruction (clip + blurred redraw), not a translucent overlay.
+    for (const o of objects) {
+      if (o.kind !== 'blur') continue
+      cx.save()
+      cx.beginPath()
+      cx.rect(o.x * nw, o.y * nh, o.w * nw, o.h * nh)
+      cx.clip()
+      cx.filter = `blur(${Math.max(6, nw * 0.012)}px)`
+      cx.drawImage(img, 0, 0, nw, nh)
+      cx.restore()
+    }
+    cx.filter = 'none'
+    const lw = Math.max(2, nw * 0.004)
+    for (const o of objects) {
+      if (o.kind === 'box') {
+        cx.strokeStyle = o.color
+        cx.lineWidth = lw
+        cx.strokeRect(o.x * nw, o.y * nh, o.w * nw, o.h * nh)
+      } else if (o.kind === 'arrow') {
+        const from = { x: o.from.x * nw, y: o.from.y * nh }
+        const to = { x: o.to.x * nw, y: o.to.y * nh }
+        const h = arrowHead(o.from, o.to, 0.035)
+        cx.strokeStyle = o.color
+        cx.lineWidth = lw
+        cx.lineCap = 'round'
+        cx.beginPath(); cx.moveTo(from.x, from.y); cx.lineTo(to.x, to.y)
+        cx.moveTo(h.left.x * nw, h.left.y * nh); cx.lineTo(to.x, to.y); cx.lineTo(h.right.x * nw, h.right.y * nh)
+        cx.stroke()
+      } else if (o.kind === 'text') {
+        const fs = Math.max(12, nh * 0.03)
+        cx.font = `600 ${fs}px sans-serif`
+        cx.textBaseline = 'top'
+        cx.lineWidth = Math.max(2, fs * 0.18)
+        cx.strokeStyle = 'rgba(0,0,0,0.55)'
+        cx.strokeText(o.text, o.x * nw, o.y * nh)
+        cx.fillStyle = o.color
+        cx.fillText(o.text, o.x * nw, o.y * nh)
+      } else if (o.kind === 'step') {
+        const rad = Math.max(10, nh * 0.025)
+        cx.beginPath(); cx.arc(o.x * nw, o.y * nh, rad, 0, Math.PI * 2)
+        cx.fillStyle = o.color; cx.fill()
+        cx.fillStyle = '#000'
+        cx.font = `700 ${rad * 1.1}px sans-serif`
+        cx.textAlign = 'center'; cx.textBaseline = 'middle'
+        cx.fillText(String(o.n), o.x * nw, o.y * nh)
+        cx.textAlign = 'start'
+      }
+    }
+    const dataUrl = canvas.toDataURL('image/png')
+    const blob = await new Promise<Blob | null>((res) => canvas.toBlob((b) => res(b), 'image/png'))
+    return blob ? { blob, dataUrl } : null
+  }, [objects])
+
+  const handleConfirm = useCallback(async () => {
+    if (busy) return
+    if (objects.length === 0) { onConfirm(result); return }
+    setBusy(true)
+    try {
+      const flat = await flatten()
+      const img = imgRef.current
+      if (!flat || !img) { onConfirm(result); return }
+      const attachment = await uploadCaptureImage(pendingSpecId, flat.blob, `screen-annotated-${Date.now()}.png`)
+      onConfirm({
+        ...result,
+        rawScreenshot: result.screenshot,
+        screenshot: attachment,
+        screenshotDataUrl: flat.dataUrl,
+        annotations: toAnnotationSet(objects, img.naturalWidth, img.naturalHeight),
+      })
+    } catch {
+      // Upload failed → fall back to the un-annotated capture so the user isn't stuck.
+      onConfirm(result)
+    } finally {
+      setBusy(false)
+    }
+  }, [busy, objects, flatten, pendingSpecId, result, onConfirm])
+
+  const handleCancel = useCallback(() => {
+    if (objects.length > 0 && !window.confirm('Discard annotations?')) return
+    onCancel()
+  }, [objects.length, onCancel])
+
+  // ─── Render ─────────────────────────────────────────────────────────────────
+
+  const px = (n: number, axis: 'w' | 'h') => n * (axis === 'w' ? disp.w : disp.h)
+  const draftBox = draft ? normalizeBox(draft.start, draft.cur) : null
+
+  return (
+    <div className="flex-1 min-h-0 flex flex-col items-center justify-center overflow-hidden p-3 gap-2">
+      {/* Floating tool strip */}
+      <div className={`flex items-center gap-1 rounded-lg border border-border/60 bg-surface/90 px-1.5 py-1 shadow-xl ${macOverlay ? 'ml-[80px]' : ''}`}>
+        {TOOLS.map(({ tool: t, icon: Icon, label }) => (
+          <button
+            key={t}
+            type="button"
+            title={label}
+            aria-label={label}
+            aria-pressed={tool === t}
+            onClick={() => setTool(t)}
+            className={`h-7 w-7 inline-flex items-center justify-center rounded transition-colors ${tool === t ? 'bg-primary/15 text-primary' : 'text-muted-foreground hover:text-foreground hover:bg-card/60'}`}
+          >
+            <Icon className="w-3.5 h-3.5" />
+          </button>
+        ))}
+        <span className="w-px h-5 bg-border/60 mx-0.5" />
+        {PALETTE.map((c) => (
+          <button
+            key={c}
+            type="button"
+            aria-label={`Colour ${c}`}
+            onClick={() => setColor(c)}
+            className={`h-5 w-5 rounded-full border transition-transform ${color === c ? 'scale-110 border-foreground' : 'border-border/60'}`}
+            style={{ background: c }}
+          />
+        ))}
+        <span className="w-px h-5 bg-border/60 mx-0.5" />
+        <button type="button" aria-label="Undo" title="Undo (⌘Z)" disabled={state.past.length === 0} onClick={() => dispatch({ type: 'undo' })} className="h-7 w-7 inline-flex items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-card/60 disabled:opacity-40">
+          <Undo2 className="w-3.5 h-3.5" />
+        </button>
+        <button type="button" aria-label="Redo" title="Redo (⌘⇧Z)" disabled={state.future.length === 0} onClick={() => dispatch({ type: 'redo' })} className="h-7 w-7 inline-flex items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-card/60 disabled:opacity-40">
+          <Redo2 className="w-3.5 h-3.5" />
+        </button>
+      </div>
+
+      {/* Frozen bitmap + overlay */}
+      <div className="relative inline-block max-w-full max-h-full">
+        <img
+          ref={imgRef}
+          src={result.screenshotDataUrl}
+          alt="Captured selection"
+          onLoad={measure}
+          draggable={false}
+          className="block max-w-full max-h-full select-none rounded shadow-2xl"
+        />
+        {/* Blur previews (under the pointer/svg layer) */}
+        {objects.map((o) => o.kind === 'blur' ? (
+          <div key={o.id} className="absolute backdrop-blur-md bg-background-deep/10 border border-border/40 pointer-events-none rounded-sm"
+            style={{ left: `${o.x * 100}%`, top: `${o.y * 100}%`, width: `${o.w * 100}%`, height: `${o.h * 100}%` }} />
+        ) : null)}
+        {draft && tool === 'blur' && draftBox && (
+          <div className="absolute backdrop-blur-md bg-background-deep/10 border border-accent-info pointer-events-none rounded-sm"
+            style={{ left: `${draftBox.x * 100}%`, top: `${draftBox.y * 100}%`, width: `${draftBox.w * 100}%`, height: `${draftBox.h * 100}%` }} />
+        )}
+        <svg
+          className={`absolute inset-0 w-full h-full ${tool === 'text' || tool === 'step' ? 'cursor-pointer' : 'cursor-crosshair'}`}
+          viewBox={`0 0 ${disp.w} ${disp.h}`}
+          preserveAspectRatio="none"
+          onPointerDown={onDown}
+          onPointerMove={onMove}
+          onPointerUp={onUp}
+        >
+          {objects.map((o) => {
+            if (o.kind === 'box') return <rect key={o.id} x={px(o.x, 'w')} y={px(o.y, 'h')} width={px(o.w, 'w')} height={px(o.h, 'h')} fill="none" stroke={o.color} strokeWidth={Math.max(2, disp.w * 0.004)} />
+            if (o.kind === 'arrow') {
+              const h = arrowHead(o.from, o.to, 0.035)
+              const sw = Math.max(2, disp.w * 0.004)
+              return (
+                <g key={o.id} stroke={o.color} strokeWidth={sw} strokeLinecap="round" fill="none">
+                  <line x1={px(o.from.x, 'w')} y1={px(o.from.y, 'h')} x2={px(o.to.x, 'w')} y2={px(o.to.y, 'h')} />
+                  <polyline points={`${px(h.left.x, 'w')},${px(h.left.y, 'h')} ${px(o.to.x, 'w')},${px(o.to.y, 'h')} ${px(h.right.x, 'w')},${px(h.right.y, 'h')}`} />
+                </g>
+              )
+            }
+            if (o.kind === 'text') return <text key={o.id} x={px(o.x, 'w')} y={px(o.y, 'h')} dominantBaseline="hanging" fontSize={Math.max(12, disp.h * 0.03)} fontWeight={600} fill={o.color} stroke="rgba(0,0,0,0.55)" strokeWidth={1} paintOrder="stroke">{o.text}</text>
+            if (o.kind === 'step') {
+              const rad = Math.max(10, disp.h * 0.025)
+              return (
+                <g key={o.id}>
+                  <circle cx={px(o.x, 'w')} cy={px(o.y, 'h')} r={rad} fill={o.color} />
+                  <text x={px(o.x, 'w')} y={px(o.y, 'h')} textAnchor="middle" dominantBaseline="central" fontSize={rad * 1.1} fontWeight={700} fill="#000">{o.n}</text>
+                </g>
+              )
+            }
+            return null
+          })}
+          {draft && (tool === 'box') && draftBox && (
+            <rect x={px(draftBox.x, 'w')} y={px(draftBox.y, 'h')} width={px(draftBox.w, 'w')} height={px(draftBox.h, 'h')} fill="none" stroke={color} strokeDasharray="4 3" strokeWidth={Math.max(2, disp.w * 0.004)} />
+          )}
+          {draft && tool === 'arrow' && (
+            <line x1={px(draft.start.x, 'w')} y1={px(draft.start.y, 'h')} x2={px(draft.cur.x, 'w')} y2={px(draft.cur.y, 'h')} stroke={color} strokeWidth={Math.max(2, disp.w * 0.004)} strokeLinecap="round" />
+          )}
+        </svg>
+        {busy && (
+          <div className="absolute inset-0 flex items-center justify-center gap-2 bg-background-deep/50 text-sm text-foreground">
+            <Loader2 className="w-4 h-4 animate-spin" /> Saving…
+          </div>
+        )}
+      </div>
+
+      {/* Footer actions */}
+      <div className="flex items-center gap-2">
+        <Button size="sm" variant="ghost" className="gap-1.5" onClick={onReselect} disabled={busy}>
+          <ArrowLeft className="w-3.5 h-3.5" /> Reselect
+        </Button>
+        <Button size="sm" variant="ghost" className="gap-1.5" onClick={handleCancel} disabled={busy}>
+          <X className="w-3.5 h-3.5" /> Cancel
+        </Button>
+        <Button size="sm" className="gap-1.5" onClick={() => void handleConfirm()} disabled={busy} data-testid="annotation-confirm">
+          <Check className="w-3.5 h-3.5" /> {objects.length > 0 ? 'Create spec' : 'Skip & continue'}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/client/src/components/browser-capture/BrowserCaptureModal.tsx
+++ b/client/src/components/browser-capture/BrowserCaptureModal.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, ArrowRight, RotateCw, X, Crop, Loader2, Globe, AlertTriangle
 import { toast } from 'sonner'
 import { Button } from '../ui/button'
 import { useBrowserCaptureSession } from './useBrowserCaptureSession'
+import { AnnotationEditor } from './AnnotationEditor'
 import {
   mapPointToViewport,
   mapRectToDisplay,
@@ -69,6 +70,8 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
   const [captureNetwork, setCaptureNetwork] = useState(true)
   // Capture the selected element at desktop/tablet/mobile in one shot.
   const [captureAllSizes, setCaptureAllSizes] = useState(false)
+  // When set, a single capture is frozen and the markup editor is shown over it.
+  const [markup, setMarkup] = useState<CaptureResult | null>(null)
 
   const containerRef = useRef<HTMLDivElement | null>(null)
   const pendingMoveRef = useRef<{ x: number; y: number } | null>(null)
@@ -198,13 +201,18 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
   const runCapture = useCallback(async (rect: CaptureRect) => {
     setCapturing(true)
     try {
-      const anchorPoint = { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 }
-      const result = captureAllSizes
-        ? await session.captureBreakpoints(rect, anchorPoint, pendingSpecId, BREAKPOINT_DIMS)
-        : await session.capture(rect, pendingSpecId, { captureNetwork })
-      onCaptured(result)
-      toast.success('Captured page selection')
-      onClose()
+      if (captureAllSizes) {
+        // Multi-breakpoint = 3 reference images; no markup step.
+        const anchorPoint = { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 }
+        const result = await session.captureBreakpoints(rect, anchorPoint, pendingSpecId, BREAKPOINT_DIMS)
+        onCaptured(result)
+        toast.success('Captured page selection')
+        onClose()
+      } else {
+        // Freeze the single capture and hand it to the in-place markup editor.
+        const result = await session.capture(rect, pendingSpecId, { captureNetwork })
+        setMarkup(result)
+      }
     } catch {
       toast.error('Capture failed')
     } finally {
@@ -284,6 +292,17 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
 
   return createPortal(
     <div className="fixed inset-0 z-[80] flex flex-col bg-background-deep/95 backdrop-blur-sm pointer-events-auto" role="dialog" aria-modal="true" aria-label="Browser capture">
+      {markup ? (
+        <AnnotationEditor
+          result={markup}
+          pendingSpecId={pendingSpecId}
+          macOverlay={macOverlay}
+          onConfirm={(aug) => { onCaptured(aug); onClose() }}
+          onReselect={() => { setMarkup(null); setSelecting(true) }}
+          onCancel={() => { setMarkup(null); onClose() }}
+        />
+      ) : (
+      <>
       {/* Toolbar */}
       <div className={`flex items-center gap-2 py-1.5 border-b border-border/50 bg-surface/80 shrink-0 ${macOverlay ? 'pr-3' : 'px-3'}`}>
         {/* On macOS desktop the native traffic-light controls float over the top-left;
@@ -448,6 +467,8 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
         <div className="px-3 py-1.5 text-center text-[11px] text-muted-foreground border-t border-border/40 shrink-0">
           Click a highlighted element to capture it, or drag a custom rectangle. Press Esc to cancel.
         </div>
+      )}
+      </>
       )}
     </div>,
     document.body,

--- a/client/src/components/browser-capture/BrowserCaptureModal.tsx
+++ b/client/src/components/browser-capture/BrowserCaptureModal.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { ArrowLeft, ArrowRight, RotateCw, X, Crop, Loader2, Globe, AlertTriangle, Monitor, Tablet, Smartphone, Maximize2, Network, Ratio } from 'lucide-react'
+import { ArrowLeft, ArrowRight, RotateCw, X, Crop, Loader2, Globe, AlertTriangle, Monitor, Tablet, Smartphone, Maximize2, Network, Ratio, ChevronRight, Lock } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '../ui/button'
 import { useBrowserCaptureSession } from './useBrowserCaptureSession'
@@ -14,6 +14,8 @@ import {
   type CaptureRect,
   type CaptureResult,
   type BrowserInputEvent,
+  type BreadcrumbSegment,
+  type ElementProbe,
 } from '../../lib/browser-capture'
 
 /**
@@ -58,7 +60,7 @@ const PRESET_DIMS: Record<Exclude<ViewportPreset, 'fit'>, { w: number; h: number
  */
 export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, onCaptured }: BrowserCaptureModalProps) {
   const session = useBrowserCaptureSession({ projectId, open })
-  const { canvasRef, viewport, status, errorMsg, url, title, hoverRect } = session
+  const { canvasRef, viewport, status, errorMsg, url, title, hoverRect, hoverSelector, hoverPath } = session
 
   const [addressValue, setAddressValue] = useState('')
   const [selecting, setSelecting] = useState(false)
@@ -72,6 +74,9 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
   const [captureAllSizes, setCaptureAllSizes] = useState(false)
   // When set, a single capture is frozen and the markup editor is shown over it.
   const [markup, setMarkup] = useState<CaptureResult | null>(null)
+  // Breadcrumb lock: when the user steps up/down the DOM tree (arrows / clicking a
+  // segment) the selection locks to that element until the cursor moves again.
+  const [locked, setLocked] = useState<ElementProbe | null>(null)
 
   const containerRef = useRef<HTMLDivElement | null>(null)
   const pendingMoveRef = useRef<{ x: number; y: number } | null>(null)
@@ -79,6 +84,13 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
   const presetRef = useRef<ViewportPreset>('fit')
   const canvasRectRef = useRef<{ left: number; top: number; width: number; height: number } | null>(null)
   const lastProbeAtRef = useRef(0)
+  // Refs for the breadcrumb keyboard handler (avoid re-subscribing on every hover).
+  const lockedRef = useRef<ElementProbe | null>(null)
+  const hoverSelectorRef = useRef<string | null>(null)
+  const navigateElementRef = useRef(session.navigateElement)
+  useEffect(() => { lockedRef.current = locked }, [locked])
+  useEffect(() => { hoverSelectorRef.current = hoverSelector }, [hoverSelector])
+  navigateElementRef.current = session.navigateElement
 
   useEffect(() => { setAddressValue(url ?? '') }, [url])
 
@@ -126,13 +138,30 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
     if (!open) return
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        if (selecting) { setSelecting(false); setBox(null) }
+        if (selecting) { setSelecting(false); setBox(null); setLocked(null) }
         else onClose()
       }
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
   }, [open, selecting, onClose])
+
+  // Breadcrumb navigation: ↑ = parent, ↓ = child of the locked-or-hovered element.
+  // Locks the selection to the resolved element until the cursor moves again.
+  useEffect(() => {
+    if (!open || !selecting) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return
+      const sel = lockedRef.current?.selector ?? hoverSelectorRef.current
+      if (!sel) return
+      e.preventDefault()
+      void navigateElementRef.current(sel, e.key === 'ArrowUp' ? 'parent' : 'child').then((probe) => {
+        if (probe) setLocked(probe)
+      })
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, selecting])
 
   const canvasRect = useCallback((): DOMRect | null => {
     const r = canvasRef.current?.getBoundingClientRect() ?? null
@@ -242,9 +271,14 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
       setCapturing(false)
       setSelecting(false)
       setBox(null)
+      setLocked(null)
       session.clearHover()
     }
   }, [session, pendingSpecId, captureNetwork, captureAllSizes, onCaptured, onClose])
+
+  const onBreadcrumbClick = useCallback((segment: BreadcrumbSegment) => {
+    void session.navigateElement(segment.selector, 'self').then((probe) => { if (probe) setLocked(probe) })
+  }, [session])
 
   const onSelectDown = useCallback((e: React.PointerEvent) => {
     ;(e.target as HTMLElement).setPointerCapture?.(e.pointerId)
@@ -257,6 +291,8 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
       setBox((b) => (b ? { ...b, curX: cx, curY: cy } : b))
       return
     }
+    // Moving the cursor over the page resumes live hover (drops a breadcrumb lock).
+    if (lockedRef.current) setLocked(null)
     // Not dragging → hover-probe the element under the cursor (throttled: at most
     // one probe per animation frame AND no more often than every 40ms, to avoid
     // flooding the WS / the page's elementFromPoint on fast movement).
@@ -275,6 +311,7 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
   }, [box, toViewport, session])
 
   const onSelectUp = useCallback((e: React.PointerEvent) => {
+    const lk = lockedRef.current
     setBox((b) => {
       if (b) {
         const a = toViewport(b.startX, b.startY)
@@ -283,6 +320,9 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
         if (isUsableSelection(dragRect)) {
           // A real drag → capture the custom rectangle.
           void runCapture(dragRect)
+        } else if (lk) {
+          // A click with a breadcrumb lock → capture the locked element.
+          void runCapture(lk.rect)
         } else if (hoverRect) {
           // A click (no meaningful drag) → capture the hovered element.
           void runCapture(hoverRect)
@@ -307,8 +347,10 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
   // mid-drag). Uses the canvas rect cached during the last pointer move so we
   // never measure layout during the render phase.
   const cr = canvasRectRef.current
-  const hoverStyle = selecting && hoverRect && !box && cr
-    ? mapRectToDisplay(hoverRect, cr, viewport)
+  const activeRect = locked?.rect ?? hoverRect
+  const activePath = locked?.path ?? hoverPath
+  const hoverStyle = selecting && activeRect && !box && cr
+    ? mapRectToDisplay(activeRect, cr, viewport)
     : null
 
   const macOverlay = isMacTauriOverlay()
@@ -394,7 +436,7 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
           size="sm"
           variant={selecting ? 'default' : 'secondary'}
           className="gap-1.5"
-          onClick={() => { setSelecting((v) => !v); setBox(null); session.clearHover() }}
+          onClick={() => { setSelecting((v) => !v); setBox(null); setLocked(null); session.clearHover() }}
           disabled={status !== 'ready' || capturing}
           data-testid="browser-select-toggle"
         >
@@ -486,9 +528,29 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
         )}
       </div>
 
+      {selecting && activePath && activePath.length > 0 && (
+        <div className="flex items-center gap-1 px-3 py-1.5 border-t border-border/40 bg-surface/70 shrink-0 overflow-x-auto text-[11px]">
+          {locked ? <Lock className="w-3 h-3 shrink-0 text-accent-info" /> : null}
+          {activePath.map((seg, i) => (
+            <Fragment key={`${seg.selector}-${i}`}>
+              {i > 0 && <ChevronRight className="w-3 h-3 text-muted-foreground/50 shrink-0" />}
+              <button
+                type="button"
+                onClick={() => onBreadcrumbClick(seg)}
+                title={seg.selector}
+                className={`shrink-0 font-mono px-1 rounded hover:bg-card/60 transition-colors ${i === activePath.length - 1 ? 'text-accent-info font-medium' : 'text-foreground/70'}`}
+              >
+                {seg.label}
+              </button>
+            </Fragment>
+          ))}
+          <span className="text-muted-foreground/60 shrink-0 ml-auto pl-2 hidden md:inline">↑ parent · ↓ child</span>
+        </div>
+      )}
+
       {selecting && (
         <div className="px-3 py-1.5 text-center text-[11px] text-muted-foreground border-t border-border/40 shrink-0">
-          Click a highlighted element to capture it, or drag a custom rectangle. Press Esc to cancel.
+          Click a highlighted element to capture it, or drag a custom rectangle. Use the breadcrumb (or ↑/↓) to refine. Press Esc to cancel.
         </div>
       )}
       </>

--- a/client/src/components/browser-capture/BrowserCaptureModal.tsx
+++ b/client/src/components/browser-capture/BrowserCaptureModal.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { ArrowLeft, ArrowRight, RotateCw, X, Crop, Loader2, Globe, AlertTriangle, Monitor, Tablet, Smartphone, Maximize2, Network } from 'lucide-react'
+import { ArrowLeft, ArrowRight, RotateCw, X, Crop, Loader2, Globe, AlertTriangle, Monitor, Tablet, Smartphone, Maximize2, Network, Ratio } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '../ui/button'
 import { useBrowserCaptureSession } from './useBrowserCaptureSession'
@@ -9,6 +9,7 @@ import {
   mapRectToDisplay,
   rectFromPoints,
   isUsableSelection,
+  BREAKPOINT_DIMS,
   type CaptureRect,
   type CaptureResult,
   type BrowserInputEvent,
@@ -66,6 +67,8 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
   // Capture the page's XHR/fetch requests alongside the selection (ON by default;
   // a user can disable it for a privacy-sensitive page).
   const [captureNetwork, setCaptureNetwork] = useState(true)
+  // Capture the selected element at desktop/tablet/mobile in one shot.
+  const [captureAllSizes, setCaptureAllSizes] = useState(false)
 
   const containerRef = useRef<HTMLDivElement | null>(null)
   const pendingMoveRef = useRef<{ x: number; y: number } | null>(null)
@@ -195,7 +198,10 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
   const runCapture = useCallback(async (rect: CaptureRect) => {
     setCapturing(true)
     try {
-      const result = await session.capture(rect, pendingSpecId, { captureNetwork })
+      const anchorPoint = { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 }
+      const result = captureAllSizes
+        ? await session.captureBreakpoints(rect, anchorPoint, pendingSpecId, BREAKPOINT_DIMS)
+        : await session.capture(rect, pendingSpecId, { captureNetwork })
       onCaptured(result)
       toast.success('Captured page selection')
       onClose()
@@ -207,7 +213,7 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
       setBox(null)
       session.clearHover()
     }
-  }, [session, pendingSpecId, captureNetwork, onCaptured, onClose])
+  }, [session, pendingSpecId, captureNetwork, captureAllSizes, onCaptured, onClose])
 
   const onSelectDown = useCallback((e: React.PointerEvent) => {
     ;(e.target as HTMLElement).setPointerCapture?.(e.pointerId)
@@ -330,6 +336,17 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
         >
           <Network className="w-3.5 h-3.5" />
           Network
+        </button>
+        <button
+          type="button"
+          aria-label="Capture at all screen sizes"
+          aria-pressed={captureAllSizes}
+          title={captureAllSizes ? 'Will capture this element at desktop, tablet and mobile (click to disable)' : 'Capture at all sizes: desktop, tablet and mobile'}
+          onClick={() => setCaptureAllSizes((v) => !v)}
+          className={`hidden md:inline-flex items-center gap-1 h-7 px-2 rounded-md border text-[11px] shrink-0 transition-colors ${captureAllSizes ? 'border-accent-highlight/40 bg-accent-highlight/10 text-accent-highlight' : 'border-border/50 text-muted-foreground hover:text-foreground hover:bg-card/60'}`}
+        >
+          <Ratio className="w-3.5 h-3.5" />
+          All sizes
         </button>
         <Button
           size="sm"

--- a/client/src/components/browser-capture/BrowserCaptureModal.tsx
+++ b/client/src/components/browser-capture/BrowserCaptureModal.tsx
@@ -186,7 +186,30 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
 
   const onKeyDown = useCallback((e: React.KeyboardEvent) => {
     if (selecting || e.key === 'Escape') return
-    const ev: BrowserInputEvent = { type: 'key', action: 'down', key: e.key, code: e.code, text: e.key.length === 1 ? e.key : undefined }
+    const meta = e.metaKey || e.ctrlKey
+    // Clipboard bridge: the embedded headless page can't reach the OS clipboard,
+    // so ⌘/Ctrl+C/X read the page selection into the host clipboard and ⌘/Ctrl+V
+    // injects the host clipboard text into the page.
+    if (meta && (e.key === 'c' || e.key === 'v' || e.key === 'x')) {
+      e.preventDefault()
+      const key = e.key
+      void (async () => {
+        try {
+          if (key === 'v') {
+            const text = await navigator.clipboard.readText()
+            if (text) await session.clipboard('paste', text)
+          } else {
+            const { text } = await session.clipboard(key === 'x' ? 'cut' : 'copy')
+            if (text) await navigator.clipboard.writeText(text)
+          }
+        } catch {
+          /* clipboard permission denied / unavailable — ignore */
+        }
+      })()
+      return
+    }
+    // Don't type the letter of an unhandled ⌘/Ctrl combo (e.g. ⌘A) into the page.
+    const ev: BrowserInputEvent = { type: 'key', action: 'down', key: e.key, code: e.code, text: !meta && e.key.length === 1 ? e.key : undefined }
     session.forwardInput(ev)
     if (e.key === 'Tab' || e.key === ' ' || e.key.startsWith('Arrow')) e.preventDefault()
   }, [selecting, session])

--- a/client/src/components/browser-capture/BrowserCaptureModal.tsx
+++ b/client/src/components/browser-capture/BrowserCaptureModal.tsx
@@ -14,6 +14,17 @@ import {
   type BrowserInputEvent,
 } from '../../lib/browser-capture'
 
+/**
+ * Detect Tauri-on-Mac. The overlay is portaled to <body> as `fixed inset-0`, so it
+ * covers the custom titlebar and the native traffic-light controls (close/min/max)
+ * float over its top-left. Reserve a left gutter there so the nav buttons clear them.
+ */
+function isMacTauriOverlay(): boolean {
+  if (typeof window === 'undefined') return false
+  if (!('__TAURI_INTERNALS__' in window)) return false
+  return /mac/i.test(navigator.platform)
+}
+
 interface BrowserCaptureModalProps {
   open: boolean
   onClose: () => void
@@ -260,20 +271,25 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
     ? mapRectToDisplay(hoverRect, cr, viewport)
     : null
 
+  const macOverlay = isMacTauriOverlay()
+
   return createPortal(
     <div className="fixed inset-0 z-[80] flex flex-col bg-background-deep/95 backdrop-blur-sm pointer-events-auto" role="dialog" aria-modal="true" aria-label="Browser capture">
       {/* Toolbar */}
-      <div className="flex items-center gap-2 px-3 py-2 border-b border-border/50 bg-surface/80 shrink-0">
+      <div className={`flex items-center gap-2 py-1.5 border-b border-border/50 bg-surface/80 shrink-0 ${macOverlay ? 'pr-3' : 'px-3'}`}>
+        {/* On macOS desktop the native traffic-light controls float over the top-left;
+            this drag-region gutter reserves their space and keeps the window movable. */}
+        {macOverlay && <div data-tauri-drag-region className="w-20 self-stretch shrink-0" aria-hidden />}
         <div className="flex items-center gap-1">
-          <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Back" onClick={() => session.navigate('back')}><ArrowLeft className="w-4 h-4" /></Button>
-          <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Forward" onClick={() => session.navigate('forward')}><ArrowRight className="w-4 h-4" /></Button>
-          <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Reload" onClick={() => session.navigate('reload')}><RotateCw className="w-4 h-4" /></Button>
+          <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="Back" onClick={() => session.navigate('back')}><ArrowLeft className="w-4 h-4" /></Button>
+          <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="Forward" onClick={() => session.navigate('forward')}><ArrowRight className="w-4 h-4" /></Button>
+          <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="Reload" onClick={() => session.navigate('reload')}><RotateCw className="w-4 h-4" /></Button>
         </div>
         <form
           className="flex-1 flex items-center gap-2 min-w-0"
           onSubmit={(e) => { e.preventDefault(); go() }}
         >
-          <div className="flex items-center gap-2 flex-1 min-w-0 rounded-md border border-border bg-background px-2.5 py-1.5">
+          <div className="flex items-center gap-2 flex-1 min-w-0 rounded-md border border-border bg-background px-2.5 py-1">
             <Globe className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
             <input
               value={addressValue}
@@ -312,7 +328,7 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
           <Crop className="w-3.5 h-3.5" />
           {selecting ? 'Click an element or drag…' : 'Select to create spec'}
         </Button>
-        <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Close browser" onClick={onClose}><X className="w-4 h-4" /></Button>
+        <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="Close browser" onClick={onClose}><X className="w-4 h-4" /></Button>
       </div>
 
       <div className="px-3 py-1 text-[11px] text-muted-foreground truncate shrink-0 flex items-center gap-2">

--- a/client/src/components/browser-capture/BrowserCaptureModal.tsx
+++ b/client/src/components/browser-capture/BrowserCaptureModal.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { ArrowLeft, ArrowRight, RotateCw, X, Crop, Loader2, Globe, AlertTriangle, Monitor, Tablet, Smartphone, Maximize2 } from 'lucide-react'
+import { ArrowLeft, ArrowRight, RotateCw, X, Crop, Loader2, Globe, AlertTriangle, Monitor, Tablet, Smartphone, Maximize2, Network } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '../ui/button'
 import { useBrowserCaptureSession } from './useBrowserCaptureSession'
@@ -63,6 +63,9 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
   const [box, setBox] = useState<SelectionBox | null>(null)
   const [capturing, setCapturing] = useState(false)
   const [preset, setPreset] = useState<ViewportPreset>('fit')
+  // Capture the page's XHR/fetch requests alongside the selection (ON by default;
+  // a user can disable it for a privacy-sensitive page).
+  const [captureNetwork, setCaptureNetwork] = useState(true)
 
   const containerRef = useRef<HTMLDivElement | null>(null)
   const pendingMoveRef = useRef<{ x: number; y: number } | null>(null)
@@ -192,7 +195,7 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
   const runCapture = useCallback(async (rect: CaptureRect) => {
     setCapturing(true)
     try {
-      const result = await session.capture(rect, pendingSpecId)
+      const result = await session.capture(rect, pendingSpecId, { captureNetwork })
       onCaptured(result)
       toast.success('Captured page selection')
       onClose()
@@ -204,7 +207,7 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
       setBox(null)
       session.clearHover()
     }
-  }, [session, pendingSpecId, onCaptured, onClose])
+  }, [session, pendingSpecId, captureNetwork, onCaptured, onClose])
 
   const onSelectDown = useCallback((e: React.PointerEvent) => {
     ;(e.target as HTMLElement).setPointerCapture?.(e.pointerId)
@@ -317,6 +320,17 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
             </button>
           ))}
         </div>
+        <button
+          type="button"
+          aria-label="Capture network requests"
+          aria-pressed={captureNetwork}
+          title={captureNetwork ? 'Capturing the page’s network requests (click to disable)' : 'Network capture off (click to enable)'}
+          onClick={() => setCaptureNetwork((v) => !v)}
+          className={`hidden md:inline-flex items-center gap-1 h-7 px-2 rounded-md border text-[11px] shrink-0 transition-colors ${captureNetwork ? 'border-accent-info/40 bg-accent-info/10 text-accent-info' : 'border-border/50 text-muted-foreground hover:text-foreground hover:bg-card/60'}`}
+        >
+          <Network className="w-3.5 h-3.5" />
+          Network
+        </button>
         <Button
           size="sm"
           variant={selecting ? 'default' : 'secondary'}

--- a/client/src/components/browser-capture/CapturedDomPanel.test.tsx
+++ b/client/src/components/browser-capture/CapturedDomPanel.test.tsx
@@ -72,6 +72,46 @@ describe('CapturedDomPanel', () => {
     expect(screen.getByText(/Captured page · example\.com/)).toBeInTheDocument()
   })
 
+  const tokens = {
+    contractVersion: 1,
+    anchor: { color: 'rgb(17, 24, 39)', backgroundColor: 'rgb(59, 130, 246)', fontFamily: 'Inter, sans-serif', fontSize: '16px', borderRadius: '8px' },
+    byTag: { button: { color: 'rgb(255, 255, 255)' } },
+    palette: ['rgb(17, 24, 39)', 'rgb(59, 130, 246)'],
+    fonts: ['Inter, sans-serif'],
+  }
+
+  it('shows a tokens badge and the design-tokens section when designTokens are present', () => {
+    render(<CapturedDomPanel dom={makeDom({ designTokens: tokens })} />)
+    expect(screen.getByText(/· tokens/)).toBeInTheDocument()
+    // Collapsed by default.
+    fireEvent.click(screen.getByRole('button', { name: /Captured page/ }))
+    expect(screen.queryByTestId('captured-dom-tokens')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /Design tokens/ }))
+    const block = screen.getByTestId('captured-dom-tokens')
+    expect(block.textContent).toContain('rgb(59, 130, 246)') // palette swatch + anchor value
+    expect(block.textContent).toContain('borderRadius')
+    expect(block.textContent).toContain('8px')
+    expect(block.textContent).toContain('Inter, sans-serif') // fonts row
+  })
+
+  it('copies the tokens as JSON', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+    render(<CapturedDomPanel dom={makeDom({ designTokens: tokens })} />)
+    fireEvent.click(screen.getByRole('button', { name: /Captured page/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Design tokens/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Copy as JSON/ }))
+    expect(writeText).toHaveBeenCalledOnce()
+    expect(writeText.mock.calls[0][0]).toContain('"contractVersion": 1')
+  })
+
+  it('renders no tokens section nor badge for a capture without designTokens', () => {
+    render(<CapturedDomPanel dom={makeDom()} />)
+    expect(screen.queryByText(/· tokens/)).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /Captured page/ }))
+    expect(screen.queryByRole('button', { name: /Design tokens/ })).not.toBeInTheDocument()
+  })
+
   it('invokes onRemove when the remove button is clicked', () => {
     const onRemove = vi.fn()
     render(<CapturedDomPanel dom={makeDom()} onRemove={onRemove} />)

--- a/client/src/components/browser-capture/CapturedDomPanel.test.tsx
+++ b/client/src/components/browser-capture/CapturedDomPanel.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { fireEvent } from '@testing-library/react'
 import { render, screen } from '../../test-utils'
 import { CapturedDomPanel } from './CapturedDomPanel'
-import type { CapturedDom } from '../../lib/browser-capture'
+import type { CapturedDom, CapturedNetworkRequest } from '../../lib/browser-capture'
 
 function makeDom(over: Partial<CapturedDom> = {}): CapturedDom {
   return {
@@ -110,6 +110,32 @@ describe('CapturedDomPanel', () => {
     expect(screen.queryByText(/· tokens/)).not.toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /Captured page/ }))
     expect(screen.queryByRole('button', { name: /Design tokens/ })).not.toBeInTheDocument()
+  })
+
+  const netRequests: CapturedNetworkRequest[] = [
+    { method: 'GET', url: 'https://api.example.com/items?token=secret', status: 200, resourceType: 'Fetch', mimeType: 'application/json', requestBodyShape: null, responseShape: '{ items: [object] }', durationMs: 42, startedAt: 0 },
+    { method: 'POST', url: 'https://api.example.com/save', status: 500, resourceType: 'Fetch', mimeType: 'application/json', durationMs: 88, startedAt: 1 },
+  ]
+
+  it('shows a request-count badge and the network section', () => {
+    render(<CapturedDomPanel dom={makeDom({ networkRequests: netRequests })} />)
+    expect(screen.getByText(/· 2 req/)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /Captured page/ }))
+    expect(screen.queryByTestId('captured-dom-network')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /Network · 2 requests/ }))
+    const net = screen.getByTestId('captured-dom-network')
+    expect(net.textContent).toContain('api.example.com/items') // query dropped from the label
+    expect(net.textContent).not.toContain('token=secret')
+    expect(net.textContent).toContain('{ items: [object] }')
+    expect(net.textContent).toContain('42ms')
+    expect(net.textContent).toContain('500')
+  })
+
+  it('renders no network section nor badge without networkRequests', () => {
+    render(<CapturedDomPanel dom={makeDom()} />)
+    expect(screen.queryByText(/req/)).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /Captured page/ }))
+    expect(screen.queryByRole('button', { name: /Network ·/ })).not.toBeInTheDocument()
   })
 
   it('invokes onRemove when the remove button is clicked', () => {

--- a/client/src/components/browser-capture/CapturedDomPanel.tsx
+++ b/client/src/components/browser-capture/CapturedDomPanel.tsx
@@ -1,6 +1,16 @@
 import { Fragment, useMemo, useState } from 'react'
-import { ChevronRight, Code2, Palette, Pipette, X } from 'lucide-react'
+import { ChevronRight, Code2, Palette, Pipette, Network, X } from 'lucide-react'
 import { domSummary, type CapturedDom } from '../../lib/browser-capture'
+
+/** Short, readable path for a captured request URL (host + pathname, query dropped). */
+function reqLabel(url: string): string {
+  try {
+    const u = new URL(url)
+    return u.host + u.pathname
+  } catch {
+    return url
+  }
+}
 import { tokenizeHtml, HL_CLASS } from '../../lib/html-highlight'
 
 interface CapturedDomPanelProps {
@@ -37,11 +47,14 @@ export function CapturedDomPanel({ dom, onRemove }: CapturedDomPanelProps) {
   const [openPanel, setOpenPanel] = useState(false)
   const [openCss, setOpenCss] = useState(false)
   const [openTokens, setOpenTokens] = useState(false)
+  const [openNet, setOpenNet] = useState(false)
   const [copied, setCopied] = useState(false)
   const summary = domSummary(dom)
   const tokens = dom.designTokens
   const anchorRows = tokens ? Object.entries(tokens.anchor) : []
   const hasTokens = !!tokens && (tokens.palette.length > 0 || anchorRows.length > 0)
+  const requests = dom.networkRequests ?? []
+  const hasNetwork = requests.length > 0
   const host = (() => {
     try { return new URL(dom.url).host } catch { return dom.url }
   })()
@@ -70,7 +83,7 @@ export function CapturedDomPanel({ dom, onRemove }: CapturedDomPanelProps) {
           <span className="truncate font-medium">Captured page · {dom.title || host}</span>
         </button>
         <span className="shrink-0 text-[10px] text-muted-foreground tabular-nums">
-          {summary.nodeCount} elements{dom.css ? ' · CSS' : ''}{hasTokens ? ' · tokens' : ''}{summary.truncated ? ' · truncated' : ''}
+          {summary.nodeCount} elements{dom.css ? ' · CSS' : ''}{hasTokens ? ' · tokens' : ''}{hasNetwork ? ` · ${requests.length} req` : ''}{summary.truncated ? ' · truncated' : ''}
         </span>
         {onRemove && (
           <button
@@ -166,6 +179,39 @@ export function CapturedDomPanel({ dom, onRemove }: CapturedDomPanelProps) {
                   >
                     {copied ? 'Copied!' : 'Copy as JSON'}
                   </button>
+                </div>
+              )}
+            </div>
+          )}
+          {hasNetwork && (
+            <div className="border-t border-accent-secondary/30">
+              <button
+                type="button"
+                onClick={() => setOpenNet((v) => !v)}
+                aria-expanded={openNet}
+                className="flex items-center gap-2 w-full px-3 py-2 text-left text-foreground/90 hover:text-foreground transition-colors"
+              >
+                <ChevronRight className={`w-3.5 h-3.5 shrink-0 transition-transform ${openNet ? 'rotate-90' : ''}`} />
+                <Network className="w-3.5 h-3.5 shrink-0 text-accent-info" />
+                <span className="font-medium">Network · {requests.length} request{requests.length === 1 ? '' : 's'}</span>
+              </button>
+              {openNet && (
+                <div className="max-h-64 overflow-auto px-3 pb-3 space-y-1.5" data-testid="captured-dom-network">
+                  {requests.map((r, i) => (
+                    <div key={i} className="font-mono text-[11px] leading-snug">
+                      <div className="flex items-baseline gap-2">
+                        <span className="text-accent-highlight shrink-0">{r.method}</span>
+                        <span className={`shrink-0 tabular-nums ${r.failed ? 'text-destructive' : (r.status ?? 0) >= 400 ? 'text-accent-warning' : 'text-accent-success/90'}`}>
+                          {r.failed ? 'ERR' : r.status ?? '…'}
+                        </span>
+                        <span className="truncate flex-1 text-foreground/80" title={r.url}>{reqLabel(r.url)}</span>
+                        {r.durationMs != null && <span className="shrink-0 text-muted-foreground tabular-nums">{r.durationMs}ms</span>}
+                      </div>
+                      {r.responseShape && (
+                        <div className="pl-4 text-accent-info/80 break-all whitespace-pre-wrap">→ {r.responseShape}</div>
+                      )}
+                    </div>
+                  ))}
                 </div>
               )}
             </div>

--- a/client/src/components/browser-capture/CapturedDomPanel.tsx
+++ b/client/src/components/browser-capture/CapturedDomPanel.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useState } from 'react'
-import { ChevronRight, Code2, Palette, X } from 'lucide-react'
+import { Fragment, useMemo, useState } from 'react'
+import { ChevronRight, Code2, Palette, Pipette, X } from 'lucide-react'
 import { domSummary, type CapturedDom } from '../../lib/browser-capture'
 import { tokenizeHtml, HL_CLASS } from '../../lib/html-highlight'
 
@@ -36,10 +36,25 @@ function HighlightedHtml({ html }: { html: string }) {
 export function CapturedDomPanel({ dom, onRemove }: CapturedDomPanelProps) {
   const [openPanel, setOpenPanel] = useState(false)
   const [openCss, setOpenCss] = useState(false)
+  const [openTokens, setOpenTokens] = useState(false)
+  const [copied, setCopied] = useState(false)
   const summary = domSummary(dom)
+  const tokens = dom.designTokens
+  const anchorRows = tokens ? Object.entries(tokens.anchor) : []
+  const hasTokens = !!tokens && (tokens.palette.length > 0 || anchorRows.length > 0)
   const host = (() => {
     try { return new URL(dom.url).host } catch { return dom.url }
   })()
+
+  const copyTokens = () => {
+    try {
+      void navigator.clipboard?.writeText(JSON.stringify(tokens, null, 2))
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      /* clipboard unavailable (non-secure context / jsdom) — ignore */
+    }
+  }
 
   return (
     <div className="rounded-lg border border-accent-secondary/40 bg-accent-secondary/5 text-xs">
@@ -55,7 +70,7 @@ export function CapturedDomPanel({ dom, onRemove }: CapturedDomPanelProps) {
           <span className="truncate font-medium">Captured page · {dom.title || host}</span>
         </button>
         <span className="shrink-0 text-[10px] text-muted-foreground tabular-nums">
-          {summary.nodeCount} elements{dom.css ? ' · CSS' : ''}{summary.truncated ? ' · truncated' : ''}
+          {summary.nodeCount} elements{dom.css ? ' · CSS' : ''}{hasTokens ? ' · tokens' : ''}{summary.truncated ? ' · truncated' : ''}
         </span>
         {onRemove && (
           <button
@@ -98,6 +113,60 @@ export function CapturedDomPanel({ dom, onRemove }: CapturedDomPanelProps) {
                 >
                   {dom.css}
                 </pre>
+              )}
+            </div>
+          )}
+          {hasTokens && tokens && (
+            <div className="border-t border-accent-secondary/30">
+              <button
+                type="button"
+                onClick={() => setOpenTokens((v) => !v)}
+                aria-expanded={openTokens}
+                className="flex items-center gap-2 w-full px-3 py-2 text-left text-foreground/90 hover:text-foreground transition-colors"
+              >
+                <ChevronRight className={`w-3.5 h-3.5 shrink-0 transition-transform ${openTokens ? 'rotate-90' : ''}`} />
+                <Pipette className="w-3.5 h-3.5 shrink-0 text-accent-highlight" />
+                <span className="font-medium">Design tokens</span>
+              </button>
+              {openTokens && (
+                <div className="px-3 pb-3 space-y-2" data-testid="captured-dom-tokens">
+                  {tokens.palette.length > 0 && (
+                    <div className="flex items-center gap-1.5 flex-wrap">
+                      {tokens.palette.map((c, i) => (
+                        <span
+                          key={i}
+                          className="inline-flex items-center gap-1 rounded border border-border/50 px-1.5 py-0.5 font-mono text-[10px] text-foreground/80"
+                        >
+                          {/* Swatch colour is captured data (not a layout/brand token) → inline style is intentional. */}
+                          <span className="inline-block w-3 h-3 rounded-sm border border-border/40" style={{ background: c }} aria-hidden />
+                          {c}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                  {anchorRows.length > 0 && (
+                    <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 font-mono text-[11px]">
+                      {anchorRows.map(([k, v]) => (
+                        <Fragment key={k}>
+                          <dt className="text-muted-foreground">{k}</dt>
+                          <dd className="text-accent-success/90 break-all">{v}</dd>
+                        </Fragment>
+                      ))}
+                    </dl>
+                  )}
+                  {tokens.fonts.length > 0 && (
+                    <div className="text-[11px] text-muted-foreground">
+                      Fonts: <span className="font-mono text-foreground/80 break-all">{tokens.fonts.join(', ')}</span>
+                    </div>
+                  )}
+                  <button
+                    type="button"
+                    onClick={copyTokens}
+                    className="text-[10px] text-accent-info hover:underline"
+                  >
+                    {copied ? 'Copied!' : 'Copy as JSON'}
+                  </button>
+                </div>
               )}
             </div>
           )}

--- a/client/src/components/browser-capture/useBrowserCaptureSession.ts
+++ b/client/src/components/browser-capture/useBrowserCaptureSession.ts
@@ -4,6 +4,7 @@ import {
   openBrowserWs,
   navigateBrowser,
   captureBrowserRegion,
+  captureBrowserBreakpoints,
   killBrowserSession,
   BrowserSessionLimitError,
   BrowserLaunchFailedError,
@@ -30,6 +31,8 @@ export interface UseBrowserCaptureSession extends BrowserSessionState {
   forwardInput: (e: BrowserInputEvent) => void
   navigate: (action: 'goto' | 'back' | 'forward' | 'reload', url?: string) => Promise<void>
   capture: (rect: CaptureRect, pendingSpecId: string, opts?: { captureNetwork?: boolean }) => Promise<CaptureResult>
+  /** Capture the same selection at several viewport sizes (responsive reference). */
+  captureBreakpoints: (rect: CaptureRect, anchorPoint: { x: number; y: number }, pendingSpecId: string, breakpoints?: Record<string, { width: number; height: number }>) => Promise<CaptureResult>
   setViewport: (width: number, height: number) => void
   /** Ask the server which element is at a viewport point (hover-to-select). */
   probe: (point: { x: number; y: number }) => void
@@ -187,6 +190,12 @@ export function useBrowserCaptureSession(opts: {
     return captureBrowserRegion(sid, rect, pendingSpecId, opts)
   }, [])
 
+  const captureBreakpoints = useCallback(async (rect: CaptureRect, anchorPoint: { x: number; y: number }, pendingSpecId: string, breakpoints?: Record<string, { width: number; height: number }>): Promise<CaptureResult> => {
+    const sid = sessionIdRef.current
+    if (!sid) throw new Error('No active browser session')
+    return captureBrowserBreakpoints(sid, rect, anchorPoint, pendingSpecId, breakpoints)
+  }, [])
+
   const setViewport = useCallback((width: number, height: number) => {
     const w = Math.max(1, Math.round(width))
     const h = Math.max(1, Math.round(height))
@@ -211,6 +220,7 @@ export function useBrowserCaptureSession(opts: {
     forwardInput,
     navigate,
     capture,
+    captureBreakpoints,
     setViewport,
     probe,
     clearHover,

--- a/client/src/components/browser-capture/useBrowserCaptureSession.ts
+++ b/client/src/components/browser-capture/useBrowserCaptureSession.ts
@@ -6,12 +6,15 @@ import {
   captureBrowserRegion,
   captureBrowserBreakpoints,
   browserClipboard,
+  navigateBrowserElement,
   killBrowserSession,
   BrowserSessionLimitError,
   BrowserLaunchFailedError,
   type BrowserInputEvent,
+  type BreadcrumbSegment,
   type CaptureRect,
   type CaptureResult,
+  type ElementProbe,
 } from '../../lib/browser-capture'
 
 export type SessionStatus = 'connecting' | 'ready' | 'error'
@@ -25,6 +28,10 @@ export interface BrowserSessionState {
   /** Bounding box (viewport coords) of the element under the cursor in select
    *  mode — server-resolved via the hover probe; null when nothing is hovered. */
   hoverRect: CaptureRect | null
+  /** Selector of the hovered element (for breadcrumb up/down navigation). */
+  hoverSelector: string | null
+  /** Ancestor breadcrumb (root→element) of the hovered element. */
+  hoverPath: BreadcrumbSegment[] | null
 }
 
 export interface UseBrowserCaptureSession extends BrowserSessionState {
@@ -37,6 +44,8 @@ export interface UseBrowserCaptureSession extends BrowserSessionState {
   setViewport: (width: number, height: number) => void
   /** Bridge the host clipboard to the page (copy/cut → returns selection; paste → inject). */
   clipboard: (action: 'copy' | 'paste' | 'cut', text?: string) => Promise<{ text: string }>
+  /** Step the breadcrumb to a parent/child/self element; null when can't step. */
+  navigateElement: (selector: string, direction: 'parent' | 'child' | 'self') => Promise<ElementProbe | null>
   /** Ask the server which element is at a viewport point (hover-to-select). */
   probe: (point: { x: number; y: number }) => void
   /** Clear the current hover highlight. */
@@ -68,6 +77,8 @@ export function useBrowserCaptureSession(opts: {
     title: null,
     viewport: { width: 1280, height: 800 },
     hoverRect: null,
+    hoverSelector: null,
+    hoverPath: null,
   })
 
   const drawFrame = useCallback(async (buf: ArrayBuffer) => {
@@ -116,13 +127,13 @@ export function useBrowserCaptureSession(opts: {
         ws.onmessage = (ev: MessageEvent) => {
           if (typeof ev.data === 'string') {
             try {
-              const msg = JSON.parse(ev.data) as { type: string; url?: string; title?: string; viewport?: { width: number; height: number }; rect?: CaptureRect | null }
+              const msg = JSON.parse(ev.data) as { type: string; url?: string; title?: string; viewport?: { width: number; height: number }; rect?: CaptureRect | null; selector?: string | null; path?: BreadcrumbSegment[] | null }
               if (msg.type === 'ready') {
                 setState((s) => ({ ...s, status: 'ready', url: msg.url ?? s.url, title: msg.title ?? s.title, viewport: msg.viewport ?? s.viewport }))
               } else if (msg.type === 'nav') {
                 setState((s) => ({ ...s, url: msg.url ?? s.url, title: msg.title ?? s.title }))
               } else if (msg.type === 'hover') {
-                setState((s) => ({ ...s, hoverRect: msg.rect ?? null }))
+                setState((s) => ({ ...s, hoverRect: msg.rect ?? null, hoverSelector: msg.selector ?? null, hoverPath: msg.path ?? null }))
               }
             } catch {
               /* ignore */
@@ -220,7 +231,13 @@ export function useBrowserCaptureSession(opts: {
   }, [])
 
   const clearHover = useCallback(() => {
-    setState((s) => (s.hoverRect ? { ...s, hoverRect: null } : s))
+    setState((s) => (s.hoverRect || s.hoverPath ? { ...s, hoverRect: null, hoverSelector: null, hoverPath: null } : s))
+  }, [])
+
+  const navigateElement = useCallback(async (selector: string, direction: 'parent' | 'child' | 'self'): Promise<ElementProbe | null> => {
+    const sid = sessionIdRef.current
+    if (!sid) return null
+    return navigateBrowserElement(sid, selector, direction)
   }, [])
 
   return {
@@ -231,6 +248,7 @@ export function useBrowserCaptureSession(opts: {
     capture,
     captureBreakpoints,
     clipboard,
+    navigateElement,
     setViewport,
     probe,
     clearHover,

--- a/client/src/components/browser-capture/useBrowserCaptureSession.ts
+++ b/client/src/components/browser-capture/useBrowserCaptureSession.ts
@@ -5,6 +5,7 @@ import {
   navigateBrowser,
   captureBrowserRegion,
   captureBrowserBreakpoints,
+  browserClipboard,
   killBrowserSession,
   BrowserSessionLimitError,
   BrowserLaunchFailedError,
@@ -34,6 +35,8 @@ export interface UseBrowserCaptureSession extends BrowserSessionState {
   /** Capture the same selection at several viewport sizes (responsive reference). */
   captureBreakpoints: (rect: CaptureRect, anchorPoint: { x: number; y: number }, pendingSpecId: string, breakpoints?: Record<string, { width: number; height: number }>) => Promise<CaptureResult>
   setViewport: (width: number, height: number) => void
+  /** Bridge the host clipboard to the page (copy/cut → returns selection; paste → inject). */
+  clipboard: (action: 'copy' | 'paste' | 'cut', text?: string) => Promise<{ text: string }>
   /** Ask the server which element is at a viewport point (hover-to-select). */
   probe: (point: { x: number; y: number }) => void
   /** Clear the current hover highlight. */
@@ -196,6 +199,12 @@ export function useBrowserCaptureSession(opts: {
     return captureBrowserBreakpoints(sid, rect, anchorPoint, pendingSpecId, breakpoints)
   }, [])
 
+  const clipboard = useCallback(async (action: 'copy' | 'paste' | 'cut', text?: string): Promise<{ text: string }> => {
+    const sid = sessionIdRef.current
+    if (!sid) return { text: '' }
+    return browserClipboard(sid, action, text)
+  }, [])
+
   const setViewport = useCallback((width: number, height: number) => {
     const w = Math.max(1, Math.round(width))
     const h = Math.max(1, Math.round(height))
@@ -221,6 +230,7 @@ export function useBrowserCaptureSession(opts: {
     navigate,
     capture,
     captureBreakpoints,
+    clipboard,
     setViewport,
     probe,
     clearHover,

--- a/client/src/components/browser-capture/useBrowserCaptureSession.ts
+++ b/client/src/components/browser-capture/useBrowserCaptureSession.ts
@@ -29,7 +29,7 @@ export interface UseBrowserCaptureSession extends BrowserSessionState {
   canvasRef: React.RefObject<HTMLCanvasElement | null>
   forwardInput: (e: BrowserInputEvent) => void
   navigate: (action: 'goto' | 'back' | 'forward' | 'reload', url?: string) => Promise<void>
-  capture: (rect: CaptureRect, pendingSpecId: string) => Promise<CaptureResult>
+  capture: (rect: CaptureRect, pendingSpecId: string, opts?: { captureNetwork?: boolean }) => Promise<CaptureResult>
   setViewport: (width: number, height: number) => void
   /** Ask the server which element is at a viewport point (hover-to-select). */
   probe: (point: { x: number; y: number }) => void
@@ -181,10 +181,10 @@ export function useBrowserCaptureSession(opts: {
     }
   }, [])
 
-  const capture = useCallback(async (rect: CaptureRect, pendingSpecId: string): Promise<CaptureResult> => {
+  const capture = useCallback(async (rect: CaptureRect, pendingSpecId: string, opts?: { captureNetwork?: boolean }): Promise<CaptureResult> => {
     const sid = sessionIdRef.current
     if (!sid) throw new Error('No active browser session')
-    return captureBrowserRegion(sid, rect, pendingSpecId)
+    return captureBrowserRegion(sid, rect, pendingSpecId, opts)
   }, [])
 
   const setViewport = useCallback((width: number, height: number) => {

--- a/client/src/lib/annotations.test.ts
+++ b/client/src/lib/annotations.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+import {
+  annotationReducer,
+  initialEditorState,
+  nextStepNumber,
+  normalizeBox,
+  arrowHead,
+  isUsableDrag,
+  clamp01,
+  toAnnotationSet,
+  type Annotation,
+  type EditorState,
+} from './annotations'
+
+const box = (id: string): Annotation => ({ id, kind: 'box', x: 0.1, y: 0.1, w: 0.2, h: 0.2, color: '#f00' })
+
+describe('annotationReducer', () => {
+  it('adds objects and clears the redo stack', () => {
+    let s = initialEditorState
+    s = annotationReducer(s, { type: 'add', obj: box('a') })
+    s = annotationReducer(s, { type: 'add', obj: box('b') })
+    expect(s.objects.map((o) => o.id)).toEqual(['a', 'b'])
+    expect(s.past).toHaveLength(2)
+    expect(s.future).toHaveLength(0)
+  })
+
+  it('undo and redo move objects across the history stacks', () => {
+    let s = annotationReducer(initialEditorState, { type: 'add', obj: box('a') })
+    s = annotationReducer(s, { type: 'add', obj: box('b') })
+    s = annotationReducer(s, { type: 'undo' })
+    expect(s.objects.map((o) => o.id)).toEqual(['a'])
+    expect(s.future).toHaveLength(1)
+    s = annotationReducer(s, { type: 'redo' })
+    expect(s.objects.map((o) => o.id)).toEqual(['a', 'b'])
+    expect(s.future).toHaveLength(0)
+  })
+
+  it('adding after an undo discards the redo future', () => {
+    let s = annotationReducer(initialEditorState, { type: 'add', obj: box('a') })
+    s = annotationReducer(s, { type: 'add', obj: box('b') })
+    s = annotationReducer(s, { type: 'undo' })
+    s = annotationReducer(s, { type: 'add', obj: box('c') })
+    expect(s.objects.map((o) => o.id)).toEqual(['a', 'c'])
+    expect(s.future).toHaveLength(0)
+  })
+
+  it('delete removes by id and is a no-op for unknown ids', () => {
+    let s = annotationReducer(initialEditorState, { type: 'add', obj: box('a') })
+    const before = s
+    s = annotationReducer(s, { type: 'delete', id: 'zzz' })
+    expect(s).toBe(before) // unchanged reference
+    s = annotationReducer(s, { type: 'delete', id: 'a' })
+    expect(s.objects).toHaveLength(0)
+  })
+
+  it('undo/redo on empty stacks are no-ops', () => {
+    expect(annotationReducer(initialEditorState, { type: 'undo' })).toBe(initialEditorState)
+    expect(annotationReducer(initialEditorState, { type: 'redo' })).toBe(initialEditorState)
+  })
+
+  it('clear wipes objects (recorded for undo) and is a no-op when empty', () => {
+    expect(annotationReducer(initialEditorState, { type: 'clear' })).toBe(initialEditorState)
+    let s = annotationReducer(initialEditorState, { type: 'add', obj: box('a') })
+    s = annotationReducer(s, { type: 'clear' })
+    expect(s.objects).toHaveLength(0)
+    s = annotationReducer(s, { type: 'undo' })
+    expect(s.objects.map((o) => o.id)).toEqual(['a'])
+  })
+
+  it('ignores unknown actions', () => {
+    const s: EditorState = initialEditorState
+    expect(annotationReducer(s, { type: 'bogus' } as unknown as { type: 'undo' })).toBe(s)
+  })
+})
+
+describe('geometry', () => {
+  it('nextStepNumber is contiguous and based on the max', () => {
+    expect(nextStepNumber([])).toBe(1)
+    expect(nextStepNumber([{ id: '1', kind: 'step', x: 0, y: 0, n: 1, color: '#f00' }, { id: '2', kind: 'step', x: 0, y: 0, n: 3, color: '#f00' }])).toBe(4)
+    expect(nextStepNumber([box('b')])).toBe(1) // no steps
+  })
+
+  it('normalizeBox handles any drag direction', () => {
+    const r = normalizeBox({ x: 0.4, y: 0.5 }, { x: 0.1, y: 0.2 })
+    expect(r.x).toBeCloseTo(0.1)
+    expect(r.y).toBeCloseTo(0.2)
+    expect(r.w).toBeCloseTo(0.3)
+    expect(r.h).toBeCloseTo(0.3)
+  })
+
+  it('arrowHead returns two barbs near the tip', () => {
+    const { left, right } = arrowHead({ x: 0, y: 0 }, { x: 1, y: 0 }, 0.1)
+    // pointing right → barbs sit left of the tip, symmetric in y
+    expect(left.x).toBeLessThan(1)
+    expect(right.x).toBeLessThan(1)
+    expect(left.y).toBeCloseTo(-right.y, 6)
+  })
+
+  it('isUsableDrag rejects tiny drags', () => {
+    expect(isUsableDrag({ x: 0.1, y: 0.1 }, { x: 0.1005, y: 0.1005 })).toBe(false)
+    expect(isUsableDrag({ x: 0.1, y: 0.1 }, { x: 0.2, y: 0.1 })).toBe(true)
+  })
+
+  it('clamp01 bounds points with a small overshoot', () => {
+    expect(clamp01({ x: 2, y: -1 })).toEqual({ x: 1.05, y: -0.05 })
+    expect(clamp01({ x: 0.5, y: 0.5 })).toEqual({ x: 0.5, y: 0.5 })
+  })
+
+  it('toAnnotationSet wraps objects with the schema version + base size', () => {
+    expect(toAnnotationSet([box('a')], 800, 600)).toEqual({ schemaVersion: 1, objects: [box('a')], baseWidth: 800, baseHeight: 600 })
+  })
+})

--- a/client/src/lib/annotations.ts
+++ b/client/src/lib/annotations.ts
@@ -1,0 +1,110 @@
+// Pure, framework-free model + geometry for the capture annotation editor.
+//
+// All editor LOGIC (object model, undo/redo reducer, geometry, step numbering)
+// lives here so it is fully unit-tested. The canvas/pointer SHELL
+// (`AnnotationEditor.tsx`) is excluded from coverage like the other
+// browser-capture canvas components. Coordinates are NORMALISED to [0,1] over the
+// captured image, so they are resolution-independent and replayable when the
+// annotations are flattened onto the bitmap at its natural pixel size.
+
+export interface Pt {
+  x: number
+  y: number
+}
+
+export type Annotation =
+  | { id: string; kind: 'arrow'; from: Pt; to: Pt; color: string }
+  | { id: string; kind: 'box'; x: number; y: number; w: number; h: number; color: string }
+  | { id: string; kind: 'text'; x: number; y: number; text: string; color: string }
+  | { id: string; kind: 'blur'; x: number; y: number; w: number; h: number }
+  | { id: string; kind: 'step'; x: number; y: number; n: number; color: string }
+
+export type AnnotationTool = 'arrow' | 'box' | 'text' | 'blur' | 'step'
+
+export interface AnnotationSet {
+  schemaVersion: 1
+  objects: Annotation[]
+  baseWidth: number
+  baseHeight: number
+}
+
+// ─── Undo/redo reducer (object-level snapshots) ───────────────────────────────
+
+export interface EditorState {
+  objects: Annotation[]
+  past: Annotation[][]
+  future: Annotation[][]
+}
+
+export type EditorAction =
+  | { type: 'add'; obj: Annotation }
+  | { type: 'delete'; id: string }
+  | { type: 'undo' }
+  | { type: 'redo' }
+  | { type: 'clear' }
+
+export const initialEditorState: EditorState = { objects: [], past: [], future: [] }
+
+export function annotationReducer(state: EditorState, action: EditorAction): EditorState {
+  switch (action.type) {
+    case 'add':
+      return { objects: [...state.objects, action.obj], past: [...state.past, state.objects], future: [] }
+    case 'delete': {
+      if (!state.objects.some((o) => o.id === action.id)) return state
+      return { objects: state.objects.filter((o) => o.id !== action.id), past: [...state.past, state.objects], future: [] }
+    }
+    case 'undo': {
+      if (state.past.length === 0) return state
+      const prev = state.past[state.past.length - 1]
+      return { objects: prev, past: state.past.slice(0, -1), future: [state.objects, ...state.future] }
+    }
+    case 'redo': {
+      if (state.future.length === 0) return state
+      const next = state.future[0]
+      return { objects: next, past: [...state.past, state.objects], future: state.future.slice(1) }
+    }
+    case 'clear':
+      return state.objects.length === 0 ? state : { objects: [], past: [...state.past, state.objects], future: [] }
+    default:
+      return state
+  }
+}
+
+// ─── Geometry helpers ─────────────────────────────────────────────────────────
+
+/** Next auto-incrementing step badge number (1-based, contiguous). */
+export function nextStepNumber(objects: Annotation[]): number {
+  const ns = objects.filter((o): o is Extract<Annotation, { kind: 'step' }> => o.kind === 'step').map((s) => s.n)
+  return ns.length === 0 ? 1 : Math.max(...ns) + 1
+}
+
+/** Normalise two drag corners (any direction) into an {x,y,w,h} box. */
+export function normalizeBox(a: Pt, b: Pt): { x: number; y: number; w: number; h: number } {
+  return { x: Math.min(a.x, b.x), y: Math.min(a.y, b.y), w: Math.abs(a.x - b.x), h: Math.abs(a.y - b.y) }
+}
+
+/** The two barb endpoints of an arrowhead at `to`, given the line and a length. */
+export function arrowHead(from: Pt, to: Pt, len = 0.04): { left: Pt; right: Pt } {
+  const angle = Math.atan2(to.y - from.y, to.x - from.x)
+  const a1 = angle - Math.PI / 7
+  const a2 = angle + Math.PI / 7
+  return {
+    left: { x: to.x - len * Math.cos(a1), y: to.y - len * Math.sin(a1) },
+    right: { x: to.x - len * Math.cos(a2), y: to.y - len * Math.sin(a2) },
+  }
+}
+
+/** True when a drag is large enough to be a deliberate shape (not a stray click). */
+export function isUsableDrag(a: Pt, b: Pt, min = 0.01): boolean {
+  return Math.abs(a.x - b.x) >= min || Math.abs(a.y - b.y) >= min
+}
+
+/** Clamp a normalised point to [0,1] (allow a small overshoot for callout arrows). */
+export function clamp01(p: Pt, overshoot = 0.05): Pt {
+  const c = (v: number) => Math.min(1 + overshoot, Math.max(-overshoot, v))
+  return { x: c(p.x), y: c(p.y) }
+}
+
+export function toAnnotationSet(objects: Annotation[], baseWidth: number, baseHeight: number): AnnotationSet {
+  return { schemaVersion: 1, objects, baseWidth, baseHeight }
+}

--- a/client/src/lib/browser-capture.test.ts
+++ b/client/src/lib/browser-capture.test.ts
@@ -11,6 +11,7 @@ import {
   createBrowserSession,
   navigateBrowser,
   captureBrowserRegion,
+  captureBrowserBreakpoints,
   killBrowserSession,
   BrowserSessionLimitError,
   BrowserLaunchFailedError,
@@ -154,6 +155,19 @@ describe('browser-capture lib', () => {
     it('captureBrowserRegion throws on non-ok', async () => {
       global.fetch = mockFetch(() => ({ status: 500 })) as typeof fetch
       await expect(captureBrowserRegion('s1', { x: 0, y: 0, width: 1, height: 1 }, 'p')).rejects.toThrow()
+    })
+
+    it('captureBrowserBreakpoints posts rect, anchor + breakpoints and returns the result', async () => {
+      global.fetch = mockFetch((url, init) => {
+        expect(url).toContain('/browser/sessions/s1/capture-breakpoints')
+        const body = JSON.parse(String(init?.body))
+        expect(body.pendingSpecId).toBe('pend-1')
+        expect(body.anchorPoint).toEqual({ x: 5, y: 5 })
+        expect(body.breakpoints.desktop).toEqual({ width: 1280, height: 800 })
+        return { body: { screenshot: { id: 'b1' }, domAttachment: { id: 'b2' }, dom, screenshotDataUrl: 'data:image/png;base64,x', breakpoints: { desktop: { attachment: { id: 'b1' }, dataUrl: 'd', viewport: { width: 1280, height: 800 } } } } }
+      }) as typeof fetch
+      const r = await captureBrowserBreakpoints('s1', { x: 1, y: 2, width: 3, height: 4 }, { x: 5, y: 5 }, 'pend-1')
+      expect(r.breakpoints!.desktop.attachment.id).toBe('b1')
     })
 
     it('killBrowserSession swallows errors', async () => {

--- a/client/src/lib/browser-capture.test.ts
+++ b/client/src/lib/browser-capture.test.ts
@@ -13,6 +13,7 @@ import {
   captureBrowserRegion,
   captureBrowserBreakpoints,
   browserClipboard,
+  navigateBrowserElement,
   uploadCaptureImage,
   killBrowserSession,
   BrowserSessionLimitError,
@@ -190,6 +191,22 @@ describe('browser-capture lib', () => {
         return { body: { text: '' } }
       }) as typeof fetch
       expect(await browserClipboard('s1', 'paste', 'hello')).toEqual({ text: '' })
+    })
+
+    it('navigateBrowserElement posts selector + direction and returns the probe', async () => {
+      global.fetch = mockFetch((url, init) => {
+        expect(url).toContain('/browser/sessions/s1/element')
+        const body = JSON.parse(String(init?.body))
+        expect(body).toEqual({ selector: 'div.box', direction: 'parent' })
+        return { body: { probe: { rect: { x: 0, y: 0, width: 1, height: 1 }, tag: 'section', selector: 'body', path: [] } } }
+      }) as typeof fetch
+      const p = await navigateBrowserElement('s1', 'div.box', 'parent')
+      expect(p!.tag).toBe('section')
+    })
+
+    it('navigateBrowserElement returns null when the server reports no further step', async () => {
+      global.fetch = mockFetch(() => ({ body: { probe: null } })) as typeof fetch
+      expect(await navigateBrowserElement('s1', 'body', 'parent')).toBeNull()
     })
 
     it('killBrowserSession swallows errors', async () => {

--- a/client/src/lib/browser-capture.test.ts
+++ b/client/src/lib/browser-capture.test.ts
@@ -12,6 +12,7 @@ import {
   navigateBrowser,
   captureBrowserRegion,
   captureBrowserBreakpoints,
+  uploadCaptureImage,
   killBrowserSession,
   BrowserSessionLimitError,
   BrowserLaunchFailedError,
@@ -168,6 +169,16 @@ describe('browser-capture lib', () => {
       }) as typeof fetch
       const r = await captureBrowserBreakpoints('s1', { x: 1, y: 2, width: 3, height: 4 }, { x: 5, y: 5 }, 'pend-1')
       expect(r.breakpoints!.desktop.attachment.id).toBe('b1')
+    })
+
+    it('uploadCaptureImage posts the blob as multipart and returns the attachment', async () => {
+      global.fetch = mockFetch((url, init) => {
+        expect(url).toContain('/api/projects/proj-1/tickets/pend-1/attachments')
+        expect(init?.body).toBeInstanceOf(FormData)
+        return { status: 201, body: { attachment: { id: 'an1' } } }
+      }) as typeof fetch
+      const att = await uploadCaptureImage('pend-1', new Blob(['x'], { type: 'image/png' }), 'annotated.png')
+      expect(att.id).toBe('an1')
     })
 
     it('killBrowserSession swallows errors', async () => {

--- a/client/src/lib/browser-capture.test.ts
+++ b/client/src/lib/browser-capture.test.ts
@@ -92,7 +92,15 @@ describe('browser-capture lib', () => {
     })
 
     it('summarises a captured DOM', () => {
-      expect(domSummary(dom)).toEqual({ nodeCount: 1, htmlBytes: dom.html.length, truncated: true })
+      expect(domSummary(dom)).toEqual({ nodeCount: 1, htmlBytes: dom.html.length, truncated: true, networkCount: 0 })
+    })
+
+    it('counts captured network requests', () => {
+      const withNet = { ...dom, networkRequests: [
+        { method: 'GET', url: 'https://api.x/a', status: 200, resourceType: 'Fetch', mimeType: 'application/json', durationMs: 1, startedAt: 0 },
+        { method: 'POST', url: 'https://api.x/b', status: 201, resourceType: 'Fetch', mimeType: 'application/json', durationMs: 2, startedAt: 1 },
+      ] }
+      expect(domSummary(withNet).networkCount).toBe(2)
     })
   })
 

--- a/client/src/lib/browser-capture.test.ts
+++ b/client/src/lib/browser-capture.test.ts
@@ -12,6 +12,7 @@ import {
   navigateBrowser,
   captureBrowserRegion,
   captureBrowserBreakpoints,
+  browserClipboard,
   uploadCaptureImage,
   killBrowserSession,
   BrowserSessionLimitError,
@@ -179,6 +180,16 @@ describe('browser-capture lib', () => {
       }) as typeof fetch
       const att = await uploadCaptureImage('pend-1', new Blob(['x'], { type: 'image/png' }), 'annotated.png')
       expect(att.id).toBe('an1')
+    })
+
+    it('browserClipboard posts the action + text and returns the selection', async () => {
+      global.fetch = mockFetch((url, init) => {
+        expect(url).toContain('/browser/sessions/s1/clipboard')
+        const body = JSON.parse(String(init?.body))
+        expect(body).toEqual({ action: 'paste', text: 'hello' })
+        return { body: { text: '' } }
+      }) as typeof fetch
+      expect(await browserClipboard('s1', 'paste', 'hello')).toEqual({ text: '' })
     })
 
     it('killBrowserSession swallows errors', async () => {

--- a/client/src/lib/browser-capture.ts
+++ b/client/src/lib/browser-capture.ts
@@ -91,6 +91,18 @@ export interface CapturedDom {
   capturedAt: string
 }
 
+export interface BreadcrumbSegment {
+  label: string
+  selector: string
+}
+
+export interface ElementProbe {
+  rect: CaptureRect
+  tag: string
+  selector: string
+  path: BreadcrumbSegment[]
+}
+
 export interface BrowserSessionMeta {
   id: string
   projectId: string
@@ -226,6 +238,23 @@ export async function browserClipboard(
   })
   if (!res.ok) throw new Error(`Clipboard failed (${res.status})`)
   return (await res.json()) as { text: string }
+}
+
+/** Re-resolve an element by selector and step to parent/child/self for the
+ *  DevTools-style breadcrumb. Returns null when it can't step further. */
+export async function navigateBrowserElement(
+  sessionId: string,
+  selector: string,
+  direction: 'parent' | 'child' | 'self',
+): Promise<ElementProbe | null> {
+  const res = await fetch(`${getApiBase()}/browser/sessions/${sessionId}/element`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ selector, direction }),
+  })
+  if (!res.ok) throw new Error(`Element navigate failed (${res.status})`)
+  const data = (await res.json()) as { probe: ElementProbe | null }
+  return data.probe
 }
 
 export async function killBrowserSession(sessionId: string): Promise<void> {

--- a/client/src/lib/browser-capture.ts
+++ b/client/src/lib/browser-capture.ts
@@ -35,6 +35,29 @@ export interface CapturedNode {
   styles: Record<string, string>
 }
 
+export interface TokenSet {
+  color?: string
+  backgroundColor?: string
+  fontFamily?: string
+  fontSize?: string
+  fontWeight?: string
+  lineHeight?: string
+  letterSpacing?: string
+  padding?: string
+  margin?: string
+  border?: string
+  borderRadius?: string
+  boxShadow?: string
+}
+
+export interface CapturedDesignTokens {
+  contractVersion: number
+  anchor: TokenSet
+  byTag: Record<string, TokenSet>
+  palette: string[]
+  fonts: string[]
+}
+
 export interface CapturedDom {
   url: string
   title: string
@@ -45,6 +68,9 @@ export interface CapturedDom {
   css: string
   cssTruncated: boolean
   nodes: CapturedNode[]
+  /** Exact computed design tokens for the selection (optional; absent on
+   *  captures taken before this feature). */
+  designTokens?: CapturedDesignTokens
   capturedAt: string
 }
 

--- a/client/src/lib/browser-capture.ts
+++ b/client/src/lib/browser-capture.ts
@@ -2,6 +2,7 @@ import { getApiBase } from './api'
 import { WS_URL } from './ws-url'
 import { getHubTokenProtocol } from './auth'
 import type { Attachment } from '../types'
+import type { AnnotationSet } from './annotations'
 
 // ─── Feature flag ─────────────────────────────────────────────────────────────
 
@@ -121,6 +122,12 @@ export interface CaptureResult {
   screenshotDataUrl: string
   /** Present only for a multi-breakpoint capture: the same element at each size. */
   breakpoints?: Record<string, BreakpointCapture>
+  /** Present when the user annotated the capture: the original (pre-markup) image,
+   *  so it can be cleaned up; `screenshot`/`screenshotDataUrl` point at the
+   *  flattened, annotated image that the spec uses. */
+  rawScreenshot?: Attachment
+  /** Structured annotation objects (metadata; the image already carries them). */
+  annotations?: AnnotationSet
 }
 
 /** Default device sizes for "capture at all sizes". Sent in the request body so
@@ -192,6 +199,17 @@ export async function captureBrowserBreakpoints(
   })
   if (!res.ok) throw new Error(`Capture failed (${res.status})`)
   return (await res.json()) as CaptureResult
+}
+
+/** Upload a flattened (annotated) capture image to the pending spec's attachment
+ *  dir, reusing the generic multipart attachment endpoint. Returns the Attachment. */
+export async function uploadCaptureImage(pendingSpecId: string, blob: Blob, filename: string): Promise<Attachment> {
+  const form = new FormData()
+  form.append('file', blob, filename)
+  const res = await fetch(`${getApiBase()}/tickets/${pendingSpecId}/attachments`, { method: 'POST', body: form })
+  if (!res.ok) throw new Error(`Upload failed (${res.status})`)
+  const data = (await res.json()) as { attachment: Attachment }
+  return data.attachment
 }
 
 export async function killBrowserSession(sessionId: string): Promise<void> {

--- a/client/src/lib/browser-capture.ts
+++ b/client/src/lib/browser-capture.ts
@@ -58,6 +58,20 @@ export interface CapturedDesignTokens {
   fonts: string[]
 }
 
+export interface CapturedNetworkRequest {
+  method: string
+  url: string
+  status: number | null
+  resourceType: string
+  mimeType: string | null
+  requestBodyShape?: string | null
+  responseShape?: string | null
+  durationMs: number | null
+  startedAt: number
+  failed?: boolean
+  errorText?: string
+}
+
 export interface CapturedDom {
   url: string
   title: string
@@ -71,6 +85,8 @@ export interface CapturedDom {
   /** Exact computed design tokens for the selection (optional; absent on
    *  captures taken before this feature). */
   designTokens?: CapturedDesignTokens
+  /** XHR/fetch requests the page made around capture time (optional). */
+  networkRequests?: CapturedNetworkRequest[]
   capturedAt: string
 }
 
@@ -135,11 +151,12 @@ export async function captureBrowserRegion(
   sessionId: string,
   rect: CaptureRect,
   pendingSpecId: string,
+  opts?: { captureNetwork?: boolean },
 ): Promise<CaptureResult> {
   const res = await fetch(`${getApiBase()}/browser/sessions/${sessionId}/capture`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ rect, pendingSpecId }),
+    body: JSON.stringify({ rect, pendingSpecId, captureNetwork: opts?.captureNetwork ?? true }),
   })
   if (!res.ok) throw new Error(`Capture failed (${res.status})`)
   return (await res.json()) as CaptureResult
@@ -238,10 +255,11 @@ export function isUsableSelection(rect: CaptureRect, minPx = 8): boolean {
 }
 
 /** Count populated (non-empty) facets of a captured DOM for the panel badge. */
-export function domSummary(dom: CapturedDom): { nodeCount: number; htmlBytes: number; truncated: boolean } {
+export function domSummary(dom: CapturedDom): { nodeCount: number; htmlBytes: number; truncated: boolean; networkCount: number } {
   return {
     nodeCount: dom.nodes.length,
     htmlBytes: dom.html.length,
     truncated: dom.htmlTruncated,
+    networkCount: dom.networkRequests?.length ?? 0,
   }
 }

--- a/client/src/lib/browser-capture.ts
+++ b/client/src/lib/browser-capture.ts
@@ -106,6 +106,12 @@ export type BrowserInputEvent =
   | { type: 'key'; action: 'down' | 'up'; key: string; code?: string; text?: string; modifiers?: number }
   | { type: 'resize'; width: number; height: number }
 
+export interface BreakpointCapture {
+  attachment: Attachment
+  dataUrl: string
+  viewport: { width: number; height: number }
+}
+
 export interface CaptureResult {
   screenshot: Attachment
   domAttachment: Attachment
@@ -113,6 +119,16 @@ export interface CaptureResult {
   /** Inline data URL of the screenshot for a thumbnail (avoids an unauthenticated
    *  <img src> to the attachment endpoint). */
   screenshotDataUrl: string
+  /** Present only for a multi-breakpoint capture: the same element at each size. */
+  breakpoints?: Record<string, BreakpointCapture>
+}
+
+/** Default device sizes for "capture at all sizes". Sent in the request body so
+ *  the server has a single source of truth (no drift with this constant). */
+export const BREAKPOINT_DIMS: Record<'desktop' | 'tablet' | 'mobile', { width: number; height: number }> = {
+  desktop: { width: 1280, height: 800 },
+  tablet: { width: 768, height: 1024 },
+  mobile: { width: 375, height: 667 },
 }
 
 export class BrowserSessionLimitError extends Error {}
@@ -157,6 +173,22 @@ export async function captureBrowserRegion(
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ rect, pendingSpecId, captureNetwork: opts?.captureNetwork ?? true }),
+  })
+  if (!res.ok) throw new Error(`Capture failed (${res.status})`)
+  return (await res.json()) as CaptureResult
+}
+
+export async function captureBrowserBreakpoints(
+  sessionId: string,
+  rect: CaptureRect,
+  anchorPoint: { x: number; y: number },
+  pendingSpecId: string,
+  breakpoints: Record<string, { width: number; height: number }> = BREAKPOINT_DIMS,
+): Promise<CaptureResult> {
+  const res = await fetch(`${getApiBase()}/browser/sessions/${sessionId}/capture-breakpoints`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ rect, anchorPoint, pendingSpecId, breakpoints }),
   })
   if (!res.ok) throw new Error(`Capture failed (${res.status})`)
   return (await res.json()) as CaptureResult

--- a/client/src/lib/browser-capture.ts
+++ b/client/src/lib/browser-capture.ts
@@ -212,6 +212,22 @@ export async function uploadCaptureImage(pendingSpecId: string, blob: Blob, file
   return data.attachment
 }
 
+/** Bridge the host clipboard to the embedded page (which can't reach the OS
+ *  clipboard): copy/cut return the page's selection text; paste injects text. */
+export async function browserClipboard(
+  sessionId: string,
+  action: 'copy' | 'paste' | 'cut',
+  text?: string,
+): Promise<{ text: string }> {
+  const res = await fetch(`${getApiBase()}/browser/sessions/${sessionId}/clipboard`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ action, text }),
+  })
+  if (!res.ok) throw new Error(`Clipboard failed (${res.status})`)
+  return (await res.json()) as { text: string }
+}
+
 export async function killBrowserSession(sessionId: string): Promise<void> {
   try {
     await fetch(`${getApiBase()}/browser/sessions/${sessionId}`, { method: 'DELETE' })

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -62,6 +62,9 @@ export default defineConfig({
         // lib/browser-capture.ts and CapturedDomPanel, both unit-tested.
         'src/components/browser-capture/useBrowserCaptureSession.ts',
         'src/components/browser-capture/BrowserCaptureModal.tsx',
+        // Annotation markup editor: canvas flatten + pointer-drag drawing; the
+        // model/geometry/undo-reducer live in lib/annotations.ts and are tested.
+        'src/components/browser-capture/AnnotationEditor.tsx',
       ],
       thresholds: {
         lines: 80,

--- a/server/browser-capture-manager.test.ts
+++ b/server/browser-capture-manager.test.ts
@@ -6,6 +6,7 @@ import {
   BrowserLaunchError,
   type BrowserContextHandle,
   type BrowserPageHandle,
+  type CaptureRect,
   type CapturedDom,
   type CapturedNetworkRequest,
   type ContextLauncher,
@@ -61,6 +62,11 @@ class FakePage implements BrowserPageHandle {
   async probeElementAt(point: { x: number; y: number }) { return { rect: { x: point.x, y: point.y, width: 50, height: 20 }, tag: 'div' } }
   async enableNetwork() { this.enabledNetwork = true }
   recentNetwork() { return this.network }
+  anchorSelector: string | null = '#el'
+  anchorRect: CaptureRect | null = { x: 0, y: 0, width: 100, height: 40 }
+  async resolveAnchorSelector() { this.calls.push('anchorSel'); return this.anchorSelector }
+  async resolveAnchorRect() { return this.anchorRect }
+  async waitForStable() { this.calls.push('stable') }
   async close() { this.closed = true }
   emitFrame(data: Buffer) { this.frameCb?.({ data, width: 1280, height: 800 }) }
 }
@@ -307,6 +313,57 @@ describe('BrowserCaptureManager', () => {
   it('capture returns null for an unknown session', async () => {
     const { mgr } = makeManager({ db })
     expect(await mgr.capture('nope', { x: 0, y: 0, width: 1, height: 1 }, 'p')).toBeNull()
+  })
+
+  const BPS = { desktop: { width: 1280, height: 800 }, tablet: { width: 768, height: 1024 }, mobile: { width: 375, height: 667 } }
+
+  it('captureBreakpoints shoots the selection at every size and restores the live viewport', async () => {
+    const attachments = makeAttachments()
+    const { mgr, ctx } = makeManager({ db, attachments })
+    const meta = await mgr.create()
+    const result = await mgr.captureBreakpoints(meta.id, { x: 0, y: 0, width: 100, height: 50 }, { x: 50, y: 25 }, 'pend', BPS)
+    expect(result).not.toBeNull()
+    expect(Object.keys(result!.breakpoints!)).toEqual(['desktop', 'tablet', 'mobile'])
+    expect(result!.breakpoints!.tablet.viewport).toEqual({ width: 768, height: 1024 })
+    expect(result!.breakpoints!.mobile.attachment.mimeType).toBe('image/png')
+    // canonical screenshot/dom point at the first (desktop) breakpoint
+    expect(result!.screenshot.id).toBe(result!.breakpoints!.desktop.attachment.id)
+    expect(result!.screenshotDataUrl.startsWith('data:image/png;base64,')).toBe(true)
+    // 3 screenshots + 1 canonical DOM
+    expect(attachments.uploads.filter((u) => u.mime === 'image/png')).toHaveLength(3)
+    expect(attachments.uploads.filter((u) => u.mime === 'application/json')).toHaveLength(1)
+    // viewport visited each size then restored to the live (default) viewport
+    expect(ctx.pages[0].calls.filter((c) => c.startsWith('viewport:'))).toEqual([
+      'viewport:1280x800', 'viewport:768x1024', 'viewport:375x667', 'viewport:1280x800',
+    ])
+    expect(mgr.getSession(meta.id)!.viewport).toEqual({ width: 1280, height: 800 })
+  })
+
+  it('captureBreakpoints falls back to the original rect when no anchor selector resolves', async () => {
+    const { mgr } = makeManager({ db })
+    const meta = await mgr.create()
+    mgr.getSession(meta.id)!.page.resolveAnchorSelector = async () => null
+    const result = await mgr.captureBreakpoints(meta.id, { x: 1, y: 2, width: 30, height: 40 }, { x: 5, y: 5 }, 'pend', { desktop: { width: 1280, height: 800 } })
+    expect(result).not.toBeNull()
+    expect(Object.keys(result!.breakpoints!)).toEqual(['desktop'])
+  })
+
+  it('captureBreakpoints returns null for unknown session, empty dims, or after shutdown', async () => {
+    const { mgr } = makeManager({ db })
+    const meta = await mgr.create()
+    expect(await mgr.captureBreakpoints('nope', { x: 0, y: 0, width: 1, height: 1 }, { x: 0, y: 0 }, 'p', BPS)).toBeNull()
+    expect(await mgr.captureBreakpoints(meta.id, { x: 0, y: 0, width: 1, height: 1 }, { x: 0, y: 0 }, 'p', {})).toBeNull()
+    await mgr.shutdown()
+    expect(await mgr.captureBreakpoints(meta.id, { x: 0, y: 0, width: 1, height: 1 }, { x: 0, y: 0 }, 'p', BPS)).toBeNull()
+  })
+
+  it('captureBreakpoints kills the session when the page dies mid-sequence', async () => {
+    const { mgr } = makeManager({ db })
+    const meta = await mgr.create()
+    mgr.getSession(meta.id)!.page.screenshotClip = async () => { throw new Error('Target page, context or browser has been closed') }
+    const result = await mgr.captureBreakpoints(meta.id, { x: 0, y: 0, width: 10, height: 10 }, { x: 5, y: 5 }, 'pend', BPS)
+    expect(result).toBeNull()
+    expect(mgr.getSession(meta.id)).toBeUndefined()
   })
 
   it('capture returns null (and kills the session) when the page is already closed', async () => {

--- a/server/browser-capture-manager.test.ts
+++ b/server/browser-capture-manager.test.ts
@@ -60,7 +60,11 @@ class FakePage implements BrowserPageHandle {
   clips: CaptureRect[] = []
   async screenshotClip(rect: CaptureRect) { this.clips.push(rect); return Buffer.from('PNGDATA') }
   async extractDom() { return makeDom() }
-  async probeElementAt(point: { x: number; y: number }) { return { rect: { x: point.x, y: point.y, width: 50, height: 20 }, tag: 'div' } }
+  async probeElementAt(point: { x: number; y: number }) { return { rect: { x: point.x, y: point.y, width: 50, height: 20 }, tag: 'div', selector: 'div.box', path: [{ label: 'body', selector: 'body' }, { label: 'div.box', selector: 'div.box' }] } }
+  async navigateElement(selector: string, direction: 'parent' | 'child' | 'self') {
+    if (direction === 'parent' && selector === 'body') return null
+    return { rect: { x: 0, y: 0, width: 10, height: 10 }, tag: direction === 'parent' ? 'section' : 'span', selector: `${selector} ${direction}`, path: [{ label: 'body', selector: 'body' }, { label: 'x', selector: `${selector} ${direction}` }] }
+  }
   async enableNetwork() { this.enabledNetwork = true }
   recentNetwork() { return this.network }
   anchorSelector: string | null = '#el'
@@ -424,10 +428,25 @@ describe('BrowserCaptureManager', () => {
     const { mgr } = makeManager({ db })
     const meta = await mgr.create()
     const probe = await mgr.probeElement(meta.id, { x: 12, y: 34 })
-    expect(probe).toEqual({ rect: { x: 12, y: 34, width: 50, height: 20 }, tag: 'div' })
+    expect(probe!.rect).toEqual({ x: 12, y: 34, width: 50, height: 20 })
+    expect(probe!.tag).toBe('div')
+    expect(probe!.path.map((p) => p.label)).toEqual(['body', 'div.box'])
     expect(await mgr.probeElement('nope', { x: 0, y: 0 })).toBeNull()
     await mgr.shutdown()
     expect(await mgr.probeElement(meta.id, { x: 0, y: 0 })).toBeNull()
+  })
+
+  it('navigateElement steps the breadcrumb to parent/child/self; null when it cannot', async () => {
+    const { mgr } = makeManager({ db })
+    const meta = await mgr.create()
+    const up = await mgr.navigateElement(meta.id, 'div.box', 'parent')
+    expect(up!.selector).toBe('div.box parent')
+    expect(up!.tag).toBe('section')
+    expect(up!.path.length).toBeGreaterThan(0)
+    const down = await mgr.navigateElement(meta.id, 'div.box', 'child')
+    expect(down!.tag).toBe('span')
+    expect(await mgr.navigateElement(meta.id, 'body', 'parent')).toBeNull() // can't go above body
+    expect(await mgr.navigateElement('nope', 'div', 'self')).toBeNull()
   })
 
   it('kills a session, closing page + clients; unknown kill returns false', async () => {

--- a/server/browser-capture-manager.test.ts
+++ b/server/browser-capture-manager.test.ts
@@ -67,6 +67,12 @@ class FakePage implements BrowserPageHandle {
   async resolveAnchorSelector() { this.calls.push('anchorSel'); return this.anchorSelector }
   async resolveAnchorRect() { return this.anchorRect }
   async waitForStable() { this.calls.push('stable') }
+  selection = ''
+  pasted: string[] = []
+  deleted = 0
+  async getSelectionText() { return this.selection }
+  async insertText(t: string) { this.pasted.push(t) }
+  async deleteSelection() { this.deleted++ }
   async close() { this.closed = true }
   emitFrame(data: Buffer) { this.frameCb?.({ data, width: 1280, height: 800 }) }
 }
@@ -375,6 +381,27 @@ describe('BrowserCaptureManager', () => {
     const result = await mgr.capture(meta.id, { x: 0, y: 0, width: 10, height: 10 }, 'pend')
     expect(result).toBeNull()
     expect(mgr.getSession(meta.id)).toBeUndefined()
+  })
+
+  it('clipboard copy returns the selection, paste injects, cut returns + deletes', async () => {
+    const { mgr, ctx } = makeManager({ db })
+    const meta = await mgr.create()
+    const page = ctx.pages[0]
+    page.selection = 'copied text'
+    expect(await mgr.clipboard(meta.id, 'copy')).toEqual({ text: 'copied text' })
+    await mgr.clipboard(meta.id, 'paste', 'pasted!')
+    expect(page.pasted).toEqual(['pasted!'])
+    const cut = await mgr.clipboard(meta.id, 'cut')
+    expect(cut).toEqual({ text: 'copied text' })
+    expect(page.deleted).toBe(1)
+  })
+
+  it('clipboard returns null for unknown session or after shutdown', async () => {
+    const { mgr } = makeManager({ db })
+    const meta = await mgr.create()
+    expect(await mgr.clipboard('nope', 'copy')).toBeNull()
+    await mgr.shutdown()
+    expect(await mgr.clipboard(meta.id, 'copy')).toBeNull()
   })
 
   it('probeElement returns the hovered element rect; null for unknown/disposed', async () => {

--- a/server/browser-capture-manager.test.ts
+++ b/server/browser-capture-manager.test.ts
@@ -57,7 +57,8 @@ class FakePage implements BrowserPageHandle {
   async dispatchInput(e: unknown) { this.inputs.push(e) }
   async startScreencast(cb: (f: ScreencastFrame) => void) { this.screencasting = true; this.frameCb = cb }
   async stopScreencast() { this.screencasting = false; this.frameCb = null }
-  async screenshotClip() { return Buffer.from('PNGDATA') }
+  clips: CaptureRect[] = []
+  async screenshotClip(rect: CaptureRect) { this.clips.push(rect); return Buffer.from('PNGDATA') }
   async extractDom() { return makeDom() }
   async probeElementAt(point: { x: number; y: number }) { return { rect: { x: point.x, y: point.y, width: 50, height: 20 }, tag: 'div' } }
   async enableNetwork() { this.enabledNetwork = true }
@@ -343,6 +344,21 @@ describe('BrowserCaptureManager', () => {
       'viewport:1280x800', 'viewport:768x1024', 'viewport:375x667', 'viewport:1280x800',
     ])
     expect(mgr.getSession(meta.id)!.viewport).toEqual({ width: 1280, height: 800 })
+  })
+
+  it('captureBreakpoints clamps an out-of-bounds rect to each breakpoint viewport', async () => {
+    const { mgr, ctx } = makeManager({ db })
+    const meta = await mgr.create()
+    // No selector → fall back to the (huge, desktop-sized) original rect, which
+    // would sit outside a smaller viewport and make screenshot throw if unclamped.
+    mgr.getSession(meta.id)!.page.resolveAnchorSelector = async () => null
+    await mgr.captureBreakpoints(meta.id, { x: 1000, y: 700, width: 800, height: 600 }, { x: 5, y: 5 }, 'pend', { mobile: { width: 375, height: 667 } })
+    const clip = ctx.pages[0].clips[0]
+    expect(clip.x).toBeLessThan(375)
+    expect(clip.x + clip.width).toBeLessThanOrEqual(375)
+    expect(clip.y + clip.height).toBeLessThanOrEqual(667)
+    expect(clip.width).toBeGreaterThanOrEqual(1)
+    expect(clip.height).toBeGreaterThanOrEqual(1)
   })
 
   it('captureBreakpoints falls back to the original rect when no anchor selector resolves', async () => {

--- a/server/browser-capture-manager.test.ts
+++ b/server/browser-capture-manager.test.ts
@@ -7,6 +7,7 @@ import {
   type BrowserContextHandle,
   type BrowserPageHandle,
   type CapturedDom,
+  type CapturedNetworkRequest,
   type ContextLauncher,
   type ScreencastFrame,
 } from './browser-capture-types'
@@ -38,6 +39,8 @@ class FakePage implements BrowserPageHandle {
   screencasting = false
   closed = false
   nextNav: { url: string; title: string } | null = null
+  enabledNetwork = false
+  network: CapturedNetworkRequest[] = []
 
   private nav(): { url: string; title: string } {
     if (this.nextNav) { this.url = this.nextNav.url; this.title = this.nextNav.title }
@@ -56,6 +59,8 @@ class FakePage implements BrowserPageHandle {
   async screenshotClip() { return Buffer.from('PNGDATA') }
   async extractDom() { return makeDom() }
   async probeElementAt(point: { x: number; y: number }) { return { rect: { x: point.x, y: point.y, width: 50, height: 20 }, tag: 'div' } }
+  async enableNetwork() { this.enabledNetwork = true }
+  recentNetwork() { return this.network }
   async close() { this.closed = true }
   emitFrame(data: Buffer) { this.frameCb?.({ data, width: 1280, height: 800 }) }
 }
@@ -274,6 +279,29 @@ describe('BrowserCaptureManager', () => {
     expect(attachments.uploads).toHaveLength(2)
     expect(attachments.uploads.every((u) => u.ticketKey === 'pending-1')).toBe(true)
     expect(attachments.uploads.map((u) => u.mime)).toEqual(['image/png', 'application/json'])
+  })
+
+  it('enables network capture on session create and folds requests into the DOM', async () => {
+    const { mgr, ctx } = makeManager({ db })
+    const meta = await mgr.create()
+    expect(ctx.pages[0].enabledNetwork).toBe(true)
+    ctx.pages[0].network = [
+      { method: 'GET', url: 'https://api.x/items', status: 200, resourceType: 'Fetch', mimeType: 'application/json', requestBodyShape: null, responseShape: '{ items: [object] }', durationMs: 42, startedAt: 0 },
+    ]
+    const result = await mgr.capture(meta.id, { x: 0, y: 0, width: 10, height: 10 }, 'pend')
+    expect(result!.dom.networkRequests).toHaveLength(1)
+    expect(result!.dom.networkRequests![0].url).toBe('https://api.x/items')
+    expect(result!.dom.networkRequests![0].responseShape).toBe('{ items: [object] }')
+  })
+
+  it('omits network requests when captureNetwork is false', async () => {
+    const { mgr, ctx } = makeManager({ db })
+    const meta = await mgr.create()
+    ctx.pages[0].network = [
+      { method: 'GET', url: 'https://api.x/items', status: 200, resourceType: 'Fetch', mimeType: 'application/json', durationMs: 1, startedAt: 0 } as CapturedNetworkRequest,
+    ]
+    const result = await mgr.capture(meta.id, { x: 0, y: 0, width: 10, height: 10 }, 'pend', { captureNetwork: false })
+    expect(result!.dom.networkRequests).toBeUndefined()
   })
 
   it('capture returns null for an unknown session', async () => {

--- a/server/browser-capture-manager.ts
+++ b/server/browser-capture-manager.ts
@@ -470,11 +470,17 @@ export class BrowserCaptureManager {
             if (r && r.width > 0 && r.height > 0) useRect = r
           } catch { /* fall back to the original rect */ }
         }
+        // CLAMP to the current (breakpoint) viewport: a rect resolved at a larger
+        // viewport — or the original-rect fallback when the element collapsed /
+        // is hidden at this size — can sit outside the smaller viewport, which
+        // makes page.screenshot throw "Clipped area is outside the image".
+        const cx = Math.max(0, Math.min(useRect.x, d.width - 1))
+        const cy = Math.max(0, Math.min(useRect.y, d.height - 1))
         const safeRect: CaptureRect = {
-          x: Math.max(0, useRect.x),
-          y: Math.max(0, useRect.y),
-          width: Math.max(1, useRect.width),
-          height: Math.max(1, useRect.height),
+          x: cx,
+          y: cy,
+          width: Math.max(1, Math.min(useRect.width, d.width - cx)),
+          height: Math.max(1, Math.min(useRect.height, d.height - cy)),
         }
         const [png, dom] = await Promise.all([
           s.page.screenshotClip(safeRect),

--- a/server/browser-capture-manager.ts
+++ b/server/browser-capture-manager.ts
@@ -59,6 +59,13 @@ interface BrowserSession {
   closed: boolean
 }
 
+/** One per-breakpoint screenshot in a multi-breakpoint capture. */
+export interface BreakpointCapture {
+  attachment: Attachment
+  dataUrl: string
+  viewport: { width: number; height: number }
+}
+
 export interface CaptureResult {
   screenshot: Attachment
   domAttachment: Attachment
@@ -67,6 +74,9 @@ export interface CaptureResult {
    *  without a second authenticated request (an <img src> to the attachment GET
    *  endpoint would omit the X-Hub-Token header and 401). */
   screenshotDataUrl: string
+  /** Present only for a multi-breakpoint capture: the same element shot at each
+   *  viewport. `screenshot`/`dom` above point at the first (canonical) entry. */
+  breakpoints?: Record<string, BreakpointCapture>
 }
 
 export interface BrowserCaptureManagerOptions {
@@ -395,6 +405,105 @@ export class BrowserCaptureManager {
       },
     })
     return { screenshot, domAttachment, dom, screenshotDataUrl: `data:image/png;base64,${png.toString('base64')}` }
+  }
+
+  // ─── Multi-breakpoint capture ───────────────────────────────────────────────
+
+  /**
+   * Capture the SAME selection at several viewport sizes. The element occupies a
+   * different rect at each breakpoint (a nav collapses on mobile), so we resolve
+   * a stable anchor selector once at the live viewport and re-query its box per
+   * breakpoint, falling back to the original rect when it can't be resolved. The
+   * whole sequence is driven server-side (set viewport → settle → re-resolve →
+   * shoot) so there is no fire-and-forget WS resize race; the live viewport is
+   * always restored. One canonical DOM (the first breakpoint) is stored.
+   */
+  async captureBreakpoints(
+    sessionId: string,
+    rect: CaptureRect,
+    anchorPoint: { x: number; y: number },
+    pendingSpecId: string,
+    dims: Record<string, { width: number; height: number }>,
+  ): Promise<CaptureResult | null> {
+    if (this.disposed) return null
+    const s = this.getSession(sessionId)
+    if (!s) return null
+    const order = Object.keys(dims)
+    if (order.length === 0) return null
+
+    const stashed = { ...s.viewport }
+    let selector: string | null = null
+    try { selector = (await s.page.resolveAnchorSelector?.(anchorPoint)) ?? null } catch { selector = null }
+
+    const captured: Record<string, { png: Buffer; dom: CapturedDom }> = {}
+    try {
+      for (const key of order) {
+        const d = dims[key]
+        await s.page.setViewport(d.width, d.height)
+        s.viewport = { width: d.width, height: d.height }
+        try { await s.page.waitForStable?.() } catch { /* settle is best-effort */ }
+        let useRect = rect
+        if (selector) {
+          try {
+            const r = await s.page.resolveAnchorRect?.(selector)
+            if (r && r.width > 0 && r.height > 0) useRect = r
+          } catch { /* fall back to the original rect */ }
+        }
+        const safeRect: CaptureRect = {
+          x: Math.max(0, useRect.x),
+          y: Math.max(0, useRect.y),
+          width: Math.max(1, useRect.width),
+          height: Math.max(1, useRect.height),
+        }
+        const [png, dom] = await Promise.all([
+          s.page.screenshotClip(safeRect),
+          s.page.extractDom(safeRect, DOM_HTML_BYTE_CAP),
+        ])
+        captured[key] = { png, dom }
+      }
+    } catch (err) {
+      if (isTargetClosedError(err)) {
+        await this.kill(sessionId)
+        return null
+      }
+      throw err
+    } finally {
+      try { await s.page.setViewport(stashed.width, stashed.height) } catch { /* ignore */ }
+      s.viewport = stashed
+    }
+
+    const stamp = this.now()
+    const breakpoints: Record<string, BreakpointCapture> = {}
+    for (const key of order) {
+      const { png } = captured[key]
+      const attachment = await this.attachments.upload({
+        slug: this.projectSlug,
+        ticketKey: pendingSpecId,
+        projectPath: null,
+        file: { buffer: png, originalname: `screen-capture-${key}-${stamp}.png`, mimetype: 'image/png', size: png.length },
+      })
+      breakpoints[key] = { attachment, dataUrl: `data:image/png;base64,${png.toString('base64')}`, viewport: dims[key] }
+    }
+
+    // Canonical = the first breakpoint: only its DOM is persisted (avoid tripling
+    // the DOM artifact / prompt cost). screenshot/dom point at it.
+    const canonicalKey = order[0]
+    const canonicalDom = captured[canonicalKey].dom
+    const domJson = Buffer.from(JSON.stringify(canonicalDom, null, 2), 'utf-8')
+    const domAttachment = await this.attachments.upload({
+      slug: this.projectSlug,
+      ticketKey: pendingSpecId,
+      projectPath: null,
+      file: { buffer: domJson, originalname: `page-dom-${stamp}.json`, mimetype: 'application/json', size: domJson.length },
+    })
+
+    return {
+      screenshot: breakpoints[canonicalKey].attachment,
+      domAttachment,
+      dom: canonicalDom,
+      screenshotDataUrl: breakpoints[canonicalKey].dataUrl,
+      breakpoints,
+    }
   }
 
   // ─── Teardown ───────────────────────────────────────────────────────────────

--- a/server/browser-capture-manager.ts
+++ b/server/browser-capture-manager.ts
@@ -312,6 +312,14 @@ export class BrowserCaptureManager {
     return s.page.probeElementAt(point)
   }
 
+  /** Re-resolve an element by selector and step to parent/child/self (breadcrumb). */
+  async navigateElement(sessionId: string, selector: string, direction: 'parent' | 'child' | 'self'): Promise<ElementProbe | null> {
+    if (this.disposed) return null
+    const s = this.getSession(sessionId)
+    if (!s) return null
+    return (await s.page.navigateElement?.(selector, direction)) ?? null
+  }
+
   async handleInput(sessionId: string, event: BrowserInputEvent): Promise<void> {
     if (this.disposed) return
     const s = this.getSession(sessionId)

--- a/server/browser-capture-manager.ts
+++ b/server/browser-capture-manager.ts
@@ -31,6 +31,8 @@ function isTargetClosedError(err: unknown): boolean {
 const MAX_SESSIONS_PER_PROJECT = 4
 const DOM_HTML_BYTE_CAP = 100_000
 const LAST_URL_KEY = 'config.browser_last_url'
+/** How far back from capture time to include buffered network requests. */
+const NETWORK_WINDOW_MS = 30_000
 
 /** A minimal structural view of a `ws` WebSocket — keeps the manager decoupled
  *  from the `ws` package so tests can pass plain fakes. */
@@ -209,6 +211,11 @@ export class BrowserCaptureManager {
     }
     this.sessions.set(id, session)
 
+    // Start capturing the page's network requests before the first navigation so
+    // XHR/fetch made during page load are available at capture time. Best-effort:
+    // a handle that doesn't support it (or a failure) just yields no network data.
+    try { await page.enableNetwork?.() } catch { /* network capture is best-effort */ }
+
     const target = opts?.initialUrl?.trim() || this.getLastUrl() || 'about:blank'
     const result = await page.goto(target)
     session.url = result.url
@@ -326,7 +333,7 @@ export class BrowserCaptureManager {
 
   // ─── Capture: screenshot + rich DOM → attachments ───────────────────────────
 
-  async capture(sessionId: string, rect: CaptureRect, pendingSpecId: string): Promise<CaptureResult | null> {
+  async capture(sessionId: string, rect: CaptureRect, pendingSpecId: string, opts?: { captureNetwork?: boolean }): Promise<CaptureResult | null> {
     if (this.disposed) return null
     const s = this.getSession(sessionId)
     if (!s) return null
@@ -352,6 +359,15 @@ export class BrowserCaptureManager {
         return null
       }
       throw err
+    }
+
+    // Snapshot the recent network requests into the DOM payload (rides the same
+    // JSON attachment → spec prompt). ON unless the spec explicitly disabled it.
+    if (opts?.captureNetwork !== false) {
+      try {
+        const reqs = s.page.recentNetwork?.(this.now() - NETWORK_WINDOW_MS) ?? []
+        if (reqs.length > 0) dom.networkRequests = reqs
+      } catch { /* network snapshot is best-effort */ }
     }
 
     const stamp = this.now()

--- a/server/browser-capture-manager.ts
+++ b/server/browser-capture-manager.ts
@@ -407,6 +407,27 @@ export class BrowserCaptureManager {
     return { screenshot, domAttachment, dom, screenshotDataUrl: `data:image/png;base64,${png.toString('base64')}` }
   }
 
+  // ─── Clipboard bridge ───────────────────────────────────────────────────────
+
+  /**
+   * Bridge the host clipboard to the embedded (headless) page, which has no
+   * access to the OS clipboard. `copy`/`cut` return the page's current selection
+   * text for the client to write to the host clipboard; `paste` inserts the
+   * host clipboard text (sent by the client) at the focused element.
+   */
+  async clipboard(sessionId: string, action: 'copy' | 'paste' | 'cut', text?: string): Promise<{ text: string } | null> {
+    if (this.disposed) return null
+    const s = this.getSession(sessionId)
+    if (!s) return null
+    if (action === 'paste') {
+      if (text) await s.page.insertText?.(text)
+      return { text: '' }
+    }
+    const sel = (await s.page.getSelectionText?.()) ?? ''
+    if (action === 'cut' && sel) await s.page.deleteSelection?.()
+    return { text: sel }
+  }
+
   // ─── Multi-breakpoint capture ───────────────────────────────────────────────
 
   /**

--- a/server/browser-capture-types.ts
+++ b/server/browser-capture-types.ts
@@ -168,6 +168,13 @@ export interface BrowserPageHandle {
   /** Buffered network requests that started at/after `sinceMs` (newest-first,
    *  capped). Optional — returns nothing when unimplemented. */
   recentNetwork?(sinceMs: number): CapturedNetworkRequest[]
+  // ─── Multi-breakpoint capture (optional) ──────────────────────────────────
+  /** Build a stable-ish CSS selector for the element at a viewport point. */
+  resolveAnchorSelector?(point: { x: number; y: number }): Promise<string | null>
+  /** Current bounding box of the element matching `selector`, or null. */
+  resolveAnchorRect?(selector: string): Promise<CaptureRect | null>
+  /** Wait for layout to settle after a viewport change (best-effort). */
+  waitForStable?(): Promise<void>
   close(): Promise<void>
 }
 

--- a/server/browser-capture-types.ts
+++ b/server/browser-capture-types.ts
@@ -75,6 +75,27 @@ export interface CapturedDesignTokens {
   fonts: string[]
 }
 
+/** One XHR/fetch (or document) request the page made around capture time. Bodies
+ *  are NEVER stored raw — only a structural shape sketch (key names), so captured
+ *  pages can't leak tokens/PII into a ticket. */
+export interface CapturedNetworkRequest {
+  method: string
+  url: string
+  status: number | null
+  /** CDP resource type (e.g. "Fetch", "XHR", "Document"). */
+  resourceType: string
+  mimeType: string | null
+  /** Sketch of the request body shape (JSON key names), never raw values. */
+  requestBodyShape?: string | null
+  /** Sketch of the response JSON shape (top-level keys / array element keys). */
+  responseShape?: string | null
+  durationMs: number | null
+  /** Wall-clock ms when the request started (for windowed capture). */
+  startedAt: number
+  failed?: boolean
+  errorText?: string
+}
+
 /** The rich DOM payload captured for a selection. Serialised to JSON and stored
  *  as an attachment (mime application/json) so it flows through the existing
  *  attachment → prompt pipeline for both Quick and Explore. */
@@ -95,6 +116,9 @@ export interface CapturedDom {
   /** Exact computed design tokens for the selection. Optional — absent on
    *  captures taken before this feature, so old serialised JSON still parses. */
   designTokens?: CapturedDesignTokens
+  /** XHR/fetch requests the page made around capture time. Optional — absent on
+   *  old captures or when network capture is disabled for the spec. */
+  networkRequests?: CapturedNetworkRequest[]
   capturedAt: string
 }
 
@@ -138,6 +162,12 @@ export interface BrowserPageHandle {
   extractDom(rect: CaptureRect, htmlByteCap: number): Promise<CapturedDom>
   /** The element at a viewport point (for hover-to-select highlighting). */
   probeElementAt(point: { x: number; y: number }): Promise<ElementProbe | null>
+  /** Begin capturing the page's network requests (best-effort, idempotent).
+   *  Optional — a handle that doesn't implement it simply captures no network. */
+  enableNetwork?(): Promise<void>
+  /** Buffered network requests that started at/after `sinceMs` (newest-first,
+   *  capped). Optional — returns nothing when unimplemented. */
+  recentNetwork?(sinceMs: number): CapturedNetworkRequest[]
   close(): Promise<void>
 }
 

--- a/server/browser-capture-types.ts
+++ b/server/browser-capture-types.ts
@@ -175,6 +175,13 @@ export interface BrowserPageHandle {
   resolveAnchorRect?(selector: string): Promise<CaptureRect | null>
   /** Wait for layout to settle after a viewport change (best-effort). */
   waitForStable?(): Promise<void>
+  // ─── Clipboard bridge (optional) ──────────────────────────────────────────
+  /** The page's current selection text (for copy/cut). */
+  getSelectionText?(): Promise<string>
+  /** Insert text at the focused element's caret (for paste). */
+  insertText?(text: string): Promise<void>
+  /** Delete the current selection (for cut). */
+  deleteSelection?(): Promise<void>
   close(): Promise<void>
 }
 

--- a/server/browser-capture-types.ts
+++ b/server/browser-capture-types.ts
@@ -40,6 +40,41 @@ export interface CapturedNode {
   styles: Record<string, string>
 }
 
+/** A digest of computed design tokens for a single element. Values are raw
+ *  computed-style strings (e.g. "16px", "rgb(59, 130, 246)"); empty/default
+ *  values (transparent colour, 0px spacing, no border, "normal" line-height) are
+ *  omitted so the digest stays small. */
+export interface TokenSet {
+  color?: string
+  backgroundColor?: string
+  fontFamily?: string
+  fontSize?: string
+  fontWeight?: string
+  lineHeight?: string
+  letterSpacing?: string
+  padding?: string
+  margin?: string
+  border?: string
+  borderRadius?: string
+  boxShadow?: string
+}
+
+/** Exact design tokens derived from the selection's computed styles so a
+ *  "clone this UI" spec carries precise values instead of guesses. A
+ *  deterministic byproduct of the styles already collected — no extra CDP work. */
+export interface CapturedDesignTokens {
+  /** Schema version of this digest, for forward-compatible parsing. */
+  contractVersion: number
+  /** Tokens of the container/anchor element covering the selection. */
+  anchor: TokenSet
+  /** Deduped tokens for the most frequent tags inside the selection (cap ~8). */
+  byTag: Record<string, TokenSet>
+  /** Deduped non-transparent colours (text + background), cap ~12. */
+  palette: string[]
+  /** Deduped font-family stacks used inside the selection (cap ~6). */
+  fonts: string[]
+}
+
 /** The rich DOM payload captured for a selection. Serialised to JSON and stored
  *  as an attachment (mime application/json) so it flows through the existing
  *  attachment → prompt pipeline for both Quick and Explore. */
@@ -57,6 +92,9 @@ export interface CapturedDom {
   /** True when `css` was truncated at the size cap. */
   cssTruncated: boolean
   nodes: CapturedNode[]
+  /** Exact computed design tokens for the selection. Optional — absent on
+   *  captures taken before this feature, so old serialised JSON still parses. */
+  designTokens?: CapturedDesignTokens
   capturedAt: string
 }
 

--- a/server/browser-capture-types.ts
+++ b/server/browser-capture-types.ts
@@ -136,10 +136,23 @@ export interface ScreencastFrame {
   height: number
 }
 
-/** The element under a point, for hover-to-select highlighting. */
+/** One node in the hovered element's ancestor breadcrumb. */
+export interface BreadcrumbSegment {
+  /** Short human label, e.g. "div.container" or "button#cta". */
+  label: string
+  /** Stable-ish CSS selector to re-resolve this node (for up/down navigation). */
+  selector: string
+}
+
+/** The element under a point (or re-resolved by selector), for hover-to-select
+ *  highlighting + DevTools-style breadcrumb navigation. */
 export interface ElementProbe {
   rect: CaptureRect
   tag: string
+  /** Selector for the probed element (used to step to parent/child). */
+  selector: string
+  /** Ancestor chain root→element (inclusive), capped for readability. */
+  path: BreadcrumbSegment[]
 }
 
 /** Minimal page abstraction the manager drives. Implemented for real over CDP in
@@ -162,6 +175,9 @@ export interface BrowserPageHandle {
   extractDom(rect: CaptureRect, htmlByteCap: number): Promise<CapturedDom>
   /** The element at a viewport point (for hover-to-select highlighting). */
   probeElementAt(point: { x: number; y: number }): Promise<ElementProbe | null>
+  /** Re-resolve an element by selector and optionally step to its parent/child,
+   *  for breadcrumb navigation. Optional — unimplemented handles can't navigate. */
+  navigateElement?(selector: string, direction: 'parent' | 'child' | 'self'): Promise<ElementProbe | null>
   /** Begin capturing the page's network requests (best-effort, idempotent).
    *  Optional — a handle that doesn't implement it simply captures no network. */
   enableNetwork?(): Promise<void>

--- a/server/browser-network.test.ts
+++ b/server/browser-network.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest'
+import { NetworkRingBuffer, sketchJsonShape, shouldSkipNetworkEntry, NETWORK_DENY_TYPES } from './browser-network'
+
+describe('sketchJsonShape', () => {
+  it('sketches a flat object as key:type pairs', () => {
+    expect(sketchJsonShape('{"id":1,"name":"x","ok":true}')).toBe('{ id: number, name: string, ok: boolean }')
+  })
+
+  it('sketches an array of objects using the first element', () => {
+    expect(sketchJsonShape('[{"id":1,"name":"x"}]')).toBe('[{ id: number, name: string }]')
+  })
+
+  it('marks arrays with more than one element', () => {
+    expect(sketchJsonShape('["a","b","c"]')).toBe('[string, …]')
+  })
+
+  it('handles empty arrays and null', () => {
+    expect(sketchJsonShape('[]')).toBe('[]')
+    expect(sketchJsonShape('null')).toBe('null')
+    expect(sketchJsonShape('{"x":null}')).toBe('{ x: null }')
+  })
+
+  it('caps nesting depth', () => {
+    const deep = JSON.stringify({ a: { b: { c: { d: 1 } } } })
+    // maxDepth default 3 → the 4th level collapses to "object"
+    expect(sketchJsonShape(deep)).toBe('{ a: { b: { c: object } } }')
+  })
+
+  it('truncates objects past maxKeys', () => {
+    const obj: Record<string, number> = {}
+    for (let i = 0; i < 30; i++) obj[`k${i}`] = i
+    const out = sketchJsonShape(JSON.stringify(obj), { maxKeys: 3 })
+    expect(out).toContain('k0: number')
+    expect(out).toContain(', … }')
+  })
+
+  it('returns null for non-JSON, empty, or oversized input', () => {
+    expect(sketchJsonShape('not json')).toBeNull()
+    expect(sketchJsonShape('')).toBeNull()
+    expect(sketchJsonShape('a'.repeat(300_000))).toBeNull()
+    // @ts-expect-error guarding non-string at runtime
+    expect(sketchJsonShape(undefined)).toBeNull()
+  })
+})
+
+describe('shouldSkipNetworkEntry', () => {
+  it('skips static asset resource types', () => {
+    for (const t of NETWORK_DENY_TYPES) expect(shouldSkipNetworkEntry(t, 'https://x/y')).toBe(true)
+  })
+  it('skips data: and blob: URLs', () => {
+    expect(shouldSkipNetworkEntry('Fetch', 'data:application/json,{}')).toBe(true)
+    expect(shouldSkipNetworkEntry('XHR', 'blob:https://x/abc')).toBe(true)
+  })
+  it('keeps real XHR/Fetch/Document requests', () => {
+    expect(shouldSkipNetworkEntry('Fetch', 'https://api.x/items')).toBe(false)
+    expect(shouldSkipNetworkEntry('XHR', 'https://api.x/items')).toBe(false)
+    expect(shouldSkipNetworkEntry('Document', 'https://x/')).toBe(false)
+  })
+})
+
+describe('NetworkRingBuffer', () => {
+  it('records a full request lifecycle and exposes it via recent()', () => {
+    const buf = new NetworkRingBuffer()
+    buf.start('1', { method: 'GET', url: 'https://api.x/items?secret=abc', resourceType: 'Fetch', startedAt: 1000, requestBodyShape: null })
+    buf.response('1', { status: 200, mimeType: 'application/json' })
+    buf.finish('1', { finishedAt: 1120 })
+    const [r] = buf.recent(0)
+    expect(r.method).toBe('GET')
+    expect(r.status).toBe(200)
+    expect(r.mimeType).toBe('application/json')
+    expect(r.durationMs).toBe(120)
+    expect(r.url).toContain('secret=abc') // URL preserved (window is local-dev)
+  })
+
+  it('drops static-asset and data: entries at insertion', () => {
+    const buf = new NetworkRingBuffer()
+    buf.start('img', { method: 'GET', url: 'https://x/a.png', resourceType: 'Image', startedAt: 1 })
+    buf.start('data', { method: 'GET', url: 'data:image/png;base64,AAA', resourceType: 'Fetch', startedAt: 1 })
+    expect(buf.size).toBe(0)
+    // response/finish for an unknown id are no-ops
+    buf.response('img', { status: 200, mimeType: 'image/png' })
+    expect(buf.recent(0)).toHaveLength(0)
+  })
+
+  it('records failures with errorText and a duration', () => {
+    const buf = new NetworkRingBuffer()
+    buf.start('1', { method: 'POST', url: 'https://api.x/save', resourceType: 'Fetch', startedAt: 100, requestBodyShape: '{ name: string }' })
+    buf.fail('1', { finishedAt: 250, errorText: 'net::ERR_FAILED' })
+    const [r] = buf.recent(0)
+    expect(r.failed).toBe(true)
+    expect(r.errorText).toBe('net::ERR_FAILED')
+    expect(r.durationMs).toBe(150)
+    expect(r.requestBodyShape).toBe('{ name: string }')
+  })
+
+  it('filters by sinceMs, returns newest-first, and caps the result', () => {
+    const buf = new NetworkRingBuffer()
+    for (let i = 0; i < 5; i++) buf.start(`r${i}`, { method: 'GET', url: `https://api.x/${i}`, resourceType: 'Fetch', startedAt: i * 100 })
+    // since 250 → only startedAt 300, 400 qualify
+    const recent = buf.recent(250)
+    expect(recent.map((r) => r.url)).toEqual(['https://api.x/4', 'https://api.x/3'])
+    // cap
+    const buf2 = new NetworkRingBuffer()
+    for (let i = 0; i < 10; i++) buf2.start(`r${i}`, { method: 'GET', url: `https://x/${i}`, resourceType: 'Fetch', startedAt: i })
+    expect(buf2.recent(0, 3)).toHaveLength(3)
+  })
+
+  it('evicts the oldest entries past the cap', () => {
+    const buf = new NetworkRingBuffer(2)
+    buf.start('a', { method: 'GET', url: 'https://x/a', resourceType: 'Fetch', startedAt: 1 })
+    buf.start('b', { method: 'GET', url: 'https://x/b', resourceType: 'Fetch', startedAt: 2 })
+    buf.start('c', { method: 'GET', url: 'https://x/c', resourceType: 'Fetch', startedAt: 3 })
+    expect(buf.size).toBe(2)
+    expect(buf.recent(0).map((r) => r.url)).toEqual(['https://x/c', 'https://x/b'])
+  })
+
+  it('gates body sketching on JSON mime and applies it once', () => {
+    const buf = new NetworkRingBuffer()
+    buf.start('1', { method: 'GET', url: 'https://api.x/items', resourceType: 'Fetch', startedAt: 1 })
+    expect(buf.wantsBodySketch('1')).toBe(false) // no mime yet
+    buf.response('1', { status: 200, mimeType: 'text/html' })
+    expect(buf.wantsBodySketch('1')).toBe(false) // not JSON
+    buf.response('1', { status: 200, mimeType: 'application/json; charset=utf-8' })
+    expect(buf.wantsBodySketch('1')).toBe(true)
+    buf.setResponseShape('1', '{ items: [object] }')
+    expect(buf.wantsBodySketch('1')).toBe(false) // already sketched
+    expect(buf.recent(0)[0].responseShape).toBe('{ items: [object] }')
+    // null/empty shape is ignored; unknown id is a no-op
+    buf.setResponseShape('1', null)
+    buf.setResponseShape('nope', '{ x: number }')
+    expect(buf.recent(0)[0].responseShape).toBe('{ items: [object] }')
+  })
+})

--- a/server/browser-network.ts
+++ b/server/browser-network.ts
@@ -1,0 +1,157 @@
+// Pure, side-effect-free helpers for the browser-capture network feature.
+//
+// The Playwright/CDP wiring lives in `browser-playwright.ts` (excluded from
+// coverage — needs a live Chromium). Everything testable — the request ring
+// buffer and the response-shape sketcher — lives HERE so it is fully unit-tested.
+//
+// Privacy invariant: we NEVER store a raw request/response body. Only a
+// structural shape (key names) is derived via `sketchJsonShape`, so a capture of
+// an arbitrary website cannot leak tokens / PII into a spec ticket.
+
+import type { CapturedNetworkRequest } from './browser-capture-types'
+
+/** Static-asset resource types we never record — only XHR/Fetch/Document/etc. */
+export const NETWORK_DENY_TYPES = new Set(['Image', 'Stylesheet', 'Font', 'Media', 'Manifest'])
+
+const URL_CAP = 2000
+const RESPONSE_BODY_CAP = 200_000
+const SHAPE_CAP = 400
+
+/** True when an entry should be dropped (static asset or non-network URL scheme). */
+export function shouldSkipNetworkEntry(resourceType: string, url: string): boolean {
+  if (NETWORK_DENY_TYPES.has(resourceType)) return true
+  if (/^(data|blob):/i.test(url)) return true
+  return false
+}
+
+/**
+ * Derive a compact structural sketch of a JSON payload — key names and leaf
+ * TYPES only, never values. Returns null for non-JSON or oversized input.
+ *   '{"id":1,"tags":["a"]}'        → '{ id: number, tags: [string] }'
+ *   '[{"id":1,"name":"x"}]'        → '[{ id: number, name: string }]'
+ */
+export function sketchJsonShape(
+  bodyText: string,
+  opts: { maxKeys?: number; maxDepth?: number } = {},
+): string | null {
+  if (typeof bodyText !== 'string' || bodyText.length === 0 || bodyText.length > RESPONSE_BODY_CAP) return null
+  const maxKeys = opts.maxKeys ?? 24
+  const maxDepth = opts.maxDepth ?? 3
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(bodyText)
+  } catch {
+    return null
+  }
+  const describe = (v: unknown, depth: number): string => {
+    if (v === null) return 'null'
+    if (Array.isArray(v)) {
+      if (v.length === 0) return '[]'
+      return `[${describe(v[0], depth)}${v.length > 1 ? ', …' : ''}]`
+    }
+    const t = typeof v
+    if (t === 'object') {
+      if (depth >= maxDepth) return 'object'
+      const obj = v as Record<string, unknown>
+      const keys = Object.keys(obj)
+      const shown = keys.slice(0, maxKeys)
+      const inner = shown.map((k) => `${k}: ${describe(obj[k], depth + 1)}`).join(', ')
+      const more = keys.length > maxKeys ? ', …' : ''
+      return `{ ${inner}${more} }`
+    }
+    return t // 'string' | 'number' | 'boolean' | 'function' | 'undefined'
+  }
+  const sketch = describe(parsed, 0)
+  return sketch.length > SHAPE_CAP ? sketch.slice(0, SHAPE_CAP) + '…' : sketch
+}
+
+interface StartInfo {
+  method: string
+  url: string
+  resourceType: string
+  startedAt: number
+  requestBodyShape?: string | null
+}
+
+/**
+ * Bounded, insertion-ordered buffer of in-flight + completed network requests,
+ * keyed by CDP requestId. Oldest entries are evicted past `cap`. Static assets
+ * and data:/blob: URLs are dropped at insertion.
+ */
+export class NetworkRingBuffer {
+  private readonly cap: number
+  private readonly map = new Map<string, CapturedNetworkRequest>()
+
+  constructor(cap = 150) {
+    this.cap = Math.max(1, cap)
+  }
+
+  start(requestId: string, info: StartInfo): void {
+    if (shouldSkipNetworkEntry(info.resourceType, info.url)) return
+    if (!this.map.has(requestId)) {
+      while (this.map.size >= this.cap) {
+        const oldest = this.map.keys().next().value
+        if (oldest === undefined) break
+        this.map.delete(oldest)
+      }
+    }
+    this.map.set(requestId, {
+      method: info.method,
+      url: info.url.slice(0, URL_CAP),
+      status: null,
+      resourceType: info.resourceType,
+      mimeType: null,
+      requestBodyShape: info.requestBodyShape ?? null,
+      responseShape: null,
+      durationMs: null,
+      startedAt: info.startedAt,
+    })
+  }
+
+  response(requestId: string, info: { status: number; mimeType: string | null }): void {
+    const e = this.map.get(requestId)
+    if (!e) return
+    e.status = info.status
+    e.mimeType = info.mimeType
+  }
+
+  finish(requestId: string, info: { finishedAt: number }): void {
+    const e = this.map.get(requestId)
+    if (!e) return
+    e.durationMs = Math.max(0, Math.round(info.finishedAt - e.startedAt))
+  }
+
+  fail(requestId: string, info: { finishedAt: number; errorText?: string }): void {
+    const e = this.map.get(requestId)
+    if (!e) return
+    e.failed = true
+    e.errorText = info.errorText
+    e.durationMs = Math.max(0, Math.round(info.finishedAt - e.startedAt))
+  }
+
+  setResponseShape(requestId: string, shape: string | null): void {
+    const e = this.map.get(requestId)
+    if (!e || !shape) return
+    e.responseShape = shape
+  }
+
+  /** True when the entry is a JSON response still missing a body sketch — used to
+   *  avoid fetching response bodies for non-JSON resources. */
+  wantsBodySketch(requestId: string): boolean {
+    const e = this.map.get(requestId)
+    return !!e && !e.responseShape && !!e.mimeType && e.mimeType.includes('json')
+  }
+
+  /** Entries that started at/after `sinceMs`, newest-first, capped at `cap`. */
+  recent(sinceMs: number, cap = 40): CapturedNetworkRequest[] {
+    return [...this.map.values()]
+      .filter((e) => e.startedAt >= sinceMs)
+      .sort((a, b) => b.startedAt - a.startedAt)
+      .slice(0, cap)
+      .map((e) => ({ ...e }))
+  }
+
+  get size(): number {
+    return this.map.size
+  }
+}

--- a/server/browser-playwright.ts
+++ b/server/browser-playwright.ts
@@ -246,6 +246,58 @@ class PlaywrightPageHandle implements BrowserPageHandle {
     return this.netBuffer.recent(sinceMs)
   }
 
+  async resolveAnchorSelector(point: { x: number; y: number }): Promise<string | null> {
+    try {
+      return await this.page.evaluate((p: { x: number; y: number }) => {
+        const el = document.elementFromPoint(p.x, p.y)
+        if (!el) return null
+        const esc = (s: string) => (window.CSS && CSS.escape ? CSS.escape(s) : s.replace(/[^a-zA-Z0-9_-]/g, '\\$&'))
+        const target = el as HTMLElement
+        if (target.id) return '#' + esc(target.id)
+        const testid = target.getAttribute('data-testid')
+        if (testid) return `[data-testid="${testid.replace(/"/g, '\\"')}"]`
+        const parts: string[] = []
+        let node: Element | null = el
+        let depth = 0
+        while (node && node.nodeType === 1 && node !== document.body && depth < 6) {
+          const tag = node.tagName.toLowerCase()
+          const parent: Element | null = node.parentElement
+          if (!parent) { parts.unshift(tag); break }
+          const sameTag = Array.from(parent.children).filter((c) => c.tagName === (node as Element).tagName)
+          const idx = sameTag.indexOf(node) + 1
+          parts.unshift(sameTag.length > 1 ? `${tag}:nth-of-type(${idx})` : tag)
+          node = parent
+          depth++
+        }
+        return parts.length ? parts.join(' > ') : null
+      }, point)
+    } catch {
+      return null
+    }
+  }
+
+  async resolveAnchorRect(selector: string): Promise<CaptureRect | null> {
+    try {
+      return await this.page.evaluate((sel: string) => {
+        const el = document.querySelector(sel)
+        if (!el) return null
+        const b = el.getBoundingClientRect()
+        if (b.width <= 0 || b.height <= 0) return null
+        return { x: b.x, y: b.y, width: b.width, height: b.height }
+      }, selector)
+    } catch {
+      return null
+    }
+  }
+
+  async waitForStable(): Promise<void> {
+    try {
+      await this.page.evaluate(() => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r()))))
+    } catch { /* ignore */ }
+    // A small extra settle for late reflow / lazy-loaded images / web fonts.
+    try { await this.page.waitForTimeout?.(120) } catch { /* ignore */ }
+  }
+
   async close(): Promise<void> {
     await this.stopScreencast()
     if (this.netCdp) {

--- a/server/browser-playwright.ts
+++ b/server/browser-playwright.ts
@@ -18,6 +18,7 @@ import type {
   ScreencastFrame,
 } from './browser-capture-types'
 import { resolveBundledChromiumExecutable } from './chromium-resolver'
+import { NetworkRingBuffer, sketchJsonShape } from './browser-network'
 
 function normalizeUrl(raw: string): string {
   const trimmed = raw.trim()
@@ -31,6 +32,12 @@ class PlaywrightPageHandle implements BrowserPageHandle {
   // dependency on playwright's exported types leaking through the abstraction.
   private cdp: any = null
   private screencastHandler: ((frame: ScreencastFrame) => void) | null = null
+  // A dedicated, long-lived CDP session for the Network domain — kept SEPARATE
+  // from `cdp` (which is attached/detached around screencast) so request capture
+  // survives screencast toggles.
+  private netCdp: any = null
+  private netEnabled = false
+  private readonly netBuffer = new NetworkRingBuffer()
 
   constructor(private readonly page: any) {}
 
@@ -183,8 +190,69 @@ class PlaywrightPageHandle implements BrowserPageHandle {
     }
   }
 
+  async enableNetwork(): Promise<void> {
+    if (this.netEnabled) return
+    this.netEnabled = true
+    try {
+      const ctx = this.page.context()
+      this.netCdp = await ctx.newCDPSession(this.page)
+      await this.netCdp.send('Network.enable', { maxResourceBufferSize: 5_000_000, maxTotalBufferSize: 10_000_000 })
+      this.netCdp.on('Network.requestWillBeSent', (e: any) => {
+        try {
+          this.netBuffer.start(e.requestId, {
+            method: e.request?.method ?? 'GET',
+            url: e.request?.url ?? '',
+            resourceType: e.type ?? 'Other',
+            startedAt: Date.now(),
+            requestBodyShape: e.request?.postData ? sketchJsonShape(e.request.postData) : null,
+          })
+        } catch { /* never let a network event bubble */ }
+      })
+      this.netCdp.on('Network.responseReceived', (e: any) => {
+        try {
+          this.netBuffer.response(e.requestId, { status: e.response?.status ?? 0, mimeType: e.response?.mimeType ?? null })
+        } catch { /* ignore */ }
+      })
+      this.netCdp.on('Network.loadingFinished', (e: any) => {
+        try {
+          this.netBuffer.finish(e.requestId, { finishedAt: Date.now() })
+          // Sketch JSON response shapes only, body under a cap, fully guarded.
+          if (this.netBuffer.wantsBodySketch(e.requestId)) void this.sketchResponseBody(e.requestId)
+        } catch { /* ignore */ }
+      })
+      this.netCdp.on('Network.loadingFailed', (e: any) => {
+        try { this.netBuffer.fail(e.requestId, { finishedAt: Date.now(), errorText: e.errorText }) } catch { /* ignore */ }
+      })
+    } catch {
+      // Network capture is best-effort — a failure here never breaks the session.
+      this.netEnabled = false
+    }
+  }
+
+  private async sketchResponseBody(requestId: string): Promise<void> {
+    if (!this.netCdp) return
+    try {
+      const res = await this.netCdp.send('Network.getResponseBody', { requestId })
+      if (!res || res.base64Encoded) return // binary — skip
+      const body = typeof res.body === 'string' ? res.body : ''
+      const shape = sketchJsonShape(body)
+      if (shape) this.netBuffer.setResponseShape(requestId, shape)
+    } catch {
+      // The body may already be evicted / unavailable — degrade to no shape.
+    }
+  }
+
+  recentNetwork(sinceMs: number) {
+    return this.netBuffer.recent(sinceMs)
+  }
+
   async close(): Promise<void> {
     await this.stopScreencast()
+    if (this.netCdp) {
+      try { await this.netCdp.send('Network.disable') } catch { /* ignore */ }
+      try { await this.netCdp.detach() } catch { /* ignore */ }
+      this.netCdp = null
+    }
     try { await this.page.close() } catch { /* ignore */ }
   }
 }

--- a/server/browser-playwright.ts
+++ b/server/browser-playwright.ts
@@ -176,15 +176,19 @@ class PlaywrightPageHandle implements BrowserPageHandle {
   }
 
   async probeElementAt(point: { x: number; y: number }): Promise<ElementProbe | null> {
+    return this.runProbe({ point })
+  }
+
+  async navigateElement(selector: string, direction: 'parent' | 'child' | 'self'): Promise<ElementProbe | null> {
+    return this.runProbe({ selector, direction })
+  }
+
+  private async runProbe(arg: { point?: { x: number; y: number }; selector?: string; direction?: 'parent' | 'child' | 'self' }): Promise<ElementProbe | null> {
     try {
-      // Inline arrow with no inner named functions → esbuild/tsx won't inject the
-      // `__name` helper, so it's safe to pass directly to page.evaluate.
-      return await this.page.evaluate((p: { x: number; y: number }) => {
-        const el = document.elementFromPoint(p.x, p.y)
-        if (!el) return null
-        const b = el.getBoundingClientRect()
-        return { rect: { x: b.x, y: b.y, width: b.width, height: b.height }, tag: el.tagName.toLowerCase() }
-      }, point)
+      // Serialise with the `__name` shim (same pattern as extractDom) so the inner
+      // const-arrow helpers survive esbuild keepNames in the page context.
+      const src = `(() => { const __name = (f) => f; return (${probeScript.toString()})(${JSON.stringify(arg)}); })()`
+      return (await this.page.evaluate(src)) as ElementProbe | null
     } catch {
       return null
     }
@@ -672,6 +676,78 @@ function domExtractScript(arg: { rect: CaptureRect; htmlByteCap: number }): {
     cssTruncated,
     nodes,
     designTokens,
+  }
+}
+
+// Serialised into the page via page.evaluate (with a `__name` shim). Resolves an
+// element by point or by selector (+optional parent/child step) and returns its
+// rect, a stable-ish selector, and the ancestor breadcrumb root→element.
+function probeScript(arg: {
+  point?: { x: number; y: number }
+  selector?: string
+  direction?: 'parent' | 'child' | 'self'
+}): {
+  rect: { x: number; y: number; width: number; height: number }
+  tag: string
+  selector: string
+  path: Array<{ label: string; selector: string }>
+} | null {
+  const { point, selector, direction } = arg
+  const SKIP = new Set(['SCRIPT', 'STYLE', 'NOSCRIPT'])
+  let el: Element | null = null
+  if (point) {
+    el = document.elementFromPoint(point.x, point.y)
+  } else if (selector) {
+    const base = document.querySelector(selector)
+    if (base) {
+      if (direction === 'parent') el = base.parentElement
+      else if (direction === 'child') el = Array.from(base.children).find((c) => !SKIP.has(c.tagName)) ?? null
+      else el = base
+    }
+  }
+  if (el === document.documentElement) el = document.body
+  if (!el || el.nodeType !== 1) return null
+
+  const cssEsc = (s: string) => (window.CSS && CSS.escape ? CSS.escape(s) : s.replace(/[^a-zA-Z0-9_-]/g, '\\$&'))
+  const partFor = (node: Element): string => {
+    const tag = node.tagName.toLowerCase()
+    const id = (node as HTMLElement).id
+    if (id) return '#' + cssEsc(id)
+    const parent = node.parentElement
+    if (!parent) return tag
+    const sameTag = Array.from(parent.children).filter((c) => c.tagName === node.tagName)
+    return sameTag.length > 1 ? `${tag}:nth-of-type(${sameTag.indexOf(node) + 1})` : tag
+  }
+  const labelFor = (node: Element): string => {
+    const tag = node.tagName.toLowerCase()
+    const id = (node as HTMLElement).id
+    if (id) return `${tag}#${id}`
+    const cn = node.getAttribute('class')
+    const first = cn ? cn.trim().split(/\s+/)[0] : ''
+    return first ? `${tag}.${first}` : tag
+  }
+
+  const chain: Element[] = []
+  let node: Element | null = el
+  while (node && node.nodeType === 1 && node !== document.documentElement) {
+    chain.unshift(node)
+    node = node.parentElement
+  }
+  const capped = new Set(chain.slice(Math.max(0, chain.length - 8)))
+  const path: Array<{ label: string; selector: string }> = []
+  let sel = ''
+  for (const n of chain) {
+    const part = partFor(n)
+    sel = part.charAt(0) === '#' ? part : sel ? `${sel} > ${part}` : part
+    if (capped.has(n)) path.push({ label: labelFor(n), selector: sel })
+  }
+
+  const b = el.getBoundingClientRect()
+  return {
+    rect: { x: b.x, y: b.y, width: b.width, height: b.height },
+    tag: el.tagName.toLowerCase(),
+    selector: sel,
+    path,
   }
 }
 

--- a/server/browser-playwright.ts
+++ b/server/browser-playwright.ts
@@ -281,6 +281,9 @@ class PlaywrightPageHandle implements BrowserPageHandle {
       return await this.page.evaluate((sel: string) => {
         const el = document.querySelector(sel)
         if (!el) return null
+        // Bring it into view so a below-the-fold element at this breakpoint yields
+        // an on-screen rect (instant scroll → getBoundingClientRect reflects it).
+        try { el.scrollIntoView({ block: 'center', inline: 'center' }) } catch { /* ignore */ }
         const b = el.getBoundingClientRect()
         if (b.width <= 0 || b.height <= 0) return null
         return { x: b.x, y: b.y, width: b.width, height: b.height }

--- a/server/browser-playwright.ts
+++ b/server/browser-playwright.ts
@@ -298,6 +298,22 @@ class PlaywrightPageHandle implements BrowserPageHandle {
     try { await this.page.waitForTimeout?.(120) } catch { /* ignore */ }
   }
 
+  async getSelectionText(): Promise<string> {
+    try {
+      return await this.page.evaluate(() => window.getSelection()?.toString() ?? '')
+    } catch {
+      return ''
+    }
+  }
+
+  async insertText(text: string): Promise<void> {
+    try { await this.page.keyboard.insertText(text) } catch { /* ignore */ }
+  }
+
+  async deleteSelection(): Promise<void> {
+    try { await this.page.keyboard.press('Delete') } catch { /* ignore */ }
+  }
+
   async close(): Promise<void> {
     await this.stopScreencast()
     if (this.netCdp) {

--- a/server/browser-playwright.ts
+++ b/server/browser-playwright.ts
@@ -163,6 +163,7 @@ class PlaywrightPageHandle implements BrowserPageHandle {
       css: raw.css,
       cssTruncated: raw.cssTruncated,
       nodes: raw.nodes,
+      designTokens: raw.designTokens,
       capturedAt: new Date().toISOString(),
     }
   }
@@ -204,6 +205,13 @@ function domExtractScript(arg: { rect: CaptureRect; htmlByteCap: number }): {
     attributes: Record<string, string>
     styles: Record<string, string>
   }>
+  designTokens?: {
+    contractVersion: number
+    anchor: Record<string, string>
+    byTag: Record<string, Record<string, string>>
+    palette: string[]
+    fonts: string[]
+  }
 } {
   const { rect, htmlByteCap } = arg
   const NODE_CAP = 60
@@ -256,6 +264,70 @@ function domExtractScript(arg: { rect: CaptureRect; htmlByteCap: number }): {
       if (v) out[k] = String(v).slice(0, 120)
     }
     return out
+  }
+
+  // ─── Design tokens: exact computed values for "clone this UI" specs ───────────
+  // getComputedStyle does not reliably populate the `border`/`borderRadius`/
+  // `padding`/`margin` shorthands, so we read the longhands and recompose. All
+  // helpers are `const` arrows (no inner named functions) so esbuild/tsx don't
+  // inject the `__name` helper that breaks page.evaluate (see extractDom).
+  const SIDES = ['top', 'right', 'bottom', 'left']
+  const collapse4 = (vals: string[]): string => {
+    const [t, r, b, l] = vals
+    if (t === r && r === b && b === l) return t
+    if (t === b && r === l) return `${t} ${r}`
+    return vals.join(' ')
+  }
+  const tokenSetFor = (el: Element): Record<string, string> => {
+    const cs = window.getComputedStyle(el)
+    const g = (p: string): string => cs.getPropertyValue(p) || ''
+    const out: Record<string, string> = {}
+    const setIf = (k: string, v: string, drop: string[]) => {
+      const t = String(v).trim()
+      if (t && !drop.includes(t)) out[k] = t.slice(0, 240)
+    }
+    setIf('color', g('color'), ['rgba(0, 0, 0, 0)'])
+    setIf('backgroundColor', g('background-color'), ['rgba(0, 0, 0, 0)', 'transparent'])
+    setIf('fontFamily', g('font-family'), [])
+    setIf('fontSize', g('font-size'), [])
+    setIf('fontWeight', g('font-weight'), [])
+    setIf('lineHeight', g('line-height'), ['normal'])
+    setIf('letterSpacing', g('letter-spacing'), ['normal'])
+    setIf('padding', collapse4(SIDES.map((s) => g('padding-' + s))), ['0px'])
+    setIf('margin', collapse4(SIDES.map((s) => g('margin-' + s))), ['0px'])
+    const bw = g('border-top-width')
+    const bsStyle = g('border-top-style')
+    const widthsUniform = SIDES.every((s) => g('border-' + s + '-width') === bw)
+    const stylesUniform = SIDES.every((s) => g('border-' + s + '-style') === bsStyle)
+    if (bsStyle && bsStyle !== 'none' && bw && bw !== '0px' && widthsUniform && stylesUniform) {
+      setIf('border', `${bw} ${bsStyle} ${g('border-top-color')}`, [])
+    }
+    const radii = ['top-left', 'top-right', 'bottom-right', 'bottom-left'].map((c) => g('border-' + c + '-radius'))
+    setIf('borderRadius', collapse4(radii), ['0px'])
+    setIf('boxShadow', g('box-shadow'), ['none'])
+    return out
+  }
+  const deriveDesignTokens = (anchorEl: Element, els: Element[]) => {
+    const anchor = tokenSetFor(anchorEl)
+    const tagCount: Record<string, number> = {}
+    for (const el of els) { const t = el.tagName.toLowerCase(); tagCount[t] = (tagCount[t] || 0) + 1 }
+    const topTags = Object.keys(tagCount).sort((a, b) => tagCount[b] - tagCount[a]).slice(0, 8)
+    const byTag: Record<string, Record<string, string>> = {}
+    for (const t of topTags) {
+      const el = els.find((e) => e.tagName.toLowerCase() === t)
+      if (el) byTag[t] = tokenSetFor(el)
+    }
+    const palette: string[] = []
+    const fonts: string[] = []
+    const consider = (ts: Record<string, string>) => {
+      for (const v of [ts.color, ts.backgroundColor]) {
+        if (v && !palette.includes(v) && palette.length < 12) palette.push(v)
+      }
+      if (ts.fontFamily && !fonts.includes(ts.fontFamily) && fonts.length < 6) fonts.push(ts.fontFamily)
+    }
+    consider(anchor)
+    for (const t of Object.keys(byTag)) consider(byTag[t])
+    return { contractVersion: 1, anchor, byTag, palette, fonts }
   }
 
   // Sample a grid of points across the selection to discover candidate elements.
@@ -450,6 +522,9 @@ function domExtractScript(arg: { rect: CaptureRect; htmlByteCap: number }): {
     css = ''
   }
 
+  let designTokens
+  try { designTokens = deriveDesignTokens(container, nodeEls) } catch { designTokens = undefined }
+
   return {
     viewport: { width: window.innerWidth, height: window.innerHeight },
     html,
@@ -457,6 +532,7 @@ function domExtractScript(arg: { rect: CaptureRect; htmlByteCap: number }): {
     css,
     cssTruncated,
     nodes,
+    designTokens,
   }
 }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -311,7 +311,7 @@ server.on('upgrade', (request, socket, head) => {
             // Hover-to-select: resolve the element under the cursor and reply with
             // its rect so the client can draw a highlight box.
             void mgr.probeElement(sessionId, { x: msg.x, y: msg.y }).then((probe) => {
-              try { ws.send(JSON.stringify({ type: 'hover', rect: probe?.rect ?? null })) } catch { /* drop */ }
+              try { ws.send(JSON.stringify({ type: 'hover', rect: probe?.rect ?? null, selector: probe?.selector ?? null, path: probe?.path ?? null })) } catch { /* drop */ }
             })
           }
         } catch { /* ignore malformed control */ }

--- a/server/project-router.browser.test.ts
+++ b/server/project-router.browser.test.ts
@@ -15,6 +15,7 @@ function makeBrowserManager(overrides: Record<string, unknown> = {}) {
     navigate: vi.fn(async () => ({ url: 'https://x.dev', title: 'X' })),
     capture: vi.fn(async () => ({ screenshot: { id: 'a1' }, domAttachment: { id: 'a2' }, dom: { html: '<i>', nodes: [] } })),
     captureBreakpoints: vi.fn(async () => ({ screenshot: { id: 'b1' }, domAttachment: { id: 'b2' }, dom: { html: '<i>', nodes: [] }, screenshotDataUrl: 'data:image/png;base64,x', breakpoints: { desktop: { attachment: { id: 'b1' }, dataUrl: 'data:image/png;base64,x', viewport: { width: 1280, height: 800 } } } })),
+    clipboard: vi.fn(async () => ({ text: 'sel' })),
     kill: vi.fn(async () => true),
     ...overrides,
   }
@@ -196,6 +197,18 @@ describe('project-router browser endpoints', () => {
     const app = createApp(makeContext(db, browser))
     const res = await request(app).post('/api/projects/proj-1/browser/sessions/s1/capture').send({ rect: { x: 0, y: 0, width: 5, height: 5 }, pendingSpecId: 'p' })
     expect(res.status).toBe(404)
+  })
+
+  it('POST clipboard validates the action and forwards copy/paste', async () => {
+    const app = createApp(makeContext(db, browser))
+    const base = '/api/projects/proj-1/browser/sessions/s1/clipboard'
+    expect((await request(app).post(base).send({ action: 'bogus' })).status).toBe(400)
+    expect(browser.clipboard).not.toHaveBeenCalled()
+    const res = await request(app).post(base).send({ action: 'copy' })
+    expect(res.status).toBe(200)
+    expect(res.body.text).toBe('sel')
+    await request(app).post(base).send({ action: 'paste', text: 'hi' })
+    expect(browser.clipboard).toHaveBeenCalledWith('s1', 'paste', 'hi')
   })
 
   it('DELETE kills the session; 404 when unknown', async () => {

--- a/server/project-router.browser.test.ts
+++ b/server/project-router.browser.test.ts
@@ -16,6 +16,7 @@ function makeBrowserManager(overrides: Record<string, unknown> = {}) {
     capture: vi.fn(async () => ({ screenshot: { id: 'a1' }, domAttachment: { id: 'a2' }, dom: { html: '<i>', nodes: [] } })),
     captureBreakpoints: vi.fn(async () => ({ screenshot: { id: 'b1' }, domAttachment: { id: 'b2' }, dom: { html: '<i>', nodes: [] }, screenshotDataUrl: 'data:image/png;base64,x', breakpoints: { desktop: { attachment: { id: 'b1' }, dataUrl: 'data:image/png;base64,x', viewport: { width: 1280, height: 800 } } } })),
     clipboard: vi.fn(async () => ({ text: 'sel' })),
+    navigateElement: vi.fn(async () => ({ rect: { x: 0, y: 0, width: 10, height: 10 }, tag: 'section', selector: 'body > section', path: [{ label: 'body', selector: 'body' }, { label: 'section', selector: 'body > section' }] })),
     kill: vi.fn(async () => true),
     ...overrides,
   }
@@ -197,6 +198,18 @@ describe('project-router browser endpoints', () => {
     const app = createApp(makeContext(db, browser))
     const res = await request(app).post('/api/projects/proj-1/browser/sessions/s1/capture').send({ rect: { x: 0, y: 0, width: 5, height: 5 }, pendingSpecId: 'p' })
     expect(res.status).toBe(404)
+  })
+
+  it('POST element validates selector + direction and forwards the breadcrumb step', async () => {
+    const app = createApp(makeContext(db, browser))
+    const base = '/api/projects/proj-1/browser/sessions/s1/element'
+    expect((await request(app).post(base).send({ selector: '', direction: 'parent' })).status).toBe(400)
+    expect((await request(app).post(base).send({ selector: 'div', direction: 'sideways' })).status).toBe(400)
+    expect(browser.navigateElement).not.toHaveBeenCalled()
+    const res = await request(app).post(base).send({ selector: 'div.box', direction: 'parent' })
+    expect(res.status).toBe(200)
+    expect(res.body.probe.tag).toBe('section')
+    expect(browser.navigateElement).toHaveBeenCalledWith('s1', 'div.box', 'parent')
   })
 
   it('POST clipboard validates the action and forwards copy/paste', async () => {

--- a/server/project-router.browser.test.ts
+++ b/server/project-router.browser.test.ts
@@ -14,6 +14,7 @@ function makeBrowserManager(overrides: Record<string, unknown> = {}) {
     create: vi.fn(async () => ({ id: 's1', projectId: 'proj-1', url: 'about:blank', title: null, viewportWidth: 1280, viewportHeight: 800, createdAt: 1 })),
     navigate: vi.fn(async () => ({ url: 'https://x.dev', title: 'X' })),
     capture: vi.fn(async () => ({ screenshot: { id: 'a1' }, domAttachment: { id: 'a2' }, dom: { html: '<i>', nodes: [] } })),
+    captureBreakpoints: vi.fn(async () => ({ screenshot: { id: 'b1' }, domAttachment: { id: 'b2' }, dom: { html: '<i>', nodes: [] }, screenshotDataUrl: 'data:image/png;base64,x', breakpoints: { desktop: { attachment: { id: 'b1' }, dataUrl: 'data:image/png;base64,x', viewport: { width: 1280, height: 800 } } } })),
     kill: vi.fn(async () => true),
     ...overrides,
   }
@@ -166,6 +167,28 @@ describe('project-router browser endpoints', () => {
     const res = await request(app).post('/api/projects/proj-1/browser/sessions/s1/capture').send({ rect: { x: 1, y: 2, width: 30, height: 40 }, pendingSpecId: 'pend-1', captureNetwork: false })
     expect(res.status).toBe(200)
     expect(browser.capture).toHaveBeenCalledWith('s1', { x: 1, y: 2, width: 30, height: 40 }, 'pend-1', { captureNetwork: false })
+  })
+
+  it('POST capture-breakpoints validates rect, pendingSpecId and breakpoints', async () => {
+    const app = createApp(makeContext(db, browser))
+    const base = '/api/projects/proj-1/browser/sessions/s1/capture-breakpoints'
+    expect((await request(app).post(base).send({ rect: { x: 0, y: 0, width: 0, height: 0 }, pendingSpecId: 'p', breakpoints: { d: { width: 10, height: 10 } } })).status).toBe(400)
+    expect((await request(app).post(base).send({ rect: { x: 0, y: 0, width: 10, height: 10 }, pendingSpecId: '../x', breakpoints: { d: { width: 10, height: 10 } } })).status).toBe(400)
+    expect((await request(app).post(base).send({ rect: { x: 0, y: 0, width: 10, height: 10 }, pendingSpecId: 'p', breakpoints: {} })).status).toBe(400)
+    expect(browser.captureBreakpoints).not.toHaveBeenCalled()
+  })
+
+  it('POST capture-breakpoints forwards validated dims + a default anchor and returns the result', async () => {
+    const app = createApp(makeContext(db, browser))
+    const res = await request(app).post('/api/projects/proj-1/browser/sessions/s1/capture-breakpoints').send({
+      rect: { x: 10, y: 20, width: 100, height: 50 },
+      pendingSpecId: 'pend-1',
+      breakpoints: { desktop: { width: 1280, height: 800 }, bad: { width: 99999, height: 1 } },
+    })
+    expect(res.status).toBe(200)
+    expect(res.body.breakpoints.desktop.viewport.width).toBe(1280)
+    // out-of-range "bad" dim dropped; default anchor = rect centre
+    expect(browser.captureBreakpoints).toHaveBeenCalledWith('s1', { x: 10, y: 20, width: 100, height: 50 }, { x: 60, y: 45 }, 'pend-1', { desktop: { width: 1280, height: 800 } })
   })
 
   it('POST capture returns 404 when capture yields null', async () => {

--- a/server/project-router.browser.test.ts
+++ b/server/project-router.browser.test.ts
@@ -158,7 +158,14 @@ describe('project-router browser endpoints', () => {
     expect(res.status).toBe(200)
     expect(res.body.screenshot.id).toBe('a1')
     expect(res.body.domAttachment.id).toBe('a2')
-    expect(browser.capture).toHaveBeenCalledWith('s1', { x: 1, y: 2, width: 30, height: 40 }, 'pend-1')
+    expect(browser.capture).toHaveBeenCalledWith('s1', { x: 1, y: 2, width: 30, height: 40 }, 'pend-1', { captureNetwork: true })
+  })
+
+  it('POST capture forwards captureNetwork:false to the manager', async () => {
+    const app = createApp(makeContext(db, browser))
+    const res = await request(app).post('/api/projects/proj-1/browser/sessions/s1/capture').send({ rect: { x: 1, y: 2, width: 30, height: 40 }, pendingSpecId: 'pend-1', captureNetwork: false })
+    expect(res.status).toBe(200)
+    expect(browser.capture).toHaveBeenCalledWith('s1', { x: 1, y: 2, width: 30, height: 40 }, 'pend-1', { captureNetwork: false })
   })
 
   it('POST capture returns 404 when capture yields null', async () => {

--- a/server/project-router.ts
+++ b/server/project-router.ts
@@ -3553,6 +3553,27 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
     }
   })
 
+  router.post('/:projectId/browser/sessions/:id/clipboard', requireBrowserCaptureEnabled, async (req: Request, res: Response) => {
+    const mgr = ctx(req).browserCaptureManager
+    const action = req.body?.action
+    if (action !== 'copy' && action !== 'paste' && action !== 'cut') {
+      res.status(400).json({ error: 'action must be copy | paste | cut' })
+      return
+    }
+    const text = typeof req.body?.text === 'string' ? req.body.text.slice(0, 100_000) : undefined
+    try {
+      const out = await mgr.clipboard(req.params.id as string, action, text)
+      if (!out) {
+        res.status(404).json({ error: 'browser_session_not_found' })
+        return
+      }
+      res.json(out)
+    } catch (err) {
+      console.error('[project-router] browser clipboard error:', err)
+      res.status(500).json({ error: 'Failed clipboard op' })
+    }
+  })
+
   router.delete('/:projectId/browser/sessions/:id', requireBrowserCaptureEnabled, async (req: Request, res: Response) => {
     const mgr = ctx(req).browserCaptureManager
     const ok = await mgr.kill(req.params.id as string)

--- a/server/project-router.ts
+++ b/server/project-router.ts
@@ -3491,8 +3491,9 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
       res.status(400).json({ error: 'pendingSpecId has an invalid format' })
       return
     }
+    const captureNetwork = req.body?.captureNetwork !== false
     try {
-      const result = await mgr.capture(req.params.id as string, rect, pendingSpecId)
+      const result = await mgr.capture(req.params.id as string, rect, pendingSpecId, { captureNetwork })
       if (!result) {
         res.status(404).json({ error: 'browser_session_not_found' })
         return

--- a/server/project-router.ts
+++ b/server/project-router.ts
@@ -3505,6 +3505,54 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
     }
   })
 
+  router.post('/:projectId/browser/sessions/:id/capture-breakpoints', requireBrowserCaptureEnabled, async (req: Request, res: Response) => {
+    const mgr = ctx(req).browserCaptureManager
+    const rect = parseRect(req.body?.rect)
+    if (!rect) {
+      res.status(400).json({ error: 'rect {x,y,width,height} with positive size is required' })
+      return
+    }
+    const pendingSpecId = typeof req.body?.pendingSpecId === 'string' ? req.body.pendingSpecId.trim() : ''
+    if (!pendingSpecId || !SAFE_PENDING_ID.test(pendingSpecId)) {
+      res.status(400).json({ error: 'pendingSpecId is required and must be well-formed' })
+      return
+    }
+    // Validate the per-breakpoint viewport dims (client-supplied; single source).
+    const rawDims = req.body?.breakpoints
+    const dims: Record<string, { width: number; height: number }> = {}
+    if (rawDims && typeof rawDims === 'object') {
+      for (const [k, v] of Object.entries(rawDims as Record<string, unknown>)) {
+        if (Object.keys(dims).length >= 4) break
+        if (!/^[a-z0-9_-]{1,20}$/i.test(k)) continue
+        const d = v as { width?: unknown; height?: unknown }
+        const w = Math.round(Number(d?.width))
+        const h = Math.round(Number(d?.height))
+        if (Number.isFinite(w) && Number.isFinite(h) && w >= 1 && h >= 1 && w <= 4000 && h <= 4000) {
+          dims[k] = { width: w, height: h }
+        }
+      }
+    }
+    if (Object.keys(dims).length === 0) {
+      res.status(400).json({ error: 'breakpoints {name:{width,height}} is required' })
+      return
+    }
+    const a = req.body?.anchorPoint
+    const anchorPoint = a && typeof a.x === 'number' && typeof a.y === 'number'
+      ? { x: a.x, y: a.y }
+      : { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 }
+    try {
+      const result = await mgr.captureBreakpoints(req.params.id as string, rect, anchorPoint, pendingSpecId, dims)
+      if (!result) {
+        res.status(404).json({ error: 'browser_session_not_found' })
+        return
+      }
+      res.json(result)
+    } catch (err) {
+      console.error('[project-router] browser capture-breakpoints error:', err)
+      res.status(500).json({ error: 'Failed to capture' })
+    }
+  })
+
   router.delete('/:projectId/browser/sessions/:id', requireBrowserCaptureEnabled, async (req: Request, res: Response) => {
     const mgr = ctx(req).browserCaptureManager
     const ok = await mgr.kill(req.params.id as string)

--- a/server/project-router.ts
+++ b/server/project-router.ts
@@ -3553,6 +3553,24 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
     }
   })
 
+  router.post('/:projectId/browser/sessions/:id/element', requireBrowserCaptureEnabled, async (req: Request, res: Response) => {
+    const mgr = ctx(req).browserCaptureManager
+    const selector = typeof req.body?.selector === 'string' ? req.body.selector : ''
+    const direction = req.body?.direction
+    if (!selector || (direction !== 'parent' && direction !== 'child' && direction !== 'self')) {
+      res.status(400).json({ error: 'selector and direction (parent|child|self) are required' })
+      return
+    }
+    try {
+      // probe may be null (can't step further / element gone) — still 200.
+      const probe = await mgr.navigateElement(req.params.id as string, selector.slice(0, 4000), direction)
+      res.json({ probe })
+    } catch (err) {
+      console.error('[project-router] browser element navigate error:', err)
+      res.status(500).json({ error: 'Failed to resolve element' })
+    }
+  })
+
   router.post('/:projectId/browser/sessions/:id/clipboard', requireBrowserCaptureEnabled, async (req: Request, res: Response) => {
     const mgr = ctx(req).browserCaptureManager
     const action = req.body?.action


### PR DESCRIPTION
## What

A **super PR** that turns "Add Spec from a website" into a much richer spec-creation surface.

### Features
1. **Design tokens** (`feat`) — exact computed tokens (color, typography, spacing, border, radius, shadow) for the selection → precise "clone this UI" specs. Collapsible panel + *Copy as JSON*. No new endpoint.
2. **Network capture** (`feat`) — buffer the page's XHR/fetch via CDP and snapshot a privacy-safe summary (method, URL, status, **response-shape sketch** — never raw bodies). ON by default + toggle.
3. **Multi-breakpoint** (`feat`) — "All sizes" captures the same element at desktop/tablet/mobile (re-resolving its box per viewport, server-driven, clamped to each viewport). 3-up thumbnails + "must be responsive" note.
4. **Annotations** (`feat`) — after a single capture, freeze into an in-place markup editor (Arrow / Box / Text / Blur-redaction / Step badges, undo/redo, tool persistence). Flattened client-side; the annotated image replaces the raw one in the spec.
5. **Selection breadcrumb** (`feat`, #6) — hovering shows the element's ancestor breadcrumb; ↑/↓ or clicking a segment steps up/down the DOM tree (locks the selection) for surgical precision, like the Chrome inspector.

### Fixes
6. **Clipboard bridge** (`fix`) — ⌘/Ctrl+C/V/X now work inside the embedded headless browser (read page selection → host clipboard; inject host clipboard → page).
7. **Multi-breakpoint clip clamp** (`fix`) — clamp the per-breakpoint screenshot rect to each viewport (was crashing "Clipped area outside the image" at smaller sizes) + scroll the element into view.
8. **Compact desktop toolbar** (`fix`) — the toolbar no longer sits under the macOS traffic-light controls.

## Architecture notes
- Features 1–3 + 5 are **additive on `CapturedDom` / `CaptureResult` / `ElementProbe`** → no migrations; they reach the AI through the DOM-JSON-attachment → prompt path that already exists.
- All testable logic lives in pure modules (`server/browser-network.ts`, `client/src/lib/annotations.ts`) + the manager/route/lib layers, thoroughly unit-tested; the canvas/pointer shells (`AnnotationEditor`, `BrowserCaptureModal`, `browser-playwright`) are coverage-excluded like the existing screencast components.

## Verification (every commit kept green)
- `npm run typecheck` ✅
- Server **2530+/2531** (the lone failure is a pre-existing flaky `terminal-osc-parser` timing benchmark; passes in isolation) · coverage **82.1% stmts · 72.4% branch · 87.0% funcs · 83.7% lines** ✅
- Client **2338/2338** ✅ · coverage **80.9% stmts · 79.8% branch · 72.3% funcs · 80.9% lines** ✅

## Manual QA needed
The annotation editor, the clipboard bridge, and the breadcrumb navigation aren't jsdom-testable — please smoke-test them in the running desktop app.

## Deferred (future iteration)
Storyboard mode (record a multi-step flow → flow spec); capture-basket/tray; element code-snippet; vision pre-analysis; annotation move/resize/select.

🤖 Generated with [Claude Code](https://claude.com/claude-code)