### PR TITLE
feat(rails): Ultracode rail mode (Claude-only, autonomous, no OpenSpec)

### DIFF
--- a/client/src/components/RailControls.tsx
+++ b/client/src/components/RailControls.tsx
@@ -2,7 +2,7 @@ import { Play, Square, AlertTriangle, ScrollText } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { Button } from './ui/button'
 
-export type RailMode = 'implement' | 'batch-implement'
+export type RailMode = 'implement' | 'batch-implement' | 'ultracode'
 export type RailStatus = 'idle' | 'running' | 'failed'
 
 interface RailControlsProps {
@@ -10,11 +10,14 @@ interface RailControlsProps {
   status: RailStatus
   activeJobId?: string
   ticketCount: number
+  /** When true, show the Claude-only Ultracode segment. Ultracode bypasses
+   *  the OpenSpec pipeline and lets Claude implement the spec autonomously. */
+  ultracodeAvailable?: boolean
   onModeChange: (mode: RailMode) => void
   onToggle: () => void
 }
 
-export function RailControls({ mode, status, activeJobId, ticketCount, onModeChange, onToggle }: RailControlsProps) {
+export function RailControls({ mode, status, activeJobId, ticketCount, ultracodeAvailable, onModeChange, onToggle }: RailControlsProps) {
   const navigate = useNavigate()
   const canPlay = ticketCount > 0
   return (
@@ -58,6 +61,23 @@ export function RailControls({ mode, status, activeJobId, ticketCount, onModeCha
         >
           Batch
         </button>
+        {ultracodeAvailable && (
+          <>
+            <div className="w-px h-3 bg-border/40 shrink-0" />
+            <button
+              type="button"
+              className={`px-2 py-0.5 transition-colors ${
+                mode === 'ultracode'
+                  ? 'bg-accent-highlight/20 text-accent-highlight font-semibold'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-muted/30'
+              }`}
+              onClick={() => onModeChange('ultracode')}
+              title="Ultracode — Claude implements the spec autonomously, no pipeline"
+            >
+              Ultra
+            </button>
+          </>
+        )}
       </div>
 
       {/* Play / Stop / Failed toggle */}

--- a/client/src/components/RailRow.tsx
+++ b/client/src/components/RailRow.tsx
@@ -7,6 +7,7 @@ import { RailControls, type RailMode, type RailStatus } from './RailControls'
 import { SpecCard } from './SpecCard'
 import { RailProfileSelector } from './agents/RailProfileSelector'
 import { RailEngineSelector } from './agents/RailEngineSelector'
+import { RailModelSelector, type UltracodeModel } from './agents/RailModelSelector'
 import type { LocalTicket } from '../types'
 
 const LONG_PRESS_MS = 800
@@ -22,6 +23,8 @@ interface RailRowProps {
   profileName?: string | null
   /** Selected AI engine for this rail (multi-provider). null/undefined = primary. */
   aiEngine?: string | null
+  /** Selected model for ultracode rails. null/undefined = default (sonnet). */
+  ultracodeModel?: UltracodeModel | null
   /** Installed providers — when >1 the rail header shows an AI engine selector. */
   providers?: readonly string[]
   jiggleMode: boolean
@@ -39,6 +42,7 @@ interface RailRowProps {
   onModeChange: (mode: RailMode) => void
   onProfileChange?: (profileName: string | null) => void
   onEngineChange?: (aiEngine: 'claude' | 'codex') => void
+  onUltracodeModelChange?: (model: UltracodeModel) => void
   onToggle: () => void
   onTicketClick: (ticket: LocalTicket) => void
   onDelete: () => void
@@ -51,14 +55,29 @@ interface RailRowProps {
 }
 
 export function RailRow({
-  id, label, tickets, mode, status, activeJobId, profileName, aiEngine, providers, jiggleMode,
+  id, label, tickets, mode, status, activeJobId, profileName, aiEngine, ultracodeModel, providers, jiggleMode,
   dragHandleListeners, dragHandleAttributes, density = 'normal',
-  onModeChange, onProfileChange, onEngineChange, onToggle, onTicketClick, onDelete, onLongPress, onRename,
+  onModeChange, onProfileChange, onEngineChange, onUltracodeModelChange, onToggle, onTicketClick, onDelete, onLongPress, onRename,
   onTicketMoveToSpecs,
 }: RailRowProps) {
   // Codex has no agent profiles — hide the profile selector when this rail's
   // engine is codex (the engine selector is shown only on multi-provider projects).
   const profileApplies = (aiEngine ?? providers?.[0]) !== 'codex'
+  // Ultracode is Claude-only. Effective engine = explicit rail override, else
+  // the project's primary provider (providers[0]); default to claude when
+  // unknown (single-provider claude projects pass no providers list).
+  const engineIsClaude = (aiEngine ?? providers?.[0] ?? 'claude') === 'claude'
+  // Which secondary selectors are visible right now. When any is shown we move
+  // them onto their own row beneath the rail name so the header doesn't cram
+  // engine + model + mode segments + play into a single line.
+  const showEngineSel = !!onEngineChange && status !== 'running' && (providers?.length ?? 0) > 1
+  const showProfileSel = !!onProfileChange && status !== 'running' && profileApplies
+  const showModelSel = !!onUltracodeModelChange && status !== 'running' && mode === 'ultracode' && engineIsClaude
+  // Only the engine + model selectors crowd the header (and always render when
+  // their condition holds). The profile selector self-hides when the project
+  // has no profiles, so it can't trigger an empty row — it rides along the
+  // second row when one exists, else stays inline on the top row.
+  const hasSelectorRow = showEngineSel || showModelSel
   // Compact-tier right-click context menu state. `{ticketId, x, y}` while
   // open, `null` otherwise. Closed by outside-click, Escape, or selection.
   const [ticketCtxMenu, setTicketCtxMenu] = useState<{ ticketId: number; x: number; y: number } | null>(null)
@@ -363,11 +382,15 @@ export function RailRow({
           {onProfileChange && !isRunning && profileApplies && (
             <RailProfileSelector value={profileName ?? null} onChange={onProfileChange} />
           )}
+          {onUltracodeModelChange && !isRunning && mode === 'ultracode' && engineIsClaude && (
+            <RailModelSelector value={ultracodeModel ?? null} onChange={onUltracodeModelChange} />
+          )}
           <RailControls
             mode={mode}
             status={status}
             activeJobId={activeJobId}
             ticketCount={tickets.length}
+            ultracodeAvailable={engineIsClaude}
             onModeChange={onModeChange}
             onToggle={onToggle}
           />
@@ -430,9 +453,11 @@ export function RailRow({
           ...(railJigglePhaseMs !== undefined ? { animationDelay: `${railJigglePhaseMs}ms` } : {}),
         }}
       >
-        {/* Row header */}
-        <div className="flex items-center justify-between px-3 py-1.5 border-b border-border/30 bg-gradient-to-r from-muted/30 to-transparent shrink-0">
-          <div className="flex items-center gap-2">
+        {/* Row header — name + mode/play on top, secondary selectors on a
+            recessed config strip below so nothing crams together. */}
+        <div className="flex flex-col border-b border-border/30 bg-gradient-to-r from-muted/30 to-transparent shrink-0">
+          <div className="flex items-center justify-between gap-2 px-3 py-1.5">
+          <div className="flex items-center gap-2 min-w-0">
             <button
               type="button"
               className="touch-none cursor-grab active:cursor-grabbing text-muted-foreground/30 hover:text-muted-foreground/60 transition-colors -ml-1"
@@ -494,17 +519,13 @@ export function RailRow({
               </span>
             )}
           </div>
-          <div className="flex items-center gap-1.5">
-            {onEngineChange && status !== 'running' && (
-              <RailEngineSelector value={aiEngine ?? null} providers={providers ?? []} onChange={onEngineChange} />
+          <div className="flex items-center gap-1.5 shrink-0">
+            {/* Profile stays inline when no second row exists (it self-hides
+                with no profiles, so it never leaves an empty gap here). */}
+            {!hasSelectorRow && showProfileSel && onProfileChange && (
+              <RailProfileSelector value={profileName ?? null} onChange={onProfileChange} />
             )}
-            {onProfileChange && status !== 'running' && profileApplies && (
-              <RailProfileSelector
-                value={profileName ?? null}
-                onChange={onProfileChange}
-              />
-            )}
-            <RailControls mode={mode} status={status} activeJobId={activeJobId} ticketCount={tickets.length} onModeChange={onModeChange} onToggle={onToggle} />
+            <RailControls mode={mode} status={status} activeJobId={activeJobId} ticketCount={tickets.length} ultracodeAvailable={engineIsClaude} onModeChange={onModeChange} onToggle={onToggle} />
             {/* Jiggle-mode delete button */}
             {jiggleMode && canDelete && (
               <button
@@ -516,6 +537,24 @@ export function RailRow({
               </button>
             )}
           </div>
+          </div>
+
+          {/* Secondary selector strip (engine / profile / ultracode model).
+              A recessed bar with its own divider + faint inset background so it
+              reads as the rail's config row instead of floating controls. */}
+          {hasSelectorRow && (
+            <div className="flex items-center flex-wrap gap-x-3 gap-y-1 px-3 py-1.5 border-t border-border/20 bg-background/20">
+              {showEngineSel && onEngineChange && (
+                <RailEngineSelector value={aiEngine ?? null} providers={providers ?? []} onChange={onEngineChange} />
+              )}
+              {hasSelectorRow && showProfileSel && onProfileChange && (
+                <RailProfileSelector value={profileName ?? null} onChange={onProfileChange} />
+              )}
+              {showModelSel && onUltracodeModelChange && (
+                <RailModelSelector value={ultracodeModel ?? null} onChange={onUltracodeModelChange} />
+              )}
+            </div>
+          )}
         </div>
 
         {/* Droppable body */}

--- a/client/src/components/RailsBoard.tsx
+++ b/client/src/components/RailsBoard.tsx
@@ -4,6 +4,7 @@ import { CSS } from '@dnd-kit/utilities'
 import { Layers, Plus } from 'lucide-react'
 import { RailRow } from './RailRow'
 import type { RailMode, RailStatus } from './RailControls'
+import type { UltracodeModel } from './agents/RailModelSelector'
 import type { LocalTicket } from '../types'
 
 export const RAIL_SORT_PREFIX = '__rail:'
@@ -24,6 +25,8 @@ export interface RailState {
   profileName?: string | null
   /** Selected AI engine for this rail (multi-provider). null/undefined = primary. */
   aiEngine?: string | null
+  /** Selected model for ultracode rails. null/undefined = default (sonnet). */
+  ultracodeModel?: UltracodeModel | null
 }
 
 interface RailsBoardProps {
@@ -34,6 +37,7 @@ interface RailsBoardProps {
   onModeChange: (railId: string, mode: RailMode) => void
   onProfileChange?: (railId: string, profileName: string | null) => void
   onEngineChange?: (railId: string, aiEngine: 'claude' | 'codex') => void
+  onUltracodeModelChange?: (railId: string, model: UltracodeModel) => void
   onToggle: (railId: string) => void
   onTicketClick: (ticket: LocalTicket) => void
   onAddRail: () => void
@@ -62,7 +66,7 @@ function SortableRailWrapper({ railId, children }: { railId: string; children: (
 /** Width threshold below which rail rows switch to the compact mini-card layout. */
 export const RAILS_COMPACT_THRESHOLD_PX = 320
 
-export function RailsBoard({ rails, ticketMap, providers, onModeChange, onProfileChange, onEngineChange, onToggle, onTicketClick, onAddRail, onDeleteRail, onRenameRail, onTicketMoveToSpecs }: RailsBoardProps) {
+export function RailsBoard({ rails, ticketMap, providers, onModeChange, onProfileChange, onEngineChange, onUltracodeModelChange, onToggle, onTicketClick, onAddRail, onDeleteRail, onRenameRail, onTicketMoveToSpecs }: RailsBoardProps) {
   const activeRails = rails.filter((r) => r.status === 'running').length
   const [jiggleMode, setJiggleMode] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -138,6 +142,7 @@ export function RailsBoard({ rails, ticketMap, providers, onModeChange, onProfil
                     activeJobId={rail.activeJobId}
                     profileName={rail.profileName ?? null}
                     aiEngine={rail.aiEngine ?? null}
+                    ultracodeModel={rail.ultracodeModel ?? null}
                     providers={providers}
                     jiggleMode={jiggleMode}
                     density={density}
@@ -146,6 +151,7 @@ export function RailsBoard({ rails, ticketMap, providers, onModeChange, onProfil
                     onModeChange={(mode) => onModeChange(rail.id, mode)}
                     onProfileChange={onProfileChange ? (p) => onProfileChange(rail.id, p) : undefined}
                     onEngineChange={onEngineChange ? (e) => onEngineChange(rail.id, e) : undefined}
+                    onUltracodeModelChange={onUltracodeModelChange ? (m) => onUltracodeModelChange(rail.id, m) : undefined}
                     onToggle={() => onToggle(rail.id)}
                     onTicketClick={onTicketClick}
                     onDelete={() => onDeleteRail(rail.id)}

--- a/client/src/components/UltracodeLaunchDialog.tsx
+++ b/client/src/components/UltracodeLaunchDialog.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef } from 'react'
+import { Sparkles, GitBranch, Bot, DollarSign } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+} from './ui/dialog'
+import { Button } from './ui/button'
+
+interface Props {
+  open: boolean
+  railLabel: string
+  specCount: number
+  /** Selected model (haiku/sonnet/opus). Shown for context. */
+  model?: string | null
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+/**
+ * Confirmation modal shown before launching a rail in Ultracode mode. Ultracode
+ * bypasses the OpenSpec pipeline and lets Claude run with native agents +
+ * dynamic workflows, so cost is variable — the user explicitly opts in here.
+ * Continue is the affirmative (green) action; ⌘/Ctrl+Enter triggers it.
+ */
+export function UltracodeLaunchDialog({ open, railLabel, specCount, model, onConfirm, onCancel }: Props) {
+  const confirmRef = useRef<HTMLButtonElement>(null)
+
+  // ⌘/Ctrl + Enter confirms while the dialog is open.
+  useEffect(() => {
+    if (!open) return
+    function onKey(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+        e.preventDefault()
+        onConfirm()
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [open, onConfirm])
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onCancel() }}>
+      <DialogContent
+        showCloseButton={false}
+        className="max-w-md gap-5"
+        onOpenAutoFocus={(e) => { e.preventDefault(); confirmRef.current?.focus() }}
+      >
+        <DialogHeader>
+          <div className="flex items-center gap-2.5">
+            <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-accent-highlight/15 text-accent-highlight ring-1 ring-accent-highlight/30">
+              <Sparkles className="h-4.5 w-4.5" />
+            </span>
+            <div className="text-left">
+              <DialogTitle className="text-base">Launch in Ultracode mode</DialogTitle>
+              <DialogDescription>
+                {railLabel} · {specCount} spec{specCount === 1 ? '' : 's'}
+                {model ? ` · ${model}` : ''}
+              </DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <ul className="space-y-2.5 text-xs text-muted-foreground">
+          <li className="flex items-start gap-2.5">
+            <GitBranch className="mt-0.5 h-3.5 w-3.5 shrink-0 text-accent-warning" />
+            <span><span className="font-medium text-foreground">No OpenSpec pipeline.</span> The structured architect → developer → reviewer flow is skipped entirely.</span>
+          </li>
+          <li className="flex items-start gap-2.5">
+            <Bot className="mt-0.5 h-3.5 w-3.5 shrink-0 text-accent-info" />
+            <span><span className="font-medium text-foreground">Native Claude autonomy.</span> Claude works on its own using native agents and dynamic workflows.</span>
+          </li>
+          <li className="flex items-start gap-2.5">
+            <DollarSign className="mt-0.5 h-3.5 w-3.5 shrink-0 text-accent-success" />
+            <span><span className="font-medium text-foreground">Variable cost.</span> Spend depends on what Claude decides to do — it can be higher than expected.</span>
+          </li>
+        </ul>
+
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button variant="ghost" className="h-9" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button
+            ref={confirmRef}
+            className="h-9 gap-2 bg-emerald-500 text-white hover:bg-emerald-400 focus-visible:ring-emerald-400"
+            onClick={onConfirm}
+          >
+            Continue
+            <kbd className="hidden sm:inline-flex items-center rounded border border-white/30 bg-white/10 px-1 text-[9px] font-medium leading-4">⌘↵</kbd>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/client/src/components/__tests__/RailControls.test.tsx
+++ b/client/src/components/__tests__/RailControls.test.tsx
@@ -78,4 +78,20 @@ describe('RailControls', () => {
     render(<RailControls {...defaultProps} ticketCount={0} />)
     expect(screen.getByTitle('Add specs to this rail first')).toBeInTheDocument()
   })
+
+  it('hides the Ultra segment by default', () => {
+    render(<RailControls {...defaultProps} />)
+    expect(screen.queryByText('Ultra')).not.toBeInTheDocument()
+  })
+
+  it('shows the Ultra segment when ultracodeAvailable', () => {
+    render(<RailControls {...defaultProps} ultracodeAvailable />)
+    expect(screen.getByText('Ultra')).toBeInTheDocument()
+  })
+
+  it('calls onModeChange with ultracode when Ultra clicked', () => {
+    render(<RailControls {...defaultProps} ultracodeAvailable />)
+    fireEvent.click(screen.getByText('Ultra'))
+    expect(defaultProps.onModeChange).toHaveBeenCalledWith('ultracode')
+  })
 })

--- a/client/src/components/__tests__/UltracodeLaunchDialog.test.tsx
+++ b/client/src/components/__tests__/UltracodeLaunchDialog.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '../../test-utils'
+import { UltracodeLaunchDialog } from '../UltracodeLaunchDialog'
+
+const base = {
+  open: true,
+  railLabel: 'Rail 1',
+  specCount: 2,
+  model: 'opus',
+  onConfirm: vi.fn(),
+  onCancel: vi.fn(),
+}
+
+describe('UltracodeLaunchDialog', () => {
+  it('renders the warning content with rail context', () => {
+    render(<UltracodeLaunchDialog {...base} onConfirm={vi.fn()} onCancel={vi.fn()} />)
+    expect(screen.getByText('Launch in Ultracode mode')).toBeInTheDocument()
+    expect(screen.getByText(/Rail 1 · 2 specs · opus/)).toBeInTheDocument()
+    expect(screen.getByText(/No OpenSpec pipeline/)).toBeInTheDocument()
+    expect(screen.getByText(/Variable cost/)).toBeInTheDocument()
+  })
+
+  it('singularises the spec count', () => {
+    render(<UltracodeLaunchDialog {...base} specCount={1} onConfirm={vi.fn()} onCancel={vi.fn()} />)
+    expect(screen.getByText(/Rail 1 · 1 spec ·/)).toBeInTheDocument()
+  })
+
+  it('calls onConfirm when Continue is clicked', () => {
+    const onConfirm = vi.fn()
+    render(<UltracodeLaunchDialog {...base} onConfirm={onConfirm} onCancel={vi.fn()} />)
+    fireEvent.click(screen.getByText('Continue'))
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onCancel when Cancel is clicked', () => {
+    const onCancel = vi.fn()
+    render(<UltracodeLaunchDialog {...base} onConfirm={vi.fn()} onCancel={onCancel} />)
+    fireEvent.click(screen.getByText('Cancel'))
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('confirms on Cmd/Ctrl+Enter', () => {
+    const onConfirm = vi.fn()
+    render(<UltracodeLaunchDialog {...base} onConfirm={onConfirm} onCancel={vi.fn()} />)
+    fireEvent.keyDown(document, { key: 'Enter', metaKey: true })
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not bind the shortcut when closed', () => {
+    const onConfirm = vi.fn()
+    render(<UltracodeLaunchDialog {...base} open={false} onConfirm={onConfirm} onCancel={vi.fn()} />)
+    fireEvent.keyDown(document, { key: 'Enter', metaKey: true })
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+})

--- a/client/src/components/agents/RailModelSelector.tsx
+++ b/client/src/components/agents/RailModelSelector.tsx
@@ -1,0 +1,51 @@
+import { Sparkles } from 'lucide-react'
+
+/** Models the ultracode picker exposes (Claude aliases). Mirrors the server
+ *  rails-router allow-list. */
+export const ULTRACODE_MODELS = ['haiku', 'sonnet', 'opus'] as const
+export type UltracodeModel = (typeof ULTRACODE_MODELS)[number]
+export const DEFAULT_ULTRACODE_MODEL: UltracodeModel = 'sonnet'
+
+const LABELS: Record<UltracodeModel, string> = {
+  haiku: 'Haiku',
+  sonnet: 'Sonnet',
+  opus: 'Opus',
+}
+
+interface Props {
+  /** Selected model. null/undefined = default (sonnet). */
+  value: UltracodeModel | null | undefined
+  onChange: (value: UltracodeModel) => void
+}
+
+/**
+ * Compact rail-header model selector, shown only for ultracode rails. Lets the
+ * user pick which Claude model runs the autonomous implementation. Mirrors
+ * RailEngineSelector's dense styling.
+ */
+export function RailModelSelector({ value, onChange }: Props) {
+  const current = value ?? DEFAULT_ULTRACODE_MODEL
+  return (
+    <div
+      className="inline-flex items-center"
+      title="Model for this ultracode rail"
+      onMouseDown={(e) => e.stopPropagation()}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <Sparkles className="w-3 h-3 text-accent-highlight mr-1" />
+      <select
+        value={current}
+        aria-label="Model for this ultracode rail"
+        data-testid="rail-model-selector"
+        onChange={(e) => onChange(e.target.value as UltracodeModel)}
+        className="h-5 text-[10px] rounded border border-border/50 bg-transparent text-muted-foreground hover:text-foreground pr-4 pl-1 focus:outline-none focus:ring-1 focus:ring-primary/40"
+      >
+        {ULTRACODE_MODELS.map((m) => (
+          <option key={m} value={m}>
+            {LABELS[m]}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}

--- a/client/src/components/agents/__tests__/RailModelSelector.test.tsx
+++ b/client/src/components/agents/__tests__/RailModelSelector.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '../../../test-utils'
+import { RailModelSelector } from '../RailModelSelector'
+
+describe('RailModelSelector', () => {
+  it('renders the three model options and defaults to sonnet', () => {
+    render(<RailModelSelector value={null} onChange={vi.fn()} />)
+    const select = screen.getByTestId('rail-model-selector') as HTMLSelectElement
+    expect(select.value).toBe('sonnet')
+    expect(screen.getByText('Haiku')).toBeInTheDocument()
+    expect(screen.getByText('Sonnet')).toBeInTheDocument()
+    expect(screen.getByText('Opus')).toBeInTheDocument()
+  })
+
+  it('reflects the selected value', () => {
+    render(<RailModelSelector value="opus" onChange={vi.fn()} />)
+    expect((screen.getByTestId('rail-model-selector') as HTMLSelectElement).value).toBe('opus')
+  })
+
+  it('calls onChange with the chosen model', () => {
+    const onChange = vi.fn()
+    render(<RailModelSelector value="sonnet" onChange={onChange} />)
+    fireEvent.change(screen.getByTestId('rail-model-selector'), { target: { value: 'haiku' } })
+    expect(onChange).toHaveBeenCalledWith('haiku')
+  })
+})

--- a/client/src/hooks/useRails.ts
+++ b/client/src/hooks/useRails.ts
@@ -171,7 +171,7 @@ export function useRails() {
   )
 
   const launchRail = useCallback(
-    async (railIndex: number, mode: 'implement' | 'batch-implement'): Promise<string | null> => {
+    async (railIndex: number, mode: 'implement' | 'batch-implement' | 'ultracode'): Promise<string | null> => {
       const res = await fetch(`${getApiBase()}/rails/${railIndex}/launch`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -23,6 +23,7 @@ import { DashboardSplitter } from '../components/DashboardSplitter'
 import { useDashboardSplit } from '../hooks/useDashboardSplit'
 import { TicketDetailModal } from '../components/TicketDetailModal'
 import { CreateTicketModal } from '../components/CreateTicketModal'
+import { UltracodeLaunchDialog } from '../components/UltracodeLaunchDialog'
 import { getApiBase } from '../lib/api'
 import { useHub, projectProviders } from '../hooks/useHub'
 import { useSharedWebSocket } from '../hooks/useSharedWebSocket'
@@ -70,6 +71,7 @@ interface PersistedRail {
   mode: RailMode
   status: RailStatus
   profileName?: string | null
+  ultracodeModel?: import('../components/agents/RailModelSelector').UltracodeModel | null
 }
 
 function loadRails(projectId: string | null): RailState[] | null {
@@ -99,6 +101,8 @@ export default function DashboardPage() {
   const { specToOpen, clearSpecToOpen } = useSpecGenTracker()
   const [detailTicket, setDetailTicket] = useState<LocalTicket | null>(null)
   const [createTicketOpen, setCreateTicketOpen] = useState(false)
+  // Rail pending an ultracode-launch confirmation (variable-cost warning modal).
+  const [ultracodeConfirm, setUltracodeConfirm] = useState<{ railId: string } | null>(null)
 
   // Open a spec when the tracker signals "View" was clicked for this project
   useEffect(() => {
@@ -619,8 +623,19 @@ export default function DashboardPage() {
     }
   }
 
+  function handleUltracodeModelChange(railId: string, model: import('../components/agents/RailModelSelector').UltracodeModel) {
+    // Model lives in localStorage (like mode) and is sent inline at launch —
+    // no dedicated server endpoint needed.
+    updateRails((prev) => prev.map((r) => (r.id === railId ? { ...r, ultracodeModel: model } : r)))
+  }
+
   async function handleEngineChange(railId: string, aiEngine: 'claude' | 'codex') {
-    updateRails((prev) => prev.map((r) => (r.id === railId ? { ...r, aiEngine } : r)))
+    // Ultracode is Claude-only — if the rail leaves Claude while in Ultracode,
+    // fall back to implement so the launch can't 400.
+    updateRails((prev) => prev.map((r) =>
+      r.id === railId
+        ? { ...r, aiEngine, mode: aiEngine !== 'claude' && r.mode === 'ultracode' ? 'implement' : r.mode }
+        : r))
     const railIndex = rails.findIndex((r) => r.id === railId)
     if (railIndex === -1) return
     try {
@@ -654,6 +669,21 @@ export default function DashboardPage() {
 
     if (rail.ticketIds.length === 0) return
 
+    // Ultracode bypasses OpenSpec and has variable cost — confirm before launch.
+    if (rail.mode === 'ultracode') {
+      setUltracodeConfirm({ railId })
+      return
+    }
+
+    await doLaunchRail(railId)
+  }
+
+  async function doLaunchRail(railId: string) {
+    const railIndex = rails.findIndex((r) => r.id === railId)
+    if (railIndex === -1) return
+    const rail = rails[railIndex]
+    if (rail.ticketIds.length === 0) return
+
     // Sync ticket assignments to server before launching
     try {
       await fetch(`${getApiBase()}/rails/${railIndex}/tickets`, {
@@ -679,6 +709,8 @@ export default function DashboardPage() {
           // rail.aiEngine: explicit per-rail engine override; undefined → server
           // falls back to the stored rail engine or the project primary.
           ...(rail.aiEngine != null ? { aiEngine: rail.aiEngine } : {}),
+          // Ultracode model picker — only meaningful for ultracode launches.
+          ...(rail.mode === 'ultracode' && rail.ultracodeModel ? { model: rail.ultracodeModel } : {}),
         }),
       })
       if (!res.ok) {
@@ -754,6 +786,7 @@ export default function DashboardPage() {
             onModeChange={handleModeChange}
             onProfileChange={handleProfileChange}
             onEngineChange={handleEngineChange}
+            onUltracodeModelChange={handleUltracodeModelChange}
             onToggle={handleToggle}
             onTicketClick={setDetailTicket}
             onAddRail={handleAddRail}
@@ -838,6 +871,24 @@ export default function DashboardPage() {
         onClose={() => setCreateTicketOpen(false)}
         onCreate={createTicket}
       />
+
+      {(() => {
+        const r = ultracodeConfirm ? rails.find((x) => x.id === ultracodeConfirm.railId) : undefined
+        return (
+          <UltracodeLaunchDialog
+            open={!!ultracodeConfirm && !!r}
+            railLabel={r?.label ?? ''}
+            specCount={r?.ticketIds.length ?? 0}
+            model={r?.ultracodeModel ?? 'sonnet'}
+            onCancel={() => setUltracodeConfirm(null)}
+            onConfirm={() => {
+              const id = ultracodeConfirm?.railId
+              setUltracodeConfirm(null)
+              if (id) void doLaunchRail(id)
+            }}
+          />
+        )
+      })()}
     </DndContext>
   )
 }

--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -13,6 +13,7 @@ interface ProjectSettings {
   pipelineTelemetryEnabled: boolean
   orchestratorModel?: string
   prePrompt?: string
+  ultraPrePrompt?: string
 }
 
 export default function SettingsPage() {
@@ -59,6 +60,8 @@ export default function SettingsPage() {
   const [isSavingTelemetry, setIsSavingTelemetry] = useState(false)
   const [prePrompt, setPrePrompt] = useState('')
   const [isSavingPrePrompt, setIsSavingPrePrompt] = useState(false)
+  const [ultraPrePrompt, setUltraPrePrompt] = useState('')
+  const [isSavingUltraPrePrompt, setIsSavingUltraPrePrompt] = useState(false)
 
   const cacheRef = useRef<Map<string, ProjectConfig>>(new Map())
 
@@ -117,6 +120,7 @@ export default function SettingsPage() {
         const data = await res.json() as ProjectSettings
         setTelemetryEnabled(data.pipelineTelemetryEnabled ?? false)
         setPrePrompt(data.prePrompt ?? '')
+        setUltraPrePrompt(data.ultraPrePrompt ?? '')
       } catch {
         // ignore
       }
@@ -205,6 +209,26 @@ export default function SettingsPage() {
       toast.error('Failed to save pre-prompt', { description: (err as Error).message })
     } finally {
       setIsSavingPrePrompt(false)
+    }
+  }
+
+  async function saveUltraPrePrompt() {
+    setIsSavingUltraPrePrompt(true)
+    try {
+      const res = await fetch(`${getApiBase()}/settings`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ultraPrePrompt }),
+      })
+      if (!res.ok) throw new Error('Failed to save')
+      const data = await res.json() as { settings?: ProjectSettings }
+      const savedValue = data.settings?.ultraPrePrompt ?? ''
+      setUltraPrePrompt(savedValue)
+      toast.success(savedValue.trim() === '' ? 'Ultra pre-prompt reset to default' : 'Ultra pre-prompt saved')
+    } catch (err) {
+      toast.error('Failed to save Ultra pre-prompt', { description: (err as Error).message })
+    } finally {
+      setIsSavingUltraPrePrompt(false)
     }
   }
 
@@ -302,6 +326,43 @@ export default function SettingsPage() {
               onClick={savePrePrompt}
             >
               {isSavingPrePrompt ? 'Saving...' : 'Save pre-prompt'}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Ultracode pre-prompt</CardTitle>
+          <CardDescription>
+            Instruction sent to Claude in Ultracode (Claude-only rails). Ultracode skips the OpenSpec pipeline — it hands Claude this pre-prompt plus the spec text and lets it implement autonomously. Leave blank to use the built-in default.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-2">
+            <label htmlFor="project-ultra-pre-prompt" className="text-xs font-medium">
+              Ultra pre-prompt
+            </label>
+            <textarea
+              id="project-ultra-pre-prompt"
+              value={ultraPrePrompt}
+              onChange={(e) => setUltraPrePrompt(e.target.value)}
+              placeholder="Leave blank to use the default Ultracode instruction."
+              className="min-h-32 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/20"
+            />
+            <p className="text-xs text-muted-foreground">
+              The spec text is appended automatically after this pre-prompt. Empty = default.
+            </p>
+          </div>
+          <div className="flex justify-end">
+            <Button
+              size="sm"
+              variant="secondary"
+              className="h-7 text-xs"
+              disabled={isSavingUltraPrePrompt}
+              onClick={saveUltraPrePrompt}
+            >
+              {isSavingUltraPrePrompt ? 'Saving...' : 'Save Ultra pre-prompt'}
             </Button>
           </div>
         </CardContent>

--- a/server/db.test.ts
+++ b/server/db.test.ts
@@ -20,6 +20,10 @@ import {
   getTemplate,
   updateTemplate,
   deleteTemplate,
+  getProjectSettings,
+  updateProjectSettings,
+  getUltracodePrePrompt,
+  DEFAULT_ULTRACODE_PRE_PROMPT,
 } from './db'
 import type { DbInstance } from './db'
 
@@ -564,4 +568,29 @@ describe('job templates', () => {
 
   // The Explore MCP / Contract Refine project toggles were removed; the
   // decisions now live exclusively per-spec in chat_conversations.context_scope.
+})
+
+describe('project settings — ultracode pre-prompt', () => {
+  let db: ReturnType<typeof makeDb>
+  beforeEach(() => { db = makeDb() })
+
+  it('defaults ultraPrePrompt to empty string', () => {
+    expect(getProjectSettings(db).ultraPrePrompt).toBe('')
+  })
+
+  it('persists and clears the ultraPrePrompt override', () => {
+    updateProjectSettings(db, { ultraPrePrompt: 'Be bold.' })
+    expect(getProjectSettings(db).ultraPrePrompt).toBe('Be bold.')
+    updateProjectSettings(db, { ultraPrePrompt: '   ' })
+    expect(getProjectSettings(db).ultraPrePrompt).toBe('')
+  })
+
+  it('getUltracodePrePrompt falls back to the default when unset', () => {
+    expect(getUltracodePrePrompt(db)).toBe(DEFAULT_ULTRACODE_PRE_PROMPT)
+  })
+
+  it('getUltracodePrePrompt returns the trimmed override when set', () => {
+    updateProjectSettings(db, { ultraPrePrompt: '  Custom instruction.  ' })
+    expect(getUltracodePrePrompt(db)).toBe('Custom instruction.')
+  })
 })

--- a/server/db.ts
+++ b/server/db.ts
@@ -1021,10 +1021,27 @@ export function getStats(db: DbInstance): StatsRow {
 
 // ─── Project settings ─────────────────────────────────────────────────────────
 
+/**
+ * Default pre-prompt used by Ultracode (Claude-only rails) when the project
+ * has no per-project override. Ultracode skips the OpenSpec pipeline entirely:
+ * it hands Claude the spec text plus this instruction and lets it work
+ * autonomously end-to-end.
+ */
+export const DEFAULT_ULTRACODE_PRE_PROMPT = [
+  'You are operating in ULTRACODE: fully autonomous, end-to-end implementation.',
+  'Implement the following spec COMPLETELY in this repository. You have full access to the codebase and tools.',
+  'Work independently until the feature is done: write the code, the tests, update docs as needed, and make sure everything builds and the test suite passes.',
+  'Do NOT follow any structured architect/developer/reviewer pipeline — use your own judgement and the repo conventions.',
+  'Never ask for confirmation; there is no human to answer. Choose the recommended option and proceed.',
+].join('\n')
+
 export interface ProjectSettings {
   pipelineTelemetryEnabled: boolean
   orchestratorModel: string
   prePrompt: string
+  /** Per-project Ultracode pre-prompt override. Empty string = use
+   *  DEFAULT_ULTRACODE_PRE_PROMPT at spawn time. */
+  ultraPrePrompt: string
 }
 
 export function getProjectSettings(db: DbInstance): ProjectSettings {
@@ -1037,11 +1054,22 @@ export function getProjectSettings(db: DbInstance): ProjectSettings {
   const prePromptRow = db.prepare(
     `SELECT value FROM queue_state WHERE key = 'config.pre_prompt'`
   ).get() as { value: string } | undefined
+  const ultraPrePromptRow = db.prepare(
+    `SELECT value FROM queue_state WHERE key = 'config.ultracode_pre_prompt'`
+  ).get() as { value: string } | undefined
   return {
     pipelineTelemetryEnabled: telemetryRow?.value === 'true',
     orchestratorModel: modelRow?.value ?? 'sonnet',
     prePrompt: prePromptRow?.value ?? '',
+    ultraPrePrompt: ultraPrePromptRow?.value ?? '',
   }
+}
+
+/** Resolve the effective Ultracode pre-prompt: the per-project override when
+ *  set, otherwise the built-in default. */
+export function getUltracodePrePrompt(db: DbInstance): string {
+  const override = getProjectSettings(db).ultraPrePrompt.trim()
+  return override || DEFAULT_ULTRACODE_PRE_PROMPT
 }
 
 export function updateProjectSettings(db: DbInstance, patch: Partial<ProjectSettings>): void {
@@ -1062,6 +1090,15 @@ export function updateProjectSettings(db: DbInstance, patch: Partial<ProjectSett
       db.prepare(
         `INSERT OR REPLACE INTO queue_state (key, value) VALUES ('config.pre_prompt', ?)`
       ).run(patch.prePrompt)
+    }
+  }
+  if (patch.ultraPrePrompt !== undefined) {
+    if (patch.ultraPrePrompt.trim() === '') {
+      db.prepare(`DELETE FROM queue_state WHERE key = 'config.ultracode_pre_prompt'`).run()
+    } else {
+      db.prepare(
+        `INSERT OR REPLACE INTO queue_state (key, value) VALUES ('config.ultracode_pre_prompt', ?)`
+      ).run(patch.ultraPrePrompt)
     }
   }
 }

--- a/server/project-router.test.ts
+++ b/server/project-router.test.ts
@@ -2247,6 +2247,26 @@ describe('project-router', () => {
       expect(res.status).toBe(200)
       expect(res.body.ok).toBe(true)
     })
+
+    it('updates ultraPrePrompt', async () => {
+      const ctx = makeContext(db)
+      const { app } = createApp(new Map([['proj-1', ctx]]))
+      const res = await request(app)
+        .patch('/api/projects/proj-1/settings')
+        .send({ ultraPrePrompt: 'Ship it autonomously.' })
+      expect(res.status).toBe(200)
+      expect(res.body.settings.ultraPrePrompt).toBe('Ship it autonomously.')
+    })
+
+    it('rejects non-string ultraPrePrompt', async () => {
+      const ctx = makeContext(db)
+      const { app } = createApp(new Map([['proj-1', ctx]]))
+      const res = await request(app)
+        .patch('/api/projects/proj-1/settings')
+        .send({ ultraPrePrompt: 7 })
+      expect(res.status).toBe(400)
+      expect(res.body.error).toContain('ultraPrePrompt')
+    })
   })
 
   // ─── POST /config dailyBudgetUsd ─────────────────────────────────────────

--- a/server/project-router.ts
+++ b/server/project-router.ts
@@ -3666,7 +3666,7 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
   })
 
   router.patch('/:projectId/settings', (req: Request, res: Response) => {
-    const { pipelineTelemetryEnabled, orchestratorModel, prePrompt } = req.body ?? {}
+    const { pipelineTelemetryEnabled, orchestratorModel, prePrompt, ultraPrePrompt } = req.body ?? {}
     const patch: Parameters<typeof updateProjectSettings>[1] = {}
     if (pipelineTelemetryEnabled !== undefined) {
       patch.pipelineTelemetryEnabled = Boolean(pipelineTelemetryEnabled)
@@ -3685,6 +3685,13 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
         return
       }
       patch.prePrompt = prePrompt
+    }
+    if (ultraPrePrompt !== undefined) {
+      if (typeof ultraPrePrompt !== 'string') {
+        res.status(400).json({ error: 'ultraPrePrompt must be a string' })
+        return
+      }
+      patch.ultraPrePrompt = ultraPrePrompt
     }
     try {
       updateProjectSettings(ctx(req).db, patch)

--- a/server/queue-manager.test.ts
+++ b/server/queue-manager.test.ts
@@ -1642,6 +1642,100 @@ describe('QueueManager', () => {
       expect(spawnArgs[pIdx + 1]).not.toContain('$implement')
     })
 
+    it('ultracode: sends default pre-prompt + spec text as the claude -p prompt (no slash command)', () => {
+      vi.mocked(mockExecSync).mockReturnValue(Buffer.from('/usr/bin/claude'))
+      const child = createMockChildProcess()
+      vi.mocked(mockSpawn).mockReturnValue(child as any)
+      vi.mocked(mockUuidV4).mockReturnValue('ultracode-default' as any)
+
+      const projectDir = makeProjectDirWithTickets({
+        '7': {
+          id: 7, title: 'Add dark mode', description: 'Toggle theme in settings',
+          status: 'todo', priority: 'high', labels: [], assignee: null,
+          prerequisites: [], metadata: {},
+          created_at: new Date().toISOString(), updated_at: new Date().toISOString(),
+          created_by: 'user', source: 'manual',
+        },
+      })
+      try {
+        const qm = new QueueManager(broadcast, undefined, [], projectDir, { provider: 'claude' })
+        qm.enqueue('/specrails:ultracode #7 --yes')
+
+        const spawnArgs = vi.mocked(mockSpawn).mock.calls[0][1] as string[]
+        const pIdx = spawnArgs.indexOf('-p')
+        const prompt = spawnArgs[pIdx + 1]
+        expect(prompt).toContain('ULTRACODE')
+        expect(prompt).toContain('# Spec #7: Add dark mode')
+        expect(prompt).toContain('Toggle theme in settings')
+        // The slash command itself must NOT be sent as the prompt.
+        expect(prompt).not.toContain('/specrails:ultracode')
+      } finally {
+        fs.rmSync(projectDir, { recursive: true, force: true })
+      }
+    })
+
+    it('ultracode: uses the per-project pre-prompt override when set', () => {
+      vi.mocked(mockExecSync).mockReturnValue(Buffer.from('/usr/bin/claude'))
+      const child = createMockChildProcess()
+      vi.mocked(mockSpawn).mockReturnValue(child as any)
+      vi.mocked(mockUuidV4).mockReturnValue('ultracode-override' as any)
+
+      const projectDir = makeProjectDirWithTickets({
+        '3': {
+          id: 3, title: 'Spec three', description: 'Body three',
+          status: 'todo', priority: 'low', labels: [], assignee: null,
+          prerequisites: [], metadata: {},
+          created_at: new Date().toISOString(), updated_at: new Date().toISOString(),
+          created_by: 'user', source: 'manual',
+        },
+      })
+      const db = initDb(':memory:')
+      updateProjectSettings(db, { ultraPrePrompt: 'CUSTOM ULTRA INSTRUCTION' })
+      try {
+        const qm = new QueueManager(broadcast, db, [], projectDir, { provider: 'claude' })
+        qm.enqueue('/specrails:ultracode #3 --yes')
+
+        const spawnArgs = vi.mocked(mockSpawn).mock.calls[0][1] as string[]
+        const prompt = spawnArgs[spawnArgs.indexOf('-p') + 1]
+        expect(prompt).toContain('CUSTOM ULTRA INSTRUCTION')
+        expect(prompt).toContain('# Spec #3: Spec three')
+      } finally {
+        db.close()
+        fs.rmSync(projectDir, { recursive: true, force: true })
+      }
+    })
+
+    it('ultracode: model override is passed as --model, overriding orchestrator', () => {
+      vi.mocked(mockExecSync).mockReturnValue(Buffer.from('/usr/bin/claude'))
+      const child = createMockChildProcess()
+      vi.mocked(mockSpawn).mockReturnValue(child as any)
+      vi.mocked(mockUuidV4).mockReturnValue('ultracode-model' as any)
+
+      const projectDir = makeProjectDirWithTickets({
+        '9': {
+          id: 9, title: 'Spec nine', description: 'Body nine',
+          status: 'todo', priority: 'low', labels: [], assignee: null,
+          prerequisites: [], metadata: {},
+          created_at: new Date().toISOString(), updated_at: new Date().toISOString(),
+          created_by: 'user', source: 'manual',
+        },
+      })
+      const db = initDb(':memory:')
+      updateProjectSettings(db, { orchestratorModel: 'sonnet' })
+      try {
+        const qm = new QueueManager(broadcast, db, [], projectDir, { provider: 'claude' })
+        qm.enqueue('/specrails:ultracode #9 --yes', 'normal', { profileName: null, model: 'opus' })
+
+        const spawnArgs = vi.mocked(mockSpawn).mock.calls[0][1] as string[]
+        const mIdx = spawnArgs.indexOf('--model')
+        expect(mIdx).toBeGreaterThanOrEqual(0)
+        expect(spawnArgs[mIdx + 1]).toBe('opus')
+      } finally {
+        db.close()
+        fs.rmSync(projectDir, { recursive: true, force: true })
+      }
+    })
+
     it('embeds referenced ticket attachments in the codex prompt', () => {
       vi.mocked(mockExecSync).mockReturnValue(Buffer.from('/usr/bin/codex'))
       const child = createMockChildProcess()

--- a/server/queue-manager.ts
+++ b/server/queue-manager.ts
@@ -23,7 +23,7 @@ import { finaliseInvocationResult } from './result-event'
 import { randomUUID } from 'crypto'
 import { getAdapter, type ProviderAdapter, type AdapterEvent } from './providers'
 import { createCodexOtelBridge, type CodexOtelBridge } from './codex-otel-bridge'
-import { createJob, finishJob, appendEvent, skipJob, getProjectSettings } from './db'
+import { createJob, finishJob, appendEvent, skipJob, getProjectSettings, getUltracodePrePrompt, DEFAULT_ULTRACODE_PRE_PROMPT } from './db'
 import type { JobResult } from './db'
 import type { CommandInfo } from './config'
 import { attachmentManager, USER_ATTACHMENT_SYSTEM_NOTE } from './attachment-manager'
@@ -191,6 +191,9 @@ function extractDisplayText(event: Record<string, unknown>): string | null {
 
 const TERMINAL_STATUSES = new Set(['completed', 'failed', 'canceled', 'zombie_terminated', 'skipped'])
 
+/** Match an Ultracode rail command: `/specrails:ultracode #5 …` (or `/sr:…`). */
+export const ULTRACODE_COMMAND_RE = /^\/(specrails|sr):ultracode\b/
+
 export interface EnqueueOptions {
   dependsOnJobId?: string
   pipelineId?: string
@@ -202,6 +205,11 @@ export interface EnqueueOptions {
    *  job runs with the project's primary provider (this._adapter). Validated by
    *  the route layer against the project's installed providers. */
   provider?: 'claude' | 'codex'
+  /** Per-job model override (e.g. ultracode rails let the user pick
+   *  haiku/sonnet/opus per launch). For claude this becomes the `--model`
+   *  value, taking precedence over the project orchestrator model. In-memory
+   *  only — a queued job that survives a restart falls back to the default. */
+  model?: string
 }
 
 // ─── QueueManager ─────────────────────────────────────────────────────────────
@@ -247,6 +255,9 @@ export class QueueManager {
    *  In-memory only (mirrors _jobProfileSelection): a queued job that survives a
    *  restart falls back to the project's primary provider. */
   private _jobProviderSelection: Map<string, 'claude' | 'codex'>
+  /** Pending per-job model override keyed by jobId — read at spawn time.
+   *  In-memory only (mirrors _jobProviderSelection). */
+  private _jobModelSelection: Map<string, string>
   /** Pre-spawn working-tree snapshot refs keyed by jobId — read at exit time
    *  by the Code-Explorer provenance hook. Cleared on job exit. */
   private _snapshotRefs: Map<string, WorkingTreeSnapshot>
@@ -297,6 +308,7 @@ export class QueueManager {
     this._projectSlug = options?.projectSlug ?? null
     this._jobProfileSelection = new Map()
     this._jobProviderSelection = new Map()
+    this._jobModelSelection = new Map()
     this._snapshotRefs = new Map()
 
     const envTimeout = process.env.WM_ZOMBIE_TIMEOUT_MS !== undefined
@@ -426,6 +438,11 @@ export class QueueManager {
     // Record per-job provider override so _startJob resolves the right adapter.
     if (resolvedOpts?.provider) {
       this._jobProviderSelection.set(id, resolvedOpts.provider)
+    }
+
+    // Record per-job model override (e.g. ultracode model picker).
+    if (resolvedOpts?.model) {
+      this._jobModelSelection.set(id, resolvedOpts.model)
     }
 
     // Insert at the correct position based on priority (higher priority first, FIFO within same level)
@@ -627,6 +644,36 @@ export class QueueManager {
     }
   }
 
+  /**
+   * Build the Claude prompt for an Ultracode job. Ultracode does NOT invoke
+   * a slash command: it sends the resolved pre-prompt followed by the full spec
+   * text of every ticket referenced in the command. Fully reconstructible from
+   * the command (`/specrails:ultracode #<id> …`) + the local ticket store, so a
+   * queued job survives a server restart without losing the prompt.
+   */
+  private _buildUltracodePrompt(command: string): string {
+    const pre = this._db ? getUltracodePrePrompt(this._db) : DEFAULT_ULTRACODE_PRE_PROMPT
+    const ticketIds = this._extractTicketIds(command)
+    const specs: string[] = []
+    if (this._cwd) {
+      try {
+        const store = readStore(resolveTicketStoragePath(this._cwd))
+        for (const ticketId of ticketIds) {
+          const ticket = store.tickets[String(ticketId)]
+          if (!ticket) continue
+          const body = (ticket.description ?? '').trim()
+          specs.push(`# Spec #${ticketId}: ${ticket.title}\n\n${body || '_(no description)_'}`)
+        }
+      } catch (err) {
+        console.warn(`[queue-manager] failed to read specs for ultracode: ${(err as Error).message}`)
+      }
+    }
+    const specBlock = specs.length > 0
+      ? specs.join('\n\n---\n\n')
+      : `(No spec content found for ${ticketIds.map((id) => `#${id}`).join(', ') || 'this rail'}.)`
+    return `${pre}\n\n---\n\n${specBlock}`
+  }
+
   private _drainQueue(): void {
     if (this._disposed) return
     if (this._activeJobId !== null) return
@@ -753,12 +800,25 @@ export class QueueManager {
     //    claude slash command — propose-spec, implement, batch-implement,
     //    explore-spec, retry, …). This is the rail equivalent of the
     //    user typing `$implement #1 --yes` themselves in `codex`.
-    const railPrompt = adapter.id === 'codex'
-      ? commandToRun.replace(/^\/(specrails|sr):([\w-]+)/, '$$$2')
-      : commandToRun
-    const railModel = adapter.id === 'claude' && this._db
-      ? getProjectSettings(this._db).orchestratorModel
-      : (this._resolvedModel ?? adapter.defaultModel())
+    // Ultracode (Claude only): skip the slash command entirely and send the
+    // pre-prompt + spec text directly as the prompt. The server route guards
+    // that ultracode never reaches a non-claude adapter; defensively, a codex
+    // adapter still falls through to its skill-translation path below.
+    const isUltracode = adapter.id === 'claude' && ULTRACODE_COMMAND_RE.test(commandToRun)
+    const railPrompt = isUltracode
+      ? this._buildUltracodePrompt(commandToRun)
+      : adapter.id === 'codex'
+        ? commandToRun.replace(/^\/(specrails|sr):([\w-]+)/, '$$$2')
+        : commandToRun
+    // Per-job model override (consumed once) takes precedence — used by the
+    // ultracode model picker so the user can choose haiku/sonnet/opus per launch.
+    const modelOverride = this._jobModelSelection.get(jobId)
+    this._jobModelSelection.delete(jobId)
+    const railModel = modelOverride
+      ? modelOverride
+      : adapter.id === 'claude' && this._db
+        ? getProjectSettings(this._db).orchestratorModel
+        : (this._resolvedModel ?? adapter.defaultModel())
     const args = adapter.buildArgs('rail-job', {
       prompt: railPrompt,
       systemPrompt: systemAppend || undefined,

--- a/server/rails-router.test.ts
+++ b/server/rails-router.test.ts
@@ -175,3 +175,84 @@ describe('rails-router POST /:railIndex/launch with aiEngine', () => {
     expect((enqueue.mock.calls[0][2] as { provider?: string }).provider).toBeUndefined()
   })
 })
+
+describe('rails-router POST /:railIndex/launch ultracode mode', () => {
+  let db: DbInstance
+  beforeEach(() => { db = initDb(':memory:') })
+  afterEach(() => { db.close() })
+
+  it('enqueues one claude job per ticket with an ultracode command and no profile', async () => {
+    setRailTickets(db, 0, [5, 7])
+    let n = 0
+    const enqueue = vi.fn().mockImplementation(() => ({ id: `job-${++n}`, queuePosition: 0 }))
+    const railJobs = new Map<string, unknown>()
+    const app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as unknown as { projectCtx: unknown }).projectCtx = {
+        db, railJobs,
+        project: { id: 'p1', slug: 's1', provider: 'claude', providers: ['claude'] },
+        queueManager: { enqueue },
+        broadcast: () => {},
+      }
+      next()
+    })
+    app.use('/rails', createRailsRouter())
+
+    const res = await request(app).post('/rails/0/launch').send({ mode: 'ultracode' })
+    expect(res.status).toBe(202)
+    expect(res.body.jobIds).toEqual(['job-1', 'job-2'])
+    expect(res.body.jobId).toBe('job-1')
+    expect(enqueue).toHaveBeenCalledTimes(2)
+    expect(enqueue.mock.calls[0][0]).toBe('/specrails:ultracode #5 --yes')
+    expect(enqueue.mock.calls[1][0]).toBe('/specrails:ultracode #7 --yes')
+    const opts = enqueue.mock.calls[0][2] as { provider?: string; profileName?: unknown }
+    expect(opts.provider).toBe('claude')
+    expect(opts.profileName).toBeNull()
+    // Each job registered against the rail with its single ticket.
+    expect(railJobs.size).toBe(2)
+  })
+
+  it('rejects ultracode when the effective engine is not claude', async () => {
+    setRailTickets(db, 0, [1], 'implement', null, 'codex')
+    const enqueue = vi.fn()
+    const res = await request(appWith(db, { providers: ['claude', 'codex'], queueManager: { enqueue } }))
+      .post('/rails/0/launch').send({ mode: 'ultracode', aiEngine: 'codex' })
+    expect(res.status).toBe(400)
+    expect(enqueue).not.toHaveBeenCalled()
+  })
+
+  it('rejects an unknown mode', async () => {
+    setRailTickets(db, 0, [1])
+    const res = await request(appWith(db, { queueManager: { enqueue: vi.fn() } }))
+      .post('/rails/0/launch').send({ mode: 'bogus' })
+    expect(res.status).toBe(400)
+  })
+
+  it('passes a valid ultracode model through to enqueue', async () => {
+    setRailTickets(db, 0, [1])
+    const enqueue = vi.fn().mockReturnValue({ id: 'job-1', queuePosition: 0 })
+    const res = await request(appWith(db, { providers: ['claude'], queueManager: { enqueue } }))
+      .post('/rails/0/launch').send({ mode: 'ultracode', model: 'opus' })
+    expect(res.status).toBe(202)
+    expect((enqueue.mock.calls[0][2] as { model?: string }).model).toBe('opus')
+  })
+
+  it('rejects an invalid ultracode model', async () => {
+    setRailTickets(db, 0, [1])
+    const enqueue = vi.fn()
+    const res = await request(appWith(db, { providers: ['claude'], queueManager: { enqueue } }))
+      .post('/rails/0/launch').send({ mode: 'ultracode', model: 'gpt-5' })
+    expect(res.status).toBe(400)
+    expect(enqueue).not.toHaveBeenCalled()
+  })
+
+  it('omits model from enqueue when none is provided', async () => {
+    setRailTickets(db, 0, [1])
+    const enqueue = vi.fn().mockReturnValue({ id: 'job-1', queuePosition: 0 })
+    const res = await request(appWith(db, { providers: ['claude'], queueManager: { enqueue } }))
+      .post('/rails/0/launch').send({ mode: 'ultracode' })
+    expect(res.status).toBe(202)
+    expect((enqueue.mock.calls[0][2] as { model?: string }).model).toBeUndefined()
+  })
+})

--- a/server/rails-router.ts
+++ b/server/rails-router.ts
@@ -12,7 +12,10 @@ declare module 'express-serve-static-core' {
   }
 }
 
-const VALID_MODES = new Set(['implement', 'batch-implement'])
+const VALID_MODES = new Set(['implement', 'batch-implement', 'ultracode'])
+// Models the ultracode picker exposes (Claude aliases). Mirrors the client
+// RailModelSelector options and the project-router orchestrator-model allow-list.
+const VALID_ULTRACODE_MODELS = new Set(['haiku', 'sonnet', 'opus'])
 
 export function createRailsRouter(): Router {
   const router = Router({ mergeParams: true })
@@ -130,9 +133,16 @@ export function createRailsRouter(): Router {
       res.status(400).json({ error: 'Invalid rail index' }); return
     }
 
-    const { mode = 'implement', profileName, aiEngine } = req.body ?? {}
+    const { mode = 'implement', profileName, aiEngine, model } = req.body ?? {}
     if (!VALID_MODES.has(mode as string)) {
-      res.status(400).json({ error: 'mode must be "implement" or "batch-implement"' }); return
+      res.status(400).json({ error: 'mode must be "implement", "batch-implement" or "ultracode"' }); return
+    }
+    // Ultracode model picker: optional, validated against the allow-list.
+    // Ignored for non-ultracode modes (they use the orchestrator model).
+    if (mode === 'ultracode' && model !== undefined && model !== null) {
+      if (typeof model !== 'string' || !VALID_ULTRACODE_MODELS.has(model)) {
+        res.status(400).json({ error: 'model must be one of: haiku, sonnet, opus' }); return
+      }
     }
 
     const c = ctx(req)
@@ -154,11 +164,20 @@ export function createRailsRouter(): Router {
     // single-provider rails on the legacy code path).
     const railProvider = requestedEngine ? engineCheck.provider : undefined
 
+    // Ultracode bypasses the OpenSpec pipeline and hands the raw spec to
+    // Claude. It is Claude-only — reject when the effective engine is not claude.
+    if (mode === 'ultracode' && engineCheck.provider !== 'claude') {
+      res.status(400).json({ error: 'Ultracode requires the Claude provider' }); return
+    }
+
     // Profile selection precedence: explicit body param > stored rail profile > default resolution.
     // `null` in the body explicitly forces legacy mode. Codex has no agent
     // profiles, so force legacy mode whenever the chosen engine is not claude.
     let resolvedProfile: string | null | undefined
-    if (railProvider && railProvider !== 'claude') {
+    if (mode === 'ultracode') {
+      // Ultracode runs no agent pipeline, so profiles do not apply.
+      resolvedProfile = null
+    } else if (railProvider && railProvider !== 'claude') {
       resolvedProfile = null
     } else if (profileName === null) {
       resolvedProfile = null
@@ -173,7 +192,44 @@ export function createRailsRouter(): Router {
     try {
       let jobId: string
 
-      // Both modes create a single job with all ticket IDs.
+      if (mode === 'ultracode') {
+        // Ultracode launches ONE independent Claude job per ticket — each gets
+        // its own log and runs the spec autonomously (no pipeline). The rail UI
+        // tracks the first job as its representative active job; every job is
+        // registered so its ticket is marked done on completion.
+        // `provider: 'claude'` is explicit so the spawn resolves the claude
+        // adapter regardless of the project's primary.
+        const ultracodeModel =
+          mode === 'ultracode' && typeof model === 'string' && VALID_ULTRACODE_MODELS.has(model)
+            ? model
+            : undefined
+        const jobIds: string[] = []
+        for (const ticketId of rail.ticketIds) {
+          const command = `/specrails:ultracode #${ticketId} --yes`
+          const job = c.queueManager.enqueue(command, 'normal', {
+            profileName: null,
+            provider: 'claude',
+            ...(ultracodeModel ? { model: ultracodeModel } : {}),
+          })
+          jobIds.push(job.id)
+          c.railJobs.set(job.id, { railIndex, mode, ticketIds: [ticketId] })
+        }
+        jobId = jobIds[0]
+
+        const startMsg: RailJobStartedMessage = {
+          type: 'rail.job_started',
+          projectId: c.project.id,
+          railIndex,
+          jobId,
+          mode,
+        }
+        c.broadcast(startMsg)
+
+        res.status(202).json({ jobId, jobIds, railIndex, mode })
+        return
+      }
+
+      // Implement / batch-implement create a single job with all ticket IDs.
       // /specrails:implement handles multiple specs in parallel internally.
       const issueArgs = rail.ticketIds.map((id) => `#${id}`).join(' ')
       const commandName = mode === 'batch-implement' ? 'batch-implement' : 'implement'


### PR DESCRIPTION
## Qué

Tercer modo de lanzamiento de rail, **ultracode**, junto a implement / batch-implement. **Solo Claude.** Se salta el pipeline OpenSpec por completo: le da a Claude el pre-prompt + el texto de la spec y lo deja implementar de forma autónoma con agentes y dynamic workflows nativos.

## Por qué

implement/batch siguen el flujo estructurado (architect → developer → reviewer). Ultracode es para cuando quieres soltar a Claude con autonomía total sobre una spec — muy potente para features grandes.

## Cambios

**Servidor**
- `queue-manager.ts` — `ULTRACODE_COMMAND_RE`; `_buildUltracodePrompt` envía pre-prompt + spec por `-p` (sin slash command), reconstruible desde el comando + ticket store. Override de modelo por job (`EnqueueOptions.model`).
- `db.ts` — setting `ultraPrePrompt` (override por proyecto, fallback al default) + `getUltracodePrePrompt`.
- `rails-router.ts` — acepta `ultracode`; gate claude-only; profile forzado a `null`; **un job independiente por ticket**; valida `model` ∈ {haiku, sonnet, opus}.
- `project-router.ts` — PATCH `/settings` valida `ultraPrePrompt`.

**Cliente**
- Segmento **Ultra** en `RailControls` (solo claude).
- `RailModelSelector` — modelo por rail en ultracode.
- `RailRow` — franja de config recesada para que engine/model no apelotonen la cabecera.
- `SettingsPage` — campo del pre-prompt de ultracode.
- `UltracodeLaunchDialog` — modal de aviso (no OpenSpec, autonomía nativa, **coste variable**) antes de lanzar; Continue verde, ⌘/Ctrl+Enter confirma.

## Tests

rails-router, queue-manager, db, project-router, RailControls, RailModelSelector, UltracodeLaunchDialog. `typecheck` + coverage server/client en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)