### PR TITLE
fix(cost): accurate per-job token & USD cost for Claude and Codex (+ Explore composer fix, README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,169 +1,288 @@
-# specrails-hub
+<div align="center">
 
-**The local dashboard for shipping software with AI agents.**
+# 🚄 specrails-hub
 
-specrails-hub turns "I'll let Claude do it" into a workflow you can see, steer, and trust. Draft specs in conversation with Claude, drag them onto execution rails, and watch the pipeline ship — all from one window, on your laptop, with every cost tracked.
+### The local cockpit for shipping software with AI agents
 
-It's a local-first companion to [specrails-core](https://github.com/fjpulidop/specrails-core): one window for all your projects, one place to manage specs and pipelines, one place to see what AI cost you this week.
+**Draft specs by talking to Claude or Codex → drag them onto execution rails → watch the pipeline ship — all from one window, on your laptop, with every dollar tracked.**
 
-> 100% local. Single user. No accounts. No telemetry leaving your machine. Your code stays on your laptop unless **you** spawn an agent against it.
+[![npm version](https://img.shields.io/npm/v/specrails-hub?color=4f46e5&label=npm&logo=npm&logoColor=white&style=flat-square)](https://www.npmjs.com/package/specrails-hub)
+[![license](https://img.shields.io/badge/license-MIT-22c55e?style=flat-square)](LICENSE)
+[![node](https://img.shields.io/badge/node-%E2%89%A520-339933?logo=node.js&logoColor=white&style=flat-square)](https://nodejs.org)
+[![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178c6?logo=typescript&logoColor=white&style=flat-square)](https://www.typescriptlang.org/)
+[![React](https://img.shields.io/badge/React-18-61dafb?logo=react&logoColor=black&style=flat-square)](https://react.dev)
+[![Desktop](https://img.shields.io/badge/Desktop-Tauri-ffc131?logo=tauri&logoColor=black&style=flat-square)](https://tauri.app)
+[![providers](https://img.shields.io/badge/agents-Claude%20%2B%20Codex-ff7a59?style=flat-square)](#-bring-your-own-agent)
 
-## What you can do with it
+[Quick start](#-quick-start) · [Features](#-what-you-can-do) · [Architecture](#%EF%B8%8F-how-its-built) · [Docs](#-documentation) · [Desktop app](#%EF%B8%8F-desktop-app)
 
-- **Draft a spec by talking to Claude or Codex** — open Explore, describe what you want; the live draft updates each turn. Save it as a draft and come back later, or commit when it looks right.
-- **Generate a spec in one shot** — Quick mode for when you already know what you want. Optionally enrich it with a "Contract Layer" of names, shapes, invariants, and a file touch list.
-- **Turn a live website into a spec** — *Add Spec → From a website* opens an embedded browser. Navigate to a page, hover-select an element or drag a rectangle, and the screenshot + rich DOM + applied CSS become attachments that feed Quick or Explore. The desktop app ships its own Chromium, so it works offline.
-- **Drag specs onto execution rails** — each rail is an independent lane. Run multiple specs in parallel, with different agent profiles per rail.
-- **Compare two specs side by side** — drag any spec modal to the edge of the screen; a picker of your todo specs appears on the other side. Pick one and they live next to each other. Tablet-style.
-- **Split a big epic** — SMASH a parent spec into a family of sub-specs in one click; the children carry short summaries on their cards.
-- **Refine a spec in place** — *Continue Editing* reopens any draft / todo / backlog spec in Explore, with the original conversation resumed if there was one.
-- **Track every AI cost** — every AI CLI invocation across rails, Quick spec, Explore turns, and AI edits is recorded — across **both** Claude and Codex. Codex cost is estimated from a local rate-card since the CLI doesn't report it natively. The Analytics page shows your burn rate, top tickets, breaks down spend per provider, and lets you export CSV.
-- **Customise everything** — three themes, font sizes, terminal preferences, agent profiles, plugin integrations (Serena bundled today).
+</div>
 
-## How specrails-hub looks
+---
+
+## 🌟 What is this?
+
+**specrails-hub** turns *"I'll just let the AI do it"* into a workflow you can **see, steer, and trust**. It's a local-first dashboard and CLI that sits on top of [**specrails-core**](https://github.com/fjpulidop/specrails-core) and gives you **one window for all your projects**:
+
+- 💬 Shape a spec in conversation with an AI, or generate one in a single shot.
+- 🛤️ Drag specs onto **execution rails** and run them — many in parallel.
+- 🤖 Watch the **Architect → Developer → Reviewer → Ship** pipeline stream live.
+- 💰 See exactly **what each agent cost you** this week, per provider, per ticket.
+
+> 🔒 **100% local. Single user. No accounts. No telemetry leaves your machine.**
+> Your code stays on your laptop — nothing moves unless **you** spawn an agent against it.
+
+---
+
+## ✨ What you can do
+
+### 📝 Turn ideas into specs
+
+| | |
+|---|---|
+| 🗣️ **Explore** | Describe what you want in a chat; a **live draft** rebuilds itself every turn. Save it as a *draft ticket* and resume later, or commit when it looks right. First-token latency is tuned to feel electric. |
+| ⚡ **Quick** | Already know what you want? Generate a full spec in one shot — optionally enriched with a **Contract Layer** of exact names, data shapes, invariants, and a file-touch list so the downstream agents don't reinvent anything. |
+| 🌐 **From a website** | *Add Spec → From a website* opens an **embedded browser**. Navigate, hover-select an element or drag a rectangle, and the screenshot + DOM + applied CSS become attachments. The desktop build ships its own Chromium, so it works **offline**. |
+| 💥 **SMASH** | Explode a big epic into a family of sub-specs in one click — children carry short summaries on their cards. |
+| 🔁 **Continue Editing** | Reopen any draft / todo / backlog spec back in Explore, resuming the original conversation if there was one. |
+| 🪟 **Compare** | Drag a spec modal to the screen edge → a picker of your todo specs slides in on the other side. Pick one and review them **side by side**, tablet-style. |
+
+### 🚀 Run the pipeline
+
+| | |
+|---|---|
+| 🛤️ **Execution rails** | Each rail is an independent lane. Run multiple specs **in parallel**, each with its own **agent profile** (which agents, which models, how tasks route). |
+| 🧩 **Agent profiles** | A per-project, declarative catalog that tells the implement pipeline which agents to run and at what model — snapshotted per job so concurrent rails stay isolated. |
+| 📡 **Live job detail** | A premium ticket-identity header, live duration ticker, incremental turns/tokens, and authoritative cost on exit. |
+| 🔌 **Plugins** | A per-project marketplace of MCP-based integrations (**Serena** semantic code-nav bundled today). Additive by design — installing plugin N+1 never disturbs plugin N. |
+
+### 💸 Track every cent
+
+| | |
+|---|---|
+| 📊 **Analytics** | Every billable AI invocation — across rails, Quick, Explore, AI edits, and file summaries — is recorded for **both Claude and Codex**. Burn-rate hero, daily timeline, top tickets, model breakdown, cost-vs-turns scatter. |
+| 🧮 **Honest numbers** | Claude cost is the provider-billed figure; Codex cost is **estimated** from a local rate-card (the CLI doesn't report it) and clearly flagged with a `~`. Token totals include the cache tiers, so the figures actually reconcile. |
+| 📤 **Exports** | One-click CSV/JSON, plus per-ticket spending deep-links. |
+
+### 🛠️ Make it yours
+
+| | |
+|---|---|
+| 🖥️ **Terminal panel** | A real VS-Code-style bottom panel (`Cmd/Ctrl+J`) powered by `node-pty` + xterm.js — WebGL rendering, search, ligatures, image inline, drag-drop paths, and OSC 133 shell integration. |
+| 🎨 **Themes** | Three built-ins — `dracula`, `aurora-light`, `obsidian-dark` — applied before React hydrates (no flash). |
+| 🧭 **Code explorer** | A read-only, non-developer-friendly file tree + Monaco viewer with plain-language AI summaries and *"touched by AI"* provenance chips. |
+| 💬 **Minimizable chats** | Park an Explore or AI-Edit session into a dock chip and pick it back up later — never lost across refreshes or project switches. |
+
+---
+
+## 🤖 Bring your own agent
+
+specrails-hub treats **Claude Code** and **Codex CLI** as first-class, interchangeable providers through a single `ProviderAdapter` contract — no manager ever branches on `provider === 'X'`.
+
+| | 🟣 Claude Code | 🟢 Codex CLI |
+|---|:---:|:---:|
+| Native streaming | ✅ | ✅ |
+| Native session resume | ✅ | ✅ |
+| Native cost reporting | ✅ | ⚠️ estimated via rate-card |
+| Native OTEL telemetry | ✅ | 🔧 synthesized by the hub |
+| Agent profiles | ✅ | — |
+
+A project can install **one or both**. When both are present, the UI lets you pick the engine per spec, per rail, or per terminal launch. Adding a third provider is *one file + one registry entry* — see [`docs/internals/`](docs/internals/).
+
+---
+
+## 🖼️ How it looks
 
 ```
 ┌──────────┬───────────────────────────────────────────────────┐
 │          │  Dashboard · Jobs · Analytics · Agents · ⚙        │
 │   Arc    │ ──────────────────────────────────────────────── │
 │  side-   │                                                   │
-│   bar    │   SpecsBoard            │   Rails                 │
+│   bar    │   📋 SpecsBoard          │   🛤️  Rails             │
 │          │   (your specs)          │   (execution lanes)     │
 │ projects │                         │                         │
-│          │   #1  Login flow ●      │   ▶ Rail 1   #1 #2     │
-│ + Add    │   #2  Webhook retry     │     [profile: default]  │
+│  ● proj  │   #1  Login flow ●      │   ▶ Rail 1   #1 #2     │
+│  ○ proj  │   #2  Webhook retry     │     [profile: default]  │
 │          │   #3  Cost limits  ●    │                         │
-│          │                         │   ▶ Rail 2   running    │
+│  ➕ Add   │   #4  Draft idea  ✎     │   ▶ Rail 2   running    │
 │          │                         │     [profile: budget]   │
 │   ⚙      │                         │                         │
 └──────────┴───────────────────────────────────────────────────┘
-                  ⌥ Terminal panel (Cmd+J)
+                 ⌨️  Terminal panel  (Cmd/Ctrl + J)
 ```
 
-## Quick start
+---
+
+## 🚀 Quick start
 
 ```bash
-# 1. Install
+# 1️⃣  Install
 npm install -g specrails-hub
 
-# 2. Start the hub
+# 2️⃣  Start the hub
 specrails-hub start
 
-# 3. Add a project from the CLI…
+# 3️⃣  Add a project from the CLI…
 specrails-hub add /path/to/your/project
 
-# …or click "+ Add project" in the dashboard sidebar at
+# …or click “➕ Add project” in the dashboard sidebar at
 #   http://127.0.0.1:4200
 ```
 
-If the project doesn't have specrails-core yet, the setup wizard walks you through installing it. One flow, no tier picker. Total time: about a minute on a warm cache.
+If a project doesn't have specrails-core yet, a **5-step setup wizard** installs it for you — one flow, no tier picker, ~1 minute on a warm cache.
 
-**Prefer a desktop app?** Download a signed build for macOS or Windows from `https://specrails.dev/downloads/specrails-hub/latest/`. The desktop app bundles the server, so you don't need a separate `start` command.
+> 💡 **Prefer a desktop app?** Grab a signed macOS or Windows build — see [Desktop app](#%EF%B8%8F-desktop-app). It bundles the server, so there's no separate `start`.
 
-## Prerequisites
+### 🧑‍💻 The `specrails-hub` CLI
 
-- **Node.js 20+** (specrails-core ≥ 4.6.0 for codex projects; ≥ 4.2.0 for claude-only)
-- **At least one AI CLI** on your PATH:
-  - **[Claude Code](https://claude.com/claude-code)** — `claude` binary. Set `ANTHROPIC_API_KEY` to authenticate.
-  - **[Codex CLI](https://developers.openai.com/codex)** ≥ 0.128.0 — `codex` binary. Run `codex login` or set `OPENAI_API_KEY`.
-- **`git`**
-- (Optional) **`uv`** if you want to use the Serena plugin
+```bash
+specrails-hub start | stop | add | remove | list   # manage the hub
+specrails-hub implement #42                         # run a specrails verb
+specrails-hub --status                              # manager status
+specrails-hub --jobs                                # recent job history
+specrails-hub --project <name|path>                 # target a project
+specrails-hub --help                                # full reference
+```
 
-The provider is chosen per-project at install time and is immutable after
-creation. On macOS, the desktop app handles Homebrew/Volta/nvm paths
-automatically — see [docs/platforms/macos.md](docs/platforms/macos.md).
-**Windows users:** see [docs/platforms/windows.md](docs/platforms/windows.md)
-for Windows 10/11 specifics. For Codex-specific topics — auth, sandbox config,
-estimated cost caveats, plugin support, and emergency rollback — see
-[docs/codex.md](docs/codex.md).
+When the hub is running, the CLI talks to it over HTTP + WebSocket; when it isn't, it spawns the agent directly. Either way you get streamed logs.
 
-## Documentation
+---
 
-User guides:
+## 📦 Prerequisites
 
-| Guide | What it covers |
-|-------|----------------|
-| [Getting started](docs/getting-started.md) | Install, register a project, run your first pipeline |
-| [Creating specs](docs/creating-specs.md) | Quick vs Explore, drafts, SMASH, Compare, Continue Editing |
-| [Running pipelines](docs/running-pipelines.md) | Rails, jobs, agent profiles, plugins |
-| [Tracking cost](docs/tracking-cost.md) | Analytics page, exports, per-ticket spending |
-| [Customising the hub](docs/customizing.md) | Themes, settings, telemetry, kill switches |
-| [Terminal panel](docs/terminal.md) | Keyboard shortcuts, shell integration, drag-and-drop |
-| [CLI reference](docs/cli.md) | Every command grouped by task |
+- 🟩 **Node.js 20+**
+- 🤖 **At least one AI CLI** on your `PATH`:
+  - **[Claude Code](https://claude.com/claude-code)** — the `claude` binary. Authenticate with `ANTHROPIC_API_KEY`.
+  - **[Codex CLI](https://developers.openai.com/codex)** ≥ 0.128.0 — the `codex` binary. Run `codex login` or set `OPENAI_API_KEY`.
+- 🌿 **git**
+- 🧪 *(optional)* **`uv`** — only if you want the Serena plugin
+- 📦 **specrails-core** ≥ 4.6.0 in the project for Codex, ≥ 4.2.0 for Claude-only *(the wizard installs it)*
 
-Platform notes:
+The provider is chosen **per project at install time** and is immutable afterward. On macOS the desktop app resolves Homebrew/Volta/nvm paths for you.
 
-- [macOS](docs/platforms/macos.md) — GUI-launch PATH, broken-symlink detection
-- [Windows](docs/platforms/windows.md) — installer formats, SmartScreen, ConPTY
+---
 
-Contributing or extending:
+## 🏗️ How it's built
 
-- [`docs/internals/`](docs/internals/) — architecture, REST reference, operations runbook, OpenSpec workflow, profile internals
+A clean **three-layer TypeScript monorepo** — one Express process runs in *hub mode* and manages every project.
 
-## Development
+```
+🗄️  server/   Express 5 + WebSocket + SQLite (better-sqlite3)   · the brain
+🎨  client/   React 18 + Vite + Tailwind v4                      · the dashboard
+⌨️  cli/      specrails-hub command bridge                       · the terminal door
+```
+
+```
+~/.specrails/
+├── hub.sqlite                       # project registry
+├── manager.pid                      # running server PID
+└── projects/<slug>/
+    ├── jobs.sqlite                  # per-project DB (jobs, analytics, chats)
+    └── …                            # snapshots, telemetry, terminals, summaries
+```
+
+**Highlights under the hood:**
+
+- 🔗 **One WebSocket** multiplexes everything; every project-scoped message carries a `projectId`, injected by a `boundBroadcast` closure — managers need zero changes.
+- 🧱 **Per-project isolation** — each project gets its own SQLite, queue manager, and chat manager.
+- 🖥️ **Terminals** stream over a *dedicated* WebSocket so PTY throughput can't starve the event stream.
+- 🌐 **Embedded browser** via Playwright (CDP capture) for the *"From a website"* flow.
+- 📦 **Desktop** via Tauri, with optionally-bundled Node, Git, and Chromium runtimes so it runs fully offline.
+
+> 📖 Want the deep dive? CLAUDE.md and [`docs/internals/`](docs/internals/) document the adapter contract, REST surface, migrations, and the OpenSpec workflow.
+
+---
+
+## 🛠️ Development
 
 ```bash
 git clone https://github.com/fjpulidop/specrails-hub.git
 cd specrails-hub
 npm install                        # root deps (server + CLI)
 cd client && npm install && cd ..  # client deps (separate tree)
-npm run dev                        # server (4200) + client (4201)
+npm run dev                        # 🚀 server :4200 + client :4201, hot reload
 ```
 
-| Script | Description |
-|--------|-------------|
+| Script | What it does |
+|--------|--------------|
 | `npm run dev` | Server (4200) + client (4201) with hot reload |
 | `npm run dev:desktop` | Desktop app (Tauri) in dev mode |
-| `npm run build` | Production build (client + server + CLI) |
-| `npm test` | vitest (server + CLI) |
+| `npm run build` | Production build (server + client + CLI) |
+| `npm test` | Vitest suite (server + CLI) + core-compat check |
 | `npm run test:coverage` | Server coverage (mirrors the CI gate) |
-| `npm run build:desktop` | Desktop installers — ships an **empty** `runtimes/` |
-| `npm run build:desktop:local` | Self-contained desktop app (macOS arm64) |
+| `npm run test:client` | Client Vitest suite |
+| `npm run ci` | Everything CI runs: typecheck + tests + both coverage gates |
 
-CI gates coverage hard: 70 % global, 80 % server, 80 % client. Local runs must clear the same bars (`npm run test:coverage`, and `cd client && npm run test:coverage`).
+🛡️ **Coverage is a hard gate** — **70 % global**, **80 % server**, **80 % client**. Local runs must clear the same bars before pushing.
 
-### Building the desktop app locally
+- 🌍 `4200` — Express API + WebSocket
+- ⚡ `4201` — Vite dev server (proxies `/api` and `/hooks` to 4200)
 
-`npm run build:desktop` builds the `.app`/`.dmg`/`.exe` but does **not** assemble
-the bundled Node/Git/Chromium runtimes — the resulting app falls back to your
-system PATH, and the embedded browser downloads a Playwright-managed Chromium on
-first use. To build a self-contained app the way CI does (**macOS arm64 only**):
+---
+
+## 🖥️ Desktop app
+
+Signed, notarized builds for **macOS (Apple Silicon)** and **Windows (x64)** are published at:
+
+> 📥 `https://specrails.dev/downloads/specrails-hub/latest/`
+
+`npm run build:desktop` produces the `.app` / `.dmg` / `.exe`, but does **not** assemble the bundled runtimes — that app falls back to your system PATH and downloads a Playwright Chromium on first use. To build a self-contained app the way CI does (**macOS arm64 only**):
 
 ```bash
-# Bundle Node 22 + a relocatable Git into src-tauri/runtimes/, then build.
+# Bundle Node 22 + a relocatable Git, then build
 npm run build:desktop:local
 
-# …and bundle Chromium too, so "Add Spec from a website" works fully offline.
-# Adds a one-time ~150 MB Playwright Chromium download.
+# …and bundle Chromium too, so "Add Spec from a website" works fully offline
+# (one-time ~150 MB Playwright Chromium download)
 BUNDLE_CHROMIUM=true npm run build:desktop:local
 ```
 
-Notes:
+> ℹ️ Local builds are **unsigned** — Gatekeeper warns; right-click → Open, or `xattr -dr com.apple.quarantine <App>.app`. Signed + notarized installers come only from the `desktop-release` CI workflow.
 
-- **Local builds are unsigned.** Gatekeeper will warn ("unidentified developer") —
-  right-click → Open, or run `xattr -dr com.apple.quarantine <App>.app`.
-- Locally, Chromium is bundled **unpacked**; the app launches it straight from
-  `Contents/Resources/runtimes/chromium`.
-- The signed + notarized installers are produced only by the `desktop-release` CI
-  workflow. There, Chromium is shipped as an obfuscated `chromium.pak` blob — the
-  notarization service recurses into plain archives and would reject Chromium's
-  ad-hoc-signed binaries, so the magic bytes are XOR-broken to make it opaque. The
-  app reverses the XOR and extracts Chromium to `~/.specrails/runtimes/chromium`
-  on first use, where Google's ad-hoc signature is enough to run it.
+---
 
-## Security model
+## 🔒 Security model
 
-- Binds to `127.0.0.1` only. **Do not expose to a network.**
-- No authentication (single-user local tool).
-- Parameterised SQL throughout.
-- Reserved paths in your project (`.mcp.json`, `.specrails/plugins/state.json`, `.specrails/profiles/.user-preferred.json`) are mutated surgically — read, modify owned keys, atomic rename — so adding plugin N+1 never disturbs plugin N's state.
+- 🏠 Binds to `127.0.0.1` only — **do not expose to a network**.
+- 🙅 No authentication (single-user local tool by design).
+- 🧷 Parameterised SQL everywhere — never string-interpolated.
+- 🧬 Reserved files in your project (`.mcp.json`, `.specrails/plugins/state.json`, `.specrails/profiles/.user-preferred.json`) are mutated **surgically** — read → modify only owned keys → atomic temp+rename — so adding plugin N+1 never disturbs plugin N.
 
-## Support
+---
 
-If specrails-hub saves you time, you can buy me a coffee on [Ko-fi](https://ko-fi.com/D1D81Y002C). It funds development of the open-source ecosystem.
+## 📚 Documentation
+
+**User guides**
+
+| Guide | What it covers |
+|-------|----------------|
+| 🏁 [Getting started](docs/getting-started.md) | Install, register a project, run your first pipeline |
+| 📝 [Creating specs](docs/creating-specs.md) | Quick vs Explore, drafts, SMASH, Compare, Continue Editing |
+| 🚀 [Running pipelines](docs/running-pipelines.md) | Rails, jobs, agent profiles, plugins |
+| 💰 [Tracking cost](docs/tracking-cost.md) | Analytics, exports, per-ticket spending |
+| 🎨 [Customising the hub](docs/customizing.md) | Themes, settings, telemetry, kill switches |
+| ⌨️ [Terminal panel](docs/terminal.md) | Shortcuts, shell integration, drag-and-drop |
+| 🧑‍💻 [CLI reference](docs/cli.md) | Every command grouped by task |
+| 🟢 [Codex notes](docs/codex.md) | Auth, sandbox, estimated-cost caveats, rollback |
+
+**Platform notes** — 🍎 [macOS](docs/platforms/macos.md) · 🪟 [Windows](docs/platforms/windows.md)
+
+**Extending** — 🧩 [`docs/internals/`](docs/internals/): architecture, REST reference, ops runbook, adding a provider.
+
+---
+
+## ☕ Support
+
+If specrails-hub saves you time, you can buy me a coffee on **Ko-fi** — it funds the open-source ecosystem. 💜
 
 [![Donate on Ko-fi](https://img.shields.io/badge/Donate-Ko--fi-FF5E5B?logo=kofi&logoColor=white&style=flat-square)](https://ko-fi.com/D1D81Y002C)
 
-## License
+---
 
-MIT
+## 📄 License
+
+[MIT](LICENSE) © [Javier Pulido](https://github.com/fjpulidop)
+
+<div align="center">
+<sub>Built with TypeScript, React, Express & a lot of ☕ — and shipped by the agents it orchestrates. 🚄</sub>
+</div>

--- a/client/src/components/JobStatusPanel.tsx
+++ b/client/src/components/JobStatusPanel.tsx
@@ -21,6 +21,8 @@ interface PipelineTotals {
   totalCostUsd: number
   totalTokensIn: number
   totalTokensOut: number
+  totalTokensCacheRead: number
+  totalTokensCacheCreate: number
   jobCount: number
 }
 
@@ -73,12 +75,28 @@ function aggReducer(state: LiveAggregate, action: AggAction): LiveAggregate {
       turns += 1
       try {
         const payload = JSON.parse(ev.payload) as
-          | { message?: { usage?: { input_tokens?: number; output_tokens?: number } } }
+          | {
+              message?: {
+                usage?: {
+                  input_tokens?: number
+                  output_tokens?: number
+                  cache_read_input_tokens?: number
+                  cache_creation_input_tokens?: number
+                }
+              }
+            }
           | undefined
         const usage = payload?.message?.usage
-        const input = typeof usage?.input_tokens === 'number' ? usage.input_tokens : 0
-        const output = typeof usage?.output_tokens === 'number' ? usage.output_tokens : 0
-        tokens += input + output
+        const n = (v: unknown): number => (typeof v === 'number' ? v : 0)
+        // NOTE: this is a deliberately rough LIVE indicator — per-frame usage
+        // re-includes the re-sent context each turn, so summing over-counts.
+        // It is labelled approximate in the UI and is replaced by the
+        // authoritative job.tokens_* totals at exit.
+        tokens +=
+          n(usage?.input_tokens) +
+          n(usage?.output_tokens) +
+          n(usage?.cache_read_input_tokens) +
+          n(usage?.cache_creation_input_tokens)
       } catch {
         // unparseable assistant payload — count the turn, skip token math
       }
@@ -124,12 +142,24 @@ export function JobStatusPanel({
 
   // Authoritative values once available; live values otherwise.
   const liveTurns = job.num_turns ?? (isTerminal ? null : agg.turns)
+  // Real total tokens = fresh input + output + cache-read + cache-create. The
+  // cache tiers (especially cache_read) typically dominate agentic Claude runs,
+  // so omitting them understated the figure by an order of magnitude.
   const liveTokens =
     job.tokens_in != null
-      ? (job.tokens_in ?? 0) + (job.tokens_out ?? 0)
+      ? (job.tokens_in ?? 0) +
+        (job.tokens_out ?? 0) +
+        (job.tokens_cache_read ?? 0) +
+        (job.tokens_cache_create ?? 0)
       : isTerminal
         ? null
         : agg.tokens
+  // Live (still-running) figures are rough: tokens sum per-frame usage (which
+  // re-includes re-sent context) and turns count assistant frames, not CLI
+  // turns. Both are replaced by authoritative server values at job exit; mark
+  // them with a ~ while live so the visible jump at exit is not surprising.
+  const tokensApproximate = job.tokens_in == null && !isTerminal && liveTokens != null
+  const turnsApproximate = job.num_turns == null && !isTerminal && liveTurns != null
 
   const durationDisplay = job.finished_at
     ? formatWallClock(job.started_at, job.finished_at)
@@ -152,8 +182,11 @@ export function JobStatusPanel({
       ? 'w-4 h-4 text-emerald-400 shrink-0'
       : 'w-4 h-4 text-red-400 shrink-0'
 
+  // Codex (and any non-native-cost provider) cost is a pricing-table estimate;
+  // prefix `~` so it is never read as a provider-billed figure.
+  const costEstimated = !!job.total_cost_usd_estimated
   const costDisplay =
-    job.total_cost_usd != null ? `$${job.total_cost_usd.toFixed(4)}` : '—'
+    job.total_cost_usd != null ? `${costEstimated ? '~' : ''}$${job.total_cost_usd.toFixed(4)}` : '—'
   const costDimmed = job.total_cost_usd == null
 
   return (
@@ -201,10 +234,13 @@ export function JobStatusPanel({
               value={costDisplay}
               valueClass={costDimmed ? 'text-muted-foreground' : 'text-yellow-400'}
             />
-            <SummaryMetric label="Turns" value={liveTurns != null ? `${liveTurns}` : '—'} />
+            <SummaryMetric
+              label="Turns"
+              value={liveTurns != null ? `${turnsApproximate ? '~' : ''}${liveTurns}` : '—'}
+            />
             <SummaryMetric
               label="Tokens"
-              value={liveTokens != null ? `${(liveTokens / 1000).toFixed(1)}k` : '—'}
+              value={liveTokens != null ? `${tokensApproximate ? '~' : ''}${(liveTokens / 1000).toFixed(1)}k` : '—'}
             />
           </div>
 
@@ -222,7 +258,10 @@ export function JobStatusPanel({
                 />
                 <SummaryMetric
                   label="Total tokens"
-                  value={`${(((pipelineTotals.totalTokensIn + pipelineTotals.totalTokensOut)) / 1000).toFixed(1)}k`}
+                  value={`${((pipelineTotals.totalTokensIn +
+                    pipelineTotals.totalTokensOut +
+                    pipelineTotals.totalTokensCacheRead +
+                    pipelineTotals.totalTokensCacheCreate) / 1000).toFixed(1)}k`}
                 />
               </div>
             </div>

--- a/client/src/components/RecentJobs.tsx
+++ b/client/src/components/RecentJobs.tsx
@@ -308,7 +308,12 @@ export function RecentJobs({ jobs, isLoading, onJobsCleared, onProposalClick, on
           const statusInfo = STATUS_BADGE[job.status] ?? STATUS_BADGE.queued
           const cost = formatCost(job.total_cost_usd)
           const duration = formatWallDuration(job.started_at, job.finished_at)
-          const tokens = formatTokens(((job.tokens_in ?? 0) + (job.tokens_out ?? 0)) || null)
+          const tokens = formatTokens(
+            ((job.tokens_in ?? 0) +
+              (job.tokens_out ?? 0) +
+              (job.tokens_cache_read ?? 0) +
+              (job.tokens_cache_create ?? 0)) || null,
+          )
 
           const isProposal = job.id.startsWith('proposal:')
           const proposalId = isProposal ? job.id.replace('proposal:', '') : null

--- a/client/src/components/RichAttachmentEditor.tsx
+++ b/client/src/components/RichAttachmentEditor.tsx
@@ -36,6 +36,10 @@ interface RichAttachmentEditorProps {
   ticketKey: string | number
   placeholder?: string
   minHeight?: number
+  /** Cap on the editor's auto-grow height (px). Beyond this the content
+   *  scrolls vertically instead of expanding the box without bound — without
+   *  it, pasting a very large text grows the editor off-screen with no scroll. */
+  maxHeight?: number
   ariaLabel?: string
   autoFocus?: boolean
   className?: string
@@ -125,6 +129,7 @@ export const RichAttachmentEditor = forwardRef<RichAttachmentEditorHandle, RichA
       ticketKey,
       placeholder,
       minHeight = 120,
+      maxHeight = 320,
       ariaLabel,
       autoFocus,
       className,
@@ -525,7 +530,7 @@ export const RichAttachmentEditor = forwardRef<RichAttachmentEditorHandle, RichA
             'data-[empty=true]:before:text-muted-foreground data-[empty=true]:before:pointer-events-none',
             'data-[empty=true]:before:absolute data-[empty=true]:before:top-2 data-[empty=true]:before:left-3',
           )}
-          style={{ minHeight, resize: 'vertical', overflow: 'auto' }}
+          style={{ minHeight, maxHeight, resize: 'vertical', overflow: 'auto' }}
           data-placeholder={placeholder ?? ''}
         />
 

--- a/client/src/components/__tests__/JobStatusPanel.test.tsx
+++ b/client/src/components/__tests__/JobStatusPanel.test.tsx
@@ -145,6 +145,21 @@ describe('JobStatusPanel', () => {
     expect(screen.getByText('8.0k')).toBeInTheDocument()
   })
 
+  it('includes cache tokens in the authoritative Tokens total', () => {
+    // Real total = in + out + cache_read + cache_create (cache dominates).
+    const cacheHeavy: JobSummary = {
+      ...completedJob,
+      tokens_in: 5000,
+      tokens_out: 3000,
+      tokens_cache_read: 90_000,
+      tokens_cache_create: 2_000,
+    }
+    render(<JobStatusPanel job={cacheHeavy} events={[]} />)
+    // 5000 + 3000 + 90000 + 2000 = 100000 → 100.0k (NOT 8.0k)
+    expect(screen.getByText('100.0k')).toBeInTheDocument()
+    expect(screen.queryByText('8.0k')).not.toBeInTheDocument()
+  })
+
   it('renders "—" for null metric values', () => {
     render(<JobStatusPanel job={failedJob} events={[]} />)
     const dashes = screen.getAllByText('—')
@@ -262,9 +277,10 @@ describe('JobStatusPanel', () => {
         makeAssistantEvent(3, 300, 100),
       ]
       render(<JobStatusPanel job={runningJob} events={events} />)
-      expect(screen.getByText('3')).toBeInTheDocument() // Turns
-      // (100+50) + (200+75) + (300+100) = 825 → "0.8k"
-      expect(screen.getByText('0.8k')).toBeInTheDocument()
+      // Live (still-running) values are marked approximate with a ~ prefix.
+      expect(screen.getByText('~3')).toBeInTheDocument() // Turns
+      // (100+50) + (200+75) + (300+100) = 825 → "~0.8k"
+      expect(screen.getByText('~0.8k')).toBeInTheDocument()
     })
 
     it('tolerates missing or partial usage fields without NaN', () => {
@@ -274,9 +290,9 @@ describe('JobStatusPanel', () => {
         { ...makeAssistantEvent(3, 50, 25), payload: JSON.stringify({ message: { usage: { input_tokens: 50 } } }) },
       ]
       render(<JobStatusPanel job={runningJob} events={events} />)
-      expect(screen.getByText('3')).toBeInTheDocument()
-      // 100+50 + 0 + 50 = 200 → "0.2k"
-      expect(screen.getByText('0.2k')).toBeInTheDocument()
+      expect(screen.getByText('~3')).toBeInTheDocument()
+      // 100+50 + 0 + 50 = 200 → "~0.2k"
+      expect(screen.getByText('~0.2k')).toBeInTheDocument()
     })
 
     it('aggregator scales to thousands of events without NaN', () => {
@@ -289,8 +305,8 @@ describe('JobStatusPanel', () => {
         expectedTokens += (inT ?? 0) + (outT ?? 0)
       }
       render(<JobStatusPanel job={runningJob} events={events} />)
-      expect(screen.getByText('1000')).toBeInTheDocument()
-      const expectedDisplay = `${(expectedTokens / 1000).toFixed(1)}k`
+      expect(screen.getByText('~1000')).toBeInTheDocument()
+      const expectedDisplay = `~${(expectedTokens / 1000).toFixed(1)}k`
       expect(screen.getByText(expectedDisplay)).toBeInTheDocument()
     })
 

--- a/client/src/components/__tests__/RichAttachmentEditor.test.tsx
+++ b/client/src/components/__tests__/RichAttachmentEditor.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '../../test-utils'
+import { RichAttachmentEditor } from '../RichAttachmentEditor'
+
+describe('RichAttachmentEditor — height bounds', () => {
+  it('caps the editor height and scrolls instead of growing without bound', () => {
+    // Regression: pasting a very large text grew the contenteditable off-screen
+    // with no vertical scroll because no maxHeight was set.
+    render(<RichAttachmentEditor ticketKey="t1" ariaLabel="Composer" />)
+    const box = screen.getByRole('textbox')
+    expect(box.style.overflow).toBe('auto')
+    expect(box.style.maxHeight).toBe('320px') // default cap
+    expect(box.style.minHeight).toBe('120px') // default floor
+  })
+
+  it('honours a custom maxHeight/minHeight', () => {
+    render(<RichAttachmentEditor ticketKey="t2" ariaLabel="Composer" minHeight={72} maxHeight={200} />)
+    const box = screen.getByRole('textbox')
+    expect(box.style.minHeight).toBe('72px')
+    expect(box.style.maxHeight).toBe('200px')
+    expect(box.style.overflow).toBe('auto')
+  })
+})

--- a/client/src/components/analytics/InvocationsTable.tsx
+++ b/client/src/components/analytics/InvocationsTable.tsx
@@ -122,7 +122,11 @@ export function InvocationsTable({
               {rows.map((r) => {
                 const surface = r.surface as Surface
                 const accent = SURFACE_ACCENT[surface]
-                const totalTokens = (r.tokens_in ?? 0) + (r.tokens_out ?? 0)
+                const totalTokens =
+                  (r.tokens_in ?? 0) +
+                  (r.tokens_out ?? 0) +
+                  (r.tokens_cache_read ?? 0) +
+                  (r.tokens_cache_create ?? 0)
                 const isContractLayer = isContractLayerInvocation(r)
                 const surfaceLabel = isContractLayer ? 'Contract Layer' : SURFACE_LABEL[surface]
                 const model = inferredModelFor(r, inferredModels)

--- a/client/src/components/analytics/SpendingHero.tsx
+++ b/client/src/components/analytics/SpendingHero.tsx
@@ -20,6 +20,12 @@ function fmtUsdLarge(v: number): string {
   return `$${v.toFixed(2)}`
 }
 
+function fmtTokens(v: number): string {
+  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`
+  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k`
+  return `${v}`
+}
+
 const SURFACES: Surface[] = ['job', 'explore-spec', 'quick-spec', 'ai-edit', 'smash']
 
 export function SpendingHero({ data, loading }: Props) {
@@ -54,6 +60,7 @@ export function SpendingHero({ data, loading }: Props) {
 
   const total = data.summary.totalCostUsd
   const totalRuns = data.summary.totalRuns
+  const totalTokens = data.summary.totalTokens ?? 0
   const totalEstimated = data.summary.totalEstimatedCostUsd ?? 0
   const delta = data.summary.deltaPct
   const trackingStartedAt = data.trackingStartedAt
@@ -88,6 +95,14 @@ export function SpendingHero({ data, loading }: Props) {
           </div>
           <div className="text-xs text-muted-foreground mt-1 tabular-nums flex items-center gap-2">
             <span>{totalRuns} invocation{totalRuns === 1 ? '' : 's'}</span>
+            {totalTokens > 0 && (
+              <span
+                className="text-muted-foreground/80"
+                title="Total tokens = fresh input + output + cache-read + cache-create across all invocations in this window."
+              >
+                · {fmtTokens(totalTokens)} tokens
+              </span>
+            )}
             {hasEstimatedCost && (
               <span
                 className="text-[10px] text-muted-foreground/70 italic"

--- a/client/src/pages/JobDetailPage.tsx
+++ b/client/src/pages/JobDetailPage.tsx
@@ -284,6 +284,8 @@ export default function JobDetailPage() {
     totalCostUsd: pipelineJobs.reduce((s, j) => s + (j.total_cost_usd ?? 0), 0),
     totalTokensIn: pipelineJobs.reduce((s, j) => s + (j.tokens_in ?? 0), 0),
     totalTokensOut: pipelineJobs.reduce((s, j) => s + (j.tokens_out ?? 0), 0),
+    totalTokensCacheRead: pipelineJobs.reduce((s, j) => s + (j.tokens_cache_read ?? 0), 0),
+    totalTokensCacheCreate: pipelineJobs.reduce((s, j) => s + (j.tokens_cache_create ?? 0), 0),
     jobCount: pipelineJobs.length,
   } : null
 

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -16,6 +16,9 @@ export interface JobSummary {
   status: JobStatus
   priority?: JobPriority
   total_cost_usd?: number | null
+  /** 1 when total_cost_usd is a pricing-table estimate (codex), 0/absent when
+   *  authoritative from the provider (claude). Drives the `~` cost badge. */
+  total_cost_usd_estimated?: number | null
   duration_ms?: number | null
   model?: string | null
   tokens_in?: number | null

--- a/client/src/types/spending.ts
+++ b/client/src/types/spending.ts
@@ -72,6 +72,9 @@ export interface SpendingResponse {
      *  fell back to `server/pricing.ts` (codex, today). Drives the
      *  "Includes estimated costs" Hero footnote. */
     totalEstimatedCostUsd: number
+    /** Real total tokens across matching rows = fresh input + output +
+     *  cache-read + cache-create (cache tiers dominate agentic Claude runs). */
+    totalTokens: number
     totalRuns: number
     failureRate: number
     prevTotalCostUsd: number

--- a/server/ai-invocations.test.ts
+++ b/server/ai-invocations.test.ts
@@ -97,10 +97,22 @@ describe('ai-invocations', () => {
     expect(summary.totalCostUsd).toBeCloseTo(3.5)
     expect(summary.totalTurns).toBe(9)
     expect(summary.activeDurationMs).toBe(3500)
+    // Each fixedInput defaults tokens_in:100 + tokens_out:50 = 150; ×3 = 450.
+    expect(summary.totalTokens).toBe(450)
     expect(summary.bySurface.job.count).toBe(2)
     expect(summary.bySurface.job.costUsd).toBeCloseTo(3.0)
     expect(summary.bySurface['explore-spec'].count).toBe(1)
     expect(summary.bySurface['quick-spec'].count).toBe(0)
+  })
+
+  it('totalTokens includes cache-read and cache-create tiers', () => {
+    recordInvocation(db, fixedInput({
+      id: 'c1', surface: 'job', ticket_id: 9,
+      tokens_in: 1000, tokens_out: 200, tokens_cache_read: 50_000, tokens_cache_create: 800,
+    }))
+    const summary = getTicketSpendingSummary(db, 9)
+    // 1000 + 200 + 50000 + 800 = 52000 (cache dominates)
+    expect(summary.totalTokens).toBe(52_000)
   })
 
   it('persists provider column from input', () => {

--- a/server/ai-invocations.ts
+++ b/server/ai-invocations.ts
@@ -128,13 +128,15 @@ export function getTicketSpendingSummary(
   ticketId: number
 ): {
   totalCostUsd: number
+  totalTokens: number
   totalTurns: number
   activeDurationMs: number
   bySurface: Record<Surface, { count: number; costUsd: number }>
   totalRuns: number
 } {
   const rows = db.prepare(
-    `SELECT surface, status, total_cost_usd, num_turns, duration_ms
+    `SELECT surface, status, total_cost_usd, num_turns, duration_ms,
+            tokens_in, tokens_out, tokens_cache_read, tokens_cache_create
      FROM ai_invocations WHERE ticket_id = ?`
   ).all(ticketId) as Array<{
     surface: Surface
@@ -142,6 +144,10 @@ export function getTicketSpendingSummary(
     total_cost_usd: number | null
     num_turns: number | null
     duration_ms: number | null
+    tokens_in: number | null
+    tokens_out: number | null
+    tokens_cache_read: number | null
+    tokens_cache_create: number | null
   }>
   const bySurface: Record<Surface, { count: number; costUsd: number }> = {
     job: { count: 0, costUsd: 0 },
@@ -152,16 +158,23 @@ export function getTicketSpendingSummary(
     'file-summary': { count: 0, costUsd: 0 },
   }
   let totalCostUsd = 0
+  let totalTokens = 0
   let totalTurns = 0
   let activeDurationMs = 0
   for (const r of rows) {
     bySurface[r.surface].count += 1
     bySurface[r.surface].costUsd += r.total_cost_usd ?? 0
     totalCostUsd += r.total_cost_usd ?? 0
+    // Real total tokens = fresh input + output + cache-read + cache-create.
+    totalTokens +=
+      (r.tokens_in ?? 0) +
+      (r.tokens_out ?? 0) +
+      (r.tokens_cache_read ?? 0) +
+      (r.tokens_cache_create ?? 0)
     totalTurns += r.num_turns ?? 0
     activeDurationMs += r.duration_ms ?? 0
   }
-  return { totalCostUsd, totalTurns, activeDurationMs, bySurface, totalRuns: rows.length }
+  return { totalCostUsd, totalTokens, totalTurns, activeDurationMs, bySurface, totalRuns: rows.length }
 }
 
 /**

--- a/server/db.test.ts
+++ b/server/db.test.ts
@@ -205,6 +205,23 @@ describe('db', () => {
       expect(row.duration_ms).toBe(5000)
       expect(row.duration_api_ms).toBe(4800)
       expect(row.session_id).toBe('sess-abc')
+      // Default: claude is authoritative → estimated flag is 0.
+      expect(row.total_cost_usd_estimated).toBe(0)
+    })
+
+    it('persists the estimated flag (1) for pricing-table costs (codex)', () => {
+      const db = makeDb()
+      const id = makeJobId('est')
+      createJob(db, { id, command: '/test', started_at: new Date().toISOString() })
+      finishJob(db, id, {
+        exit_code: 0,
+        status: 'completed',
+        total_cost_usd: 0.0152,
+        total_cost_usd_estimated: true,
+      })
+      const row = getJob(db, id)!
+      expect(row.total_cost_usd).toBeCloseTo(0.0152)
+      expect(row.total_cost_usd_estimated).toBe(1)
     })
   })
 

--- a/server/db.ts
+++ b/server/db.ts
@@ -37,6 +37,10 @@ export interface JobResult {
   tokens_cache_read?: number
   tokens_cache_create?: number
   total_cost_usd?: number
+  /** 1/true when total_cost_usd is a pricing-table estimate (codex) rather
+   *  than a provider-billed figure (claude). Persisted to
+   *  jobs.total_cost_usd_estimated so hub surfaces can badge it. */
+  total_cost_usd_estimated?: boolean
   num_turns?: number
   model?: string
   duration_ms?: number
@@ -557,6 +561,22 @@ const MIGRATIONS: Migration[] = [
       db.exec(`ALTER TABLE rails ADD COLUMN ai_engine TEXT;`)
     }
   },
+
+  // Migration 27: jobs.total_cost_usd_estimated — 1 when jobs.total_cost_usd
+  // came from server/pricing.ts (estimated fallback for non-native-cost
+  // providers like codex); 0 when authoritative from the provider's terminal
+  // event. Mirrors the ai_invocations column (migration 20) so the hub
+  // dashboard, budget enforcement, and webhook can distinguish a rate-card
+  // estimate from a provider-billed figure. Additive + idempotent.
+  (db) => {
+    const cols = (db.prepare(`PRAGMA table_info(jobs)`).all() as { name: string }[]).map((r) => r.name)
+    if (!cols.includes('total_cost_usd_estimated')) {
+      db.exec(`
+        ALTER TABLE jobs
+          ADD COLUMN total_cost_usd_estimated INTEGER NOT NULL DEFAULT 0;
+      `)
+    }
+  },
 ]
 
 function applyMigrations(db: DbInstance): void {
@@ -636,6 +656,7 @@ export function finishJob(
       tokens_cache_read   = ?,
       tokens_cache_create = ?,
       total_cost_usd      = ?,
+      total_cost_usd_estimated = ?,
       num_turns           = ?,
       model               = ?,
       duration_ms         = ?,
@@ -651,6 +672,7 @@ export function finishJob(
     result.tokens_cache_read ?? null,
     result.tokens_cache_create ?? null,
     result.total_cost_usd ?? null,
+    result.total_cost_usd_estimated ? 1 : 0,
     result.num_turns ?? null,
     result.model ?? null,
     result.duration_ms ?? null,

--- a/server/pricing.test.ts
+++ b/server/pricing.test.ts
@@ -33,18 +33,38 @@ describe('pricing.PRICING — table sanity', () => {
 })
 
 describe('estimateCostUsd', () => {
-  it('computes cost = (in*p_in + out*p_out + cache_read*p_cache) / 1M', () => {
+  it('bills cached tokens at cache rate only: ((in-cache)*p_in + out*p_out + cache*p_cache) / 1M', () => {
     // codex:gpt-5.4-mini → input 0.25, output 2.00, cache_read 0.025
     const cost = estimateCostUsd('codex', 'gpt-5.4-mini', {
-      tokens_in: 100_000,
+      tokens_in: 100_000,        // TOTAL prompt tokens (includes the cached subset)
       tokens_out: 50_000,
-      tokens_cache_read: 20_000,
+      tokens_cache_read: 20_000, // subset already inside tokens_in
     })
-    // 100000 * 0.25 / 1M = 0.025
-    // 50000  * 2.00 / 1M = 0.100
-    // 20000  * 0.025 / 1M = 0.0005
-    // Total ≈ 0.1255
-    expect(cost).toBeCloseTo(0.1255, 4)
+    // fresh input = 100000 - 20000 = 80000
+    // 80000 * 0.25  / 1M = 0.020
+    // 50000 * 2.00  / 1M = 0.100
+    // 20000 * 0.025 / 1M = 0.0005
+    // Total ≈ 0.1205  (NOT 0.1255 — the cached 20k is not charged at full input rate)
+    expect(cost).toBeCloseTo(0.1205, 4)
+  })
+
+  it('does not double-charge cached tokens (cache subset billed once, at the cache rate)', () => {
+    // All input is cached → input portion is 0; only the cache-read rate applies.
+    const cost = estimateCostUsd('codex', 'gpt-5.4-mini', {
+      tokens_in: 50_000,
+      tokens_cache_read: 50_000,
+    })
+    // fresh input = 0; cache = 50000 * 0.025 / 1M = 0.00125
+    expect(cost).toBeCloseTo(0.00125, 6)
+  })
+
+  it('clamps fresh input at 0 when reported cache subset exceeds the total (malformed payload)', () => {
+    const cost = estimateCostUsd('codex', 'gpt-5.4-mini', {
+      tokens_in: 10_000,
+      tokens_cache_read: 30_000, // larger than tokens_in — must not go negative
+    })
+    // fresh input = max(0, 10000-30000) = 0; cache = 30000 * 0.025 / 1M = 0.00075
+    expect(cost).toBeCloseTo(0.00075, 6)
   })
 
   it('returns 0 when usage is empty', () => {
@@ -93,11 +113,13 @@ describe('estimateCostUsd', () => {
     for (const [key, entry] of Object.entries(PRICING)) {
       const [providerId, model] = key.split(':')
       const cost = estimateCostUsd(providerId!, model!, {
-        tokens_in: 1_000_000,
+        tokens_in: 1_500_000,       // 1M fresh + 500k cached
         tokens_out: 1_000_000,
-        tokens_cache_read: 1_000_000,
+        tokens_cache_read: 500_000, // subset of tokens_in
       })
-      expect(cost).toBeCloseTo(entry.inputPer1M + entry.outputPer1M + entry.cacheReadPer1M, 6)
+      // fresh input = 1.5M - 0.5M = 1M → entry.inputPer1M; out = entry.outputPer1M;
+      // cache = 0.5M * cacheReadPer1M / 1M = 0.5 * cacheReadPer1M
+      expect(cost).toBeCloseTo(entry.inputPer1M + entry.outputPer1M + entry.cacheReadPer1M * 0.5, 6)
     }
   })
 })

--- a/server/pricing.ts
+++ b/server/pricing.ts
@@ -67,7 +67,15 @@ export function estimateCostUsd(
   if (!model) return null
   const entry = PRICING[`${providerId}:${model}`]
   if (!entry) return null
-  const inputCost     = (usage.tokens_in         ?? 0) * entry.inputPer1M     / 1_000_000
+  // `tokens_in` is the TOTAL prompt token count and `tokens_cache_read` is a
+  // SUBSET already inside it (OpenAI/codex usage semantics: input_tokens
+  // includes cached_input_tokens). Bill the cached portion at the cache rate
+  // ONLY, and the remaining fresh input at the full input rate. Charging the
+  // full input rate over the whole `tokens_in` AND a separate cache-read cost
+  // would double-charge every cached token. Clamp at 0 to guard a malformed
+  // payload where the reported cache subset exceeds the total.
+  const freshInput    = Math.max(0, (usage.tokens_in ?? 0) - (usage.tokens_cache_read ?? 0))
+  const inputCost     = freshInput                      * entry.inputPer1M     / 1_000_000
   const outputCost    = (usage.tokens_out        ?? 0) * entry.outputPer1M    / 1_000_000
   const cacheReadCost = (usage.tokens_cache_read ?? 0) * entry.cacheReadPer1M / 1_000_000
   return inputCost + outputCost + cacheReadCost

--- a/server/profiles-router.ts
+++ b/server/profiles-router.ts
@@ -175,7 +175,8 @@ export function createProfilesRouter(): Router {
              COUNT(*) AS jobs,
              SUM(CASE WHEN j.status = 'completed' THEN 1 ELSE 0 END) AS succeeded,
              AVG(j.duration_ms) AS avgDurationMs,
-             AVG(COALESCE(j.tokens_in, 0) + COALESCE(j.tokens_out, 0)) AS avgTokens,
+             AVG(COALESCE(j.tokens_in, 0) + COALESCE(j.tokens_out, 0)
+                 + COALESCE(j.tokens_cache_read, 0) + COALESCE(j.tokens_cache_create, 0)) AS avgTokens,
              AVG(j.total_cost_usd) AS avgCostUsd
            FROM job_profiles jp
            JOIN jobs j ON j.id = jp.job_id

--- a/server/project-router.ts
+++ b/server/project-router.ts
@@ -35,7 +35,8 @@ import {
   buildScopedSystemPromptPrefix, toolFlagsForScope, defaultBootScope,
   type ContextScope,
 } from './context-scope'
-import { normaliseResultEvent } from './result-event'
+import { finaliseInvocationResult } from './result-event'
+import type { AdapterEvent } from './providers/types'
 import { getSpending, getInvocations, parseSpendingFilters } from './spending'
 import { randomUUID } from 'crypto'
 import {
@@ -1968,10 +1969,18 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
 
     let buffer = ''
     let lastResultEvent: Record<string, unknown> | null = null
+    // Canonical adapter events feed finaliseInvocationResult on close, giving
+    // codex a real pricing-table cost estimate (+ estimated flag) and tokens,
+    // instead of the legacy hardcoded $0. Accumulated ALONGSIDE the existing
+    // buffer/delta plumbing below — never in place of it.
+    const adapterEvents: AdapterEvent[] = []
     const turnStartedAt = new Date().toISOString()
     const stdoutReader = createInterface({ input: child.stdout!, crlfDelay: Infinity })
 
     stdoutReader.on('line', (line) => {
+      const adapterEv = adapter.parseStreamLine(line)
+      if (adapterEv) adapterEvents.push(adapterEv)
+
       let parsed: Record<string, unknown> | null = null
       try { parsed = JSON.parse(line) } catch { /* skip */ }
       if (!parsed) return
@@ -2197,31 +2206,33 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
 
       // ai_invocations capture (surface='quick-spec'). Always emit a row, success or fail.
       try {
-        const cliProvider: 'claude' | 'codex' = provider === 'codex' ? 'codex' : 'claude'
-        const synthCodexResult = (cliProvider === 'codex' && code === 0)
-          ? {
-              type: 'result',
-              total_cost_usd: 0,
-              model: resolvedModel,
-              num_turns: 1,
-              duration_ms: Date.now() - new Date(turnStartedAt).getTime(),
-            }
-          : null
-        const eventForParse = lastResultEvent ?? synthCodexResult
-        const normalised = eventForParse
-          ? normaliseResultEvent(eventForParse as Record<string, unknown>, cliProvider)
-          : {}
+        // Adapter-driven finalisation: claude passes its native total_cost_usd
+        // through untouched; codex (nativeCostUsd:false) gets a pricing-table
+        // estimate from its captured token usage + estimated=true. This
+        // replaces the legacy normaliseResultEvent path that hardcoded codex
+        // cost to $0 and never set the estimated flag.
+        const { result: normalised, estimated } = finaliseInvocationResult(
+          adapter,
+          adapterEvents,
+          { fallbackModel: resolvedModel },
+        )
+        // extractCodexResult does not surface duration (codex stream carries
+        // none); stamp wall-clock so the row's duration isn't lost. Claude's
+        // result event already provides duration_ms, so prefer it.
+        const wallMs = Date.now() - new Date(turnStartedAt).getTime()
         recordInvocation(ctx(req).db, {
           id: randomUUID(),
           project_id: projectId,
-          provider: cliProvider,
+          provider: adapter.id,
           surface: 'quick-spec',
           surface_ref_id: requestId,
           ticket_id: createdTicketId,
           status: code === 0 && buffer.trim() ? 'success' : 'failed',
           started_at: turnStartedAt,
           finished_at: new Date().toISOString(),
+          total_cost_usd_estimated: estimated,
           ...normalised,
+          duration_ms: normalised.duration_ms ?? wallMs,
         })
         broadcast({ type: 'spending.invalidated', projectId })
       } catch (err) {

--- a/server/providers/codex-adapter.ts
+++ b/server/providers/codex-adapter.ts
@@ -162,12 +162,16 @@ function parseCodexStreamLine(line: string): AdapterEvent | null {
 function extractCodexResult(events: readonly AdapterEvent[]): NormalisedResult {
   let sessionId: string | undefined
   let resultPayload: Record<string, unknown> | null = null
+  let turnCount = 0
   // First text-delta timestamp is unavailable from events (we'd need wall-clock
   // tracking). duration_ms is left undefined and the manager-level wrapper
   // synthesises it from the spawn-close timestamps if it wants to populate.
   for (const ev of events) {
     if (ev.kind === 'session-started') sessionId = ev.sessionId
-    else if (ev.kind === 'result') resultPayload = ev.payload
+    else if (ev.kind === 'result') {
+      resultPayload = ev.payload
+      turnCount += 1 // each turn.completed is one codex turn
+    }
   }
 
   if (!resultPayload) {
@@ -188,7 +192,9 @@ function extractCodexResult(events: readonly AdapterEvent[]): NormalisedResult {
     // Codex has no separate "cache creation" tier — left undefined.
     tokens_cache_create: undefined,
     // total_cost_usd intentionally absent — estimated via pricing.ts.
-    num_turns: 1, // codex exec is single-turn; resume is also one turn
+    // Derive from the number of turn.completed events rather than hardcoding 1
+    // (a single `codex exec` normally emits exactly one, but don't assume it).
+    num_turns: turnCount || 1,
     // Model on stream events is not present; manager-level wrapper passes
     // the requested model in via the spawn args and stamps it on the row.
     model: undefined,

--- a/server/queue-manager.ts
+++ b/server/queue-manager.ts
@@ -1230,6 +1230,7 @@ export class QueueManager {
             tokens_cache_read: normalised.tokens_cache_read,
             tokens_cache_create: normalised.tokens_cache_create,
             total_cost_usd: normalised.total_cost_usd,
+            total_cost_usd_estimated: estimated,
             num_turns: normalised.num_turns,
             model: normalised.model,
             duration_ms: normalised.duration_ms,

--- a/server/result-event.test.ts
+++ b/server/result-event.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { normaliseResultEvent, finaliseInvocationResult } from './result-event'
 import './providers' // register claude+codex adapters
 import { getAdapter } from './providers/registry'
@@ -100,8 +100,9 @@ describe('finaliseInvocationResult (new adapter-aware API)', () => {
     })
     expect(estimated).toBe(true)
     // codex:gpt-5.4-mini → input 0.25, output 2.00, cache_read 0.025 per 1M
-    // cost = 1M*0.25 + 500K*2.00 + 200K*0.025 / 1M = 0.25 + 1.00 + 0.005 = 1.255
-    expect(result.total_cost_usd).toBeCloseTo(1.255, 5)
+    // input_tokens (1M) INCLUDES cached_input_tokens (200K), so fresh input = 800K.
+    // cost = 800K*0.25 + 500K*2.00 + 200K*0.025 / 1M = 0.20 + 1.00 + 0.005 = 1.205
+    expect(result.total_cost_usd).toBeCloseTo(1.205, 5)
     expect(result.model).toBe('gpt-5.4-mini')
     expect(result.tokens_in).toBe(1_000_000)
     expect(result.tokens_out).toBe(500_000)
@@ -128,6 +129,35 @@ describe('finaliseInvocationResult (new adapter-aware API)', () => {
     expect(result.total_cost_usd).toBeUndefined()
     expect(result.model).toBe('gpt-99-future-model')
     expect(result.tokens_in).toBe(100)
+  })
+
+  it('codex: warns once when a known model id has no pricing-table entry', () => {
+    const adapter = getAdapter('codex')
+    const events: AdapterEvent[] = [
+      { kind: 'result', payload: { type: 'turn.completed', usage: { input_tokens: 100, output_tokens: 50 } } },
+    ]
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      finaliseInvocationResult(adapter, events, { fallbackModel: 'gpt-99-future-model' })
+      expect(warn).toHaveBeenCalledTimes(1)
+      expect(warn.mock.calls[0][0]).toContain('codex:gpt-99-future-model')
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('codex: does NOT warn when no model could be resolved (different failure mode)', () => {
+    const adapter = getAdapter('codex')
+    const events: AdapterEvent[] = [
+      { kind: 'result', payload: { type: 'turn.completed', usage: { input_tokens: 100, output_tokens: 50 } } },
+    ]
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      finaliseInvocationResult(adapter, events) // no fallbackModel → model undefined
+      expect(warn).not.toHaveBeenCalled()
+    } finally {
+      warn.mockRestore()
+    }
   })
 
   it('codex: no estimation when no fallbackModel and adapter cannot derive', () => {

--- a/server/result-event.ts
+++ b/server/result-event.ts
@@ -72,6 +72,16 @@ export function finaliseInvocationResult(
     if (computed !== null) {
       cloned.total_cost_usd = computed
       estimated = true
+    } else if (cloned.model) {
+      // Non-native-cost provider with a known model id but no pricing-table
+      // entry → cost is persisted NULL and silently vanishes from totals.
+      // Surface it so a new/renamed/drifted model id is caught fast (the fix
+      // is to add the rate to server/pricing.ts, per its quarterly-review
+      // contract). We deliberately do NOT fabricate a fallback rate.
+      console.warn(
+        `[pricing] no rate-card entry for "${adapter.id}:${cloned.model}" — ` +
+          `cost will be persisted NULL. Add it to server/pricing.ts PRICING.`,
+      )
     }
   }
 

--- a/server/spending.test.ts
+++ b/server/spending.test.ts
@@ -46,6 +46,17 @@ describe('getSpending', () => {
     expect(r.summary.avgCostPerRun).toBeCloseTo(2.0)
   })
 
+  it('summary.totalTokens sums all four token tiers across rows', () => {
+    const now = new Date().toISOString()
+    seed(db, [
+      { id: 'a', surface: 'job', tokens_in: 1000, tokens_out: 200, tokens_cache_read: 40_000, tokens_cache_create: 500, started_at: now },
+      { id: 'b', surface: 'explore-spec', tokens_in: 300, tokens_out: 100, started_at: now },
+    ])
+    const r = getSpending(db, 'p1', { period: 'all' })
+    // (1000+200+40000+500) + (300+100) = 41700 + 400 = 42100
+    expect(r.summary.totalTokens).toBe(42_100)
+  })
+
   it('filters by surface', () => {
     seed(db, [
       { id: 'a', surface: 'job', total_cost_usd: 5, started_at: new Date().toISOString() },

--- a/server/spending.ts
+++ b/server/spending.ts
@@ -78,6 +78,10 @@ export interface SpendingResponse {
      *  `total_cost_usd_estimated === 1` (currently codex). Drives the
      *  "Includes estimated costs" footnote in the AnalyticsPage Hero. */
     totalEstimatedCostUsd: number
+    /** Real total tokens across all matching rows = fresh input + output +
+     *  cache-read + cache-create. Cache tiers (esp. cache_read) dominate
+     *  agentic Claude runs, so this is far larger than input+output alone. */
+    totalTokens: number
     totalRuns: number
     failureRate: number
     prevTotalCostUsd: number
@@ -231,6 +235,8 @@ export function getSpending(
     SELECT
       COALESCE(SUM(total_cost_usd), 0) AS totalCost,
       COALESCE(SUM(CASE WHEN total_cost_usd_estimated = 1 THEN total_cost_usd ELSE 0 END), 0) AS totalEstimatedCost,
+      COALESCE(SUM(COALESCE(tokens_in, 0) + COALESCE(tokens_out, 0)
+                   + COALESCE(tokens_cache_read, 0) + COALESCE(tokens_cache_create, 0)), 0) AS totalTokens,
       COUNT(*) AS totalRuns,
       SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failed,
       AVG(CASE WHEN status = 'success' THEN total_cost_usd END) AS avgCost
@@ -238,6 +244,7 @@ export function getSpending(
   `).get(...where.params) as {
     totalCost: number
     totalEstimatedCost: number
+    totalTokens: number
     totalRuns: number
     failed: number | null
     avgCost: number | null
@@ -440,6 +447,7 @@ export function getSpending(
     summary: {
       totalCostUsd: summaryRow.totalCost,
       totalEstimatedCostUsd: summaryRow.totalEstimatedCost,
+      totalTokens: summaryRow.totalTokens,
       totalRuns: summaryRow.totalRuns,
       failureRate: summaryRow.totalRuns > 0 ? (summaryRow.failed ?? 0) / summaryRow.totalRuns : 0,
       prevTotalCostUsd: prevRow.totalCost,

--- a/server/types.ts
+++ b/server/types.ts
@@ -60,6 +60,9 @@ export interface JobRow {
   tokens_cache_read: number | null
   tokens_cache_create: number | null
   total_cost_usd: number | null
+  /** 1 when total_cost_usd is a pricing-table estimate (codex), 0 when
+   *  authoritative from the provider (claude). Added in migration 27. */
+  total_cost_usd_estimated?: number | null
   num_turns: number | null
   model: string | null
   duration_ms: number | null


### PR DESCRIPTION
## Summary

Three related changes from an audit of how per-job **token totals** and **USD cost** are computed across Claude and Codex. The headline is the cost-accuracy fix; a small Explore UI bug and a README refresh ride along.

### 💰 Cost & token accuracy (`fix`)
- **Codex cached-token double-charge fixed** (`server/pricing.ts`). OpenAI's `input_tokens` already includes `cached_input_tokens`, so the cached portion was billed at the **full input rate AND again** at the cache rate. Now fresh input = `max(0, tokens_in - tokens_cache_read)` at the input rate; cached tokens only at the cache rate. One change fixes both mapping sites (adapter + legacy path).
- **Codex quick-spec no longer records `$0`** (`server/project-router.ts`). `generate-spec` migrated off the legacy `normaliseResultEvent` path (which hardcoded `total_cost_usd: 0`) to `finaliseInvocationResult`, so the rate-card estimate + `estimated` flag are recorded — keeping the buffer/delta stream, codex duration, and `error_max_turns` salvage intact.
- **Token totals now include cache tiers** (`in + out + cache_read + cache_create`) everywhere they're shown or aggregated: Job Detail, pipeline totals, Recent Jobs, analytics table + Hero, per-profile avg, ticket summary, and a new spending total. Cache reads dominate agentic Claude runs, so the figure now reconciles with cost instead of understating by ~10×.
- **`jobs.total_cost_usd_estimated`** (migration 27, additive) so the hub distinguishes a codex rate-card estimate from a provider-billed figure; Job Detail badges estimated cost with `~`. Budgets still enforce on the combined total.
- **Unknown-model warning** in `finaliseInvocationResult` when a non-native-cost model id has no pricing entry (silent NULL-cost drift is now visible) — no fabricated fallback rate.
- **Codex `num_turns`** derived from the `turn.completed` count instead of hardcoded `1`.
- **Live tokens/turns** marked approximate (`~`) until authoritative server values arrive, so the number no longer jumps unexplained at job exit.

> Claude's native `total_cost_usd` is untouched — it remains the source of truth.

### 🧰 Explore composer (`fix`)
- The chat composer grew without bound on a large paste (no `maxHeight`). Added a `maxHeight` prop (default 320px) to the shared `RichAttachmentEditor` → the box now caps and scrolls. AI Edit and Propose Spec inherit the fix.

### 📖 README (`docs`)
- Rewritten from the actual source: hero + badges, feature tour with icons, Claude-vs-Codex capability table, architecture overview, verified docs links.

## Known limitations (out of scope, intentionally deferred)
- **Claude subagent token scope** and **codex multi-turn token summation** can't be settled from the repo — they need real multi-turn captures saved as fixtures before changing extraction (switching to `SUM` blindly would over-count if usage is cumulative). Cost is already correct; tokens are now cache-inclusive, the safe improvement.
- A full end-to-end integration test of the `generate-spec` close handler is not reliable in the current mock-child + readline + supertest harness (existing tests of that route only cover validation). The migration's behaviour is covered at the unit level in `result-event.test.ts`.

## Testing
- ✅ `npm run typecheck`
- ✅ `npm test` — server 2570 + client 2351 passing
- ✅ Server coverage gate (82.2% stmt / 72.6% br / 87% fn / 83.8% lines)
- ✅ Client coverage gate (80.8% stmt/lines / 72% fn)

> Note: `client/src/demo-mode/demo-api.ts` and `client/dist-demo/` appeared in the working tree during this session but are unrelated to this work, so they were **not** included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)