### PR TITLE
feat(mobile): Mobile Gateway with QR pairing and device management

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -38,6 +38,7 @@
         "highlight.js": "^11.11.1",
         "lucide-react": "^0.577.0",
         "monaco-editor": "^0.55.1",
+        "qrcode.react": "^4.2.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-markdown": "^10.1.0",
@@ -6136,6 +6137,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react": {

--- a/client/package.json
+++ b/client/package.json
@@ -43,6 +43,7 @@
     "highlight.js": "^11.11.1",
     "lucide-react": "^0.577.0",
     "monaco-editor": "^0.55.1",
+    "qrcode.react": "^4.2.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-markdown": "^10.1.0",

--- a/client/src/components/settings/MobileAccessSection.tsx
+++ b/client/src/components/settings/MobileAccessSection.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useState, useCallback } from 'react'
+import { toast } from 'sonner'
+import { Smartphone, ShieldCheck, Trash2 } from 'lucide-react'
+import { Button } from '../ui/button'
+import { PairDeviceModal } from './PairDeviceModal'
+
+interface MobileStatus {
+  enabled: boolean
+  running: boolean
+  port: number
+  certFingerprint: string | null
+  lanAddresses: string[]
+  mdnsEnabled: boolean
+  hubName: string
+}
+
+interface MobileDevice {
+  id: string
+  name: string
+  platform: 'ios' | 'android'
+  createdAt: string
+  lastSeenAt: string | null
+  revoked: boolean
+}
+
+const isWindows = typeof navigator !== 'undefined' && /Win/i.test(navigator.platform)
+
+function shortFp(fp: string | null): string {
+  if (!fp || fp.length < 16) return fp ?? '—'
+  return `${fp.slice(0, 8)}…${fp.slice(-8)}`
+}
+
+/** Hub-wide "Mobile companion" settings: enable the gateway, pair/revoke devices,
+ *  rotate the cert identity. Loopback + auth enforced server-side. */
+export function MobileAccessSection() {
+  const [status, setStatus] = useState<MobileStatus | null>(null)
+  const [devices, setDevices] = useState<MobileDevice[]>([])
+  const [busy, setBusy] = useState(false)
+  const [pairOpen, setPairOpen] = useState(false)
+
+  const loadStatus = useCallback(async () => {
+    try {
+      const r = await fetch('/api/hub/mobile/status')
+      if (r.ok) setStatus((await r.json()) as MobileStatus)
+    } catch { /* ignore */ }
+  }, [])
+
+  const loadDevices = useCallback(async () => {
+    try {
+      const r = await fetch('/api/hub/mobile/devices')
+      if (r.ok) setDevices(((await r.json()) as { devices: MobileDevice[] }).devices)
+    } catch { /* ignore */ }
+  }, [])
+
+  useEffect(() => {
+    void loadStatus()
+    void loadDevices()
+  }, [loadStatus, loadDevices])
+
+  async function toggleEnabled(): Promise<void> {
+    if (!status) return
+    setBusy(true)
+    try {
+      const path = status.enabled ? 'disable' : 'enable'
+      const r = await fetch(`/api/hub/mobile/${path}`, { method: 'POST' })
+      if (!r.ok) {
+        const body = (await r.json().catch(() => ({}))) as { error?: string }
+        throw new Error(body.error ?? `HTTP ${r.status}`)
+      }
+      setStatus((await r.json()) as MobileStatus)
+    } catch (e) {
+      toast.error(`Could not ${status.enabled ? 'disable' : 'enable'} mobile access: ${(e as Error).message}`)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function revoke(id: string): Promise<void> {
+    await fetch(`/api/hub/mobile/devices/${id}`, { method: 'DELETE' }).catch(() => {})
+    void loadDevices()
+  }
+
+  async function resetIdentity(): Promise<void> {
+    if (!window.confirm('Reset the mobile identity? Every paired device will be revoked and must pair again.')) return
+    setBusy(true)
+    try {
+      const r = await fetch('/api/hub/mobile/cert/rotate', { method: 'POST' })
+      if (r.ok) setStatus((await r.json()) as MobileStatus)
+      void loadDevices()
+      toast.success('Mobile identity reset')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (!status) return <div className="h-20 bg-muted/30 rounded-lg animate-pulse" />
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider flex items-center gap-2">
+        <Smartphone className="h-3.5 w-3.5" /> Mobile companion
+      </h3>
+      <p className="text-sm text-muted-foreground">
+        Control this hub from the SpecRails Companion app on your phone, 100% over your local network. Off by default.
+      </p>
+
+      <div className="flex items-center justify-between rounded-lg border border-border p-3">
+        <div>
+          <div className="text-sm font-medium">{status.enabled ? 'Mobile access on' : 'Mobile access off'}</div>
+          <div className="text-xs text-muted-foreground">
+            {status.running ? `Listening on port ${status.port}` : 'Not listening'}
+          </div>
+        </div>
+        <Button variant={status.enabled ? 'outline' : 'default'} disabled={busy} onClick={toggleEnabled}>
+          {status.enabled ? 'Turn off' : 'Turn on'}
+        </Button>
+      </div>
+
+      {status.enabled && status.running && (
+        <>
+          <div className="flex items-center justify-between">
+            <Button onClick={() => setPairOpen(true)} className="gap-2">
+              <Smartphone className="h-4 w-4" /> Pair device
+            </Button>
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <ShieldCheck className="h-3.5 w-3.5 text-accent-success" />
+              <span title={status.certFingerprint ?? ''}>{shortFp(status.certFingerprint)}</span>
+              <button type="button" className="underline" onClick={resetIdentity} disabled={busy}>Reset</button>
+            </div>
+          </div>
+
+          {isWindows && (
+            <p className="text-xs text-accent-warning">
+              Windows Firewall will ask to allow the SpecRails server on first enable — choose “Allow on private networks”.
+            </p>
+          )}
+
+          <div className="space-y-1">
+            <div className="text-xs font-semibold text-muted-foreground">Paired devices</div>
+            {devices.filter((d) => !d.revoked).length === 0 ? (
+              <div className="text-xs text-muted-foreground">No devices paired yet.</div>
+            ) : (
+              devices.filter((d) => !d.revoked).map((d) => (
+                <div key={d.id} className="flex items-center justify-between rounded-md bg-muted/30 px-3 py-2">
+                  <div className="text-sm">
+                    {d.name} <span className="text-xs text-muted-foreground">· {d.platform}</span>
+                  </div>
+                  <button
+                    type="button"
+                    aria-label={`Revoke ${d.name}`}
+                    className="text-muted-foreground hover:text-destructive"
+                    onClick={() => revoke(d.id)}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </div>
+              ))
+            )}
+          </div>
+        </>
+      )}
+
+      <PairDeviceModal open={pairOpen} onClose={() => setPairOpen(false)} onPaired={loadDevices} />
+    </div>
+  )
+}

--- a/client/src/components/settings/PairDeviceModal.tsx
+++ b/client/src/components/settings/PairDeviceModal.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useRef, useState, useCallback } from 'react'
+import { QRCodeSVG } from 'qrcode.react'
+import { toast } from 'sonner'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '../ui/dialog'
+import { Button } from '../ui/button'
+
+interface QrPayload {
+  v: number
+  hub: string
+  name: string
+  addrs: string[]
+  port: number
+  fp: string
+  secret: string
+  claimId: string
+  exp: number
+}
+
+interface PairState {
+  status: 'pending' | 'claimed' | 'approved' | 'denied' | 'expired' | 'none'
+  device?: { name: string; platform: 'ios' | 'android' }
+}
+
+function base64url(input: string): string {
+  return btoa(unescape(encodeURIComponent(input)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+}
+
+/** Renders the pairing QR + live claim/approve flow. Polls the loopback admin
+ *  API (no WS needed for a short-lived modal). */
+export function PairDeviceModal({ open, onClose, onPaired }: { open: boolean; onClose: () => void; onPaired: () => void }) {
+  const [qr, setQr] = useState<QrPayload | null>(null)
+  const [state, setState] = useState<PairState>({ status: 'none' })
+  const [error, setError] = useState<string | null>(null)
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current)
+      pollRef.current = null
+    }
+  }, [])
+
+  const close = useCallback(() => {
+    stopPolling()
+    void fetch('/api/hub/mobile/pairing-session', { method: 'DELETE' }).catch(() => {})
+    setQr(null)
+    setState({ status: 'none' })
+    setError(null)
+    onClose()
+  }, [onClose, stopPolling])
+
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    setError(null)
+    fetch('/api/hub/mobile/pairing-session', { method: 'POST' })
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+      .then((data: { qr: QrPayload }) => {
+        if (cancelled) return
+        setQr(data.qr)
+        setState({ status: 'pending' })
+        pollRef.current = setInterval(async () => {
+          try {
+            const res = await fetch('/api/hub/mobile/pairing-session')
+            if (!res.ok) return
+            const s = (await res.json()) as PairState
+            setState(s)
+            if (s.status === 'expired' || s.status === 'denied') stopPolling()
+          } catch {
+            /* transient */
+          }
+        }, 2000)
+      })
+      .catch((e) => { if (!cancelled) setError((e as Error).message) })
+    return () => {
+      cancelled = true
+      stopPolling()
+    }
+  }, [open, stopPolling])
+
+  async function approve(): Promise<void> {
+    try {
+      const res = await fetch('/api/hub/mobile/pairing-session/approve', { method: 'POST' })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      setState({ status: 'approved' })
+      stopPolling()
+      toast.success('Device paired')
+      onPaired()
+      setTimeout(close, 1200)
+    } catch (e) {
+      toast.error(`Approve failed: ${(e as Error).message}`)
+    }
+  }
+
+  async function deny(): Promise<void> {
+    await fetch('/api/hub/mobile/pairing-session/deny', { method: 'POST' }).catch(() => {})
+    close()
+  }
+
+  const deepLink = qr ? `specrails://pair?d=${base64url(JSON.stringify(qr))}` : ''
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) close() }}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Pair a device</DialogTitle>
+          <DialogDescription>
+            Open SpecRails Companion on your phone and scan this code. It only works while this dialog is open.
+          </DialogDescription>
+        </DialogHeader>
+
+        {error && <p className="text-sm text-destructive">Could not start pairing: {error}</p>}
+
+        {state.status === 'claimed' && state.device ? (
+          <div className="flex flex-col items-center gap-4 py-4">
+            <p className="text-sm text-center">
+              <span className="font-semibold">{state.device.name}</span> ({state.device.platform}) wants to pair.
+            </p>
+            <div className="flex gap-3">
+              <Button variant="outline" onClick={deny}>Deny</Button>
+              <Button onClick={approve}>Approve</Button>
+            </div>
+          </div>
+        ) : state.status === 'approved' ? (
+          <p className="py-6 text-center text-accent-success font-medium">✓ Paired</p>
+        ) : qr ? (
+          <div className="flex flex-col items-center gap-3 py-2">
+            <div className="bg-white p-3 rounded-lg">
+              <QRCodeSVG value={deepLink} size={220} />
+            </div>
+            <p className="text-xs text-muted-foreground text-center">
+              Waiting for a device… (on {qr.addrs[0] ?? 'this hub'}:{qr.port})
+            </p>
+            <button
+              type="button"
+              className="text-xs text-accent-info underline"
+              onClick={() => { void navigator.clipboard?.writeText(deepLink); toast.success('Pairing code copied') }}
+            >
+              Copy code (for "Enter manually")
+            </button>
+          </div>
+        ) : (
+          <div className="h-56 bg-muted/30 rounded-lg animate-pulse" />
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/client/src/components/settings/__tests__/MobileAccessSection.test.tsx
+++ b/client/src/components/settings/__tests__/MobileAccessSection.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+
+import { MobileAccessSection } from '../MobileAccessSection'
+
+interface Handler { match: (u: string, m: string) => boolean; ok?: boolean; status?: number; body?: unknown }
+
+function mockApi(handlers: Handler[]) {
+  global.fetch = vi.fn(async (url: unknown, opts?: { method?: string }) => {
+    const u = String(url)
+    const m = (opts?.method ?? 'GET').toUpperCase()
+    const h = handlers.find((x) => x.match(u, m))
+    return {
+      ok: h?.ok ?? true,
+      status: h?.status ?? 200,
+      json: async () => h?.body ?? {},
+    } as Response
+  }) as never
+}
+
+const OFF = { enabled: false, running: false, port: 4202, certFingerprint: null, lanAddresses: [], mdnsEnabled: true, hubName: 'Mac' }
+const ON = { enabled: true, running: true, port: 4202, certFingerprint: 'a'.repeat(64), lanAddresses: ['192.168.1.5'], mdnsEnabled: true, hubName: 'Mac' }
+
+beforeEach(() => { vi.clearAllMocks() })
+
+describe('MobileAccessSection', () => {
+  it('renders the off state with a Turn on button', async () => {
+    mockApi([
+      { match: (u) => u.endsWith('/status'), body: OFF },
+      { match: (u) => u.endsWith('/devices'), body: { devices: [] } },
+    ])
+    render(<MobileAccessSection />)
+    await screen.findByText('Mobile companion')
+    expect(screen.getByText('Mobile access off')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Turn on' })).toBeInTheDocument()
+  })
+
+  it('enabling reveals Pair device + fingerprint', async () => {
+    mockApi([
+      { match: (u, m) => u.endsWith('/status') && m === 'GET', body: OFF },
+      { match: (u) => u.endsWith('/devices'), body: { devices: [] } },
+      { match: (u, m) => u.endsWith('/enable') && m === 'POST', body: ON },
+    ])
+    render(<MobileAccessSection />)
+    const turnOn = await screen.findByRole('button', { name: 'Turn on' })
+    fireEvent.click(turnOn)
+    await screen.findByRole('button', { name: /Pair device/ })
+    expect(screen.getByText(/aaaaaaaa…aaaaaaaa/)).toBeInTheDocument()
+  })
+
+  it('lists paired devices and calls DELETE on revoke', async () => {
+    const devices = [{ id: 'd1', name: 'iPhone', platform: 'ios', createdAt: '', lastSeenAt: null, revoked: false }]
+    mockApi([
+      { match: (u) => u.endsWith('/status'), body: ON },
+      { match: (u, m) => u.endsWith('/devices') && m === 'GET', body: { devices } },
+      { match: (u, m) => u.includes('/devices/d1') && m === 'DELETE', body: { ok: true } },
+    ])
+    render(<MobileAccessSection />)
+    await screen.findByText('iPhone')
+    fireEvent.click(screen.getByRole('button', { name: 'Revoke iPhone' }))
+    await waitFor(() => {
+      const calls = (global.fetch as unknown as { mock: { calls: unknown[][] } }).mock.calls
+      const del = calls.find((c) => String(c[0]).includes('/devices/d1') && (c[1] as { method?: string })?.method === 'DELETE')
+      expect(del).toBeTruthy()
+    })
+  })
+
+  it('reset identity rotates the cert after confirm', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const ROT = { ...ON, certFingerprint: 'b'.repeat(64) }
+    mockApi([
+      { match: (u) => u.endsWith('/status'), body: ON },
+      { match: (u) => u.endsWith('/devices'), body: { devices: [] } },
+      { match: (u, m) => u.endsWith('/cert/rotate') && m === 'POST', body: ROT },
+    ])
+    render(<MobileAccessSection />)
+    const reset = await screen.findByRole('button', { name: 'Reset' })
+    fireEvent.click(reset)
+    await waitFor(() => expect(screen.getByText(/bbbbbbbb…bbbbbbbb/)).toBeInTheDocument())
+    confirmSpy.mockRestore()
+  })
+})

--- a/client/src/components/settings/__tests__/PairDeviceModal.test.tsx
+++ b/client/src/components/settings/__tests__/PairDeviceModal.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+
+import { PairDeviceModal } from '../PairDeviceModal'
+
+const QR = {
+  v: 1, hub: 'h', name: 'Mac', addrs: ['192.168.1.5'], port: 4202,
+  fp: 'a'.repeat(64), secret: 'sec', claimId: 'cid', exp: 9999999999,
+}
+
+interface Handler { match: (u: string, m: string) => boolean; ok?: boolean; body?: unknown }
+function mockApi(handlers: Handler[]) {
+  global.fetch = vi.fn(async (url: unknown, opts?: { method?: string }) => {
+    const u = String(url); const m = (opts?.method ?? 'GET').toUpperCase()
+    const h = handlers.find((x) => x.match(u, m))
+    return { ok: h?.ok ?? true, status: 200, json: async () => h?.body ?? {} } as Response
+  }) as never
+}
+
+beforeEach(() => { vi.clearAllMocks() })
+afterEach(() => { vi.useRealTimers() })
+
+describe('PairDeviceModal', () => {
+  it('renders nothing when closed (no pairing session created)', () => {
+    mockApi([])
+    render(<PairDeviceModal open={false} onClose={() => {}} onPaired={() => {}} />)
+    expect(screen.queryByText('Pair a device')).not.toBeInTheDocument()
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('creates a session and renders the QR + copy affordance', async () => {
+    mockApi([
+      { match: (u, m) => u.endsWith('/pairing-session') && m === 'POST', body: { qr: QR } },
+      { match: (u, m) => u.endsWith('/pairing-session') && m === 'GET', body: { status: 'pending' } },
+    ])
+    render(<PairDeviceModal open onClose={() => {}} onPaired={() => {}} />)
+    await screen.findByText('Pair a device')
+    await screen.findByText(/Waiting for a device/)
+    expect(screen.getByText(/Copy code/)).toBeInTheDocument()
+  })
+
+  it('shows Approve/Deny when the poll reports a claim, and approves', async () => {
+    const onPaired = vi.fn()
+    mockApi([
+      { match: (u, m) => u.endsWith('/pairing-session') && m === 'POST', body: { qr: QR } },
+      { match: (u, m) => u.endsWith('/pairing-session/approve') && m === 'POST', body: { ok: true } },
+      { match: (u, m) => u.endsWith('/pairing-session') && m === 'GET', body: { status: 'claimed', device: { name: 'iPhone', platform: 'ios' } } },
+    ])
+    render(<PairDeviceModal open onClose={() => {}} onPaired={onPaired} />)
+    // The 2s real-timer poll surfaces the claim → Approve/Deny appear.
+    await screen.findByText(/wants to pair/, {}, { timeout: 4000 })
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
+    await waitFor(() => expect(onPaired).toHaveBeenCalled())
+  }, 8000)
+})

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -193,6 +193,40 @@ export default function DashboardPage() {
     return () => { cancelled = true }
   }, [activeProjectId, connectionStatus])
 
+  // ── Adopt server-side rail names on load/switch (desktop ⇄ mobile sync) ──────
+  // Names only — never ticketIds — so a fresh load can't clobber locally-dragged
+  // assignments. A null server name leaves the local label untouched (so an
+  // existing desktop-only custom label survives until explicitly renamed).
+  useEffect(() => {
+    if (!activeProjectId) return
+    let cancelled = false
+    fetch(`${getApiBase()}/rails`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: { rails?: { railIndex: number; name?: string | null }[] } | null) => {
+        if (cancelled || !data?.rails) return
+        const nameByIndex = new Map<number, string | null>()
+        for (const r of data.rails) nameByIndex.set(r.railIndex, r.name ?? null)
+        setRails((prev) => {
+          let changed = false
+          const next = prev.map((r) => {
+            const n = parseInt(r.id.replace('rail-', ''), 10)
+            if (n < 1 || n > 3) return r
+            const name = nameByIndex.get(n - 1) ?? null
+            if (!name) return r
+            const label = `Rail ${name}`
+            if (label === r.label) return r
+            changed = true
+            return { ...r, label }
+          })
+          if (!changed) return prev
+          saveRails(activeProjectId, next)
+          return next
+        })
+      })
+      .catch(() => {})
+    return () => { cancelled = true }
+  }, [activeProjectId])
+
   // ── Auto-remove done tickets from rails ──────────────────────────────────────
   // When ticket status changes to 'done' (via WS ticket_updated, re-fetch, etc.),
   // strip those tickets from rails so they appear in Done Specs instead.
@@ -268,6 +302,17 @@ export default function DashboardPage() {
 
   const handleRenameRail = useCallback((railId: string, newLabel: string) => {
     updateRails((prev) => prev.map((r) => (r.id === railId ? { ...r, label: `Rail ${newLabel}` } : r)))
+    // Sync the name to the server so the mobile companion (and any other
+    // desktop client) reflects it live via rail.updated. Only the canonical
+    // rails 0..2 exist server-side; locally-added rails (rail-4+) are skipped.
+    const n = parseInt(railId.replace('rail-', ''), 10)
+    if (n >= 1 && n <= 3) {
+      fetch(`${getApiBase()}/rails/${n - 1}/name`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: newLabel }),
+      }).catch(() => { /* best-effort; localStorage already holds the label */ })
+    }
   }, [updateRails])
 
 
@@ -276,8 +321,29 @@ export default function DashboardPage() {
   useEffect(() => { activeProjectIdRef.current = activeProjectId }, [activeProjectId])
 
   const handleRailWsMessage = useCallback((msg: unknown) => {
-    const m = msg as { type?: string; projectId?: string; railIndex?: number; status?: string; ticketIds?: number[] }
+    const m = msg as {
+      type?: string; projectId?: string; railIndex?: number; status?: string
+      ticketIds?: number[]; changed?: 'tickets' | 'name' | 'profile' | 'engine'; name?: string | null
+    }
     if (m.projectId !== activeProjectIdRef.current) return
+
+    // A rail's config changed elsewhere (mobile companion / another desktop).
+    // Adopt the name on every variant; adopt ticketIds ONLY on a tickets-change
+    // so a remote rename never wipes this client's locally-dragged assignments.
+    if (m.type === 'rail.updated') {
+      const idx = m.railIndex ?? 0
+      const railId = `rail-${idx + 1}`
+      const serverTicketIds = m.ticketIds ?? []
+      const label = m.name ? `Rail ${m.name}` : `Rail ${idx + 1}`
+      updateRails((prev) => prev.map((r) => {
+        if (r.id !== railId) return r
+        // A running rail keeps its launched ticket set; still adopt the name.
+        if (m.changed !== 'tickets' || r.status === 'running') return { ...r, label }
+        return { ...r, label, ticketIds: serverTicketIds }
+      }))
+      return
+    }
+
     if (m.type === 'rail.job_completed') {
       const targetIndex = m.railIndex ?? 0
       // Strip this job's tickets from the rail on every terminal outcome so they

--- a/client/src/pages/GlobalSettingsPage.tsx
+++ b/client/src/pages/GlobalSettingsPage.tsx
@@ -3,6 +3,7 @@ import { toast } from 'sonner'
 import { TerminalSettingsSection } from '../components/settings/TerminalSettingsSection'
 import { AppearanceSection } from '../components/settings/AppearanceSection'
 import { CodeSectionSettings } from '../components/settings/CodeSectionSettings'
+import { MobileAccessSection } from '../components/settings/MobileAccessSection'
 import { Settings, Trash2, Zap, Plus, Bell, GraduationCap } from 'lucide-react'
 import { Button } from '../components/ui/button'
 import { Input } from '../components/ui/input'
@@ -330,6 +331,8 @@ export default function SettingsDialog({ open, onClose, onOpenOnboarding }: Sett
             <AppearanceSection />
 
             <CodeSectionSettings />
+
+            <MobileAccessSection />
 
             {/* Projects section */}
             <div className="space-y-2">

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.65.2",
       "license": "MIT",
       "dependencies": {
+        "@homebridge/ciao": "^1.3.9",
         "@tailwindcss/typography": "^0.5.19",
         "ajv": "^8.17.1",
         "better-sqlite3": "^12.8.0",
@@ -21,6 +22,7 @@
         "pdf-parse": "^2.4.5",
         "playwright": "^1.60.0",
         "read-excel-file": "^9.0.6",
+        "selfsigned": "^5.5.0",
         "tree-kill": "^1.2.2",
         "ws": "^8.16.0"
       },
@@ -587,6 +589,21 @@
         "node": ">=18"
       }
     },
+    "node_modules/@homebridge/ciao": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.9.tgz",
+      "integrity": "sha512-TMy9zy173jDOpnFXDqL3BPIQn5lfcAkSsivYQatCCakoHk4fLGd7QjfAaNGYE3Ox+/ZI6Lq0e1gGcz1qdw/IbA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "fast-deep-equal": "^3.1.3",
+        "source-map-support": "^0.5.21",
+        "tslib": "^2.8.1"
+      },
+      "bin": {
+        "ciao-bcs": "lib/bonjour-conformance-testing.js"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -864,6 +881,163 @@
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.7.0.tgz",
+      "integrity": "sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.7.0.tgz",
+      "integrity": "sha512-VVsAyGqErT9D1SY4aEqozThXMVI+ssVRiv2DDeYuvpBKLIgZ3hYs3Ay3u/VSoKq6ESFi9cf6rf3IOOzfwh7oMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.7.0.tgz",
+      "integrity": "sha512-n7KEs/Q/wrB415cxy4fHOBhegp4NdJ15fkJPwcB/3/8iNBQC2L/N7SChJPKDJPZGYH0jD4Tg4/0vnHmwghnbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.7.0.tgz",
+      "integrity": "sha512-V/nrlQVmhg7lYAsM7E13UDL5erAwFv6kCIVFqNaMIHSVi7dngcT839JkRTkQBqznMG98l2XjxYk74ZztAohZzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-rsa": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.7.0.tgz",
+      "integrity": "sha512-9GTl1nE8Mx1kTZ+7QyYatDyKsm34QcWRBFkY1iPvWC3X4Dona5s/tlLiQsx5WzVdZqiMBZNYT0buyw4/vbhnjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.7.0.tgz",
+      "integrity": "sha512-Bh7m+OuIaSEllPQcSd9OSp93F4ROWH7sbITWV8MI+8dwsjE5111/87VxiWVvYFKyww3vp39geLv9ENqhwWHcew==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pfx": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.7.0.tgz",
+      "integrity": "sha512-/qvENQrXyTZURjMqSeofHul0JJt2sNSzSwk36pl2olkHbaioMQgrASDZAlHXl0xUlnVbHj0uGgOrBMTb5x2aJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.7.0.tgz",
+      "integrity": "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.7.0.tgz",
+      "integrity": "sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.7.0.tgz",
+      "integrity": "sha512-NS8e7SOgXipkzUPLF/sce7ukpMpWjhxYsH0n6Y+bHYo4TTxOb95Zv7hqwSuL212mj5YxovjdOKQOgH1As3E94w==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+      "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1832,6 +2006,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1993,6 +2181,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/bytestreamjs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+      "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -3792,6 +3989,35 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pkijs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+      "integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@noble/hashes": "1.4.0",
+        "asn1js": "^3.0.6",
+        "bytestreamjs": "^2.0.1",
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/pkijs/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/playwright": {
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
@@ -3934,6 +4160,24 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/qs": {
       "version": "6.14.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
@@ -4028,6 +4272,12 @@
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -4143,6 +4393,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/selfsigned": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-5.5.0.tgz",
+      "integrity": "sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/x509": "^1.14.2",
+        "pkijs": "^3.3.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -4390,6 +4653,15 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4398,6 +4670,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/stackback": {
@@ -4643,7 +4925,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {
@@ -5149,6 +5430,24 @@
         "@esbuild/win32-ia32": "0.27.7",
         "@esbuild/win32-x64": "0.27.7"
       }
+    },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "ci": "npm run typecheck && npm run check-core-compat && npm run test:coverage && cd client && npm run test:coverage"
   },
   "dependencies": {
+    "@homebridge/ciao": "^1.3.9",
     "@tailwindcss/typography": "^0.5.19",
     "ajv": "^8.17.1",
     "better-sqlite3": "^12.8.0",
@@ -54,6 +55,7 @@
     "pdf-parse": "^2.4.5",
     "playwright": "^1.60.0",
     "read-excel-file": "^9.0.6",
+    "selfsigned": "^5.5.0",
     "tree-kill": "^1.2.2",
     "ws": "^8.16.0"
   },

--- a/scripts/generate-mobile-types.mjs
+++ b/scripts/generate-mobile-types.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+// Drift-proof contract for the Mobile Gateway.
+//
+// The gateway's /v1 surface and pairing QR are the contract between THIS repo
+// (server/mobile/*) and the separate specrails-companion Flutter app. To keep the
+// two from drifting, this script emits a JSON Schema describing every shape the
+// gateway returns/accepts. The companion app regenerates its Dart DTOs from it:
+//
+//   node scripts/generate-mobile-types.mjs                 # writes the schema
+//   cd ../specrails-companion
+//   npx quicktype -s schema lib/data/contract/gateway.schema.json \
+//     -o lib/data/gateway_dtos.g.dart --lang dart
+//
+// v1's companion uses hand-written tolerant parsers (lib/data/models.dart); this
+// schema is the source of truth they mirror and the input for the generator when
+// the contract grows. Keep this file in sync with server/mobile/mobile-router.ts
+// (the allow-list) and mobile-types.ts (the QR payload).
+
+import fs from 'fs'
+import path from 'path'
+import url from 'url'
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
+
+const schema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  title: 'SpecRails Mobile Gateway contract',
+  definitions: {
+    QrPayload: {
+      type: 'object',
+      required: ['v', 'hub', 'name', 'addrs', 'port', 'fp', 'secret', 'claimId', 'exp'],
+      properties: {
+        v: { type: 'integer' },
+        hub: { type: 'string' },
+        name: { type: 'string' },
+        addrs: { type: 'array', items: { type: 'string' } },
+        port: { type: 'integer' },
+        fp: { type: 'string', description: 'sha256 hex of the gateway cert DER (pin target)' },
+        secret: { type: 'string' },
+        claimId: { type: 'string' },
+        exp: { type: 'integer' },
+      },
+    },
+    Project: {
+      type: 'object',
+      required: ['id', 'name', 'providers'],
+      properties: {
+        id: { type: 'string' },
+        name: { type: 'string' },
+        providers: { type: 'array', items: { type: 'string' } },
+      },
+    },
+    Ticket: {
+      type: 'object',
+      required: ['id', 'title', 'status'],
+      properties: {
+        id: { type: 'integer' },
+        title: { type: 'string' },
+        description: { type: 'string' },
+        status: { type: 'string', enum: ['todo', 'in_progress', 'done', 'cancelled', 'draft'] },
+        priority: { type: ['string', 'null'] },
+        labels: { type: 'array', items: { type: 'string' } },
+      },
+    },
+    Job: {
+      type: 'object',
+      required: ['id', 'command', 'status'],
+      properties: {
+        id: { type: 'string' },
+        command: { type: 'string' },
+        status: { type: 'string' },
+        startedAt: { type: ['string', 'null'] },
+        finishedAt: { type: ['string', 'null'] },
+        total_cost_usd: { type: ['number', 'null'] },
+        model: { type: ['string', 'null'] },
+        duration_ms: { type: ['integer', 'null'] },
+        num_turns: { type: ['integer', 'null'] },
+      },
+    },
+    QueueSnapshot: {
+      type: 'object',
+      required: ['jobs', 'paused'],
+      properties: {
+        jobs: { type: 'array', items: { $ref: '#/definitions/Job' } },
+        activeJobId: { type: ['string', 'null'] },
+        paused: { type: 'boolean' },
+      },
+    },
+  },
+}
+
+const outDir = path.resolve(__dirname, '..', '..', 'specrails-companion', 'lib', 'data', 'contract')
+const fallbackDir = path.resolve(__dirname, '..', 'build')
+const target = fs.existsSync(path.dirname(outDir)) ? outDir : fallbackDir
+fs.mkdirSync(target, { recursive: true })
+const outFile = path.join(target, 'gateway.schema.json')
+fs.writeFileSync(outFile, JSON.stringify(schema, null, 2) + '\n')
+console.log(`[generate-mobile-types] wrote ${outFile}`)
+console.log('[generate-mobile-types] regenerate Dart DTOs with:')
+console.log('  npx quicktype -s schema lib/data/contract/gateway.schema.json -o lib/data/gateway_dtos.g.dart --lang dart')

--- a/server/db.test.ts
+++ b/server/db.test.ts
@@ -54,6 +54,13 @@ describe('db', () => {
       expect(names).toContain('schema_migrations')
     })
 
+    it('creates the rail_meta table (migration 28) with rail_index + name', () => {
+      const db = makeDb()
+      const cols = (db.prepare('PRAGMA table_info(rail_meta)').all() as { name: string }[]).map((c) => c.name)
+      expect(cols).toContain('rail_index')
+      expect(cols).toContain('name')
+    })
+
     it('orphan detection marks running jobs as failed on initDb', () => {
       // Simulate: a DB already has a 'running' job (from a previous crashed session).
       // When initDb runs on that DB, it should mark the running job as 'failed'.

--- a/server/db.ts
+++ b/server/db.ts
@@ -578,6 +578,22 @@ const MIGRATIONS: Migration[] = [
       `)
     }
   },
+
+  // Migration 28: rail_meta — per-rail display name, keyed by rail_index.
+  // The `rails` table stores name-less ticket rows (and has NO rows for an
+  // empty rail), so a rail's user-given name can't live there — a renamed but
+  // empty rail would lose its name. rail_meta is a separate, ticket-independent
+  // store so every rail (0/1/2) keeps its name regardless of assignments.
+  // NULL name = client falls back to the default "Rail N" label. This backs the
+  // desktop ⇄ mobile rail-name sync (broadcast via rail.updated).
+  (db) => {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS rail_meta (
+        rail_index  INTEGER PRIMARY KEY,
+        name        TEXT
+      );
+    `)
+  },
 ]
 
 function applyMigrations(db: DbInstance): void {

--- a/server/hub-db.test.ts
+++ b/server/hub-db.test.ts
@@ -69,17 +69,17 @@ describe('hub-db', () => {
       expect(names).toContain('idx_projects_path')
     })
 
-    it('applies migrations 1 through 11 and records them', () => {
+    it('applies migrations 1 through 12 and records them', () => {
       const versions = db.prepare('SELECT version FROM schema_migrations ORDER BY version').all() as { version: number }[]
-      expect(versions).toHaveLength(11)
-      expect(versions.map((v) => v.version)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
+      expect(versions).toHaveLength(12)
+      expect(versions.map((v) => v.version)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
     })
 
     it('is idempotent — calling initHubDb again does not fail', () => {
       // Re-init on same DB (in-memory so we just call again)
       const db2 = makeDb()
       const versions = db2.prepare('SELECT version FROM schema_migrations').all() as { version: number }[]
-      expect(versions).toHaveLength(11)
+      expect(versions).toHaveLength(12)
     })
   })
 

--- a/server/hub-db.ts
+++ b/server/hub-db.ts
@@ -239,6 +239,29 @@ function applyHubMigrations(db: DbInstance): void {
         upd.run(value, r.id)
       }
     },
+    // Migration 12: mobile companion devices. Each paired phone/tablet gets a
+    // hashed per-device bearer token (never the master hub token), scoped to
+    // `companion`, bound to the gateway cert fingerprint active at pair time
+    // (rotating the cert revokes every device), with a sliding-expiry last_seen
+    // and a one-tap revoke (revoked_at). See server/mobile/* for the gateway.
+    () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS mobile_devices (
+          id               TEXT PRIMARY KEY,
+          name             TEXT NOT NULL,
+          platform         TEXT NOT NULL,
+          token_hash       TEXT NOT NULL,
+          scopes           TEXT NOT NULL DEFAULT 'companion',
+          cert_fingerprint TEXT NOT NULL,
+          created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+          last_seen_at     TEXT,
+          last_ip          TEXT,
+          revoked_at       TEXT
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_mobile_devices_token ON mobile_devices(token_hash);
+      `)
+    },
   ]
 
   for (let i = 0; i < migrations.length; i++) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -20,6 +20,7 @@ import { shouldDeliverToSubscriber, parseSubscribeFrame } from './ws-routing'
 import { getTerminalManager } from './terminal-manager'
 import { cleanupStaleShimDirs } from './terminal-shell-integration'
 import { isBrowserCaptureEnabled } from './feature-flags'
+import { MobileGateway, createMobileAdminRouter, getMobileEventBus } from './mobile'
 import type { BrowserWsClient } from './browser-capture-manager'
 import type { BrowserInputEvent } from './browser-capture-types'
 import { createTelemetryRouter } from './telemetry-receiver'
@@ -235,6 +236,9 @@ function broadcast(msg: WsMessage): void {
     if (client.bufferedAmount > WS_BACKPRESSURE_LIMIT_BYTES) continue
     client.send(data)
   }
+  // Fan a copy to the Mobile Gateway's in-process bus (no-op when no phone is
+  // attached). publish() swallows mobile-side errors so the main loop is safe.
+  getMobileEventBus().publish(msg)
 }
 
 // ─── Health endpoint state (populated by hub bootstrap below) ────────────────
@@ -243,6 +247,8 @@ let _getProjectCount: () => number = () => 0
 /** Captured by the hub bootstrap block so graceful shutdown can tear down every
  *  project's spawners (rail/chat children) instead of orphaning them. */
 let _registry: ProjectRegistry | null = null
+/** The mobile companion gateway (off by default); torn down on shutdown. */
+let _mobileGateway: MobileGateway | null = null
 
 server.on('upgrade', (request, socket, head) => {
   const urlStr = request.url ?? '/'
@@ -450,6 +456,21 @@ function applyWsRateLimiting(ws: WebSocket): void {
     console.error('[telemetry-compactor] startup compaction error:', err)
   })
 
+  // ─── Mobile companion gateway (off by default; boot if previously enabled) ──
+  // Second HTTPS+WSS listener in THIS process; the main server stays loopback.
+  // The control plane is desktop-only: loopback + (via /api below) requireAuth.
+  // Mounted before /api/hub so its sub-path is unambiguous.
+  const mobileGateway = new MobileGateway({ hubDb: registry.hubDb, hubPort: port, broadcast })
+  _mobileGateway = mobileGateway
+  app.use('/api/hub/mobile', requireLoopback, createMobileAdminRouter({
+    gateway: mobileGateway,
+    hubDb: registry.hubDb,
+    broadcast,
+  }))
+  if (mobileGateway.isEnabledSetting()) {
+    mobileGateway.start().catch((err) => console.error('[mobile-gateway] boot start failed:', err))
+  }
+
   // Hub-level routes
   app.use('/api/hub', createHubRouter(registry, broadcast))
 
@@ -553,6 +574,9 @@ async function shutdown(): Promise<void> {
   } catch { /* ignore */ }
   try {
     await getTerminalManager().shutdown()
+  } catch { /* ignore */ }
+  try {
+    await _mobileGateway?.stop()
   } catch { /* ignore */ }
   try { wss.close() } catch { /* ignore */ }
   try { terminalWss.close() } catch { /* ignore */ }

--- a/server/mobile/index.ts
+++ b/server/mobile/index.ts
@@ -1,0 +1,11 @@
+// Mobile Gateway — public surface. The gateway is a second HTTPS+WSS listener in
+// the same Node process (default :4202, OFF by default) that pairs phones by QR +
+// desktop approval and exposes a redacted, deny-by-default allow-list of the hub
+// API over per-device tokens. The hub at 127.0.0.1:4200 is never exposed.
+
+export { MobileGateway } from './mobile-gateway'
+export type { MobileGatewayStatus, MobileGatewayDeps } from './mobile-gateway'
+export { createMobileAdminRouter } from './mobile-admin-router'
+export { getMobileEventBus } from './mobile-event-bus'
+export { MOBILE_ALLOWLIST } from './mobile-router'
+export type { MobileDevicePublic, QrPayload } from './mobile-types'

--- a/server/mobile/mobile-admin-router.test.ts
+++ b/server/mobile/mobile-admin-router.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import { initHubDb, setHubSetting } from '../hub-db'
+import type { DbInstance } from '../db'
+import type { WsMessage } from '../types'
+import { MobileGateway } from './mobile-gateway'
+import { createMobileAdminRouter } from './mobile-admin-router'
+
+describe('mobile-admin-router', () => {
+  let db: DbInstance
+  let gw: MobileGateway
+  let app: express.Express
+  let events: WsMessage[]
+
+  beforeEach(() => {
+    db = initHubDb(':memory:')
+    setHubSetting(db, 'mobile.mdns_enabled', 'false')
+    events = []
+    gw = new MobileGateway({ hubDb: db, hubPort: 4200, broadcast: (m) => events.push(m), bindHost: '127.0.0.1', port: 0 })
+    app = express()
+    app.use(express.json())
+    app.use('/api/hub/mobile', createMobileAdminRouter({ gateway: gw, hubDb: db, broadcast: (m) => events.push(m) }))
+  })
+
+  afterEach(async () => { await gw.stop() })
+
+  it('status → enable → status running', async () => {
+    let res = await request(app).get('/api/hub/mobile/status')
+    expect(res.status).toBe(200)
+    expect(res.body.running).toBe(false)
+
+    res = await request(app).post('/api/hub/mobile/enable')
+    expect(res.status).toBe(200)
+    expect(res.body.running).toBe(true)
+    expect(res.body.port).toBeGreaterThan(0)
+  })
+
+  it('pairing-session requires the gateway running', async () => {
+    const res = await request(app).post('/api/hub/mobile/pairing-session')
+    expect(res.status).toBe(409)
+  })
+
+  it('end-to-end: enable, pair, list devices, revoke', async () => {
+    await request(app).post('/api/hub/mobile/enable')
+
+    const session = await request(app).post('/api/hub/mobile/pairing-session')
+    expect(session.status).toBe(200)
+    expect(session.body.qr.secret).toBeTruthy()
+
+    // Simulate the phone claiming + desktop approving.
+    gw.pairing!.claim(session.body.qr.secret, { name: 'iPhone', platform: 'ios' }, '1.2.3.4')
+    const desktopState = await request(app).get('/api/hub/mobile/pairing-session')
+    expect(desktopState.body.status).toBe('claimed')
+
+    const approve = await request(app).post('/api/hub/mobile/pairing-session/approve')
+    expect(approve.status).toBe(200)
+
+    const devices = await request(app).get('/api/hub/mobile/devices')
+    expect(devices.body.devices).toHaveLength(1)
+    const id = devices.body.devices[0].id
+
+    const del = await request(app).delete(`/api/hub/mobile/devices/${id}`)
+    expect(del.status).toBe(200)
+    expect(del.body.ok).toBe(true)
+    expect(events.some((e) => e.type === 'mobile.device_revoked')).toBe(true)
+  })
+
+  it('rejects an invalid device id', async () => {
+    const res = await request(app).delete('/api/hub/mobile/devices/has spaces!')
+    expect(res.status).toBe(400)
+  })
+
+  it('deny + cancel pairing session', async () => {
+    await request(app).post('/api/hub/mobile/enable')
+    await request(app).post('/api/hub/mobile/pairing-session')
+    expect((await request(app).post('/api/hub/mobile/pairing-session/deny')).status).toBe(200)
+    expect((await request(app).delete('/api/hub/mobile/pairing-session')).status).toBe(200)
+  })
+
+  it('cert rotate + disable', async () => {
+    await request(app).post('/api/hub/mobile/enable')
+    const rot = await request(app).post('/api/hub/mobile/cert/rotate')
+    expect(rot.status).toBe(200)
+    expect(rot.body.certFingerprint).toMatch(/^[0-9a-f]{64}$/)
+    const dis = await request(app).post('/api/hub/mobile/disable')
+    expect(dis.status).toBe(200)
+    expect(dis.body.running).toBe(false)
+  })
+})

--- a/server/mobile/mobile-admin-router.ts
+++ b/server/mobile/mobile-admin-router.ts
@@ -1,0 +1,108 @@
+import { Router } from 'express'
+import type { Request, Response } from 'express'
+import type { DbInstance } from '../db'
+import type { WsMessage } from '../types'
+import type { MobileGateway } from './mobile-gateway'
+import { listDevices, revokeDevice } from './mobile-devices'
+
+// Loopback-only control plane for the desktop UI, mounted on the MAIN hub server
+// at /api/hub/mobile (behind requireAuth + requireLoopback). The phone never
+// touches these routes — they manage the gateway and pairing from the desktop.
+
+export interface MobileAdminDeps {
+  gateway: MobileGateway
+  hubDb: DbInstance
+  broadcast: (msg: WsMessage) => void
+}
+
+const DEVICE_ID_RE = /^[A-Za-z0-9-]{1,64}$/
+
+export function createMobileAdminRouter(deps: MobileAdminDeps): Router {
+  const router = Router()
+  const { gateway, hubDb } = deps
+
+  router.get('/status', (_req: Request, res: Response) => {
+    res.json(gateway.status())
+  })
+
+  router.post('/enable', async (_req: Request, res: Response) => {
+    try {
+      const status = await gateway.setEnabled(true)
+      res.json(status)
+    } catch (err) {
+      // EADDRINUSE etc — keep the flag off and report, never crash.
+      res.status(409).json({ error: err instanceof Error ? err.message : 'Failed to start gateway' })
+    }
+  })
+
+  router.post('/disable', async (_req: Request, res: Response) => {
+    await gateway.setEnabled(false)
+    res.json(gateway.status())
+  })
+
+  // —— Pairing session ——
+  router.post('/pairing-session', (_req: Request, res: Response) => {
+    if (!gateway.running || !gateway.pairing) {
+      res.status(409).json({ error: 'Enable mobile access first' })
+      return
+    }
+    res.json({ qr: gateway.pairing.createSession() })
+  })
+
+  router.get('/pairing-session', (_req: Request, res: Response) => {
+    if (!gateway.pairing) {
+      res.json({ status: 'none' })
+      return
+    }
+    res.json(gateway.pairing.getDesktopState() ?? { status: 'none' })
+  })
+
+  router.post('/pairing-session/approve', (_req: Request, res: Response) => {
+    if (!gateway.pairing) {
+      res.status(409).json({ error: 'No pairing session' })
+      return
+    }
+    const result = gateway.pairing.approve()
+    if (!result.ok) {
+      res.status(409).json({ error: result.reason })
+      return
+    }
+    res.json({ ok: true })
+  })
+
+  router.post('/pairing-session/deny', (_req: Request, res: Response) => {
+    gateway.pairing?.deny()
+    res.json({ ok: true })
+  })
+
+  router.delete('/pairing-session', (_req: Request, res: Response) => {
+    gateway.pairing?.cancel()
+    res.json({ ok: true })
+  })
+
+  // —— Devices ——
+  router.get('/devices', (_req: Request, res: Response) => {
+    res.json({ devices: listDevices(hubDb) })
+  })
+
+  router.delete('/devices/:id', (req: Request, res: Response) => {
+    const id = typeof req.params.id === 'string' ? req.params.id : ''
+    if (!DEVICE_ID_RE.test(id)) {
+      res.status(400).json({ error: 'Invalid device id' })
+      return
+    }
+    const changed = revokeDevice(hubDb, id)
+    if (changed) {
+      gateway.bridge?.closeForDevice(id)
+      deps.broadcast({ type: 'mobile.device_revoked', deviceId: id, timestamp: new Date().toISOString() })
+    }
+    res.json({ ok: changed })
+  })
+
+  router.post('/cert/rotate', async (_req: Request, res: Response) => {
+    const status = await gateway.rotateCert()
+    res.json(status)
+  })
+
+  return router
+}

--- a/server/mobile/mobile-auth.test.ts
+++ b/server/mobile/mobile-auth.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { Request, Response } from 'express'
+import { initHubDb } from '../hub-db'
+import type { DbInstance } from '../db'
+import { createDevice, hashToken } from './mobile-devices'
+import { extractBearer, resolveDevice, createMobileAuthMiddleware } from './mobile-auth'
+
+function fakeReq(over: Partial<{ headers: Record<string, string>; remoteAddress: string }> = {}): Request {
+  return {
+    headers: over.headers ?? {},
+    socket: { remoteAddress: over.remoteAddress ?? '1.2.3.4' },
+  } as unknown as Request
+}
+
+function fakeRes(): { res: Response; captured: { status: number; body: unknown } } {
+  const captured = { status: 200, body: undefined as unknown }
+  const res = {
+    status(code: number) { captured.status = code; return this },
+    json(obj: unknown) { captured.body = obj; return this },
+  } as unknown as Response
+  return { res, captured }
+}
+
+describe('mobile-auth', () => {
+  let db: DbInstance
+  beforeEach(() => { db = initHubDb(':memory:') })
+
+  it('extractBearer parses the Authorization header', () => {
+    expect(extractBearer(fakeReq({ headers: { authorization: 'Bearer abc' } }))).toBe('abc')
+    expect(extractBearer(fakeReq({ headers: { authorization: 'Basic xyz' } }))).toBeNull()
+    expect(extractBearer(fakeReq())).toBeNull()
+  })
+
+  it('resolveDevice requires a known, non-revoked, fingerprint-matching token', () => {
+    createDevice(db, { name: 'A', platform: 'ios', tokenHash: hashToken('tok'), certFingerprint: 'fp1' })
+    expect(resolveDevice(db, 'tok', 'fp1')?.name).toBe('A')
+    expect(resolveDevice(db, 'tok', 'fp2')).toBeNull() // cert rotated
+    expect(resolveDevice(db, 'wrong', 'fp1')).toBeNull()
+    expect(resolveDevice(db, null, 'fp1')).toBeNull()
+  })
+
+  it('middleware: 403 on Origin, 401 on bad token, next on valid', () => {
+    createDevice(db, { name: 'A', platform: 'ios', tokenHash: hashToken('tok'), certFingerprint: 'fp' })
+    const mw = createMobileAuthMiddleware({ db, currentFingerprint: () => 'fp' })
+
+    // Origin present → 403
+    {
+      const { res, captured } = fakeRes()
+      let nexted = false
+      mw(fakeReq({ headers: { origin: 'http://evil', authorization: 'Bearer tok' } }), res, () => { nexted = true })
+      expect(captured.status).toBe(403)
+      expect(nexted).toBe(false)
+    }
+    // Bad token → 401
+    {
+      const { res, captured } = fakeRes()
+      mw(fakeReq({ headers: { authorization: 'Bearer nope' } }), res, () => { /* noop */ })
+      expect(captured.status).toBe(401)
+    }
+    // Valid → next + req.mobileDevice set
+    {
+      const { res } = fakeRes()
+      const req = fakeReq({ headers: { authorization: 'Bearer tok' } })
+      let nexted = false
+      mw(req, res, () => { nexted = true })
+      expect(nexted).toBe(true)
+      expect((req as unknown as { mobileDevice?: { name: string } }).mobileDevice?.name).toBe('A')
+    }
+  })
+
+  it('middleware enforces a per-IP rate limit', () => {
+    createDevice(db, { name: 'A', platform: 'ios', tokenHash: hashToken('tok'), certFingerprint: 'fp' })
+    const t = 1000
+    const mw = createMobileAuthMiddleware({ db, currentFingerprint: () => 'fp', ratePerMinute: 3, clock: () => t })
+    let lastStatus = 0
+    for (let i = 0; i < 5; i++) {
+      const { res, captured } = fakeRes()
+      mw(fakeReq({ headers: { authorization: 'Bearer tok' }, remoteAddress: '5.5.5.5' }), res, () => { captured.status = 200 })
+      lastStatus = captured.status
+    }
+    expect(lastStatus).toBe(429)
+  })
+})

--- a/server/mobile/mobile-auth.ts
+++ b/server/mobile/mobile-auth.ts
@@ -1,0 +1,96 @@
+import type { Request, Response, NextFunction } from 'express'
+import type { DbInstance } from '../db'
+import type { MobileDeviceRow } from './mobile-types'
+import { hashToken, getActiveDeviceByTokenHash, touchDevice } from './mobile-devices'
+
+// Auth for the gateway's /v1 surface and WS upgrades. A request is authenticated
+// iff it carries `Authorization: Bearer <deviceToken>` whose sha256 matches a
+// non-revoked row in mobile_devices AND that row's cert_fingerprint equals the
+// gateway's CURRENT cert fingerprint (so rotating the cert instantly invalidates
+// every device — the KDE-Connect-2025 lesson: verify identity + credential
+// together, every request).
+//
+// Additional guards:
+//  - Reject any request carrying an `Origin` header. Native clients never set
+//    one; a browser does. Combined with the gateway sending no CORS headers, this
+//    closes the DNS-rebinding / drive-by vector (the browser couldn't read the
+//    response anyway, but we refuse to even process it).
+//  - Per-IP request rate limit (coarse) to blunt floods.
+
+export interface MobileAuthedRequest extends Request {
+  mobileDevice?: MobileDeviceRow
+}
+
+export function extractBearer(req: Request): string | null {
+  const h = req.headers['authorization']
+  if (typeof h === 'string' && h.startsWith('Bearer ')) {
+    const t = h.slice(7).trim()
+    return t.length > 0 ? t : null
+  }
+  return null
+}
+
+/** Resolve a device from a raw token against the current cert fingerprint, or
+ *  null. Shared by the REST middleware and the WS upgrade check. */
+export function resolveDevice(
+  db: DbInstance,
+  token: string | null,
+  currentFingerprint: string,
+): MobileDeviceRow | null {
+  if (!token) return null
+  const row = getActiveDeviceByTokenHash(db, hashToken(token))
+  if (!row) return null
+  if (row.cert_fingerprint !== currentFingerprint) return null
+  return row
+}
+
+export interface MobileAuthOptions {
+  db: DbInstance
+  currentFingerprint: () => string
+  /** Coarse per-IP requests/minute cap (default 600). */
+  ratePerMinute?: number
+  clock?: () => number
+}
+
+export function createMobileAuthMiddleware(opts: MobileAuthOptions) {
+  const ratePerMinute = opts.ratePerMinute ?? 600
+  const clock = opts.clock ?? (() => Date.now())
+  const lastTouch = new Map<string, number>()
+  const ipHits = new Map<string, number[]>()
+
+  return function mobileAuth(req: Request, res: Response, next: NextFunction): void {
+    // 1. Refuse browser-origin requests outright.
+    if (req.headers['origin']) {
+      res.status(403).json({ error: 'Forbidden: origin not allowed' })
+      return
+    }
+
+    // 2. Coarse per-IP rate limit.
+    const ip = req.socket?.remoteAddress ?? 'unknown'
+    const now = clock()
+    const hits = (ipHits.get(ip) ?? []).filter((t) => now - t < 60_000)
+    hits.push(now)
+    ipHits.set(ip, hits)
+    if (hits.length > ratePerMinute) {
+      res.status(429).json({ error: 'Too many requests' })
+      return
+    }
+
+    // 3. Token → device, fingerprint-bound.
+    const device = resolveDevice(opts.db, extractBearer(req), opts.currentFingerprint())
+    if (!device) {
+      res.status(401).json({ error: 'Unauthorized' })
+      return
+    }
+
+    // 4. Throttled last-seen update (≤1/min per device).
+    const prev = lastTouch.get(device.id) ?? 0
+    if (now - prev > 60_000) {
+      lastTouch.set(device.id, now)
+      try { touchDevice(opts.db, device.id, ip) } catch { /* non-fatal */ }
+    }
+
+    ;(req as MobileAuthedRequest).mobileDevice = device
+    next()
+  }
+}

--- a/server/mobile/mobile-devices.test.ts
+++ b/server/mobile/mobile-devices.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initHubDb } from '../hub-db'
+import type { DbInstance } from '../db'
+import {
+  hashToken,
+  createDevice,
+  getActiveDeviceByTokenHash,
+  listDevices,
+  revokeDevice,
+  revokeAllDevices,
+  touchDevice,
+  sweepExpiredDevices,
+} from './mobile-devices'
+
+describe('mobile-devices', () => {
+  let db: DbInstance
+  beforeEach(() => {
+    db = initHubDb(':memory:')
+  })
+
+  it('hashToken is deterministic sha256 hex', () => {
+    expect(hashToken('abc')).toBe(hashToken('abc'))
+    expect(hashToken('abc')).toMatch(/^[0-9a-f]{64}$/)
+    expect(hashToken('abc')).not.toBe(hashToken('abd'))
+  })
+
+  it('creates and resolves an active device by token hash', () => {
+    const token = 'tok-123'
+    const row = createDevice(db, { name: 'iPhone', platform: 'ios', tokenHash: hashToken(token), certFingerprint: 'fp1' })
+    expect(row.id).toBeTruthy()
+    const found = getActiveDeviceByTokenHash(db, hashToken(token))
+    expect(found?.id).toBe(row.id)
+    expect(found?.scopes).toBe('companion')
+    expect(getActiveDeviceByTokenHash(db, hashToken('other'))).toBeUndefined()
+  })
+
+  it('revoked devices resolve as undefined', () => {
+    const row = createDevice(db, { name: 'A', platform: 'android', tokenHash: hashToken('t'), certFingerprint: 'fp' })
+    expect(revokeDevice(db, row.id)).toBe(true)
+    expect(revokeDevice(db, row.id)).toBe(false) // idempotent (already revoked)
+    expect(getActiveDeviceByTokenHash(db, hashToken('t'))).toBeUndefined()
+  })
+
+  it('lists devices (public shape, no token_hash) newest-first', () => {
+    createDevice(db, { name: 'A', platform: 'ios', tokenHash: hashToken('a'), certFingerprint: 'fp' })
+    createDevice(db, { name: 'B', platform: 'ios', tokenHash: hashToken('b'), certFingerprint: 'fp' })
+    const list = listDevices(db)
+    expect(list).toHaveLength(2)
+    expect(Object.keys(list[0])).not.toContain('token_hash')
+    expect(list[0]).toHaveProperty('revoked', false)
+  })
+
+  it('revokeAllDevices revokes every active device', () => {
+    createDevice(db, { name: 'A', platform: 'ios', tokenHash: hashToken('a'), certFingerprint: 'fp' })
+    createDevice(db, { name: 'B', platform: 'ios', tokenHash: hashToken('b'), certFingerprint: 'fp' })
+    expect(revokeAllDevices(db)).toBe(2)
+    expect(listDevices(db).every((d) => d.revoked)).toBe(true)
+  })
+
+  it('touchDevice updates last_seen_at/last_ip', () => {
+    const row = createDevice(db, { name: 'A', platform: 'ios', tokenHash: hashToken('a'), certFingerprint: 'fp' })
+    touchDevice(db, row.id, '192.168.1.5')
+    const found = getActiveDeviceByTokenHash(db, hashToken('a'))
+    expect(found?.last_ip).toBe('192.168.1.5')
+    expect(found?.last_seen_at).toBeTruthy()
+  })
+
+  it('sweepExpiredDevices revokes devices older than the window', () => {
+    const row = createDevice(db, { name: 'old', platform: 'ios', tokenHash: hashToken('a'), certFingerprint: 'fp' })
+    // Backdate created_at beyond 90 days.
+    db.prepare("UPDATE mobile_devices SET created_at = datetime('now', '-100 days') WHERE id = ?").run(row.id)
+    expect(sweepExpiredDevices(db, 90)).toBe(1)
+    expect(getActiveDeviceByTokenHash(db, hashToken('a'))).toBeUndefined()
+    // A fresh device is untouched.
+    createDevice(db, { name: 'new', platform: 'ios', tokenHash: hashToken('b'), certFingerprint: 'fp' })
+    expect(sweepExpiredDevices(db, 90)).toBe(0)
+  })
+})

--- a/server/mobile/mobile-devices.ts
+++ b/server/mobile/mobile-devices.ts
@@ -1,0 +1,87 @@
+import { createHash, randomUUID } from 'crypto'
+import type { DbInstance } from '../db'
+import type { MobileDeviceRow, MobileDevicePublic, MobilePlatform } from './mobile-types'
+
+// CRUD over hub.sqlite `mobile_devices` (table created by hub migration 12).
+// Tokens are stored ONLY as sha256 hashes; the plaintext token is shown to the
+// phone exactly once at approval and never persisted.
+
+export function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex')
+}
+
+export function createDevice(
+  db: DbInstance,
+  opts: { name: string; platform: MobilePlatform; tokenHash: string; certFingerprint: string },
+): MobileDeviceRow {
+  const id = randomUUID()
+  db.prepare(
+    `INSERT INTO mobile_devices (id, name, platform, token_hash, scopes, cert_fingerprint)
+     VALUES (?, ?, ?, ?, 'companion', ?)`,
+  ).run(id, opts.name, opts.platform, opts.tokenHash, opts.certFingerprint)
+  return db.prepare('SELECT * FROM mobile_devices WHERE id = ?').get(id) as MobileDeviceRow
+}
+
+/** Look up a device by its token hash. Returns undefined if unknown OR revoked —
+ *  a revoked device must behave as if it never existed. */
+export function getActiveDeviceByTokenHash(db: DbInstance, tokenHash: string): MobileDeviceRow | undefined {
+  const row = db
+    .prepare('SELECT * FROM mobile_devices WHERE token_hash = ?')
+    .get(tokenHash) as MobileDeviceRow | undefined
+  if (!row || row.revoked_at) return undefined
+  return row
+}
+
+export function listDevices(db: DbInstance): MobileDevicePublic[] {
+  const rows = db
+    .prepare('SELECT * FROM mobile_devices ORDER BY created_at DESC')
+    .all() as MobileDeviceRow[]
+  return rows.map(toPublic)
+}
+
+export function toPublic(row: MobileDeviceRow): MobileDevicePublic {
+  return {
+    id: row.id,
+    name: row.name,
+    platform: row.platform,
+    scopes: row.scopes,
+    createdAt: row.created_at,
+    lastSeenAt: row.last_seen_at,
+    lastIp: row.last_ip,
+    revoked: !!row.revoked_at,
+  }
+}
+
+/** Mark a device revoked (idempotent). Returns true if a row was affected. */
+export function revokeDevice(db: DbInstance, id: string): boolean {
+  const res = db
+    .prepare("UPDATE mobile_devices SET revoked_at = datetime('now') WHERE id = ? AND revoked_at IS NULL")
+    .run(id)
+  return res.changes > 0
+}
+
+/** Revoke EVERY device — used by cert rotation ("Reset mobile identity"). */
+export function revokeAllDevices(db: DbInstance): number {
+  const res = db
+    .prepare("UPDATE mobile_devices SET revoked_at = datetime('now') WHERE revoked_at IS NULL")
+    .run()
+  return res.changes
+}
+
+/** Refresh last_seen_at/last_ip. Callers throttle this to ~1/min per device. */
+export function touchDevice(db: DbInstance, id: string, ip: string | undefined): void {
+  db.prepare("UPDATE mobile_devices SET last_seen_at = datetime('now'), last_ip = ? WHERE id = ?").run(ip ?? null, id)
+}
+
+/** Sliding-expiry sweep: revoke devices unseen for `days` (default 90). Devices
+ *  that have never connected are measured from created_at. Returns count revoked. */
+export function sweepExpiredDevices(db: DbInstance, days = 90): number {
+  const res = db
+    .prepare(
+      `UPDATE mobile_devices SET revoked_at = datetime('now')
+       WHERE revoked_at IS NULL
+         AND COALESCE(last_seen_at, created_at) < datetime('now', ?)`,
+    )
+    .run(`-${days} days`)
+  return res.changes
+}

--- a/server/mobile/mobile-event-bus.ts
+++ b/server/mobile/mobile-event-bus.ts
@@ -1,0 +1,41 @@
+import { EventEmitter } from 'events'
+import type { WsMessage } from '../types'
+
+// In-process fan-out of every WS broadcast to the Mobile Gateway.
+//
+// The plan originally had the gateway hold a client WebSocket to
+// ws://127.0.0.1:4200. But the gateway runs in the SAME process, so a loopback
+// socket would be pure overhead AND force the bridge to JSON.parse the whole
+// firehose (a gap the critic flagged). Instead the main `broadcast()` emits each
+// already-structured WsMessage here; the gateway's WS bridge subscribes and does
+// per-subscription filtering + redaction on plain objects. REST still forwards
+// via a real loopback HTTP request (so it re-enters requireAuth and never hits
+// the SPA catch-all) — only the WS path uses this bus.
+
+class MobileEventBus extends EventEmitter {
+  /** Emit a broadcast copy to any subscribed gateway sockets. Never throws into
+   *  the caller (the main broadcast loop must not be perturbed by a mobile bug). */
+  publish(msg: WsMessage): void {
+    try {
+      this.emit('message', msg)
+    } catch {
+      /* swallow — a misbehaving mobile listener must not break the main bus */
+    }
+  }
+
+  onMessage(cb: (msg: WsMessage) => void): () => void {
+    this.on('message', cb)
+    return () => this.off('message', cb)
+  }
+}
+
+// EventEmitter defaults to 10 listeners; the gateway attaches one shared listener
+// that fans out to many sockets, so the default is plenty — but lift it anyway
+// to be safe against future multi-listener designs.
+const bus = new MobileEventBus()
+bus.setMaxListeners(64)
+
+/** Process-wide singleton bus. */
+export function getMobileEventBus(): MobileEventBus {
+  return bus
+}

--- a/server/mobile/mobile-gateway.test.ts
+++ b/server/mobile/mobile-gateway.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import net from 'net'
+import { initHubDb, setHubSetting, getHubSetting } from '../hub-db'
+import type { DbInstance } from '../db'
+import type { WsMessage } from '../types'
+import { listDevices } from './mobile-devices'
+import { MobileGateway } from './mobile-gateway'
+
+describe('MobileGateway', () => {
+  let db: DbInstance
+  let events: WsMessage[]
+  let gw: MobileGateway
+
+  beforeEach(() => {
+    db = initHubDb(':memory:')
+    setHubSetting(db, 'mobile.mdns_enabled', 'false') // skip multicast in tests
+    events = []
+    gw = new MobileGateway({
+      hubDb: db,
+      hubPort: 4200,
+      broadcast: (m) => { events.push(m) },
+      bindHost: '127.0.0.1',
+      port: 0, // ephemeral
+    })
+  })
+
+  afterEach(async () => {
+    await gw.stop()
+  })
+
+  it('starts on an ephemeral port and reports status', async () => {
+    expect(gw.running).toBe(false)
+    const status = await gw.setEnabled(true)
+    expect(status.running).toBe(true)
+    expect(status.port).toBeGreaterThan(0)
+    expect(status.certFingerprint).toMatch(/^[0-9a-f]{64}$/)
+    expect(getHubSetting(db, 'mobile.enabled')).toBe('true')
+    // broadcast a gateway_state event
+    expect(events.some((e) => e.type === 'mobile.gateway_state')).toBe(true)
+  })
+
+  it('start() is idempotent', async () => {
+    await gw.start()
+    const port = gw.status().port
+    await gw.start()
+    expect(gw.status().port).toBe(port)
+  })
+
+  it('full pairing flow persists a device, then rotateCert revokes it', async () => {
+    await gw.start()
+    const qr = gw.pairing!.createSession()
+    expect(gw.pairing!.claim(qr.secret, { name: 'iPhone', platform: 'ios' }, '1.2.3.4').ok).toBe(true)
+    expect(gw.pairing!.approve().ok).toBe(true)
+
+    let devices = listDevices(db)
+    expect(devices).toHaveLength(1)
+    expect(devices[0].revoked).toBe(false)
+    expect(events.some((e) => e.type === 'mobile.device_paired')).toBe(true)
+    expect(events.some((e) => e.type === 'mobile.pair_requested')).toBe(true)
+
+    const fpBefore = gw.status().certFingerprint
+    await gw.rotateCert()
+    devices = listDevices(db)
+    expect(devices[0].revoked).toBe(true)
+    expect(gw.status().certFingerprint).not.toBe(fpBefore)
+  })
+
+  it('disable stops the listener', async () => {
+    await gw.setEnabled(true)
+    expect(gw.running).toBe(true)
+    await gw.setEnabled(false)
+    expect(gw.running).toBe(false)
+    expect(getHubSetting(db, 'mobile.enabled')).toBe('false')
+  })
+
+  it('isEnabledSetting reflects the persisted flag', () => {
+    expect(gw.isEnabledSetting()).toBe(false)
+    setHubSetting(db, 'mobile.enabled', 'true')
+    expect(gw.isEnabledSetting()).toBe(true)
+  })
+
+  it('rejects start() when the port is already in use (no crash)', async () => {
+    const blocker = net.createServer()
+    await new Promise<void>((r) => blocker.listen(0, '127.0.0.1', r))
+    const port = (blocker.address() as { port: number }).port
+    const gw2 = new MobileGateway({ hubDb: db, hubPort: 4200, broadcast: () => {}, bindHost: '127.0.0.1', port })
+    await expect(gw2.start()).rejects.toThrow(/in use/i)
+    await new Promise<void>((r) => blocker.close(() => r()))
+  })
+})

--- a/server/mobile/mobile-gateway.ts
+++ b/server/mobile/mobile-gateway.ts
@@ -1,0 +1,282 @@
+import os from 'os'
+import https from 'https'
+import { randomUUID } from 'crypto'
+import express from 'express'
+import type { Express } from 'express'
+import { WebSocketServer, type WebSocket } from 'ws'
+import type { IncomingMessage } from 'http'
+import type { DbInstance } from '../db'
+import type { WsMessage } from '../types'
+import { getHubSetting, setHubSetting } from '../hub-db'
+import { loadOrCreateCert, rotateCert, mobileDir, type GatewayCert } from './mobile-tls'
+import { PairingManager } from './mobile-pairing'
+import { createMobileRouter } from './mobile-router'
+import { MobileWsBridge } from './mobile-ws'
+import { advertiseMdns, withdrawMdns } from './mobile-mdns'
+import { createDevice, hashToken, revokeAllDevices, sweepExpiredDevices } from './mobile-devices'
+import { resolveDevice, extractBearer } from './mobile-auth'
+import type { MobilePlatform } from './mobile-types'
+
+// Lifecycle owner of the second HTTPS+WSS listener (default :4202), hard-isolated
+// from the main hub server. Off by default; started on enable or boot-if-enabled.
+
+const DEFAULT_PORT = 4202
+const SETTING = {
+  enabled: 'mobile.enabled',
+  port: 'mobile.port',
+  instanceId: 'mobile.hub_instance_id',
+  name: 'mobile.hub_name',
+  mdns: 'mobile.mdns_enabled',
+  fingerprint: 'mobile.cert_fingerprint',
+} as const
+
+export interface MobileGatewayDeps {
+  hubDb: DbInstance
+  hubPort: number
+  broadcast: (msg: WsMessage) => void
+  /** Test seams. */
+  bindHost?: string
+  /** Overrides the `mobile.port` setting (use 0 for an ephemeral test port). */
+  port?: number
+}
+
+export interface MobileGatewayStatus {
+  enabled: boolean
+  running: boolean
+  port: number
+  certFingerprint: string | null
+  lanAddresses: string[]
+  mdnsEnabled: boolean
+  hubName: string
+}
+
+function lanAddresses(): string[] {
+  const out: string[] = []
+  const ifaces = os.networkInterfaces()
+  for (const name of Object.keys(ifaces)) {
+    for (const ni of ifaces[name] ?? []) {
+      if (ni.family === 'IPv4' && !ni.internal) out.push(ni.address)
+    }
+  }
+  return out
+}
+
+export class MobileGateway {
+  private readonly _db: DbInstance
+  private readonly _hubPort: number
+  private readonly _broadcast: (msg: WsMessage) => void
+  private readonly _bindHost: string
+  private _cert: GatewayCert | null = null
+  private _server: https.Server | null = null
+  private _wss: WebSocketServer | null = null
+  private _bridge: MobileWsBridge | null = null
+  private _pairing: PairingManager | null = null
+  private _running = false
+  private _boundPort = DEFAULT_PORT
+  private readonly _portOverride?: number
+
+  constructor(deps: MobileGatewayDeps) {
+    this._db = deps.hubDb
+    this._hubPort = deps.hubPort
+    this._broadcast = deps.broadcast
+    this._bindHost = deps.bindHost ?? '0.0.0.0'
+    this._portOverride = deps.port
+  }
+
+  get pairing(): PairingManager | null {
+    return this._pairing
+  }
+  get bridge(): MobileWsBridge | null {
+    return this._bridge
+  }
+  get running(): boolean {
+    return this._running
+  }
+
+  private configuredPort(): number {
+    if (this._portOverride !== undefined) return this._portOverride
+    const raw = getHubSetting(this._db, SETTING.port)
+    const n = raw ? parseInt(raw, 10) : NaN
+    return Number.isInteger(n) && n > 0 && n < 65536 ? n : DEFAULT_PORT
+  }
+
+  private hubName(): string {
+    const v = getHubSetting(this._db, SETTING.name)
+    if (v && v.trim()) return v
+    try { return os.hostname() } catch { return 'SpecRails Hub' }
+  }
+
+  private instanceId(): string {
+    let id = getHubSetting(this._db, SETTING.instanceId)
+    if (!id) {
+      id = randomUUID()
+      setHubSetting(this._db, SETTING.instanceId, id)
+    }
+    return id
+  }
+
+  private mdnsEnabled(): boolean {
+    return getHubSetting(this._db, SETTING.mdns) !== 'false'
+  }
+
+  isEnabledSetting(): boolean {
+    return getHubSetting(this._db, SETTING.enabled) === 'true'
+  }
+
+  status(): MobileGatewayStatus {
+    return {
+      enabled: this.isEnabledSetting(),
+      running: this._running,
+      port: this._running ? this._boundPort : this.configuredPort(),
+      certFingerprint: this._cert?.fingerprint ?? getHubSetting(this._db, SETTING.fingerprint) ?? null,
+      lanAddresses: lanAddresses(),
+      mdnsEnabled: this.mdnsEnabled(),
+      hubName: this.hubName(),
+    }
+  }
+
+  /** Flip the persisted enable flag + (start|stop). */
+  async setEnabled(enabled: boolean): Promise<MobileGatewayStatus> {
+    setHubSetting(this._db, SETTING.enabled, enabled ? 'true' : 'false')
+    if (enabled) await this.start()
+    else await this.stop()
+    this._broadcast({ type: 'mobile.gateway_state', running: this._running, port: this._boundPort, timestamp: new Date().toISOString() })
+    return this.status()
+  }
+
+  /** Idempotent. Loads/creates cert, binds the listener, starts the WS bridge. */
+  async start(): Promise<void> {
+    if (this._running) return
+    // Sliding-expiry sweep on each (re)start.
+    try { sweepExpiredDevices(this._db) } catch { /* non-fatal */ }
+
+    this._cert = await loadOrCreateCert(mobileDir())
+    setHubSetting(this._db, SETTING.fingerprint, this._cert.fingerprint)
+
+    this._pairing = new PairingManager({
+      certFingerprint: () => this._cert!.fingerprint,
+      hubInstanceId: () => this.instanceId(),
+      hubName: () => this.hubName(),
+      port: () => this._boundPort,
+      lanAddresses,
+      createDevice: ({ name, platform, token, certFingerprint }) => {
+        const row = createDevice(this._db, { name, platform, tokenHash: hashToken(token), certFingerprint })
+        this._broadcast({ type: 'mobile.device_paired', deviceId: row.id, name: row.name, timestamp: new Date().toISOString() })
+        return row.id
+      },
+      onClaimed: (device) => {
+        this._broadcast({ type: 'mobile.pair_requested', deviceName: device.name, platform: device.platform, timestamp: new Date().toISOString() })
+      },
+    })
+
+    const app: Express = express()
+    app.use(express.json({ limit: '256kb' }))
+    app.use(createMobileRouter({
+      db: this._db,
+      hubPort: this._hubPort,
+      currentFingerprint: () => this._cert!.fingerprint,
+      pairing: this._pairing,
+    }))
+
+    const server = https.createServer({ cert: this._cert.certPem, key: this._cert.keyPem }, app)
+    const wss = new WebSocketServer({ noServer: true })
+    const bridge = new MobileWsBridge()
+    bridge.start()
+
+    server.on('upgrade', (request: IncomingMessage, socket, head) => {
+      if ((request.url ?? '').split('?')[0] !== '/mws') {
+        socket.write('HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n')
+        socket.destroy()
+        return
+      }
+      const token = tokenFromUpgrade(request)
+      const device = resolveDevice(this._db, token, this._cert!.fingerprint)
+      if (!device) {
+        socket.write('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n')
+        socket.destroy()
+        return
+      }
+      wss.handleUpgrade(request, socket, head, (ws: WebSocket) => {
+        bridge.attach(ws as unknown as Parameters<MobileWsBridge['attach']>[0], device.id)
+      })
+    })
+
+    const port = this.configuredPort()
+    await new Promise<void>((resolve, reject) => {
+      const onError = (err: NodeJS.ErrnoException): void => {
+        server.removeListener('listening', onListening)
+        // EADDRINUSE (or any bind error) must NOT crash the sidecar — surface it.
+        reject(new Error(err.code === 'EADDRINUSE' ? `Port ${port} is already in use` : (err.message || 'listen failed')))
+      }
+      const onListening = (): void => {
+        server.removeListener('error', onError)
+        const addr = server.address()
+        this._boundPort = typeof addr === 'object' && addr ? addr.port : port
+        resolve()
+      }
+      server.once('error', onError)
+      server.once('listening', onListening)
+      server.listen(port, this._bindHost)
+    })
+
+    this._server = server
+    this._wss = wss
+    this._bridge = bridge
+    this._running = true
+
+    if (this.mdnsEnabled()) {
+      void advertiseMdns({
+        name: this.hubName(),
+        port: this._boundPort,
+        instanceId: this.instanceId(),
+        fingerprint: this._cert.fingerprint,
+      })
+    }
+  }
+
+  /** Idempotent teardown. */
+  async stop(): Promise<void> {
+    await withdrawMdns()
+    if (this._bridge) { this._bridge.stop(); this._bridge = null }
+    if (this._wss) { try { this._wss.close() } catch { /* ignore */ } this._wss = null }
+    if (this._server) {
+      await new Promise<void>((resolve) => this._server!.close(() => resolve()))
+      this._server = null
+    }
+    this._running = false
+  }
+
+  /** "Reset mobile identity": new cert + revoke every device + relisten. */
+  async rotateCert(): Promise<MobileGatewayStatus> {
+    await rotateCert(mobileDir())
+    revokeAllDevices(this._db)
+    const wasRunning = this._running
+    if (wasRunning) {
+      await this.stop()
+      await this.start()
+    } else {
+      this._cert = await loadOrCreateCert(mobileDir())
+      setHubSetting(this._db, SETTING.fingerprint, this._cert.fingerprint)
+    }
+    this._broadcast({ type: 'mobile.gateway_state', running: this._running, port: this._boundPort, timestamp: new Date().toISOString() })
+    return this.status()
+  }
+}
+
+/** Extract a device token from a /mws upgrade: Authorization header (native
+ *  clients can set it) or the `hub-token.<token>` subprotocol carrier. */
+function tokenFromUpgrade(request: IncomingMessage): string | null {
+  const fake = { headers: request.headers } as unknown as import('express').Request
+  const bearer = extractBearer(fake)
+  if (bearer) return bearer
+  const proto = request.headers['sec-websocket-protocol']
+  if (typeof proto === 'string') {
+    for (const part of proto.split(',')) {
+      const p = part.trim()
+      if (p.startsWith('hub-token.')) return p.slice('hub-token.'.length).trim()
+    }
+  }
+  return null
+}
+
+export type { MobilePlatform }

--- a/server/mobile/mobile-mdns.test.ts
+++ b/server/mobile/mobile-mdns.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { withdrawMdns } from './mobile-mdns'
+
+// advertiseMdns opens a real multicast socket, so it is exercised only in the
+// bundled-app smoke test (scripts), not here. withdrawMdns must be a safe no-op
+// when nothing was advertised — that is the path the gateway hits on every
+// stop()/disable when mDNS was off or failed.
+describe('mobile-mdns', () => {
+  it('withdrawMdns is a safe no-op when nothing is advertised', async () => {
+    await expect(withdrawMdns()).resolves.toBeUndefined()
+    // Idempotent.
+    await expect(withdrawMdns()).resolves.toBeUndefined()
+  })
+})

--- a/server/mobile/mobile-mdns.ts
+++ b/server/mobile/mobile-mdns.ts
@@ -1,0 +1,60 @@
+// Best-effort mDNS/DNS-SD advertising via @homebridge/ciao (pure-JS, RFC
+// 6762/6763, Windows-safe). Discovery is a SECONDARY convenience — the QR is the
+// primary path — so any failure here is logged and swallowed; the gateway works
+// without it. TXT carries only { id, fp } (never a token or a revealing name).
+
+interface CiaoService {
+  advertise(): Promise<void>
+  end(): Promise<void>
+  destroy(): void
+}
+interface CiaoResponder {
+  createService(opts: unknown): CiaoService
+  shutdown(): Promise<void>
+}
+
+let responder: CiaoResponder | null = null
+let service: CiaoService | null = null
+
+export interface MdnsOptions {
+  name: string
+  port: number
+  instanceId: string
+  fingerprint: string
+}
+
+export async function advertiseMdns(opts: MdnsOptions): Promise<boolean> {
+  try {
+    const mod = (await import('@homebridge/ciao')) as unknown as {
+      getResponder?: () => CiaoResponder
+      default?: { getResponder?: () => CiaoResponder }
+    }
+    const getResponder = mod.getResponder ?? mod.default?.getResponder
+    if (!getResponder) return false
+    responder = getResponder()
+    service = responder.createService({
+      name: opts.name,
+      type: 'specrailshub',
+      port: opts.port,
+      txt: { id: opts.instanceId, fp: opts.fingerprint },
+    })
+    await service.advertise()
+    return true
+  } catch (err) {
+    console.warn('[mobile-mdns] advertise failed (non-fatal):', err instanceof Error ? err.message : err)
+    responder = null
+    service = null
+    return false
+  }
+}
+
+export async function withdrawMdns(): Promise<void> {
+  try {
+    if (service) await service.end()
+  } catch { /* ignore */ }
+  try {
+    if (responder) await responder.shutdown()
+  } catch { /* ignore */ }
+  service = null
+  responder = null
+}

--- a/server/mobile/mobile-pairing.test.ts
+++ b/server/mobile/mobile-pairing.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { PairingManager, type PairingDeps } from './mobile-pairing'
+
+// Deterministic byte source: returns predictable buffers so secrets are known.
+function makeDeps(over: Partial<PairingDeps> = {}): { mgr: PairingManager; created: Array<{ name: string; token: string }>; claimed: string[] } {
+  const created: Array<{ name: string; token: string }> = []
+  const claimed: string[] = []
+  let counter = 0
+  const mgr = new PairingManager({
+    certFingerprint: () => 'fp-current',
+    hubInstanceId: () => 'hub-1',
+    hubName: () => 'Mac',
+    port: () => 4202,
+    lanAddresses: () => ['192.168.1.10'],
+    createDevice: (o) => { created.push({ name: o.name, token: o.token }); return `dev-${created.length}` },
+    onClaimed: (d) => { claimed.push(d.name) },
+    // Each call returns a unique deterministic buffer so secret != claimId != token.
+    genBytes: (n) => Buffer.alloc(n, (counter++ % 250) + 1),
+    clock: () => 1_000_000,
+    ...over,
+  })
+  return { mgr, created, claimed }
+}
+
+describe('PairingManager', () => {
+  it('creates a session with a QR payload carrying fp/secret/claimId/exp', () => {
+    const { mgr } = makeDeps()
+    const qr = mgr.createSession()
+    expect(qr.v).toBe(1)
+    expect(qr.fp).toBe('fp-current')
+    expect(qr.addrs).toEqual(['192.168.1.10'])
+    expect(qr.port).toBe(4202)
+    expect(qr.secret).toBeTruthy()
+    expect(qr.claimId).toBeTruthy()
+    expect(qr.secret).not.toBe(qr.claimId)
+    expect(qr.exp).toBe(Math.floor((1_000_000 + 300_000) / 1000))
+  })
+
+  it('full happy path: claim → approve → token delivered exactly once', () => {
+    const { mgr, created, claimed } = makeDeps()
+    const qr = mgr.createSession()
+    expect(mgr.claim(qr.secret, { name: 'iPhone de Javi', platform: 'ios' }, '1.2.3.4')).toEqual({ ok: true })
+    expect(claimed).toEqual(['iPhone de Javi'])
+    expect(mgr.getDesktopState()?.status).toBe('claimed')
+
+    expect(mgr.approve()).toEqual({ ok: true })
+    expect(created).toHaveLength(1)
+
+    const first = mgr.pollStatus(qr.claimId)
+    expect('approved' in first && first.approved).toBe(true)
+    if ('deviceToken' in first) {
+      expect(first.deviceToken).toBeTruthy()
+      expect(first.deviceId).toBe('dev-1')
+    }
+    // Second poll must NOT return the token again.
+    const second = mgr.pollStatus(qr.claimId)
+    expect('status' in second && second.status).toBe('expired')
+  })
+
+  it('rejects a wrong secret and locks the IP after 5 failures', () => {
+    const { mgr } = makeDeps()
+    const qr = mgr.createSession()
+    for (let i = 0; i < 4; i++) {
+      expect(mgr.claim('wrong', { name: 'x', platform: 'ios' }, '9.9.9.9')).toEqual({ ok: false, reason: 'invalid' })
+    }
+    // 5th wrong → still invalid but now locks.
+    expect(mgr.claim('wrong', { name: 'x', platform: 'ios' }, '9.9.9.9')).toEqual({ ok: false, reason: 'invalid' })
+    // 6th attempt from the same IP → locked, even with the RIGHT secret.
+    expect(mgr.claim(qr.secret, { name: 'x', platform: 'ios' }, '9.9.9.9')).toEqual({ ok: false, reason: 'locked' })
+  })
+
+  it('global attempt cap destroys the session (defeats IP rotation)', () => {
+    const { mgr } = makeDeps()
+    const qr = mgr.createSession()
+    // 21 attempts from distinct IPs trips the global cap (>20).
+    let lastReason = ''
+    for (let i = 0; i < 21; i++) {
+      const r = mgr.claim('wrong', { name: 'x', platform: 'ios' }, `10.0.0.${i}`)
+      if (!r.ok) lastReason = r.reason
+    }
+    expect(lastReason).toBe('locked')
+    // Session destroyed → a correct secret now finds no session.
+    expect(mgr.claim(qr.secret, { name: 'x', platform: 'ios' }, '1.1.1.1')).toEqual({ ok: false, reason: 'no-session' })
+  })
+
+  it('expires after the TTL', () => {
+    let t = 1_000_000
+    const { mgr } = makeDeps({ clock: () => t })
+    const qr = mgr.createSession()
+    t += 301_000
+    expect(mgr.claim(qr.secret, { name: 'x', platform: 'ios' }, '1.1.1.1')).toEqual({ ok: false, reason: 'expired' })
+    expect(mgr.pollStatus(qr.claimId).status ?? '').toBe('expired')
+  })
+
+  it('claim without a session, approve without a claim, deny + cancel', () => {
+    const { mgr } = makeDeps()
+    expect(mgr.claim('x', { name: 'a', platform: 'ios' }, 'ip')).toEqual({ ok: false, reason: 'no-session' })
+    expect(mgr.approve()).toEqual({ ok: false, reason: 'no-session' })
+    const qr = mgr.createSession()
+    expect(mgr.approve()).toEqual({ ok: false, reason: 'not-claimed' })
+    mgr.claim(qr.secret, { name: 'a', platform: 'ios' }, 'ip')
+    mgr.deny()
+    expect(mgr.pollStatus(qr.claimId).status).toBe('denied')
+    mgr.cancel()
+    expect(mgr.getDesktopState()).toBeNull()
+  })
+
+  it('a second claim on an already-claimed session is rejected', () => {
+    const { mgr } = makeDeps()
+    const qr = mgr.createSession()
+    mgr.claim(qr.secret, { name: 'a', platform: 'ios' }, 'ip')
+    expect(mgr.claim(qr.secret, { name: 'b', platform: 'android' }, 'ip')).toEqual({ ok: false, reason: 'already-claimed' })
+  })
+
+  it('pollStatus with an unknown claimId returns expired', () => {
+    const { mgr } = makeDeps()
+    mgr.createSession()
+    expect(mgr.pollStatus('not-the-claim-id').status ?? '').toBe('expired')
+  })
+})

--- a/server/mobile/mobile-pairing.ts
+++ b/server/mobile/mobile-pairing.ts
@@ -1,0 +1,206 @@
+import { randomBytes } from 'crypto'
+import { safeEqual } from '../auth'
+import type { MobilePlatform, QrPayload, PairingSessionState, PairApprovedResult } from './mobile-types'
+
+// In-memory pairing state machine. At most one pairing session is open at a time
+// (the desktop opens it when the user clicks "Pair device"). Sessions, lockout
+// counters, and the one-time token delivery live ONLY in memory — they are voided
+// by a process restart/sleep/self-update, which is acceptable (paired devices
+// survive in hub.sqlite; an in-progress pair just restarts).
+//
+// Security (verified gaps from the adversarial review):
+//  - secret: 16 random bytes (128-bit), single-use, 60s TTL → no PAKE needed.
+//  - claimId: separate 16-byte handle; the token is delivered EXACTLY ONCE then
+//    scrubbed (a later poll returns approved-without-token).
+//  - lockout: per-IP (5 bad secrets → 60s) AND a global attempt cap (defeats
+//    IPv6 privacy-address rotation) that destroys the session on breach.
+//  - desktop Approve click gates token issuance (QR possession is not enough).
+
+// 5 minutes: long enough for a manual copy→paste→type flow (e.g. pairing a
+// simulator with no camera) while still single-use + gated by the desktop
+// approval click + a 128-bit secret, so the leaked-QR window stays small.
+const DEFAULT_TTL_MS = 300_000
+const PER_IP_MAX_FAILS = 5
+const PER_IP_LOCKOUT_MS = 60_000
+const GLOBAL_WINDOW_MS = 60_000
+const GLOBAL_MAX_ATTEMPTS = 20
+
+export type ClaimResult =
+  | { ok: true }
+  | { ok: false; reason: 'no-session' | 'expired' | 'locked' | 'invalid' | 'already-claimed' }
+
+export interface PairingDeps {
+  certFingerprint: () => string
+  hubInstanceId: () => string
+  hubName: () => string
+  port: () => number
+  lanAddresses: () => string[]
+  /** Persists an approved device, returns its new id. */
+  createDevice: (opts: { name: string; platform: MobilePlatform; token: string; certFingerprint: string }) => string
+  /** Fired when a phone successfully claims (desktop shows "X wants to pair"). */
+  onClaimed?: (device: { name: string; platform: MobilePlatform }) => void
+  clock?: () => number
+  genBytes?: (n: number) => Buffer
+  ttlMs?: number
+}
+
+interface Session {
+  secret: string
+  claimId: string
+  exp: number
+  status: 'pending' | 'claimed' | 'approved' | 'denied'
+  device?: { name: string; platform: MobilePlatform }
+  approved?: PairApprovedResult
+  delivered: boolean
+}
+
+export class PairingManager {
+  private _session: Session | null = null
+  private _perIp = new Map<string, { count: number; until: number }>()
+  private _globalAttempts: number[] = []
+  private readonly _deps: Required<Pick<PairingDeps, 'clock' | 'genBytes' | 'ttlMs'>> & PairingDeps
+
+  constructor(deps: PairingDeps) {
+    this._deps = {
+      ...deps,
+      clock: deps.clock ?? (() => Date.now()),
+      genBytes: deps.genBytes ?? ((n) => randomBytes(n)),
+      ttlMs: deps.ttlMs ?? DEFAULT_TTL_MS,
+    }
+  }
+
+  private now(): number {
+    return this._deps.clock()
+  }
+
+  private b64url(n: number): string {
+    return this._deps.genBytes(n).toString('base64url')
+  }
+
+  /** Open (or replace) a pairing session and return the QR payload to render. */
+  createSession(): QrPayload {
+    const now = this.now()
+    const session: Session = {
+      secret: this.b64url(16),
+      claimId: this.b64url(16),
+      exp: now + this._deps.ttlMs,
+      status: 'pending',
+      delivered: false,
+    }
+    this._session = session
+    this._perIp.clear()
+    this._globalAttempts = []
+    return {
+      v: 1,
+      hub: this._deps.hubInstanceId(),
+      name: this._deps.hubName(),
+      addrs: this._deps.lanAddresses(),
+      port: this._deps.port(),
+      fp: this._deps.certFingerprint(),
+      secret: session.secret,
+      claimId: session.claimId,
+      exp: Math.floor(session.exp / 1000),
+    }
+  }
+
+  private isExpired(s: Session): boolean {
+    return this.now() > s.exp && s.status !== 'approved'
+  }
+
+  /** Phone submits the QR secret. Enforces lockout + single-claim. */
+  claim(secret: string, device: { name: string; platform: MobilePlatform }, ip: string): ClaimResult {
+    const s = this._session
+    if (!s) return { ok: false, reason: 'no-session' }
+    if (this.isExpired(s)) {
+      this._session = null
+      return { ok: false, reason: 'expired' }
+    }
+
+    // Per-IP lockout
+    const rec = this._perIp.get(ip)
+    if (rec && rec.until > this.now()) return { ok: false, reason: 'locked' }
+
+    // Global attempt cap (sliding 60s window) — defeats IPv6 privacy rotation.
+    const now = this.now()
+    this._globalAttempts = this._globalAttempts.filter((t) => now - t < GLOBAL_WINDOW_MS)
+    this._globalAttempts.push(now)
+    if (this._globalAttempts.length > GLOBAL_MAX_ATTEMPTS) {
+      this._session = null
+      return { ok: false, reason: 'locked' }
+    }
+
+    if (s.status !== 'pending') return { ok: false, reason: 'already-claimed' }
+
+    if (!safeEqual(secret, s.secret)) {
+      const next = { count: (rec?.count ?? 0) + 1, until: rec?.until ?? 0 }
+      if (next.count >= PER_IP_MAX_FAILS) next.until = now + PER_IP_LOCKOUT_MS
+      this._perIp.set(ip, next)
+      return { ok: false, reason: 'invalid' }
+    }
+
+    s.status = 'claimed'
+    s.device = { name: device.name.slice(0, 80) || 'Unknown device', platform: device.platform }
+    try { this._deps.onClaimed?.(s.device) } catch { /* non-fatal */ }
+    return { ok: true }
+  }
+
+  /** Desktop approves → issue a per-device token (delivered once via pollStatus). */
+  approve(): { ok: true } | { ok: false; reason: 'no-session' | 'not-claimed' } {
+    const s = this._session
+    if (!s) return { ok: false, reason: 'no-session' }
+    if (s.status !== 'claimed' || !s.device) return { ok: false, reason: 'not-claimed' }
+    const token = this._deps.genBytes(32).toString('hex')
+    const deviceId = this._deps.createDevice({
+      name: s.device.name,
+      platform: s.device.platform,
+      token,
+      certFingerprint: this._deps.certFingerprint(),
+    })
+    s.approved = {
+      approved: true,
+      deviceToken: token,
+      deviceId,
+      hubName: this._deps.hubName(),
+      hubInstanceId: this._deps.hubInstanceId(),
+    }
+    s.status = 'approved'
+    return { ok: true }
+  }
+
+  deny(): void {
+    if (this._session) this._session.status = 'denied'
+  }
+
+  cancel(): void {
+    this._session = null
+  }
+
+  /** Desktop UI poll. */
+  getDesktopState(): PairingSessionState | null {
+    const s = this._session
+    if (!s) return null
+    const status = this.isExpired(s) ? 'expired' : s.status
+    return { status, claimId: s.claimId, device: s.device }
+  }
+
+  /** Phone poll. Delivers the token EXACTLY ONCE, then scrubs it. */
+  pollStatus(claimId: string): { status: 'pending' | 'claimed' | 'denied' | 'expired' } | PairApprovedResult {
+    const s = this._session
+    if (!s || !safeEqual(claimId, s.claimId)) return { status: 'expired' }
+    if (s.status === 'approved' && s.approved) {
+      if (!s.delivered) {
+        s.delivered = true
+        const result = s.approved
+        // Scrub the token from memory after the single delivery.
+        s.approved = { ...result, deviceToken: '' }
+        return result
+      }
+      // Already delivered — never hand the token out twice.
+      return { status: 'expired' }
+    }
+    if (this.isExpired(s)) return { status: 'expired' }
+    if (s.status === 'denied') return { status: 'denied' }
+    if (s.status === 'claimed') return { status: 'claimed' }
+    return { status: 'pending' }
+  }
+}

--- a/server/mobile/mobile-redact.test.ts
+++ b/server/mobile/mobile-redact.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import os from 'os'
+import { redact, stripHome } from './mobile-redact'
+
+describe('mobile-redact', () => {
+  it('strips the home dir from strings', () => {
+    const home = os.homedir()
+    expect(stripHome(`${home}/repos/x`)).toBe('~/repos/x')
+    expect(stripHome('no home here')).toBe('no home here')
+  })
+
+  it('drops sensitive keys at any depth', () => {
+    const input = {
+      id: 'p1',
+      path: '/Users/x/secret',
+      db_path: '/Users/x/db.sqlite',
+      nested: { absolutePath: '/a/b', keep: 'yes', cwd: '/c' },
+      list: [{ projectPath: '/p', name: 'ok' }],
+    }
+    const out = redact(input) as Record<string, unknown>
+    expect(out.path).toBeUndefined()
+    expect(out.db_path).toBeUndefined()
+    expect((out.nested as Record<string, unknown>).absolutePath).toBeUndefined()
+    expect((out.nested as Record<string, unknown>).cwd).toBeUndefined()
+    expect((out.nested as Record<string, unknown>).keep).toBe('yes')
+    expect((out.list as Array<Record<string, unknown>>)[0].projectPath).toBeUndefined()
+    expect((out.list as Array<Record<string, unknown>>)[0].name).toBe('ok')
+  })
+
+  it('scrubs the home dir inside surviving strings (e.g. job command)', () => {
+    const home = os.homedir()
+    const out = redact({ command: `cd ${home}/p && run` }) as { command: string }
+    expect(out.command).toBe('cd ~/p && run')
+  })
+
+  it('passes primitives through unchanged and never mutates input', () => {
+    expect(redact(42)).toBe(42)
+    expect(redact(true)).toBe(true)
+    expect(redact(null)).toBe(null)
+    const input = { a: 1 }
+    redact(input)
+    expect(input).toEqual({ a: 1 })
+  })
+})

--- a/server/mobile/mobile-redact.ts
+++ b/server/mobile/mobile-redact.ts
@@ -1,0 +1,47 @@
+import os from 'os'
+
+// Information-minimisation for everything the gateway hands a phone. Two rules:
+//   1. Drop same-machine keys outright (filesystem paths, db handles).
+//   2. Replace the user's home directory inside any remaining string with `~`
+//      so a `command` like `/specrails:implement #34` keeps its useful shape but
+//      an embedded absolute path (or a stray cwd) leaks no local layout.
+//
+// Applied to EVERY proxied REST JSON body and EVERY outbound WS payload.
+
+const SENSITIVE_KEYS = new Set(['path', 'db_path', 'dbPath', 'absolutePath', 'cwd', 'filePath', 'projectPath'])
+
+function homeDir(): string {
+  try {
+    return os.homedir()
+  } catch {
+    return ''
+  }
+}
+
+/** Replace occurrences of the user's home dir with `~` (covers the common leak:
+ *  project paths live under ~/...). Cheap and safe — never mangles normal text. */
+export function stripHome(s: string): string {
+  const home = homeDir()
+  if (!home) return s
+  return s.split(home).join('~')
+}
+
+/** Deep-redact a JSON-serialisable value: drop sensitive keys, scrub home dir in
+ *  strings. Returns a new structure; never mutates the input. */
+export function redact<T>(value: T): T {
+  return _redact(value) as T
+}
+
+function _redact(value: unknown): unknown {
+  if (typeof value === 'string') return stripHome(value)
+  if (Array.isArray(value)) return value.map(_redact)
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (SENSITIVE_KEYS.has(k)) continue
+      out[k] = _redact(v)
+    }
+    return out
+  }
+  return value
+}

--- a/server/mobile/mobile-router.test.ts
+++ b/server/mobile/mobile-router.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import express from 'express'
+import http from 'http'
+import request from 'supertest'
+import { initHubDb } from '../hub-db'
+import type { DbInstance } from '../db'
+import { createDevice, hashToken } from './mobile-devices'
+import { createMobileRouter } from './mobile-router'
+import { PairingManager } from './mobile-pairing'
+
+// A stand-in "internal hub" the gateway forwards to. Captures the last body so we
+// can assert narrowing, and echoes auth so we can assert the master token is
+// injected.
+let internal: http.Server
+let internalPort = 0
+let lastPatchBody: unknown = null
+let lastAuth: string | undefined
+
+beforeAll(async () => {
+  const app = express()
+  app.use(express.json())
+  app.get('/api/hub/projects', (req, res) => {
+    lastAuth = req.headers['authorization']
+    res.json({ projects: [{ id: 'p1', name: 'P', slug: 's', path: '/Users/x/secret', db_path: '/d' }] })
+  })
+  app.get('/api/projects/:id/tickets', (_req, res) => res.json({ tickets: [{ id: 1, title: 'T' }] }))
+  app.patch('/api/projects/:id/tickets/:tid', (req, res) => { lastPatchBody = req.body; res.json({ ok: true, received: req.body }) })
+  app.get('/api/projects/:id/spending', (req, res) => res.json({ query: req.query }))
+  // Generic echo for every other forwarded route (actions, other reads): returns
+  // the method/path/body so tests can assert narrowing + reachability.
+  app.use((req, res) => res.json({ echoed: true, method: req.method, route: req.path, body: req.body }))
+  internal = http.createServer(app)
+  await new Promise<void>((r) => internal.listen(0, '127.0.0.1', r))
+  internalPort = (internal.address() as { port: number }).port
+})
+
+afterAll(async () => {
+  await new Promise<void>((r) => internal.close(() => r()))
+})
+
+function buildApp(db: DbInstance): express.Express {
+  const pairing = new PairingManager({
+    certFingerprint: () => 'fp', hubInstanceId: () => 'h', hubName: () => 'Mac',
+    port: () => 4202, lanAddresses: () => ['10.0.0.1'], createDevice: () => 'd1',
+  })
+  const app = express()
+  app.use(express.json())
+  app.use(createMobileRouter({ db, hubPort: internalPort, currentFingerprint: () => 'fp', pairing }))
+  return app
+}
+
+describe('mobile-router', () => {
+  let db: DbInstance
+  let app: express.Express
+  beforeEach(() => {
+    db = initHubDb(':memory:')
+    createDevice(db, { name: 'A', platform: 'ios', tokenHash: hashToken('tok'), certFingerprint: 'fp' })
+    app = buildApp(db)
+    lastPatchBody = null
+  })
+
+  it('GET /v1/projects returns redacted projects with the master token injected', async () => {
+    const res = await request(app).get('/v1/projects').set('Authorization', 'Bearer tok')
+    expect(res.status).toBe(200)
+    expect(res.body.projects[0].path).toBeUndefined()
+    expect(res.body.projects[0].db_path).toBeUndefined()
+    expect(res.body.projects[0].id).toBe('p1')
+    expect(lastAuth).toMatch(/^Bearer .+/)
+  })
+
+  it('401 without a device token', async () => {
+    const res = await request(app).get('/v1/projects')
+    expect(res.status).toBe(401)
+  })
+
+  it('403 when a browser Origin header is present', async () => {
+    const res = await request(app).get('/v1/projects').set('Authorization', 'Bearer tok').set('Origin', 'http://evil')
+    expect(res.status).toBe(403)
+  })
+
+  it('400 on a param with a traversal/dot (regex guard)', async () => {
+    const res = await request(app).get('/v1/projects/ba..d/tickets').set('Authorization', 'Bearer tok')
+    expect(res.status).toBe(400)
+  })
+
+  it('narrows the PATCH body to {status,priority,title}', async () => {
+    const res = await request(app)
+      .patch('/v1/projects/p1/tickets/5')
+      .set('Authorization', 'Bearer tok')
+      .send({ status: 'done', evil: 'x', assignee: 'hacker' })
+    expect(res.status).toBe(200)
+    expect(lastPatchBody).toEqual({ status: 'done' })
+  })
+
+  it('forwards the query string on reads', async () => {
+    const res = await request(app).get('/v1/projects/p1/spending?period=30d&surface=job').set('Authorization', 'Bearer tok')
+    expect(res.status).toBe(200)
+    expect(res.body.query).toEqual({ period: '30d', surface: 'job' })
+  })
+
+  it('chat: create conversation narrows kind/model/contextScope', async () => {
+    const res = await request(app)
+      .post('/v1/projects/p1/chat/conversations')
+      .set('Authorization', 'Bearer tok')
+      .send({ kind: 'explore', model: 'opus', evil: 1, contextScope: { specrails: true, full: true, bogus: 'x' } })
+    expect(res.status).toBe(200)
+    expect(res.body.body).toEqual({ kind: 'explore', model: 'opus', contextScope: { specrails: true, full: true } })
+  })
+
+  it('chat: send message narrows text/lightweight', async () => {
+    const res = await request(app)
+      .post('/v1/projects/p1/chat/conversations/abc-123/messages')
+      .set('Authorization', 'Bearer tok')
+      .send({ text: 'hi', evil: 1 })
+    expect(res.body.body).toEqual({ text: 'hi', lightweight: true })
+    expect(res.body.route).toBe('/api/projects/p1/chat/conversations/abc-123/messages')
+  })
+
+  it('chat: interrupt + spec-draft + default-spec-model reachable', async () => {
+    expect((await request(app).delete('/v1/projects/p1/chat/conversations/abc-123/messages/stream').set('Authorization', 'Bearer tok')).status).toBe(200)
+    expect((await request(app).get('/v1/projects/p1/chat/conversations/abc-123/spec-draft').set('Authorization', 'Bearer tok')).status).toBe(200)
+    expect((await request(app).get('/v1/projects/p1/default-spec-model?provider=claude').set('Authorization', 'Bearer tok')).status).toBe(200)
+  })
+
+  it('from-draft narrows the commit body', async () => {
+    const res = await request(app)
+      .post('/v1/projects/p1/tickets/from-draft')
+      .set('Authorization', 'Bearer tok')
+      .send({ title: 'T', conversationId: 'c1', priority: 'high', labels: ['a', 2], acceptanceCriteria: ['x'], evil: 1 })
+    expect(res.body.body).toEqual({ title: 'T', conversationId: 'c1', priority: 'high', labels: ['a'], acceptanceCriteria: ['x'] })
+  })
+
+  it('unknown gateway path → 404 JSON (never a SPA)', async () => {
+    const res = await request(app).get('/v1/nope').set('Authorization', 'Bearer tok')
+    expect(res.status).toBe(404)
+    expect(res.body.error).toBe('Not found')
+  })
+
+  it('rail launch narrows the body and reaches the internal route', async () => {
+    const res = await request(app)
+      .post('/v1/projects/p1/rails/0/launch')
+      .set('Authorization', 'Bearer tok')
+      .send({ mode: 'implement', profileName: 'default', evil: 'x' })
+    expect(res.status).toBe(200)
+    expect(res.body.body).toEqual({ mode: 'implement', profileName: 'default' })
+    expect(res.body.route).toBe('/api/projects/p1/rails/0/launch')
+  })
+
+  it('rail stop, queue pause/resume, job delete, put rail tickets are reachable', async () => {
+    expect((await request(app).post('/v1/projects/p1/rails/0/stop').set('Authorization', 'Bearer tok')).status).toBe(200)
+    expect((await request(app).post('/v1/projects/p1/queue/pause').set('Authorization', 'Bearer tok')).status).toBe(200)
+    expect((await request(app).post('/v1/projects/p1/queue/resume').set('Authorization', 'Bearer tok')).status).toBe(200)
+    expect((await request(app).delete('/v1/projects/p1/jobs/job-1').set('Authorization', 'Bearer tok')).status).toBe(200)
+    const put = await request(app).put('/v1/projects/p1/rails/0/tickets').set('Authorization', 'Bearer tok').send({ ticketIds: [1, 2, 'x'] })
+    expect(put.status).toBe(200)
+    expect(put.body.body).toEqual({ ticketIds: [1, 2] })
+  })
+
+  it('put rail name forwards a narrowed {name} body', async () => {
+    const named = await request(app).put('/v1/projects/p1/rails/0/name').set('Authorization', 'Bearer tok').send({ name: 'Backend', evil: 1 })
+    expect(named.status).toBe(200)
+    expect(named.body.route).toBe('/api/projects/p1/rails/0/name')
+    expect(named.body.body).toEqual({ name: 'Backend' })
+    // Non-string name coerces to null (clear).
+    const cleared = await request(app).put('/v1/projects/p1/rails/0/name').set('Authorization', 'Bearer tok').send({ name: 42 })
+    expect(cleared.body.body).toEqual({ name: null })
+  })
+
+  it('generate-spec and from-prompt narrow their bodies', async () => {
+    const gs = await request(app).post('/v1/projects/p1/tickets/generate-spec').set('Authorization', 'Bearer tok').send({ prompt: 'do x', evil: 1, contractRefine: true, contextScope: { specrails: true, full: false, bogus: 1 } })
+    // prompt → idea, and the context scope is forwarded so the hub injects specs + dedups.
+    expect(gs.body.body).toEqual({ idea: 'do x', contractRefine: true, contextScope: { specrails: true, full: false } })
+    const fp = await request(app).post('/v1/projects/p1/tickets/from-prompt').set('Authorization', 'Bearer tok').send({ prompt: 'p', title: 't', evil: 1 })
+    expect(fp.body.body).toEqual({ description: 'p', title: 't' }) // prompt → description (hub contract)
+  })
+
+  it('reads: jobs/:jid, tickets/:tid, spending-summary, state, activity, stats', async () => {
+    for (const p of [
+      '/v1/projects/p1/jobs/job-1',
+      '/v1/projects/p1/tickets/5',
+      '/v1/projects/p1/tickets/5/spending-summary',
+      '/v1/projects/p1/state',
+      '/v1/projects/p1/activity',
+      '/v1/projects/p1/stats',
+      '/v1/projects/p1/rails',
+      '/v1/projects/p1/jobs',
+      '/v1/projects/p1/queue',
+    ]) {
+      const res = await request(app).get(p).set('Authorization', 'Bearer tok')
+      expect(res.status, p).toBe(200)
+    }
+  })
+
+  it('502 when the internal hub is unreachable', async () => {
+    const pairing = new PairingManager({
+      certFingerprint: () => 'fp', hubInstanceId: () => 'h', hubName: () => 'Mac',
+      port: () => 4202, lanAddresses: () => [], createDevice: () => 'd1',
+    })
+    const a = express()
+    a.use(express.json())
+    // Point at a port nothing is listening on.
+    a.use(createMobileRouter({ db, hubPort: 9, currentFingerprint: () => 'fp', pairing }))
+    const res = await request(a).get('/v1/projects').set('Authorization', 'Bearer tok')
+    expect(res.status).toBe(502)
+  })
+
+  it('pairing claim + status are reachable without auth', async () => {
+    // Fresh app with a real pairing session.
+    const pairing = new PairingManager({
+      certFingerprint: () => 'fp', hubInstanceId: () => 'h', hubName: () => 'Mac',
+      port: () => 4202, lanAddresses: () => ['10.0.0.1'], createDevice: () => 'd1',
+    })
+    const a = express()
+    a.use(express.json())
+    a.use(createMobileRouter({ db, hubPort: internalPort, currentFingerprint: () => 'fp', pairing }))
+    const qr = pairing.createSession()
+
+    const claim = await request(a).post('/pair/claim').send({ secret: qr.secret, deviceName: 'iPhone', platform: 'ios' })
+    expect(claim.status).toBe(200)
+    expect(claim.body.ok).toBe(true)
+
+    const bad = await request(a).post('/pair/claim').send({ deviceName: 'x' })
+    expect(bad.status).toBe(400)
+
+    const status = await request(a).get(`/pair/status?claimId=${encodeURIComponent(qr.claimId)}`)
+    expect(status.status).toBe(200)
+    expect(status.body.status).toBe('claimed')
+  })
+})

--- a/server/mobile/mobile-router.ts
+++ b/server/mobile/mobile-router.ts
@@ -1,0 +1,409 @@
+import { Router } from 'express'
+import type { Request, Response } from 'express'
+import { loadOrGenerateToken } from '../auth'
+import { redact } from './mobile-redact'
+import { createMobileAuthMiddleware } from './mobile-auth'
+import type { PairingManager } from './mobile-pairing'
+import type { DbInstance } from '../db'
+import type { MobilePlatform } from './mobile-types'
+
+// The LAN-facing REST surface. Two parts:
+//   /pair/*  — unauthenticated, locked-down pairing handshake.
+//   /v1/*    — authenticated allow-list. Each route forwards, in-process, via a
+//              REAL loopback HTTP request to http://127.0.0.1:<hubPort> with the
+//              master hub token injected server-side (it never leaves the box).
+//
+// Forwarding is PARAMETERISED: the internal path is rebuilt from Express route
+// params (each a single URL segment — `..`/`/` can't appear), never from the raw
+// request URL, so there is no path-traversal or SPA-catch-all bypass. Responses
+// are deep-redacted before reaching the phone.
+
+const PID_RE = /^[A-Za-z0-9_-]{1,64}$/
+const NUM_RE = /^\d{1,9}$/
+const JOBID_RE = /^[A-Za-z0-9_-]{1,64}$/
+const CONV_ID_RE = /^[A-Za-z0-9-]{1,64}$/
+
+export interface MobileRouterDeps {
+  db: DbInstance
+  hubPort: number
+  currentFingerprint: () => string
+  pairing: PairingManager
+}
+
+export function createMobileRouter(deps: MobileRouterDeps): Router {
+  const router = Router()
+  const internalBase = `http://127.0.0.1:${deps.hubPort}`
+  // Express 5 types a route param as `string | string[]`; coerce to a single
+  // segment (an array — which path-to-regexp never produces here — collapses to
+  // '' and fails the validators below).
+  const seg = (v: unknown): string => (typeof v === 'string' ? v : '')
+
+  // ─── Pairing (unauthenticated, rate-limited inside PairingManager) ──────────
+  const pairRouter = Router()
+
+  pairRouter.post('/claim', (req: Request, res: Response) => {
+    const body = (req.body ?? {}) as { secret?: unknown; deviceName?: unknown; platform?: unknown }
+    const secret = typeof body.secret === 'string' ? body.secret : ''
+    const deviceName = typeof body.deviceName === 'string' ? body.deviceName : 'Device'
+    const platform: MobilePlatform = body.platform === 'android' ? 'android' : 'ios'
+    const ip = req.socket?.remoteAddress ?? 'unknown'
+    if (!secret) {
+      res.status(400).json({ error: 'secret required' })
+      return
+    }
+    const result = deps.pairing.claim(secret, { name: deviceName, platform }, ip)
+    if (result.ok) {
+      res.json({ ok: true })
+      return
+    }
+    const code = result.reason === 'locked' ? 429 : result.reason === 'no-session' || result.reason === 'expired' ? 410 : 403
+    res.status(code).json({ ok: false, reason: result.reason })
+  })
+
+  pairRouter.get('/status', (req: Request, res: Response) => {
+    const claimId = typeof req.query.claimId === 'string' ? req.query.claimId : ''
+    if (!claimId) {
+      res.status(400).json({ error: 'claimId required' })
+      return
+    }
+    res.json(deps.pairing.pollStatus(claimId))
+  })
+
+  router.use('/pair', pairRouter)
+
+  // ─── Authenticated allow-list (/v1) ─────────────────────────────────────────
+  const v1 = Router()
+  v1.use(createMobileAuthMiddleware({ db: deps.db, currentFingerprint: deps.currentFingerprint }))
+
+  /** Forward to the internal hub API with the master token injected; redact the
+   *  JSON response. `internalPath` is built from validated params only. */
+  async function forward(
+    res: Response,
+    method: string,
+    internalPath: string,
+    query: string,
+    body?: unknown,
+  ): Promise<void> {
+    const url = internalBase + internalPath + (query ? `?${query}` : '')
+    try {
+      const init: RequestInit = {
+        method,
+        headers: {
+          Authorization: `Bearer ${loadOrGenerateToken()}`,
+          ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+        },
+        ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+      }
+      const upstream = await fetch(url, init)
+      const text = await upstream.text()
+      let json: unknown
+      try {
+        json = text ? JSON.parse(text) : {}
+      } catch {
+        // Non-JSON upstream (should not happen on the allow-listed API) — never
+        // forward raw bytes; collapse to a status echo.
+        res.status(502).json({ error: 'Bad upstream response' })
+        return
+      }
+      res.status(upstream.status).json(redact(json))
+    } catch {
+      res.status(502).json({ error: 'Hub unreachable' })
+    }
+  }
+
+  function rawQuery(req: Request): string {
+    const i = req.originalUrl.indexOf('?')
+    return i >= 0 ? req.originalUrl.slice(i + 1) : ''
+  }
+
+  /** 400 unless every (value, regex) pair matches. Guards param injection. */
+  function validate(res: Response, ...pairs: Array<[string, RegExp]>): boolean {
+    for (const [value, re] of pairs) {
+      if (!re.test(value)) {
+        res.status(400).json({ error: 'Invalid parameter' })
+        return false
+      }
+    }
+    return true
+  }
+
+  // —— Reads ——
+  v1.get('/projects', (req, res) => {
+    void forward(res, 'GET', '/api/hub/projects', '')
+  })
+
+  const projectReads: Array<[string, string]> = [
+    ['/projects/:pid/tickets', '/tickets'],
+    ['/projects/:pid/jobs', '/jobs'],
+    ['/projects/:pid/queue', '/queue'],
+    ['/projects/:pid/rails', '/rails'],
+    ['/projects/:pid/activity', '/activity'],
+    ['/projects/:pid/stats', '/stats'],
+    ['/projects/:pid/state', '/state'],
+    ['/projects/:pid/spending', '/spending'],
+  ]
+  for (const [gw, internal] of projectReads) {
+    v1.get(gw, (req, res) => {
+      const pid = seg(req.params.pid)
+      if (!validate(res, [pid, PID_RE])) return
+      void forward(res, 'GET', `/api/projects/${encodeURIComponent(pid)}${internal}`, rawQuery(req))
+    })
+  }
+
+  v1.get('/projects/:pid/tickets/:tid', (req, res) => {
+    const pid = seg(req.params.pid), tid = seg(req.params.tid)
+    if (!validate(res, [pid, PID_RE], [tid, NUM_RE])) return
+    void forward(res, 'GET', `/api/projects/${encodeURIComponent(pid)}/tickets/${encodeURIComponent(tid)}`, '')
+  })
+
+  v1.get('/projects/:pid/jobs/:jid', (req, res) => {
+    const pid = seg(req.params.pid), jid = seg(req.params.jid)
+    if (!validate(res, [pid, PID_RE], [jid, JOBID_RE])) return
+    void forward(res, 'GET', `/api/projects/${encodeURIComponent(pid)}/jobs/${encodeURIComponent(jid)}`, '')
+  })
+
+  v1.get('/projects/:pid/tickets/:tid/spending-summary', (req, res) => {
+    const pid = seg(req.params.pid), tid = seg(req.params.tid)
+    if (!validate(res, [pid, PID_RE], [tid, NUM_RE])) return
+    void forward(res, 'GET', `/api/projects/${encodeURIComponent(pid)}/tickets/${encodeURIComponent(tid)}/spending-summary`, '')
+  })
+
+  // —— Actions (bodies narrowed) ——
+  v1.patch('/projects/:pid/tickets/:tid', (req, res) => {
+    const pid = seg(req.params.pid), tid = seg(req.params.tid)
+    if (!validate(res, [pid, PID_RE], [tid, NUM_RE])) return
+    const b = (req.body ?? {}) as Record<string, unknown>
+    const narrowed: Record<string, unknown> = {}
+    if (typeof b.status === 'string') narrowed.status = b.status
+    if (typeof b.priority === 'string') narrowed.priority = b.priority
+    if (typeof b.title === 'string') narrowed.title = b.title
+    void forward(res, 'PATCH', `/api/projects/${encodeURIComponent(pid)}/tickets/${encodeURIComponent(tid)}`, '', narrowed)
+  })
+
+  v1.delete('/projects/:pid/tickets/:tid', (req, res) => {
+    const pid = seg(req.params.pid), tid = seg(req.params.tid)
+    if (!validate(res, [pid, PID_RE], [tid, NUM_RE])) return
+    void forward(res, 'DELETE', `/api/projects/${encodeURIComponent(pid)}/tickets/${encodeURIComponent(tid)}`, '')
+  })
+
+  v1.put('/projects/:pid/rails/:i/tickets', (req, res) => {
+    const pid = seg(req.params.pid), i = seg(req.params.i)
+    if (!validate(res, [pid, PID_RE], [i, NUM_RE])) return
+    const b = (req.body ?? {}) as Record<string, unknown>
+    const ticketIds = Array.isArray(b.ticketIds) ? b.ticketIds.filter((n) => typeof n === 'number') : []
+    void forward(res, 'PUT', `/api/projects/${encodeURIComponent(pid)}/rails/${encodeURIComponent(i)}/tickets`, '', { ticketIds })
+  })
+
+  v1.post('/projects/:pid/rails/:i/launch', (req, res) => {
+    const pid = seg(req.params.pid), i = seg(req.params.i)
+    if (!validate(res, [pid, PID_RE], [i, NUM_RE])) return
+    const b = (req.body ?? {}) as Record<string, unknown>
+    const narrowed: Record<string, unknown> = {}
+    if (typeof b.mode === 'string') narrowed.mode = b.mode
+    if (typeof b.profileName === 'string') narrowed.profileName = b.profileName
+    if (typeof b.aiEngine === 'string') narrowed.aiEngine = b.aiEngine
+    if (typeof b.model === 'string') narrowed.model = b.model // ultracode model
+    void forward(res, 'POST', `/api/projects/${encodeURIComponent(pid)}/rails/${encodeURIComponent(i)}/launch`, '', narrowed)
+  })
+
+  v1.put('/projects/:pid/rails/:i/engine', (req, res) => {
+    const pid = seg(req.params.pid), i = seg(req.params.i)
+    if (!validate(res, [pid, PID_RE], [i, NUM_RE])) return
+    const b = (req.body ?? {}) as Record<string, unknown>
+    // aiEngine: a provider string, or null to clear the override.
+    const aiEngine = typeof b.aiEngine === 'string' ? b.aiEngine : null
+    void forward(res, 'PUT', `/api/projects/${encodeURIComponent(pid)}/rails/${encodeURIComponent(i)}/engine`, '', { aiEngine })
+  })
+
+  v1.put('/projects/:pid/rails/:i/name', (req, res) => {
+    const pid = seg(req.params.pid), i = seg(req.params.i)
+    if (!validate(res, [pid, PID_RE], [i, NUM_RE])) return
+    const b = (req.body ?? {}) as Record<string, unknown>
+    // name: the display label, or null to clear back to the default "Rail N".
+    const name = typeof b.name === 'string' ? b.name : null
+    void forward(res, 'PUT', `/api/projects/${encodeURIComponent(pid)}/rails/${encodeURIComponent(i)}/name`, '', { name })
+  })
+
+  v1.post('/projects/:pid/rails/:i/stop', (req, res) => {
+    const pid = seg(req.params.pid), i = seg(req.params.i)
+    if (!validate(res, [pid, PID_RE], [i, NUM_RE])) return
+    void forward(res, 'POST', `/api/projects/${encodeURIComponent(pid)}/rails/${encodeURIComponent(i)}/stop`, '', {})
+  })
+
+  v1.delete('/projects/:pid/jobs/:jid', (req, res) => {
+    const pid = seg(req.params.pid), jid = seg(req.params.jid)
+    if (!validate(res, [pid, PID_RE], [jid, JOBID_RE])) return
+    void forward(res, 'DELETE', `/api/projects/${encodeURIComponent(pid)}/jobs/${encodeURIComponent(jid)}`, '')
+  })
+
+  v1.post('/projects/:pid/queue/pause', (req, res) => {
+    const pid = seg(req.params.pid)
+    if (!validate(res, [pid, PID_RE])) return
+    void forward(res, 'POST', `/api/projects/${encodeURIComponent(pid)}/queue/pause`, '', {})
+  })
+  v1.post('/projects/:pid/queue/resume', (req, res) => {
+    const pid = seg(req.params.pid)
+    if (!validate(res, [pid, PID_RE])) return
+    void forward(res, 'POST', `/api/projects/${encodeURIComponent(pid)}/queue/resume`, '', {})
+  })
+
+  // —— Spec capture on the go ——
+  v1.post('/projects/:pid/tickets/generate-spec', (req, res) => {
+    const pid = seg(req.params.pid)
+    if (!validate(res, [pid, PID_RE])) return
+    const b = (req.body ?? {}) as Record<string, unknown>
+    const narrowed: Record<string, unknown> = {}
+    // The hub's generate-spec expects `idea` — the app sends `prompt`.
+    if (typeof b.prompt === 'string') narrowed.idea = b.prompt
+    if (typeof b.model === 'string') narrowed.model = b.model
+    if (typeof b.aiEngine === 'string') narrowed.aiEngine = b.aiEngine
+    if (typeof b.contractRefine === 'boolean') narrowed.contractRefine = b.contractRefine
+    // Forward the context scope so the hub injects .specrails/local-tickets.json
+    // (specrails:true) and dedups against existing specs — without this the AI has
+    // no context and re-creates specs that already exist.
+    const scope = narrowScope(b.contextScope)
+    if (scope) narrowed.contextScope = scope
+    void forward(res, 'POST', `/api/projects/${encodeURIComponent(pid)}/tickets/generate-spec`, '', narrowed)
+  })
+
+  v1.post('/projects/:pid/tickets/from-prompt', (req, res) => {
+    const pid = seg(req.params.pid)
+    if (!validate(res, [pid, PID_RE])) return
+    const b = (req.body ?? {}) as Record<string, unknown>
+    const narrowed: Record<string, unknown> = {}
+    // The hub's from-prompt expects `description` — the app sends `prompt`.
+    if (typeof b.prompt === 'string') narrowed.description = b.prompt
+    if (typeof b.title === 'string') narrowed.title = b.title
+    void forward(res, 'POST', `/api/projects/${encodeURIComponent(pid)}/tickets/from-prompt`, '', narrowed)
+  })
+
+  // —— Model catalog (for the Quick/Explore model picker) ——
+  v1.get('/projects/:pid/default-spec-model', (req, res) => {
+    const pid = seg(req.params.pid)
+    if (!validate(res, [pid, PID_RE])) return
+    void forward(res, 'GET', `/api/projects/${encodeURIComponent(pid)}/default-spec-model`, rawQuery(req))
+  })
+
+  // —— Explore conversations (Add Spec → Explore: a conversational agent) ——
+  function narrowScope(raw: unknown): Record<string, boolean> | undefined {
+    if (!raw || typeof raw !== 'object') return undefined
+    const r = raw as Record<string, unknown>
+    const out: Record<string, boolean> = {}
+    for (const k of ['specrails', 'openspec', 'full', 'mcp', 'contractRefine', 'userMcp']) {
+      if (typeof r[k] === 'boolean') out[k] = r[k] as boolean
+    }
+    return out
+  }
+
+  v1.post('/projects/:pid/chat/conversations', (req, res) => {
+    const pid = seg(req.params.pid)
+    if (!validate(res, [pid, PID_RE])) return
+    const b = (req.body ?? {}) as Record<string, unknown>
+    const narrowed: Record<string, unknown> = {}
+    narrowed.kind = b.kind === 'explore' ? 'explore' : 'sidebar'
+    if (typeof b.model === 'string') narrowed.model = b.model
+    if (typeof b.aiEngine === 'string') narrowed.aiEngine = b.aiEngine
+    const scope = narrowScope(b.contextScope)
+    if (scope) narrowed.contextScope = scope
+    void forward(res, 'POST', `/api/projects/${encodeURIComponent(pid)}/chat/conversations`, '', narrowed)
+  })
+
+  v1.get('/projects/:pid/chat/conversations/:cid', (req, res) => {
+    const pid = seg(req.params.pid), cid = seg(req.params.cid)
+    if (!validate(res, [pid, PID_RE], [cid, CONV_ID_RE])) return
+    void forward(res, 'GET', `/api/projects/${encodeURIComponent(pid)}/chat/conversations/${encodeURIComponent(cid)}`, '')
+  })
+
+  v1.get('/projects/:pid/chat/conversations/:cid/spec-draft', (req, res) => {
+    const pid = seg(req.params.pid), cid = seg(req.params.cid)
+    if (!validate(res, [pid, PID_RE], [cid, CONV_ID_RE])) return
+    void forward(res, 'GET', `/api/projects/${encodeURIComponent(pid)}/chat/conversations/${encodeURIComponent(cid)}/spec-draft`, '')
+  })
+
+  v1.post('/projects/:pid/chat/conversations/:cid/messages', (req, res) => {
+    const pid = seg(req.params.pid), cid = seg(req.params.cid)
+    if (!validate(res, [pid, PID_RE], [cid, CONV_ID_RE])) return
+    const b = (req.body ?? {}) as Record<string, unknown>
+    const narrowed: Record<string, unknown> = {}
+    if (typeof b.text === 'string') narrowed.text = b.text
+    narrowed.lightweight = b.lightweight === false ? false : true
+    if (typeof b.maxTurns === 'number') narrowed.maxTurns = b.maxTurns
+    void forward(res, 'POST', `/api/projects/${encodeURIComponent(pid)}/chat/conversations/${encodeURIComponent(cid)}/messages`, '', narrowed)
+  })
+
+  v1.delete('/projects/:pid/chat/conversations/:cid/messages/stream', (req, res) => {
+    const pid = seg(req.params.pid), cid = seg(req.params.cid)
+    if (!validate(res, [pid, PID_RE], [cid, CONV_ID_RE])) return
+    void forward(res, 'DELETE', `/api/projects/${encodeURIComponent(pid)}/chat/conversations/${encodeURIComponent(cid)}/messages/stream`, '')
+  })
+
+  for (const action of ['minimize', 'restore']) {
+    v1.post(`/projects/:pid/chat/conversations/:cid/${action}`, (req, res) => {
+      const pid = seg(req.params.pid), cid = seg(req.params.cid)
+      if (!validate(res, [pid, PID_RE], [cid, CONV_ID_RE])) return
+      void forward(res, 'POST', `/api/projects/${encodeURIComponent(pid)}/chat/conversations/${encodeURIComponent(cid)}/${action}`, '', {})
+    })
+  }
+
+  // —— Commit an Explore conversation to a ticket ——
+  v1.post('/projects/:pid/tickets/from-draft', (req, res) => {
+    const pid = seg(req.params.pid)
+    if (!validate(res, [pid, PID_RE])) return
+    const b = (req.body ?? {}) as Record<string, unknown>
+    const narrowed: Record<string, unknown> = {}
+    if (typeof b.title === 'string') narrowed.title = b.title
+    if (typeof b.conversationId === 'string') narrowed.conversationId = b.conversationId
+    if (typeof b.description === 'string') narrowed.description = b.description
+    if (typeof b.priority === 'string') narrowed.priority = b.priority
+    if (Array.isArray(b.labels)) narrowed.labels = b.labels.filter((x) => typeof x === 'string')
+    if (Array.isArray(b.acceptanceCriteria)) narrowed.acceptanceCriteria = b.acceptanceCriteria.filter((x) => typeof x === 'string')
+    void forward(res, 'POST', `/api/projects/${encodeURIComponent(pid)}/tickets/from-draft`, '', narrowed)
+  })
+
+  router.use('/v1', v1)
+
+  // Any unmatched gateway path → 404 JSON (NEVER falls through to a SPA handler;
+  // the gateway serves JSON/WS only, no static client).
+  router.use((_req: Request, res: Response) => {
+    res.status(404).json({ error: 'Not found' })
+  })
+
+  return router
+}
+
+/** The allow-list, exported for the CI drift test (asserts each entry resolves
+ *  against a real internal route, and that no traversal param is accepted). */
+export const MOBILE_ALLOWLIST: Array<{ method: string; path: string }> = [
+  { method: 'GET', path: '/v1/projects' },
+  { method: 'GET', path: '/v1/projects/:pid/tickets' },
+  { method: 'GET', path: '/v1/projects/:pid/tickets/:tid' },
+  { method: 'GET', path: '/v1/projects/:pid/jobs' },
+  { method: 'GET', path: '/v1/projects/:pid/jobs/:jid' },
+  { method: 'GET', path: '/v1/projects/:pid/queue' },
+  { method: 'GET', path: '/v1/projects/:pid/rails' },
+  { method: 'GET', path: '/v1/projects/:pid/activity' },
+  { method: 'GET', path: '/v1/projects/:pid/stats' },
+  { method: 'GET', path: '/v1/projects/:pid/state' },
+  { method: 'GET', path: '/v1/projects/:pid/spending' },
+  { method: 'GET', path: '/v1/projects/:pid/tickets/:tid/spending-summary' },
+  { method: 'PATCH', path: '/v1/projects/:pid/tickets/:tid' },
+  { method: 'DELETE', path: '/v1/projects/:pid/tickets/:tid' },
+  { method: 'PUT', path: '/v1/projects/:pid/rails/:i/tickets' },
+  { method: 'POST', path: '/v1/projects/:pid/rails/:i/launch' },
+  { method: 'PUT', path: '/v1/projects/:pid/rails/:i/engine' },
+  { method: 'POST', path: '/v1/projects/:pid/rails/:i/stop' },
+  { method: 'DELETE', path: '/v1/projects/:pid/jobs/:jid' },
+  { method: 'POST', path: '/v1/projects/:pid/queue/pause' },
+  { method: 'POST', path: '/v1/projects/:pid/queue/resume' },
+  { method: 'POST', path: '/v1/projects/:pid/tickets/generate-spec' },
+  { method: 'POST', path: '/v1/projects/:pid/tickets/from-prompt' },
+  { method: 'GET', path: '/v1/projects/:pid/default-spec-model' },
+  { method: 'POST', path: '/v1/projects/:pid/chat/conversations' },
+  { method: 'GET', path: '/v1/projects/:pid/chat/conversations/:cid' },
+  { method: 'GET', path: '/v1/projects/:pid/chat/conversations/:cid/spec-draft' },
+  { method: 'POST', path: '/v1/projects/:pid/chat/conversations/:cid/messages' },
+  { method: 'DELETE', path: '/v1/projects/:pid/chat/conversations/:cid/messages/stream' },
+  { method: 'POST', path: '/v1/projects/:pid/chat/conversations/:cid/minimize' },
+  { method: 'POST', path: '/v1/projects/:pid/chat/conversations/:cid/restore' },
+  { method: 'POST', path: '/v1/projects/:pid/tickets/from-draft' },
+]

--- a/server/mobile/mobile-tls.test.ts
+++ b/server/mobile/mobile-tls.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { loadOrCreateCert, rotateCert, fingerprintOf } from './mobile-tls'
+
+describe('mobile-tls', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mobtls-'))
+  })
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('generates and persists an ECDSA cert with a 64-hex fingerprint', async () => {
+    const cert = await loadOrCreateCert(dir)
+    expect(cert.certPem).toContain('BEGIN CERTIFICATE')
+    expect(cert.keyPem).toContain('PRIVATE KEY')
+    expect(cert.fingerprint).toMatch(/^[0-9a-f]{64}$/)
+    expect(fs.existsSync(path.join(dir, 'tls-cert.pem'))).toBe(true)
+    expect(fs.existsSync(path.join(dir, 'tls-key.pem'))).toBe(true)
+  })
+
+  it('returns the SAME cert on a second load (persisted, not regenerated)', async () => {
+    const a = await loadOrCreateCert(dir)
+    const b = await loadOrCreateCert(dir)
+    expect(b.fingerprint).toBe(a.fingerprint)
+    expect(b.certPem).toBe(a.certPem)
+  })
+
+  it('fingerprintOf is consistent with the loaded cert', async () => {
+    const cert = await loadOrCreateCert(dir)
+    expect(fingerprintOf(cert.certPem)).toBe(cert.fingerprint)
+  })
+
+  it('rotateCert produces a different identity', async () => {
+    const a = await loadOrCreateCert(dir)
+    const b = await rotateCert(dir)
+    expect(b.fingerprint).not.toBe(a.fingerprint)
+    // The on-disk cert is now the rotated one.
+    const c = await loadOrCreateCert(dir)
+    expect(c.fingerprint).toBe(b.fingerprint)
+  })
+
+  it('regenerates if the stored files are corrupt', async () => {
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(path.join(dir, 'tls-cert.pem'), 'garbage')
+    fs.writeFileSync(path.join(dir, 'tls-key.pem'), 'garbage')
+    const cert = await loadOrCreateCert(dir)
+    expect(cert.certPem).toContain('BEGIN CERTIFICATE')
+  })
+})

--- a/server/mobile/mobile-tls.ts
+++ b/server/mobile/mobile-tls.ts
@@ -1,0 +1,96 @@
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { X509Certificate, createHash } from 'crypto'
+import { generate as selfsignedGenerate } from 'selfsigned'
+
+// Self-signed TLS for the gateway. Identity = sha256 of the cert DER, pinned by
+// the phone from the QR (Syncthing/LocalSend TOFU). We generate ECDSA P-256
+// (pure JS via selfsigned/node-forge — no native deps, no build-sidecar change).
+//
+// selfsigned 5.x's generate() is async-only, so the helpers here are async; every
+// caller (gateway start/rotate) already runs in an async context.
+//
+// Cert + key live under a dir (default ~/.specrails/mobile/) at mode 0600. They
+// are loaded from disk on EVERY gateway (re)start (never held only in memory),
+// so sleep/DHCP/self-update relaunch preserve device pinning.
+
+export interface GatewayCert {
+  certPem: string
+  keyPem: string
+  /** sha256 hex of the cert DER (lowercase, no separators). */
+  fingerprint: string
+}
+
+export function mobileDir(): string {
+  return path.join(os.homedir(), '.specrails', 'mobile')
+}
+
+function certPath(dir: string): string {
+  return path.join(dir, 'tls-cert.pem')
+}
+function keyPath(dir: string): string {
+  return path.join(dir, 'tls-key.pem')
+}
+
+/** sha256(DER) of a PEM cert, hex lowercase — the value put in the QR and pinned
+ *  by the phone (Dart: `sha256.convert(x509.der)`). */
+export function fingerprintOf(certPem: string): string {
+  const der = new X509Certificate(certPem).raw
+  return createHash('sha256').update(der).digest('hex')
+}
+
+async function generatePair(): Promise<{ certPem: string; keyPem: string }> {
+  const attrs = [{ name: 'commonName', value: 'specrails-hub-mobile' }]
+  const notAfter = new Date()
+  notAfter.setFullYear(notAfter.getFullYear() + 10)
+  const pems = await selfsignedGenerate(attrs, {
+    keyType: 'ec',
+    curve: 'P-256',
+    algorithm: 'sha256',
+    notAfterDate: notAfter,
+    extensions: [
+      { name: 'basicConstraints', cA: true },
+      {
+        name: 'subjectAltName',
+        altNames: [
+          { type: 2, value: 'localhost' },
+          { type: 7, ip: '127.0.0.1' },
+        ],
+      },
+    ],
+  })
+  return { certPem: pems.cert, keyPem: pems.private }
+}
+
+function writePair(dir: string, certPem: string, keyPem: string): void {
+  fs.mkdirSync(dir, { recursive: true })
+  try { fs.chmodSync(dir, 0o700) } catch { /* best-effort on platforms without chmod */ }
+  fs.writeFileSync(certPath(dir), certPem, { encoding: 'utf-8', mode: 0o600 })
+  fs.writeFileSync(keyPath(dir), keyPem, { encoding: 'utf-8', mode: 0o600 })
+}
+
+/** Load the existing gateway cert, generating + persisting one on first use. */
+export async function loadOrCreateCert(dir: string = mobileDir()): Promise<GatewayCert> {
+  try {
+    const certPem = fs.readFileSync(certPath(dir), 'utf-8')
+    const keyPem = fs.readFileSync(keyPath(dir), 'utf-8')
+    if (certPem.includes('BEGIN CERTIFICATE') && keyPem.includes('PRIVATE KEY')) {
+      return { certPem, keyPem, fingerprint: fingerprintOf(certPem) }
+    }
+  } catch {
+    // Fall through to generate.
+  }
+  const { certPem, keyPem } = await generatePair()
+  writePair(dir, certPem, keyPem)
+  return { certPem, keyPem, fingerprint: fingerprintOf(certPem) }
+}
+
+/** Generate a brand-new cert (rotation). Caller is responsible for revoking all
+ *  devices afterwards — a rotated cert no longer matches any stored fingerprint,
+ *  which is the point: "Reset mobile identity" invalidates every paired device. */
+export async function rotateCert(dir: string = mobileDir()): Promise<GatewayCert> {
+  const { certPem, keyPem } = await generatePair()
+  writePair(dir, certPem, keyPem)
+  return { certPem, keyPem, fingerprint: fingerprintOf(certPem) }
+}

--- a/server/mobile/mobile-types.ts
+++ b/server/mobile/mobile-types.ts
@@ -1,0 +1,73 @@
+// Shared types for the Mobile Gateway (server/mobile/*).
+//
+// The gateway is a second HTTPS+WSS listener in the SAME Node process as the
+// hub, default port 4202, OFF by default. It pairs phones/tablets by QR +
+// desktop-approval and exposes a deny-by-default allow-list of the existing API,
+// redacted, over a per-device token. The hub server at 127.0.0.1:4200 is never
+// itself exposed. See docs/mobile.md (and ~/Desktop/specrails-hub-mobile-plan.md).
+
+export type MobilePlatform = 'ios' | 'android'
+
+/** A paired device, as stored in hub.sqlite `mobile_devices` (migration 12). */
+export interface MobileDeviceRow {
+  id: string
+  name: string
+  platform: MobilePlatform
+  token_hash: string
+  scopes: string
+  cert_fingerprint: string
+  created_at: string
+  last_seen_at: string | null
+  last_ip: string | null
+  revoked_at: string | null
+}
+
+/** Device shape returned to the desktop UI (never includes token_hash). */
+export interface MobileDevicePublic {
+  id: string
+  name: string
+  platform: MobilePlatform
+  scopes: string
+  createdAt: string
+  lastSeenAt: string | null
+  lastIp: string | null
+  revoked: boolean
+}
+
+/** The JSON payload encoded into the pairing QR (wrapped in a `specrails://pair?d=`
+ *  deep-link). Carries everything the phone needs to connect WITHOUT any prior
+ *  discovery: candidate LAN addresses, port, the cert fingerprint to pin, and a
+ *  high-entropy single-use secret with a short TTL. */
+export interface QrPayload {
+  v: 1
+  hub: string          // hubInstanceId (stable UUID)
+  name: string         // user-visible hub name
+  addrs: string[]      // candidate LAN IPv4 addresses
+  port: number
+  fp: string           // sha256 hex of the gateway cert DER (pin target)
+  secret: string       // base64url, 16 random bytes, single-use
+  claimId: string      // base64url, 16 random bytes — opaque poll handle
+  exp: number          // unix epoch seconds
+}
+
+export type PairingStatus = 'pending' | 'claimed' | 'approved' | 'denied' | 'expired'
+
+/** State the desktop UI polls while a pairing session is open. */
+export interface PairingSessionState {
+  status: PairingStatus
+  claimId: string
+  /** Present once a phone has claimed (so the desktop can show the device name
+   *  before the user approves). */
+  device?: { name: string; platform: MobilePlatform }
+  qr?: QrPayload
+}
+
+/** Result the phone receives from GET /pair/status once approved (token is
+ *  delivered EXACTLY ONCE, then scrubbed server-side). */
+export interface PairApprovedResult {
+  approved: true
+  deviceToken: string
+  deviceId: string
+  hubName: string
+  hubInstanceId: string
+}

--- a/server/mobile/mobile-ws.test.ts
+++ b/server/mobile/mobile-ws.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest'
+import { MobileWsBridge, type SocketLike } from './mobile-ws'
+import type { WsMessage } from '../types'
+
+class StubSocket implements SocketLike {
+  readyState = 1
+  sent: unknown[] = []
+  closed: { code?: number } | null = null
+  terminated = false
+  pinged = 0
+  private handlers: Record<string, Array<(...a: unknown[]) => void>> = {}
+  send(d: string): void { this.sent.push(JSON.parse(d)) }
+  on(e: string, cb: (...a: unknown[]) => void): void { (this.handlers[e] ??= []).push(cb) }
+  ping(): void { this.pinged++ }
+  terminate(): void { this.terminated = true }
+  close(code?: number): void { this.closed = { code } }
+  emit(e: string, ...a: unknown[]): void { (this.handlers[e] ?? []).forEach((f) => f(...a)) }
+}
+
+function sub(s: StubSocket, projects: string[], topics: string[]): void {
+  s.emit('message', JSON.stringify({ type: 'subscribe', projects, topics }))
+}
+
+describe('MobileWsBridge', () => {
+  it('delivers project-scoped topics only to subscribers', () => {
+    const bridge = new MobileWsBridge()
+    const s = new StubSocket()
+    bridge.attach(s, 'dev-1')
+    sub(s, ['p1'], ['queue'])
+
+    const qmsg = { type: 'queue', jobs: [], activeJobId: null, paused: false, timestamp: '', projectId: 'p1' } as WsMessage
+    bridge.dispatch(qmsg)
+    expect(s.sent).toHaveLength(1)
+
+    // Different project → dropped.
+    bridge.dispatch({ ...qmsg, projectId: 'p2' } as WsMessage)
+    expect(s.sent).toHaveLength(1)
+
+    // Topic not subscribed → dropped.
+    bridge.dispatch({ type: 'ticket_updated', projectId: 'p1', ticket: { id: 1 } as never, timestamp: '' } as WsMessage)
+    expect(s.sent).toHaveLength(1)
+  })
+
+  it('always forwards hub-level messages, redacted (path stripped)', () => {
+    const bridge = new MobileWsBridge()
+    const s = new StubSocket()
+    bridge.attach(s, 'dev-1') // no subscription
+    bridge.dispatch({ type: 'hub.projects', projects: [{ id: 'p1', path: '/Users/x/p', slug: 's', name: 'n', db_path: '/d', provider: 'claude', providers: ['claude'], added_at: '', last_seen_at: '' }], timestamp: '' } as WsMessage)
+    expect(s.sent).toHaveLength(1)
+    const msg = s.sent[0] as { projects: Array<Record<string, unknown>> }
+    expect(msg.projects[0].path).toBeUndefined()
+    expect(msg.projects[0].db_path).toBeUndefined()
+    expect(msg.projects[0].id).toBe('p1')
+  })
+
+  it('buffers watched-job logs and flushes them as a batch', () => {
+    const bridge = new MobileWsBridge()
+    const s = new StubSocket()
+    bridge.attach(s, 'dev-1')
+    sub(s, ['p1'], [])
+    s.emit('message', JSON.stringify({ type: 'watch_job', projectId: 'p1', jobId: 'j1' }))
+
+    bridge.dispatch({ type: 'log', source: 'stdout', line: 'hello', timestamp: '', processId: 'j1', projectId: 'p1' } as WsMessage)
+    bridge.dispatch({ type: 'log', source: 'stdout', line: 'world', timestamp: '', processId: 'j1', projectId: 'p1' } as WsMessage)
+    // A log for a different job is ignored.
+    bridge.dispatch({ type: 'log', source: 'stdout', line: 'nope', timestamp: '', processId: 'jX', projectId: 'p1' } as WsMessage)
+    expect(s.sent).toHaveLength(0) // buffered, not yet flushed
+
+    ;(bridge as unknown as { flushLogs(): void }).flushLogs()
+    expect(s.sent).toHaveLength(1)
+    const batch = s.sent[0] as { type: string; jobId: string; lines: string[] }
+    expect(batch.type).toBe('log_batch')
+    expect(batch.jobId).toBe('j1')
+    expect(batch.lines).toEqual(['hello', 'world'])
+  })
+
+  it('forwards chat/spec-draft events to a chat subscriber', () => {
+    const bridge = new MobileWsBridge()
+    const s = new StubSocket()
+    bridge.attach(s, 'dev-1')
+    sub(s, ['p1'], ['chat'])
+    bridge.dispatch({ type: 'chat_stream', conversationId: 'c1', delta: 'hello', timestamp: '', projectId: 'p1' } as WsMessage)
+    bridge.dispatch({ type: 'spec_draft.update', conversationId: 'c1', draft: { title: 'T' }, ready: true, chips: [], changedFields: ['title'], timestamp: '', projectId: 'p1' } as WsMessage)
+    expect(s.sent).toHaveLength(2)
+    expect((s.sent[0] as { type: string }).type).toBe('chat_stream')
+    // Not delivered without the chat topic.
+    const s2 = new StubSocket()
+    bridge.attach(s2, 'dev-2')
+    sub(s2, ['p1'], ['queue'])
+    bridge.dispatch({ type: 'chat_done', conversationId: 'c1', fullText: 'x', timestamp: '', projectId: 'p1' } as WsMessage)
+    expect(s2.sent).toHaveLength(0)
+  })
+
+  it('forwards rail.updated to a rails subscriber', () => {
+    const bridge = new MobileWsBridge()
+    const s = new StubSocket()
+    bridge.attach(s, 'dev-1')
+    sub(s, ['p1'], ['rails'])
+    bridge.dispatch({
+      type: 'rail.updated', projectId: 'p1', railIndex: 0, changed: 'name',
+      ticketIds: [1, 2], name: 'Backend', mode: 'implement', profileName: null, aiEngine: null,
+    } as WsMessage)
+    expect(s.sent).toHaveLength(1)
+    const msg = s.sent[0] as { type: string; name: string; ticketIds: number[] }
+    expect(msg.type).toBe('rail.updated')
+    expect(msg.name).toBe('Backend')
+    expect(msg.ticketIds).toEqual([1, 2])
+    // Not delivered to a non-rails subscriber.
+    const s2 = new StubSocket()
+    bridge.attach(s2, 'dev-2')
+    sub(s2, ['p1'], ['queue'])
+    bridge.dispatch({
+      type: 'rail.updated', projectId: 'p1', railIndex: 1, changed: 'tickets',
+      ticketIds: [], name: null, mode: 'implement', profileName: null, aiEngine: null,
+    } as WsMessage)
+    expect(s2.sent).toHaveLength(0)
+  })
+
+  it('reduces a watched-job event to a payload-free summary', () => {
+    const bridge = new MobileWsBridge()
+    const s = new StubSocket()
+    bridge.attach(s, 'dev-1')
+    sub(s, ['p1'], [])
+    s.emit('message', JSON.stringify({ type: 'watch_job', projectId: 'p1', jobId: 'j1' }))
+    bridge.dispatch({ type: 'event', jobId: 'j1', event_type: 'assistant', source: 'x', payload: 'HUGE', timestamp: '', seq: 1, projectId: 'p1' } as WsMessage)
+    expect(s.sent).toHaveLength(1)
+    const ev = s.sent[0] as Record<string, unknown>
+    expect(ev.type).toBe('job_event')
+    expect(ev.eventType).toBe('assistant')
+    expect(ev.payload).toBeUndefined()
+  })
+
+  it('closes a socket that floods inbound messages', () => {
+    const bridge = new MobileWsBridge({ clock: () => 1000 })
+    const s = new StubSocket()
+    bridge.attach(s, 'dev-1')
+    for (let i = 0; i < 32; i++) s.emit('message', JSON.stringify({ type: 'noop' }))
+    expect(s.closed?.code).toBe(1008)
+  })
+
+  it('closes a socket that sends an oversized frame', () => {
+    const bridge = new MobileWsBridge()
+    const s = new StubSocket()
+    bridge.attach(s, 'dev-1')
+    s.emit('message', 'x'.repeat(5000))
+    expect(s.closed?.code).toBe(1009)
+  })
+
+  it('closeForDevice closes all sockets of a device', () => {
+    const bridge = new MobileWsBridge()
+    const s1 = new StubSocket(), s2 = new StubSocket(), s3 = new StubSocket()
+    bridge.attach(s1, 'dev-1')
+    bridge.attach(s2, 'dev-1')
+    bridge.attach(s3, 'dev-2')
+    bridge.closeForDevice('dev-1')
+    expect(s1.closed?.code).toBe(4401)
+    expect(s2.closed?.code).toBe(4401)
+    expect(s3.closed).toBeNull()
+    expect(bridge.socketCount).toBe(1)
+  })
+
+  it('heartbeat pings, then terminates an unresponsive socket', () => {
+    const bridge = new MobileWsBridge()
+    const s = new StubSocket()
+    bridge.attach(s, 'dev-1')
+    ;(bridge as unknown as { heartbeat(): void }).heartbeat()
+    expect(s.pinged).toBe(1)
+    // No pong arrived → next beat terminates.
+    ;(bridge as unknown as { heartbeat(): void }).heartbeat()
+    expect(s.terminated).toBe(true)
+  })
+
+  it('start()/stop() are safe and clear sockets', () => {
+    const bridge = new MobileWsBridge()
+    const s = new StubSocket()
+    bridge.attach(s, 'dev-1')
+    bridge.start()
+    bridge.start() // idempotent
+    bridge.stop()
+    expect(s.closed?.code).toBe(1001)
+    expect(bridge.socketCount).toBe(0)
+  })
+
+  it('removes a socket on close/error events', () => {
+    const bridge = new MobileWsBridge()
+    const s = new StubSocket()
+    bridge.attach(s, 'dev-1')
+    expect(bridge.socketCount).toBe(1)
+    s.emit('close')
+    expect(bridge.socketCount).toBe(0)
+  })
+})

--- a/server/mobile/mobile-ws.ts
+++ b/server/mobile/mobile-ws.ts
@@ -1,0 +1,240 @@
+import type { WsMessage } from '../types'
+import { getMobileEventBus } from './mobile-event-bus'
+import { redact } from './mobile-redact'
+
+// The gateway's WS fan-out. Subscribes ONCE to the in-process event bus and
+// pushes a mobile-shaped, redacted, per-subscription-filtered stream to each
+// attached socket. The raw /ws firehose (stream-json payloads, 256 KB
+// scrollbacks) is never forwarded verbatim.
+
+const OPEN = 1
+const INBOUND_MAX_BYTES = 4096
+const INBOUND_MAX_PER_MIN = 30
+const HEARTBEAT_MS = 30_000
+const LOG_FLUSH_MS = 250
+const LOG_LINE_MAX = 2048
+const LOG_BATCH_MAX = 60
+
+/** Minimal structural view of a ws.WebSocket (so tests can pass a stub). */
+export interface SocketLike {
+  readyState: number
+  send(data: string): void
+  on(event: string, cb: (...args: unknown[]) => void): void
+  ping(): void
+  terminate(): void
+  close(code?: number, reason?: string): void
+}
+
+interface SockState {
+  ws: SocketLike
+  deviceId: string
+  projects: Set<string>
+  topics: Set<string>
+  watchedJob: { projectId: string; jobId: string } | null
+  inbound: number[]
+  alive: boolean
+  logBuf: Map<string, string[]>
+  logDropped: Map<string, number>
+}
+
+type TopicName = 'queue' | 'phase' | 'tickets' | 'rails' | 'spending' | 'activity' | 'alerts' | 'chat'
+
+function topicFor(type: string): TopicName | 'jobtail' | 'hub' | null {
+  switch (type) {
+    case 'queue': return 'queue'
+    case 'phase': return 'phase'
+    case 'ticket_created':
+    case 'ticket_updated':
+    case 'ticket_deleted':
+    case 'spec_gen_stream':
+    case 'spec_gen_done':
+    case 'spec_gen_error': return 'tickets'
+    case 'rail.job_started':
+    case 'rail.job_stopped':
+    case 'rail.job_completed':
+    case 'rail.updated': return 'rails'
+    case 'spending.invalidated': return 'spending'
+    case 'chat_stream':
+    case 'chat_done':
+    case 'chat_error':
+    case 'chat_title_update':
+    case 'chat_command_proposal':
+    case 'spec_draft.update': return 'chat'
+    case 'cost_alert':
+    case 'daily_budget_exceeded':
+    case 'hub_daily_budget_exceeded': return 'alerts'
+    case 'log':
+    case 'event': return 'jobtail'
+    case 'hub.projects':
+    case 'hub.project_added':
+    case 'hub.project_removed': return 'hub'
+    default: return null
+  }
+}
+
+export class MobileWsBridge {
+  private _socks = new Set<SockState>()
+  private _unsub: (() => void) | null = null
+  private _flush: ReturnType<typeof setInterval> | null = null
+  private _hb: ReturnType<typeof setInterval> | null = null
+  private _clock: () => number
+
+  constructor(opts: { clock?: () => number } = {}) {
+    this._clock = opts.clock ?? (() => Date.now())
+  }
+
+  start(): void {
+    if (this._unsub) return
+    this._unsub = getMobileEventBus().onMessage((msg) => this.dispatch(msg))
+    this._flush = setInterval(() => this.flushLogs(), LOG_FLUSH_MS)
+    this._hb = setInterval(() => this.heartbeat(), HEARTBEAT_MS)
+    // Don't keep the event loop alive purely for these timers.
+    this._flush.unref?.()
+    this._hb.unref?.()
+  }
+
+  stop(): void {
+    if (this._unsub) { this._unsub(); this._unsub = null }
+    if (this._flush) { clearInterval(this._flush); this._flush = null }
+    if (this._hb) { clearInterval(this._hb); this._hb = null }
+    for (const s of this._socks) {
+      try { s.ws.close(1001, 'gateway stopping') } catch { /* ignore */ }
+    }
+    this._socks.clear()
+  }
+
+  get socketCount(): number {
+    return this._socks.size
+  }
+
+  /** Register a freshly-upgraded socket for an authenticated device. */
+  attach(ws: SocketLike, deviceId: string): void {
+    const state: SockState = {
+      ws, deviceId,
+      projects: new Set(), topics: new Set(), watchedJob: null,
+      inbound: [], alive: true,
+      logBuf: new Map(), logDropped: new Map(),
+    }
+    this._socks.add(state)
+    ws.on('message', (...args: unknown[]) => this.onInbound(state, args[0]))
+    ws.on('pong', () => { state.alive = true })
+    ws.on('close', () => { this._socks.delete(state) })
+    ws.on('error', () => { this._socks.delete(state) })
+  }
+
+  /** Close every socket belonging to a (just-revoked) device. */
+  closeForDevice(deviceId: string): void {
+    for (const s of this._socks) {
+      if (s.deviceId === deviceId) {
+        try { s.ws.close(4401, 'revoked') } catch { /* ignore */ }
+        this._socks.delete(s)
+      }
+    }
+  }
+
+  private onInbound(state: SockState, raw: unknown): void {
+    const text = typeof raw === 'string' ? raw : Buffer.isBuffer(raw) ? raw.toString('utf8') : ''
+    if (Buffer.byteLength(text) > INBOUND_MAX_BYTES) {
+      try { state.ws.close(1009, 'message too large') } catch { /* ignore */ }
+      return
+    }
+    const now = this._clock()
+    state.inbound = state.inbound.filter((t) => now - t < 60_000)
+    state.inbound.push(now)
+    if (state.inbound.length > INBOUND_MAX_PER_MIN) {
+      try { state.ws.close(1008, 'rate limit') } catch { /* ignore */ }
+      return
+    }
+    let msg: Record<string, unknown>
+    try { msg = JSON.parse(text) as Record<string, unknown> } catch { return }
+    switch (msg.type) {
+      case 'subscribe': {
+        const projects = Array.isArray(msg.projects) ? msg.projects.filter((x) => typeof x === 'string') as string[] : []
+        const topics = Array.isArray(msg.topics) ? msg.topics.filter((x) => typeof x === 'string') as string[] : []
+        state.projects = new Set(projects)
+        state.topics = new Set(topics)
+        break
+      }
+      case 'watch_job': {
+        if (typeof msg.projectId === 'string' && typeof msg.jobId === 'string') {
+          state.watchedJob = { projectId: msg.projectId, jobId: msg.jobId }
+        }
+        break
+      }
+      case 'unwatch_job':
+        state.watchedJob = null
+        break
+    }
+  }
+
+  /** Fan a single bus message out to matching sockets. */
+  dispatch(msg: WsMessage): void {
+    const topic = topicFor(msg.type)
+    if (!topic) return
+    for (const s of this._socks) {
+      if (topic === 'hub') {
+        // Hub-level: always forward, but redact (hub.projects carries `path`).
+        this.send(s, redact(msg))
+        continue
+      }
+      const projectId = (msg as { projectId?: string }).projectId
+      if (!projectId || !s.projects.has(projectId)) continue
+
+      if (topic === 'jobtail') {
+        if (!s.watchedJob || s.watchedJob.projectId !== projectId) continue
+        const jobId = (msg as { jobId?: string; processId?: string }).jobId
+          ?? (msg as { processId?: string }).processId
+        if (jobId !== s.watchedJob.jobId) continue
+        if (msg.type === 'log') {
+          this.bufferLog(s, s.watchedJob.jobId, (msg as { line: string }).line)
+        } else if (msg.type === 'event') {
+          this.send(s, { type: 'job_event', projectId, jobId, eventType: (msg as { event_type: string }).event_type })
+        }
+        continue
+      }
+
+      if (s.topics.has(topic)) {
+        this.send(s, redact(msg))
+      }
+    }
+  }
+
+  private bufferLog(s: SockState, jobId: string, line: string): void {
+    const buf = s.logBuf.get(jobId) ?? []
+    if (buf.length >= LOG_BATCH_MAX) {
+      s.logDropped.set(jobId, (s.logDropped.get(jobId) ?? 0) + 1)
+      return
+    }
+    buf.push(line.length > LOG_LINE_MAX ? line.slice(0, LOG_LINE_MAX) + '…' : line)
+    s.logBuf.set(jobId, buf)
+  }
+
+  private flushLogs(): void {
+    for (const s of this._socks) {
+      for (const [jobId, lines] of s.logBuf) {
+        if (lines.length === 0) continue
+        const dropped = s.logDropped.get(jobId) ?? 0
+        this.send(s, { type: 'log_batch', jobId, lines, dropped })
+      }
+      s.logBuf.clear()
+      s.logDropped.clear()
+    }
+  }
+
+  private heartbeat(): void {
+    for (const s of this._socks) {
+      if (!s.alive) {
+        try { s.ws.terminate() } catch { /* ignore */ }
+        this._socks.delete(s)
+        continue
+      }
+      s.alive = false
+      try { s.ws.ping() } catch { /* ignore */ }
+    }
+  }
+
+  private send(s: SockState, obj: unknown): void {
+    if (s.ws.readyState !== OPEN) return
+    try { s.ws.send(JSON.stringify(obj)) } catch { /* ignore */ }
+  }
+}

--- a/server/project-registry.test.ts
+++ b/server/project-registry.test.ts
@@ -59,6 +59,7 @@ vi.mock('./config', () => ({
 }))
 
 import { ProjectRegistry } from './project-registry'
+import { setRailTickets, getRail } from './rails-store'
 import { initHubDb, addProject, listProjects, getProject } from './hub-db'
 import type { DbInstance } from './db'
 import type { WsMessage } from './types'
@@ -372,6 +373,50 @@ describe('ProjectRegistry', () => {
 
       // The onJobFinished callback should not throw even if job row doesn't exist
       expect(() => options.onJobFinished('fake-job', 'completed', 0.05)).not.toThrow()
+    })
+
+    it('onJobFinished releases the finished job tickets from rails and broadcasts rail.updated', async () => {
+      const { QueueManager } = await import('./queue-manager')
+      const ctx = registry.addProject({ id: 'rr-1', slug: 'rr-proj', name: 'RR', path: '/rr' })
+
+      // Rail 0 holds tickets 5 and 7; the finishing job implements only #5.
+      setRailTickets(ctx.db, 0, [5, 7])
+      ctx.db.prepare(
+        `INSERT OR REPLACE INTO jobs (id, command, started_at, status) VALUES (?, ?, ?, 'completed')`
+      ).run('rjob-1', '/specrails:implement #5 --yes', new Date().toISOString())
+
+      const constructorCalls = vi.mocked(QueueManager).mock.calls
+      const lastCall = constructorCalls[constructorCalls.length - 1]
+      const options = lastCall[4] as any
+
+      broadcast.mockClear()
+      options.onJobFinished('rjob-1', 'completed', 0.01)
+
+      // Server rails table released #5 but kept #7 (mobile reads this table).
+      expect(getRail(ctx.db, 0).ticketIds).toEqual([7])
+      const msg = broadcast.mock.calls.map((c) => c[0] as any).find((m) => m.type === 'rail.updated')
+      expect(msg).toBeDefined()
+      expect(msg.changed).toBe('tickets')
+      expect(msg.railIndex).toBe(0)
+      expect(msg.ticketIds).toEqual([7])
+    })
+
+    it('onJobFinished releases rail tickets on failure too (specs return to the board)', async () => {
+      const { QueueManager } = await import('./queue-manager')
+      const ctx = registry.addProject({ id: 'rr-2', slug: 'rr-proj-2', name: 'RR2', path: '/rr2' })
+
+      setRailTickets(ctx.db, 1, [9])
+      ctx.db.prepare(
+        `INSERT OR REPLACE INTO jobs (id, command, started_at, status) VALUES (?, ?, ?, 'failed')`
+      ).run('rjob-2', '/specrails:implement #9 --yes', new Date().toISOString())
+
+      const constructorCalls = vi.mocked(QueueManager).mock.calls
+      const lastCall = constructorCalls[constructorCalls.length - 1]
+      const options = lastCall[4] as any
+
+      options.onJobFinished('rjob-2', 'failed', null)
+
+      expect(getRail(ctx.db, 1).ticketIds).toEqual([])
     })
   })
 

--- a/server/project-registry.ts
+++ b/server/project-registry.ts
@@ -19,7 +19,8 @@ import { getTerminalManager } from './terminal-manager'
 import { BrowserCaptureManager } from './browser-capture-manager'
 import { removeExploreCwd } from './explore-cwd-manager'
 import { resolveTicketStoragePath, mutateStore, applyJobOutcomeToTickets, type JobOutcome } from './ticket-store'
-import type { WsMessage, TicketUpdatedMessage } from './types'
+import type { WsMessage, TicketUpdatedMessage, RailUpdatedMessage } from './types'
+import { getRails, setRailTickets } from './rails-store'
 import {
   initHubDb,
   getHubDbPath,
@@ -326,6 +327,40 @@ export class ProjectRegistry {
             }
           } catch (err) {
             console.error('[project-registry] failed to apply job outcome to tickets:', err)
+          }
+        }
+
+        // Release the job's tickets from any rail that still holds them. The
+        // server `rails` table is the source of truth for mobile clients (the
+        // desktop strips its localStorage copy on rail.job_completed) — without
+        // this, a finished spec stays stranded on the rail forever. Runs on
+        // every terminal outcome, mirroring the desktop: success → spec is
+        // done; failure/cancel/zombie → spec returns to the board. Scans ALL
+        // rails (not just railMeta.railIndex) so it also heals after a server
+        // restart, when the in-memory railJobs map is lost.
+        if (
+          completedTicketIds.length > 0 &&
+          (status === 'completed' || status === 'failed' || status === 'canceled' || status === 'zombie_terminated')
+        ) {
+          try {
+            for (const rail of getRails(db)) {
+              const remaining = rail.ticketIds.filter((id) => !completedTicketIds.includes(id))
+              if (remaining.length === rail.ticketIds.length) continue
+              setRailTickets(db, rail.railIndex, remaining, rail.mode, rail.profileName, rail.aiEngine)
+              boundBroadcast({
+                type: 'rail.updated',
+                projectId: project.id,
+                railIndex: rail.railIndex,
+                changed: 'tickets',
+                ticketIds: remaining,
+                name: rail.name ?? null,
+                mode: rail.mode,
+                profileName: rail.profileName ?? null,
+                aiEngine: rail.aiEngine ?? null,
+              } as RailUpdatedMessage)
+            }
+          } catch (err) {
+            console.error('[project-registry] failed to release rail tickets after job exit:', err)
           }
         }
 

--- a/server/rails-router.test.ts
+++ b/server/rails-router.test.ts
@@ -10,6 +10,7 @@ function appWith(
   opts?: {
     providers?: ('claude' | 'codex')[]
     queueManager?: { enqueue: (...args: unknown[]) => unknown }
+    broadcast?: (msg: unknown) => void
   },
 ) {
   const providers = opts?.providers ?? ['claude']
@@ -23,7 +24,7 @@ function appWith(
       railJobs: new Map(),
       project: { id: 'p1', slug: 's1', provider: providers[0], providers },
       queueManager: opts?.queueManager,
-      broadcast: () => { /* noop */ },
+      broadcast: opts?.broadcast ?? (() => { /* noop */ }),
     }
     next()
   })
@@ -87,6 +88,99 @@ describe('rails-router PUT /:railIndex/tickets', () => {
       .put('/rails/0/tickets').send({ ticketIds: [3] })
     expect(res.status).toBe(200)
     expect(getRail(db, 0).aiEngine).toBe('codex')
+  })
+})
+
+describe('rails-router PUT /:railIndex/name', () => {
+  let db: DbInstance
+  beforeEach(() => { db = initDb(':memory:') })
+  afterEach(() => { db.close() })
+
+  it('sets a rail name (even with no tickets assigned)', async () => {
+    const res = await request(appWith(db)).put('/rails/0/name').send({ name: 'Backend' })
+    expect(res.status).toBe(200)
+    expect(res.body.rail.name).toBe('Backend')
+    expect(getRail(db, 0).name).toBe('Backend')
+  })
+
+  it('clears the name when null', async () => {
+    await request(appWith(db)).put('/rails/0/name').send({ name: 'X' })
+    const res = await request(appWith(db)).put('/rails/0/name').send({ name: null })
+    expect(res.status).toBe(200)
+    expect(getRail(db, 0).name).toBeNull()
+  })
+
+  it('rejects a body without name', async () => {
+    const res = await request(appWith(db)).put('/rails/0/name').send({})
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects a non-string, non-null name', async () => {
+    const res = await request(appWith(db)).put('/rails/0/name').send({ name: 42 })
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects an over-long name', async () => {
+    const res = await request(appWith(db)).put('/rails/0/name').send({ name: 'x'.repeat(61) })
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects an invalid rail index', async () => {
+    const res = await request(appWith(db)).put('/rails/-1/name').send({ name: 'X' })
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('rails-router rail.updated broadcasts', () => {
+  let db: DbInstance
+  beforeEach(() => { db = initDb(':memory:') })
+  afterEach(() => { db.close() })
+
+  type RailUpdated = { type: string; railIndex: number; changed: string; ticketIds: number[]; name: string | null; aiEngine: string | null }
+  const lastRailUpdated = (calls: unknown[][]): RailUpdated | undefined =>
+    [...calls].reverse().map((c) => c[0] as RailUpdated).find((m) => m?.type === 'rail.updated')
+
+  it('broadcasts changed:tickets with the new ticketIds on a tickets PUT', async () => {
+    const broadcast = vi.fn()
+    const res = await request(appWith(db, { broadcast })).put('/rails/0/tickets').send({ ticketIds: [1, 2] })
+    expect(res.status).toBe(200)
+    const msg = lastRailUpdated(broadcast.mock.calls)
+    expect(msg).toBeDefined()
+    expect(msg!.changed).toBe('tickets')
+    expect(msg!.railIndex).toBe(0)
+    expect(msg!.ticketIds).toEqual([1, 2])
+  })
+
+  it('broadcasts changed:name and carries the current ticketIds (so receivers do not drop them)', async () => {
+    setRailTickets(db, 1, [7, 8])
+    const broadcast = vi.fn()
+    const res = await request(appWith(db, { broadcast })).put('/rails/1/name').send({ name: 'Bugfixes' })
+    expect(res.status).toBe(200)
+    const msg = lastRailUpdated(broadcast.mock.calls)
+    expect(msg!.changed).toBe('name')
+    expect(msg!.name).toBe('Bugfixes')
+    // The snapshot still carries the rail's tickets — critical so a rename never
+    // looks like an empty-rail update to the desktop merge.
+    expect(msg!.ticketIds).toEqual([7, 8])
+  })
+
+  it('a tickets-change broadcast preserves the previously-set name', async () => {
+    await request(appWith(db)).put('/rails/2/name').send({ name: 'Named' })
+    const broadcast = vi.fn()
+    await request(appWith(db, { broadcast })).put('/rails/2/tickets').send({ ticketIds: [3] })
+    const msg = lastRailUpdated(broadcast.mock.calls)
+    expect(msg!.changed).toBe('tickets')
+    expect(msg!.name).toBe('Named')
+  })
+
+  it('broadcasts changed:engine on an engine PUT', async () => {
+    setRailTickets(db, 0, [1])
+    const broadcast = vi.fn()
+    await request(appWith(db, { providers: ['claude', 'codex'], broadcast }))
+      .put('/rails/0/engine').send({ aiEngine: 'codex' })
+    const msg = lastRailUpdated(broadcast.mock.calls)
+    expect(msg!.changed).toBe('engine')
+    expect(msg!.aiEngine ?? null).toBe('codex')
   })
 })
 

--- a/server/rails-router.ts
+++ b/server/rails-router.ts
@@ -1,9 +1,9 @@
 import { Router, Request, Response } from 'express'
 import type { ProjectContext } from './project-registry'
-import { getRails, getRail, setRailTickets, setRailProfile, setRailEngine } from './rails-store'
+import { getRails, getRail, setRailTickets, setRailProfile, setRailEngine, setRailName, type RailState } from './rails-store'
 import { ClaudeNotFoundError, CodexNotFoundError } from './queue-manager'
 import { validateRequestedProvider } from './provider-selection'
-import type { RailJobStartedMessage, RailJobStoppedMessage } from './types'
+import type { RailJobStartedMessage, RailJobStoppedMessage, RailUpdatedMessage } from './types'
 
 // Extend Express Request to carry resolved ProjectContext (declared in project-router)
 declare module 'express-serve-static-core' {
@@ -22,6 +22,32 @@ export function createRailsRouter(): Router {
 
   function ctx(req: Request): ProjectContext {
     return req.projectCtx!
+  }
+
+  // Broadcast the full post-mutation rail snapshot so every connected client
+  // (desktop dashboard + mobile companion) reflects non-launch rail changes
+  // live — ticket reassignments, renames, mode/profile/engine edits. Re-reads
+  // the canonical rail (getRail) so the snapshot always carries the CURRENT
+  // name — a mutation return value (e.g. setRailTickets) omits it, which would
+  // otherwise broadcast name:null and clobber the rail's label on receivers.
+  function broadcastRailUpdated(
+    c: ProjectContext,
+    railIndex: number,
+    changed: RailUpdatedMessage['changed'],
+  ): void {
+    const rail: RailState = getRail(c.db, railIndex)
+    const msg: RailUpdatedMessage = {
+      type: 'rail.updated',
+      projectId: c.project.id,
+      railIndex: rail.railIndex,
+      changed,
+      ticketIds: rail.ticketIds,
+      name: rail.name ?? null,
+      mode: rail.mode,
+      profileName: rail.profileName ?? null,
+      aiEngine: rail.aiEngine ?? null,
+    }
+    c.broadcast(msg)
   }
 
   // GET /rails — list all rail assignments + active job info
@@ -67,6 +93,7 @@ export function createRailsRouter(): Router {
       // setRailTickets re-reads the current value), so it isn't silently wiped.
       const aiEngine = 'aiEngine' in body ? body.aiEngine : undefined
       const rail = setRailTickets(c.db, railIndex, ticketIds as number[], mode, profileName, aiEngine)
+      broadcastRailUpdated(c, railIndex, 'tickets')
       res.json({ rail })
     } catch (err) {
       console.error('[rails-router] set rail tickets error:', err)
@@ -92,6 +119,7 @@ export function createRailsRouter(): Router {
     const c = ctx(req)
     try {
       const rail = setRailProfile(c.db, railIndex, value)
+      broadcastRailUpdated(c, railIndex, 'profile')
       res.json({ rail })
     } catch (err) {
       console.error('[rails-router] set rail profile error:', err)
@@ -119,10 +147,41 @@ export function createRailsRouter(): Router {
     }
     try {
       const rail = setRailEngine(c.db, railIndex, value)
+      broadcastRailUpdated(c, railIndex, 'engine')
       res.json({ rail })
     } catch (err) {
       console.error('[rails-router] set rail engine error:', err)
       res.status(500).json({ error: 'Failed to update rail engine' })
+    }
+  })
+
+  // PUT /rails/:railIndex/name — set the rail's display name (the "Rail "-suffix)
+  // Body: { name: string | null } (empty/null clears it back to the default label)
+  router.put('/:railIndex/name', (req: Request, res: Response) => {
+    const railIndex = parseInt(req.params.railIndex as string, 10)
+    if (isNaN(railIndex) || railIndex < 0) {
+      res.status(400).json({ error: 'Invalid rail index' }); return
+    }
+    const body = req.body ?? {}
+    if (!('name' in body)) {
+      res.status(400).json({ error: "body must include 'name' (string or null)" }); return
+    }
+    const value = body.name
+    if (value !== null && typeof value !== 'string') {
+      res.status(400).json({ error: 'name must be a string or null' }); return
+    }
+    // Guard against unbounded labels (UI shows a short chip).
+    if (typeof value === 'string' && value.length > 60) {
+      res.status(400).json({ error: 'name must be 60 characters or fewer' }); return
+    }
+    const c = ctx(req)
+    try {
+      const rail = setRailName(c.db, railIndex, value)
+      broadcastRailUpdated(c, railIndex, 'name')
+      res.json({ rail })
+    } catch (err) {
+      console.error('[rails-router] set rail name error:', err)
+      res.status(500).json({ error: 'Failed to update rail name' })
     }
   })
 

--- a/server/rails-store.test.ts
+++ b/server/rails-store.test.ts
@@ -5,6 +5,7 @@ import {
   getRail,
   setRailTickets,
   setRailProfile,
+  setRailName,
 } from './rails-store'
 
 let db: DbInstance
@@ -139,5 +140,59 @@ describe('setRailProfile', () => {
     setRailProfile(db, 0, 'data-heavy')
     expect(getRail(db, 0).profileName).toBe('data-heavy')
     expect(getRail(db, 1).profileName).toBe('default')
+  })
+})
+
+describe('setRailName', () => {
+  it('defaults name to null on a fresh rail', () => {
+    expect(getRail(db, 0).name).toBeNull()
+    expect(getRails(db).every((r) => r.name === null)).toBe(true)
+  })
+
+  it('persists a name independent of ticket assignment (even on an empty rail)', () => {
+    setRailName(db, 0, 'Backend')
+    expect(getRail(db, 0).name).toBe('Backend')
+    // Survives via getRails too
+    expect(getRails(db)[0].name).toBe('Backend')
+    // The rail still has no tickets — name lives in rail_meta, not the rows.
+    expect(getRail(db, 0).ticketIds).toEqual([])
+  })
+
+  it('keeps the name across ticket reassignment (delete-then-reinsert)', () => {
+    setRailName(db, 1, 'Bugfixes')
+    setRailTickets(db, 1, [3, 4])
+    setRailTickets(db, 1, [5])
+    expect(getRail(db, 1).name).toBe('Bugfixes')
+  })
+
+  it('trims whitespace and clears to null on empty/whitespace input', () => {
+    setRailName(db, 2, '  Spaced  ')
+    expect(getRail(db, 2).name).toBe('Spaced')
+    setRailName(db, 2, '   ')
+    expect(getRail(db, 2).name).toBeNull()
+    setRailName(db, 2, 'Again')
+    setRailName(db, 2, null)
+    expect(getRail(db, 2).name).toBeNull()
+  })
+
+  it('upserts (second call overwrites the first)', () => {
+    setRailName(db, 0, 'First')
+    setRailName(db, 0, 'Second')
+    expect(getRail(db, 0).name).toBe('Second')
+  })
+
+  it('isolates names per rail', () => {
+    setRailName(db, 0, 'A')
+    setRailName(db, 1, 'B')
+    expect(getRail(db, 0).name).toBe('A')
+    expect(getRail(db, 1).name).toBe('B')
+    expect(getRail(db, 2).name).toBeNull()
+  })
+
+  it('returns the post-mutation state with the new name', () => {
+    setRailTickets(db, 0, [9])
+    const out = setRailName(db, 0, 'Named')
+    expect(out.name).toBe('Named')
+    expect(out.ticketIds).toEqual([9])
   })
 })

--- a/server/rails-store.ts
+++ b/server/rails-store.ts
@@ -8,6 +8,19 @@ export interface RailState {
   profileName?: string | null
   /** Optional AI engine override (multi-provider projects). null/undefined = project's primary provider. */
   aiEngine?: string | null
+  /** User-given display name (suffix after "Rail "), synced desktop ⇄ mobile. null = default "Rail N". */
+  name?: string | null
+}
+
+/** Read the per-rail display names from rail_meta into a lookup map. */
+function railNames(db: DbInstance): Map<number, string | null> {
+  const rows = db.prepare('SELECT rail_index, name FROM rail_meta').all() as {
+    rail_index: number
+    name: string | null
+  }[]
+  const map = new Map<number, string | null>()
+  for (const r of rows) map.set(r.rail_index, r.name)
+  return map
 }
 
 // ─── Queries ─────────────────────────────────────────────────────────────────
@@ -42,6 +55,7 @@ export function getRails(db: DbInstance): RailState[] {
     map.get(row.rail_index)!.ticketIds.push(row.ticket_id)
   }
 
+  const names = railNames(db)
   return [0, 1, 2].map((railIndex) => {
     const rail = map.get(railIndex)
     return {
@@ -50,6 +64,7 @@ export function getRails(db: DbInstance): RailState[] {
       mode: rail?.mode ?? 'implement',
       profileName: rail?.profileName ?? null,
       aiEngine: rail?.aiEngine ?? null,
+      name: names.get(railIndex) ?? null,
     }
   })
 }
@@ -67,12 +82,17 @@ export function getRail(db: DbInstance, railIndex: number): RailState {
       ai_engine: string | null
     }[]
 
+  const meta = db.prepare('SELECT name FROM rail_meta WHERE rail_index = ?').get(railIndex) as
+    | { name: string | null }
+    | undefined
+
   return {
     railIndex,
     ticketIds: rows.map((r) => r.ticket_id),
     mode: rows[0]?.mode ?? 'implement',
     profileName: rows[0]?.profile_name ?? null,
     aiEngine: rows[0]?.ai_engine ?? null,
+    name: meta?.name ?? null,
   }
 }
 
@@ -142,4 +162,23 @@ export function setRailEngine(
   }
   db.prepare('UPDATE rails SET ai_engine = ? WHERE rail_index = ?').run(aiEngine, railIndex)
   return { ...current, aiEngine }
+}
+
+/**
+ * Set a rail's display name (the "Rail "-suffix the user types). Stored in
+ * rail_meta (ticket-independent) so even an empty rail keeps its name. Pass
+ * an empty/whitespace name to clear it back to the default "Rail N" label.
+ */
+export function setRailName(
+  db: DbInstance,
+  railIndex: number,
+  name: string | null,
+): RailState {
+  const trimmed = typeof name === 'string' ? name.trim() : null
+  const value = trimmed && trimmed.length > 0 ? trimmed : null
+  db.prepare(
+    `INSERT INTO rail_meta (rail_index, name) VALUES (?, ?)
+     ON CONFLICT(rail_index) DO UPDATE SET name = excluded.name`
+  ).run(railIndex, value)
+  return { ...getRail(db, railIndex), name: value }
 }

--- a/server/types.ts
+++ b/server/types.ts
@@ -725,6 +725,27 @@ export interface RailJobCompletedMessage {
   ticketIds: number[]
 }
 
+/**
+ * A rail's configuration changed (ticket assignments, name, mode, profile or
+ * engine) via a non-launch mutation. Broadcast so every connected client
+ * (desktop dashboard + mobile companion) reflects the change live. Carries the
+ * full post-mutation rail snapshot so receivers need no follow-up fetch.
+ */
+export interface RailUpdatedMessage {
+  type: 'rail.updated'
+  projectId: string
+  railIndex: number
+  /** Which field this mutation changed. Receivers that keep local un-synced
+   *  state (the desktop dashboard) adopt `ticketIds` ONLY when changed==='tickets',
+   *  so a rename never clobbers a rail's locally-dragged assignments. */
+  changed: 'tickets' | 'name' | 'profile' | 'engine'
+  ticketIds: number[]
+  name: string | null
+  mode: string
+  profileName: string | null
+  aiEngine: string | null
+}
+
 // ─── Plugin system ──────────────────────────────────────────────────────────
 
 export interface PluginRequirement {
@@ -987,7 +1008,7 @@ export type WsMessage =
   | TicketCreatedMessage | TicketUpdatedMessage | TicketDeletedMessage
   | TicketAiEditStreamMessage | TicketAiEditDoneMessage | TicketAiEditErrorMessage
   | SpecGenStreamMessage | SpecGenDoneMessage | SpecGenErrorMessage
-  | RailJobStartedMessage | RailJobStoppedMessage | RailJobCompletedMessage
+  | RailJobStartedMessage | RailJobStoppedMessage | RailJobCompletedMessage | RailUpdatedMessage
   | AgentRefineStreamMessage | AgentRefinePhaseMessage | AgentRefineReadyMessage
   | AgentRefineTestMessage | AgentRefineErrorMessage | AgentRefineCancelledMessage
   | AgentRefineAppliedMessage
@@ -1000,6 +1021,8 @@ export type WsMessage =
   | SmashFailedMessage | SmashUndoneMessage
   | FileProvenanceUpdatedMessage
   | FileSummaryUpdatedMessage | FileSummaryFailedMessage | FileSummarySkippedMessage
+  | MobilePairRequestedMessage | MobileDevicePairedMessage
+  | MobileDeviceRevokedMessage | MobileGatewayStateMessage
 
 export interface FileProvenanceUpdatedMessage {
   type: 'file.provenance_updated'
@@ -1037,6 +1060,37 @@ export interface FileSummarySkippedMessage {
 export interface SpendingInvalidatedMessage {
   type: 'spending.invalidated'
   projectId: string
+}
+
+// ─── Mobile companion (hub-level, no projectId — desktop UI only) ─────────────
+// These never reach a phone (the gateway WS bridge drops unknown types); they
+// drive the live desktop pairing UI over the existing /ws.
+
+export interface MobilePairRequestedMessage {
+  type: 'mobile.pair_requested'
+  deviceName: string
+  platform: 'ios' | 'android'
+  timestamp: string
+}
+
+export interface MobileDevicePairedMessage {
+  type: 'mobile.device_paired'
+  deviceId: string
+  name: string
+  timestamp: string
+}
+
+export interface MobileDeviceRevokedMessage {
+  type: 'mobile.device_revoked'
+  deviceId: string
+  timestamp: string
+}
+
+export interface MobileGatewayStateMessage {
+  type: 'mobile.gateway_state'
+  running: boolean
+  port: number
+  timestamp: string
 }
 
 // ─── SPECs SMASH ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Server-side **Mobile Gateway** (`server/mobile/`) enabling the mobile companion app to connect to the hub, 100% local:

- **Auth** (`mobile-auth.ts`) — token-based auth for mobile clients
- **Pairing** (`mobile-pairing.ts`) — QR pairing flow
- **Devices** (`mobile-devices.ts`, `mobile-admin-router.ts`) — paired-device registry + admin CRUD
- **TLS** (`mobile-tls.ts`) — self-signed cert provisioning (`selfsigned`)
- **mDNS** (`mobile-mdns.ts`) — local network advertisement (`@homebridge/ciao`)
- **WS event bus** (`mobile-event-bus.ts`, `mobile-ws.ts`) — scoped event streaming with payload redaction (`mobile-redact.ts`)

Client:
- **Mobile Access** section in Global Settings (`MobileAccessSection`) with `PairDeviceModal` (QR via `qrcode.react`)
- Type-generation script for the mobile API contract (`scripts/generate-mobile-types.mjs`)

## Test plan

- `npm run typecheck` ✓
- Server coverage: 2825/2826 passed (1 pre-existing flaky timing benchmark in `terminal-osc-parser.test.ts`, passes in isolation) ✓
- Client coverage: 2334/2334 passed ✓
- Full unit coverage for every new `server/mobile/*` module and both new client components

🤖 Generated with [Claude Code](https://claude.com/claude-code)