### PR TITLE
feat(onboarding): add language, theme & companion steps to welcome wizard

### DIFF
--- a/client/src/components/OnboardingWizard.tsx
+++ b/client/src/components/OnboardingWizard.tsx
@@ -32,9 +32,18 @@ import {
   ArrowRight,
   ArrowLeft,
   Check,
+  Languages,
+  Smartphone,
+  Apple,
+  QrCode,
+  ExternalLink,
 } from 'lucide-react'
+import { QRCodeSVG } from 'qrcode.react'
 import { cn } from '../lib/utils'
 import { Button } from './ui/button'
+import { LanguagePickerGrid } from './pickers/LanguagePickerGrid'
+import { ThemePickerGrid } from './pickers/ThemePickerGrid'
+import { COMPANION_IOS_URL, COMPANION_ANDROID_URL } from '../lib/companion'
 
 const ONBOARDING_KEY = 'specrails-desktop:onboarding-dismissed'
 
@@ -192,6 +201,109 @@ function FlowStrip({ steps }: { steps: { label: string; cls: string }[] }) {
   )
 }
 
+// ─── Interactive step bodies ─────────────────────────────────────────────────
+// These need hooks (theme/language context), so they are components rather
+// than static JSX inside buildSteps. Without a provider mounted the grids
+// degrade to null and only the step copy renders.
+
+function LanguageStepBody() {
+  const { t } = useTranslation('setup')
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground leading-relaxed">
+        {t('onboarding.language.intro')}
+      </p>
+      <LanguagePickerGrid />
+      <p className="text-xs text-muted-foreground italic">{t('onboarding.language.note')}</p>
+    </div>
+  )
+}
+
+function ThemeStepBody() {
+  const { t } = useTranslation('setup')
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground leading-relaxed">
+        {t('onboarding.theme.intro')}
+      </p>
+      <ThemePickerGrid />
+      <p className="text-xs text-muted-foreground italic">{t('onboarding.theme.note')}</p>
+    </div>
+  )
+}
+
+function CompanionDownloadCard({
+  icon,
+  url,
+  label,
+  testId,
+}: {
+  icon: React.ReactNode
+  url: string
+  label: string
+  testId: string
+}) {
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-border/40 bg-card/40 p-3">
+      <div className="shrink-0 rounded-md bg-white p-1.5" aria-hidden="true">
+        <QRCodeSVG value={url} size={72} />
+      </div>
+      <div className="min-w-0 space-y-1">
+        <p className="flex items-center gap-1.5 text-[13px] font-semibold text-foreground leading-tight">
+          {icon}
+          {label}
+        </p>
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-testid={testId}
+          aria-label={label}
+          className="inline-flex items-center gap-1 text-xs text-accent-info hover:underline break-all"
+        >
+          {url.replace('https://', '')}
+          <ExternalLink className="w-3 h-3 shrink-0" aria-hidden="true" />
+        </a>
+      </div>
+    </div>
+  )
+}
+
+function CompanionStepBody() {
+  const { t } = useTranslation('setup')
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground leading-relaxed">
+        <Trans t={t} i18nKey="onboarding.companion.intro" components={{ b: <span className="text-foreground font-medium" /> }} />
+      </p>
+      <Callout accent={ACCENTS.success} label={t('onboarding.companion.localLabel')}>
+        {t('onboarding.companion.localBody')}
+      </Callout>
+      <div className="space-y-2">
+        <p className="text-[13px] font-semibold text-foreground">{t('onboarding.companion.downloadLabel')}</p>
+        <p className="text-xs text-muted-foreground">{t('onboarding.companion.downloadHint')}</p>
+        <div className="grid sm:grid-cols-2 gap-3">
+          <CompanionDownloadCard
+            icon={<Apple className="w-4 h-4 shrink-0" aria-hidden="true" />}
+            url={COMPANION_IOS_URL}
+            label={t('onboarding.companion.ios')}
+            testId="companion-ios-link"
+          />
+          <CompanionDownloadCard
+            icon={<Smartphone className="w-4 h-4 shrink-0" aria-hidden="true" />}
+            url={COMPANION_ANDROID_URL}
+            label={t('onboarding.companion.android')}
+            testId="companion-android-link"
+          />
+        </div>
+      </div>
+      <Feature icon={<QrCode className="w-4 h-4" />} label={t('onboarding.companion.pairLabel')} accent={ACCENTS.success}>
+        {t('onboarding.companion.pairBody')}
+      </Feature>
+    </div>
+  )
+}
+
 // ─── Step definitions ───────────────────────────────────────────────────────
 
 interface StepConfig {
@@ -205,7 +317,27 @@ interface StepConfig {
 
 function buildSteps(t: TFunction): StepConfig[] {
   return [
-    // 1 — Welcome
+    // 1 — Language (hot-switches the rest of the tour immediately)
+    {
+      navLabel: t('onboarding.language.nav'),
+      icon: <Languages className="w-6 h-6" />,
+      accent: ACCENTS.info,
+      title: t('onboarding.language.title'),
+      subtitle: t('onboarding.language.subtitle'),
+      content: <LanguageStepBody />,
+    },
+
+    // 2 — Theme (applies live behind the dialog)
+    {
+      navLabel: t('onboarding.theme.nav'),
+      icon: <Palette className="w-6 h-6" />,
+      accent: ACCENTS.highlight,
+      title: t('onboarding.theme.title'),
+      subtitle: t('onboarding.theme.subtitle'),
+      content: <ThemeStepBody />,
+    },
+
+    // 3 — Welcome
     {
       navLabel: t('onboarding.welcome.nav'),
       icon: <Sparkles className="w-6 h-6" />,
@@ -245,7 +377,7 @@ function buildSteps(t: TFunction): StepConfig[] {
       ),
     },
 
-    // 2 — Author specs
+    // 4 — Author specs
     {
       navLabel: t('onboarding.authorSpecs.nav'),
       icon: <MessageSquare className="w-6 h-6" />,
@@ -281,7 +413,7 @@ function buildSteps(t: TFunction): StepConfig[] {
       ),
     },
 
-    // 3 — Run the pipeline (rails)
+    // 5 — Run the pipeline (rails)
     {
       navLabel: t('onboarding.rails.nav'),
       icon: <Workflow className="w-6 h-6" />,
@@ -329,7 +461,7 @@ function buildSteps(t: TFunction): StepConfig[] {
       ),
     },
 
-    // 4 — Providers
+    // 6 — Providers
     {
       navLabel: t('onboarding.providers.nav'),
       icon: <Bot className="w-6 h-6" />,
@@ -371,7 +503,7 @@ function buildSteps(t: TFunction): StepConfig[] {
       ),
     },
 
-    // 5 — Cost
+    // 7 — Cost
     {
       navLabel: t('onboarding.cost.nav'),
       icon: <Coins className="w-6 h-6" />,
@@ -401,7 +533,7 @@ function buildSteps(t: TFunction): StepConfig[] {
       ),
     },
 
-    // 6 — Workspace
+    // 8 — Workspace
     {
       navLabel: t('onboarding.workspace.nav'),
       icon: <Boxes className="w-6 h-6" />,
@@ -415,6 +547,7 @@ function buildSteps(t: TFunction): StepConfig[] {
               <Trans
                 t={t}
                 i18nKey="onboarding.workspace.terminalBody"
+                values={{ mod: MOD }}
                 components={{ mod: <Kbd>{MOD}</Kbd>, j: <Kbd>J</Kbd> }}
               />
             </Feature>
@@ -438,7 +571,17 @@ function buildSteps(t: TFunction): StepConfig[] {
       ),
     },
 
-    // 7 — Move fast / get started
+    // 9 — Companion mobile app
+    {
+      navLabel: t('onboarding.companion.nav'),
+      icon: <Smartphone className="w-6 h-6" />,
+      accent: ACCENTS.success,
+      title: t('onboarding.companion.title'),
+      subtitle: t('onboarding.companion.subtitle'),
+      content: <CompanionStepBody />,
+    },
+
+    // 10 — Move fast / get started
     {
       navLabel: t('onboarding.moveFast.nav'),
       icon: <Command className="w-6 h-6" />,
@@ -452,6 +595,7 @@ function buildSteps(t: TFunction): StepConfig[] {
               <Trans
                 t={t}
                 i18nKey="onboarding.moveFast.paletteShortcut"
+                values={{ mod: MOD }}
                 components={{
                   f: <span className="text-foreground" />,
                   m: <span className="text-muted-foreground" />,
@@ -467,6 +611,7 @@ function buildSteps(t: TFunction): StepConfig[] {
               <Trans
                 t={t}
                 i18nKey="onboarding.moveFast.terminalBody"
+                values={{ mod: MOD }}
                 components={{ mod: <Kbd>{MOD}</Kbd>, j: <Kbd>J</Kbd> }}
               />
             </Feature>
@@ -477,6 +622,7 @@ function buildSteps(t: TFunction): StepConfig[] {
               <Trans
                 t={t}
                 i18nKey="onboarding.moveFast.chatBody"
+                values={{ mod: MOD }}
                 components={{ mod: <Kbd>{MOD}</Kbd>, bkey: <Kbd>B</Kbd> }}
               />
             </Feature>
@@ -484,6 +630,7 @@ function buildSteps(t: TFunction): StepConfig[] {
               <Trans
                 t={t}
                 i18nKey="onboarding.moveFast.projectsBody"
+                values={{ alt: ALT, mod: MOD }}
                 components={{ alt: <Kbd>{ALT}</Kbd>, mod: <Kbd>{MOD}</Kbd>, bkey: <Kbd>B</Kbd> }}
               />
             </Feature>
@@ -539,12 +686,12 @@ export function OnboardingWizard({ open, onClose }: OnboardingWizardProps) {
       <DialogPrimitive.Portal>
         <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/70 backdrop-blur-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
         <DialogPrimitive.Content
-          className="fixed left-[50%] top-[50%] z-50 w-[calc(100vw-2rem)] max-w-4xl max-h-[88vh] translate-x-[-50%] translate-y-[-50%] overflow-hidden border border-border/30 bg-popover shadow-2xl backdrop-blur-xl sm:rounded-2xl duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
+          className="fixed left-[50%] top-[50%] z-50 flex flex-col w-[calc(100vw-2rem)] max-w-4xl max-h-[88vh] translate-x-[-50%] translate-y-[-50%] overflow-hidden border border-border/30 bg-popover shadow-2xl backdrop-blur-xl sm:rounded-2xl duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
           data-testid="onboarding-wizard"
           aria-describedby="onboarding-description"
         >
           {/* Accent glow bar */}
-          <div className={cn('h-1 w-full transition-all duration-500', current.accent.bar)} />
+          <div className={cn('h-1 w-full shrink-0 transition-all duration-500', current.accent.bar)} />
 
           <div className="flex min-h-0">
             {/* ── Left step navigation ── */}
@@ -556,7 +703,7 @@ export function OnboardingWizard({ open, onClose }: OnboardingWizardProps) {
                 </p>
                 <p className="text-[10px] text-muted-foreground mt-0.5">{t('onboarding.productTour')}</p>
               </div>
-              <ol className="space-y-0.5">
+              <ol className="space-y-0.5 min-h-0 overflow-y-auto">
                 {steps.map((s, i) => {
                   const isActive = i === step
                   const isDone = i < step
@@ -621,6 +768,7 @@ export function OnboardingWizard({ open, onClose }: OnboardingWizardProps) {
                       type="button"
                       onClick={() => setStep(i)}
                       aria-label={t('onboarding.stepLabel', { step: i + 1 })}
+                      aria-current={i === step ? 'step' : undefined}
                       className={cn('h-1.5 rounded-full transition-all', i === step ? cn('w-6', s.accent.bar) : 'w-1.5 bg-muted-foreground/30')}
                     />
                   ))}

--- a/client/src/components/__tests__/OnboardingWizard.test.tsx
+++ b/client/src/components/__tests__/OnboardingWizard.test.tsx
@@ -1,15 +1,22 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
 import { render } from '../../test-utils'
 import { OnboardingWizard, hasSeenOnboarding, resetOnboarding } from '../OnboardingWizard'
+import { ThemeProvider } from '../../context/ThemeContext'
+import { LanguageProvider } from '../../context/LanguageContext'
+import i18n, { DEFAULT_LANGUAGE } from '../../lib/i18n'
+import { COMPANION_IOS_URL, COMPANION_ANDROID_URL } from '../../lib/companion'
 
 const STEP_TITLES = [
+  'Choose your language',
+  'Pick your look',
   'Welcome to Specrails',
   'Turn ideas into specs',
   'Run the pipeline on rails',
   'Bring your own agent',
   'Track every cent',
   'Make it your workspace',
+  'Take Specrails with you',
   'Move at the speed of thought',
 ]
 
@@ -46,7 +53,7 @@ describe('OnboardingWizard', () => {
     expect(screen.getByText(STEP_TITLES[0])).toBeTruthy()
   })
 
-  it('navigates through all 7 steps', () => {
+  it('navigates through all 10 steps', () => {
     render(<OnboardingWizard open={true} onClose={onClose} />)
     expect(screen.getByText(STEP_TITLES[0])).toBeTruthy()
     for (let i = 1; i < STEP_TITLES.length; i++) {
@@ -104,6 +111,87 @@ describe('OnboardingWizard', () => {
     expect(navButtons).toHaveLength(STEP_TITLES.length)
     fireEvent.click(navButtons[STEP_TITLES.length - 1]) // jump to last step
     expect(screen.getByText(STEP_TITLES[STEP_TITLES.length - 1])).toBeTruthy()
+  })
+
+  it('degrades gracefully without theme/language providers — copy renders, grids do not', () => {
+    render(<OnboardingWizard open={true} onClose={onClose} />)
+    expect(screen.getByText(STEP_TITLES[0])).toBeTruthy()
+    expect(screen.queryByTestId('language-card-en')).toBeNull()
+    fireEvent.click(screen.getByTestId('onboarding-next'))
+    expect(screen.getByText(STEP_TITLES[1])).toBeTruthy()
+    expect(screen.queryByTestId('theme-card-specrails')).toBeNull()
+  })
+
+  it('renders the keyboard keys inside the shortcut chips (regression: empty <Kbd>)', () => {
+    render(<OnboardingWizard open={true} onClose={onClose} />)
+    const navButtons = screen.getAllByRole('button', { name: /^Go to step/ })
+    fireEvent.click(navButtons[9]) // move-fast step
+    // jsdom has no Mac platform, so the modifier resolves to Ctrl / Alt.
+    expect(screen.getAllByText('Ctrl').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('K').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('J').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('B').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('?').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Alt').length).toBeGreaterThan(0)
+  })
+
+  it('companion step shows iOS and Android download links', () => {
+    render(<OnboardingWizard open={true} onClose={onClose} />)
+    const navButtons = screen.getAllByRole('button', { name: /^Go to step/ })
+    fireEvent.click(navButtons[8]) // companion step
+    expect(screen.getByText(STEP_TITLES[8])).toBeTruthy()
+    const ios = screen.getByTestId('companion-ios-link')
+    const android = screen.getByTestId('companion-android-link')
+    expect(ios).toHaveAttribute('href', COMPANION_IOS_URL)
+    expect(ios).toHaveAttribute('target', '_blank')
+    expect(ios).toHaveAttribute('rel', 'noopener noreferrer')
+    expect(android).toHaveAttribute('href', COMPANION_ANDROID_URL)
+    expect(android).toHaveAttribute('target', '_blank')
+    expect(android).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+})
+
+describe('OnboardingWizard interactive steps (with providers)', () => {
+  let onClose: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    onClose = vi.fn()
+    localStorage.clear()
+    document.documentElement.removeAttribute('data-theme')
+  })
+
+  afterEach(async () => {
+    await i18n.changeLanguage(DEFAULT_LANGUAGE)
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('language step hot-switches the app language from the wizard', async () => {
+    render(
+      <LanguageProvider>
+        <OnboardingWizard open={true} onClose={onClose} />
+      </LanguageProvider>
+    )
+    expect(screen.getByTestId('language-card-en')).toHaveAttribute('data-selected', 'true')
+    fireEvent.click(screen.getByTestId('language-card-es'))
+    await waitFor(() =>
+      expect(screen.getByTestId('language-card-es')).toHaveAttribute('data-selected', 'true')
+    )
+    expect(i18n.language).toBe('es')
+  })
+
+  it('theme step applies the clicked theme to the document', async () => {
+    render(
+      <ThemeProvider>
+        <OnboardingWizard open={true} onClose={onClose} />
+      </ThemeProvider>
+    )
+    fireEvent.click(screen.getByTestId('onboarding-next')) // → theme step
+    fireEvent.click(screen.getByTestId('theme-card-matrix'))
+    await waitFor(() =>
+      expect(screen.getByTestId('theme-card-matrix')).toHaveAttribute('data-selected', 'true')
+    )
+    expect(document.documentElement.dataset.theme).toBe('matrix')
   })
 })
 

--- a/client/src/components/pickers/LanguagePickerGrid.tsx
+++ b/client/src/components/pickers/LanguagePickerGrid.tsx
@@ -1,0 +1,73 @@
+import { Check } from 'lucide-react'
+import { toast } from 'sonner'
+import { useTranslation } from 'react-i18next'
+import { useLanguageOptional } from '../../context/LanguageContext'
+import { LANGUAGE_IDS, LANGUAGES, type LanguageId } from '../../lib/i18n'
+
+/**
+ * Language card grid shared by the Settings Language section and the
+ * onboarding wizard. One card per supported language — rendered from the
+ * `LANGUAGE_IDS` registry so adding a language requires zero changes here.
+ * Click applies hot (no restart) and persists to the server; failure reverts
+ * to the previously active language.
+ */
+export function LanguagePickerGrid() {
+  const { t } = useTranslation('settings')
+  const ctx = useLanguageOptional()
+  // No provider mounted — graceful no-op (unit tests rendering the host
+  // surface in isolation).
+  if (!ctx) return null
+  const { languageId, setLanguage, isUpdating } = ctx
+
+  async function handleSelect(id: LanguageId): Promise<void> {
+    if (id === languageId) return
+    try {
+      await setLanguage(id)
+    } catch (err) {
+      toast.error(t('language.updateFailed'), {
+        description: err instanceof Error ? err.message : undefined,
+      })
+    }
+  }
+
+  return (
+    <div
+      className="grid grid-cols-2 sm:grid-cols-4 gap-2"
+      role="radiogroup"
+      aria-label={t('language.selectLabel')}
+    >
+      {LANGUAGE_IDS.map((id) => {
+        const lang = LANGUAGES[id]
+        const selected = id === languageId
+        return (
+          <button
+            key={id}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            disabled={isUpdating}
+            onClick={() => void handleSelect(id)}
+            className={
+              'flex items-center justify-between gap-2 rounded-lg border bg-card px-3 py-2 text-left transition-all ' +
+              'focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/60 ' +
+              'disabled:opacity-60 disabled:cursor-not-allowed ' +
+              (selected
+                ? 'border-accent-primary ring-1 ring-accent-primary '
+                : 'border-border hover:border-accent-primary/40 hover:shadow-md ')
+            }
+            data-testid={`language-card-${id}`}
+            data-selected={selected ? 'true' : 'false'}
+          >
+            <span className="min-w-0">
+              <span className="block text-xs font-semibold truncate">{lang.nativeName}</span>
+              <span className="block text-[10px] text-muted-foreground truncate">
+                {lang.englishName}
+              </span>
+            </span>
+            {selected && <Check className="w-3.5 h-3.5 text-accent-primary shrink-0" aria-hidden="true" />}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/client/src/components/pickers/ThemePickerGrid.tsx
+++ b/client/src/components/pickers/ThemePickerGrid.tsx
@@ -1,0 +1,99 @@
+import { Check } from 'lucide-react'
+import { toast } from 'sonner'
+import { useTranslation } from 'react-i18next'
+import { useThemeOptional } from '../../context/ThemeContext'
+import { THEME_IDS, THEMES, type ThemeId } from '../../lib/themes'
+
+/**
+ * Theme card grid shared by the Settings Appearance section and the
+ * onboarding wizard. One card per built-in theme — rendered from the
+ * `THEME_IDS` registry so adding a theme requires zero changes here. Click
+ * to apply optimistically and persist to the server. Failure reverts to the
+ * previously active theme. No live preview on hover (intentional v1
+ * decision — see openspec/changes/add-hub-theme-system/design.md D7).
+ */
+export function ThemePickerGrid() {
+  const { t: tr } = useTranslation('settings')
+  const ctx = useThemeOptional()
+  // No provider mounted — graceful no-op (only happens in unit tests that
+  // exercise the host surface in isolation without ThemeProvider).
+  if (!ctx) return null
+  const { themeId, setTheme, isUpdating } = ctx
+
+  async function handleSelect(id: ThemeId): Promise<void> {
+    if (id === themeId) return
+    try {
+      await setTheme(id)
+    } catch (err) {
+      toast.error(tr('appearance.updateFailed'), {
+        description: err instanceof Error ? err.message : undefined,
+      })
+    }
+  }
+
+  return (
+    <div
+      className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2"
+      role="radiogroup"
+      aria-label={tr('appearance.themeGroupLabel')}
+    >
+      {THEME_IDS.map((id) => {
+        const t = THEMES[id]
+        const selected = id === themeId
+        return (
+          <button
+            key={id}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            disabled={isUpdating}
+            onClick={() => void handleSelect(id)}
+            className={
+              'group relative overflow-hidden rounded-lg border text-left transition-all ' +
+              'focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/60 ' +
+              'disabled:opacity-60 disabled:cursor-not-allowed ' +
+              (selected
+                ? 'border-accent-primary ring-1 ring-accent-primary shadow-[0_0_0_1px_var(--color-accent-primary)] '
+                : 'border-border hover:border-accent-primary/40 hover:shadow-md ')
+            }
+            data-testid={`theme-card-${id}`}
+            data-selected={selected ? 'true' : 'false'}
+          >
+            {/* Preview swatch */}
+            <div
+              className="h-20 w-full flex items-end gap-1 p-2"
+              style={{
+                background:
+                  `linear-gradient(135deg, ${t.previewSwatches.background} 0%, ${t.previewSwatches.background} 60%, color-mix(in srgb, ${t.previewSwatches.accents[0]} 18%, ${t.previewSwatches.background}) 100%)`,
+              }}
+              aria-hidden="true"
+            >
+              {t.previewSwatches.accents.map((c, i) => (
+                <span
+                  key={i}
+                  className="h-3 w-3 rounded-full ring-1 ring-black/10"
+                  style={{ background: c }}
+                />
+              ))}
+            </div>
+            {/* Body */}
+            <div className="p-3 space-y-1 bg-card">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-xs font-semibold">{t.displayName}</p>
+                {selected && (
+                  <Check
+                    className="w-3.5 h-3.5 text-accent-primary shrink-0"
+                    aria-label={tr('appearance.currentlyActive')}
+                  />
+                )}
+              </div>
+              <p className="text-[10px] text-muted-foreground leading-tight">
+                {tr(`appearance.taglines.${id}`, { defaultValue: t.tagline })}
+              </p>
+            </div>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/client/src/components/settings/AppearanceSection.tsx
+++ b/client/src/components/settings/AppearanceSection.tsx
@@ -1,15 +1,11 @@
-import { Check } from 'lucide-react'
-import { toast } from 'sonner'
 import { useTranslation } from 'react-i18next'
 import { useThemeOptional } from '../../context/ThemeContext'
-import { THEME_IDS, THEMES, type ThemeId } from '../../lib/themes'
+import { ThemePickerGrid } from '../pickers/ThemePickerGrid'
 
 /**
- * Desktop-wide theme picker. One card per built-in theme — rendered from the
- * `THEME_IDS` registry so adding a theme requires zero changes here. Click
- * to apply optimistically and persist to the server. Failure reverts to the
- * previously active theme. No live preview on hover (intentional v1
- * decision — see openspec/changes/add-hub-theme-system/design.md D7).
+ * Desktop-wide theme picker. Renders the shared `ThemePickerGrid` under the
+ * Appearance heading; the grid owns selection, optimistic apply, and
+ * revert-on-failure.
  */
 export function AppearanceSection() {
   const { t: tr } = useTranslation('settings')
@@ -17,87 +13,13 @@ export function AppearanceSection() {
   // No provider mounted — graceful no-op (only happens in unit tests that
   // exercise GlobalSettingsPage in isolation without ThemeProvider).
   if (!ctx) return null
-  const { themeId, setTheme, isUpdating } = ctx
-
-  async function handleSelect(id: ThemeId): Promise<void> {
-    if (id === themeId) return
-    try {
-      await setTheme(id)
-    } catch (err) {
-      toast.error(tr('appearance.updateFailed'), {
-        description: err instanceof Error ? err.message : undefined,
-      })
-    }
-  }
 
   return (
     <div className="space-y-2">
       <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
         {tr('appearance.heading')}
       </h3>
-      <div
-        className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2"
-        role="radiogroup"
-        aria-label={tr('appearance.themeGroupLabel')}
-      >
-        {THEME_IDS.map((id) => {
-          const t = THEMES[id]
-          const selected = id === themeId
-          return (
-            <button
-              key={id}
-              type="button"
-              role="radio"
-              aria-checked={selected}
-              disabled={isUpdating}
-              onClick={() => void handleSelect(id)}
-              className={
-                'group relative overflow-hidden rounded-lg border text-left transition-all ' +
-                'focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/60 ' +
-                'disabled:opacity-60 disabled:cursor-not-allowed ' +
-                (selected
-                  ? 'border-accent-primary ring-1 ring-accent-primary shadow-[0_0_0_1px_var(--color-accent-primary)] '
-                  : 'border-border hover:border-accent-primary/40 hover:shadow-md ')
-              }
-              data-testid={`theme-card-${id}`}
-              data-selected={selected ? 'true' : 'false'}
-            >
-              {/* Preview swatch */}
-              <div
-                className="h-20 w-full flex items-end gap-1 p-2"
-                style={{
-                  background:
-                    `linear-gradient(135deg, ${t.previewSwatches.background} 0%, ${t.previewSwatches.background} 60%, color-mix(in srgb, ${t.previewSwatches.accents[0]} 18%, ${t.previewSwatches.background}) 100%)`,
-                }}
-                aria-hidden="true"
-              >
-                {t.previewSwatches.accents.map((c, i) => (
-                  <span
-                    key={i}
-                    className="h-3 w-3 rounded-full ring-1 ring-black/10"
-                    style={{ background: c }}
-                  />
-                ))}
-              </div>
-              {/* Body */}
-              <div className="p-3 space-y-1 bg-card">
-                <div className="flex items-center justify-between gap-2">
-                  <p className="text-xs font-semibold">{t.displayName}</p>
-                  {selected && (
-                    <Check
-                      className="w-3.5 h-3.5 text-accent-primary shrink-0"
-                      aria-label={tr('appearance.currentlyActive')}
-                    />
-                  )}
-                </div>
-                <p className="text-[10px] text-muted-foreground leading-tight">
-                  {t.tagline}
-                </p>
-              </div>
-            </button>
-          )
-        })}
-      </div>
+      <ThemePickerGrid />
     </div>
   )
 }

--- a/client/src/components/settings/LanguageSection.tsx
+++ b/client/src/components/settings/LanguageSection.tsx
@@ -1,14 +1,11 @@
-import { Check } from 'lucide-react'
-import { toast } from 'sonner'
 import { useTranslation } from 'react-i18next'
 import { useLanguageOptional } from '../../context/LanguageContext'
-import { LANGUAGE_IDS, LANGUAGES, type LanguageId } from '../../lib/i18n'
+import { LanguagePickerGrid } from '../pickers/LanguagePickerGrid'
 
 /**
- * Desktop-wide language picker. One card per supported language — rendered from
- * the `LANGUAGE_IDS` registry so adding a language requires zero changes
- * here. Click applies hot (no restart) and persists to the server; failure
- * reverts to the previously active language.
+ * Desktop-wide language picker. Renders the shared `LanguagePickerGrid`
+ * under the Language heading; the grid owns selection, hot-switching, and
+ * revert-on-failure.
  */
 export function LanguageSection() {
   const { t } = useTranslation('settings')
@@ -16,18 +13,6 @@ export function LanguageSection() {
   // No provider mounted — graceful no-op (unit tests rendering the settings
   // page in isolation).
   if (!ctx) return null
-  const { languageId, setLanguage, isUpdating } = ctx
-
-  async function handleSelect(id: LanguageId): Promise<void> {
-    if (id === languageId) return
-    try {
-      await setLanguage(id)
-    } catch (err) {
-      toast.error(t('language.updateFailed'), {
-        description: err instanceof Error ? err.message : undefined,
-      })
-    }
-  }
 
   return (
     <div className="space-y-2">
@@ -35,44 +20,7 @@ export function LanguageSection() {
         {t('language.title')}
       </h3>
       <p className="text-[11px] text-muted-foreground">{t('language.description')}</p>
-      <div
-        className="grid grid-cols-2 sm:grid-cols-4 gap-2"
-        role="radiogroup"
-        aria-label={t('language.selectLabel')}
-      >
-        {LANGUAGE_IDS.map((id) => {
-          const lang = LANGUAGES[id]
-          const selected = id === languageId
-          return (
-            <button
-              key={id}
-              type="button"
-              role="radio"
-              aria-checked={selected}
-              disabled={isUpdating}
-              onClick={() => void handleSelect(id)}
-              className={
-                'flex items-center justify-between gap-2 rounded-lg border bg-card px-3 py-2 text-left transition-all ' +
-                'focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/60 ' +
-                'disabled:opacity-60 disabled:cursor-not-allowed ' +
-                (selected
-                  ? 'border-accent-primary ring-1 ring-accent-primary '
-                  : 'border-border hover:border-accent-primary/40 hover:shadow-md ')
-              }
-              data-testid={`language-card-${id}`}
-              data-selected={selected ? 'true' : 'false'}
-            >
-              <span className="min-w-0">
-                <span className="block text-xs font-semibold truncate">{lang.nativeName}</span>
-                <span className="block text-[10px] text-muted-foreground truncate">
-                  {lang.englishName}
-                </span>
-              </span>
-              {selected && <Check className="w-3.5 h-3.5 text-accent-primary shrink-0" aria-hidden="true" />}
-            </button>
-          )
-        })}
-      </div>
+      <LanguagePickerGrid />
     </div>
   )
 }

--- a/client/src/lib/companion.ts
+++ b/client/src/lib/companion.ts
@@ -1,0 +1,8 @@
+// SpecRails Companion download links.
+//
+// The store listings are not live yet, so these point at stable
+// specrails.dev redirect paths the website controls — shipped desktop
+// binaries never hold a dead store URL, and flipping the redirect to the
+// final App Store / Play Store listing requires no app re-release.
+export const COMPANION_IOS_URL = 'https://specrails.dev/companion/ios'
+export const COMPANION_ANDROID_URL = 'https://specrails.dev/companion/android'

--- a/client/src/locales/de/settings.json
+++ b/client/src/locales/de/settings.json
@@ -152,6 +152,13 @@
     "budgetHelper": "Obergrenze für `surface=file-summary`-Ausgaben pro Kalendermonat. Von Nutzern angestoßene Neugenerierungen können sie überschreiten."
   },
   "appearance": {
+    "taglines": {
+      "dracula": "Das Original — dunkel mit Violettstich und lebhaften Neon-Akzenten",
+      "aurora-light": "Premium hell — Linear-inspiriertes Indigo auf warmem Cremeweiß",
+      "obsidian-dark": "Premium dunkel — fast schwarz mit Blaustich und elektrischen Akzenten",
+      "matrix": "Phosphor-Terminal — sanftes Mint auf grünlichem Fast-Schwarz",
+      "specrails": "Marken-Theme — tiefes Marine-Indigo mit satten Cyan-Akzenten"
+    },
     "heading": "Erscheinungsbild",
     "themeGroupLabel": "Theme",
     "currentlyActive": "Derzeit aktiv",

--- a/client/src/locales/de/setup.json
+++ b/client/src/locales/de/setup.json
@@ -166,6 +166,20 @@
       "developer": "Entwickler",
       "reviewer": "Reviewer"
     },
+    "language": {
+      "nav": "Sprache",
+      "title": "Wählen Sie Ihre Sprache",
+      "subtitle": "Specrails spricht Ihre Sprache",
+      "intro": "Wählen Sie die Sprache für die Oberfläche. Sie gilt sofort – diese Tour eingeschlossen.",
+      "note": "Sie können sie jederzeit unter Einstellungen → Sprache ändern."
+    },
+    "theme": {
+      "nav": "Theme",
+      "title": "Wählen Sie Ihren Look",
+      "subtitle": "Integrierte Themes, sofort angewendet",
+      "intro": "Wählen Sie, wie Specrails aussehen soll — das Theme wird sofort beim Klick angewendet.",
+      "note": "Sie können es jederzeit unter Einstellungen → Erscheinungsbild ändern."
+    },
     "welcome": {
       "nav": "Willkommen",
       "title": "Willkommen bei Specrails",
@@ -248,7 +262,7 @@
       "title": "Machen Sie es zu Ihrem Arbeitsbereich",
       "subtitle": "Alles Nötige, ohne das Fenster zu verlassen",
       "terminalLabel": "Terminal-Panel",
-      "terminalBody": "Ein echtes Terminal im VS-Code-Stil am unteren Rand (<mod></mod> <j></j>) – WebGL-Rendering, Suche, Inline-Bilder, Drag-and-drop-Pfade und Shell-Integration. Bis zu 10 Sessions pro Projekt.",
+      "terminalBody": "Ein echtes Terminal im VS-Code-Stil am unteren Rand (<mod>{{mod}}</mod> <j>J</j>) – WebGL-Rendering, Suche, Inline-Bilder, Drag-and-drop-Pfade und Shell-Integration. Bis zu 10 Sessions pro Projekt.",
       "codeLabel": "Code-Explorer",
       "codeBody": "Ein schreibgeschützter Dateibaum und Monaco-Viewer mit verständlichen KI-Zusammenfassungen und „Von KI berührt“-Herkunfts-Chips – so kann jeder nachvollziehen, was sich warum geändert hat.",
       "integrationsLabel": "Integrationen",
@@ -260,21 +274,35 @@
       "desktopLabel": "Desktop oder Browser",
       "desktopBody": "Nutzen Sie Specrails im Browser oder holen Sie sich die signierte Desktop-App (macOS & Windows) mit eigenem Server und eigenen Runtimes."
     },
+    "companion": {
+      "nav": "Mobile App",
+      "title": "Nehmen Sie Specrails überallhin mit",
+      "subtitle": "SpecRails Companion – Ihre Pipelines auf Ihrem Smartphone",
+      "intro": "<b>SpecRails Companion</b> ist die kostenlose Mobile-App für iPhone und Android, die sich über Ihr lokales Netzwerk mit diesem Desktop koppelt. Durchstöbern Sie das Specs-Board, starten und stoppen Sie Rails, verfolgen Sie Live-Job-Logs und werfen Sie einen Blick auf die Analytics – direkt vom Smartphone.",
+      "localLabel": "100 % lokal, wie alles andere",
+      "localBody": "Die App spricht über Ihr WLAN direkt mit diesem Rechner – QR-Kopplung mit TLS-Pinning. Kein Cloud-Relay, kein Konto, und Ihr Code verlässt nie Ihre vier Wände.",
+      "downloadLabel": "Holen Sie sich die App",
+      "downloadHint": "Scannen Sie einen Code mit der Kamera Ihres Smartphones oder öffnen Sie den Link.",
+      "ios": "Für iPhone laden",
+      "android": "Für Android laden",
+      "pairLabel": "Die Kopplung dauert zehn Sekunden",
+      "pairBody": "Gehen Sie nach der Installation zu Einstellungen → Mobile Companion → Gerät koppeln und scannen Sie den dort angezeigten QR-Code."
+    },
     "moveFast": {
       "nav": "Schnell arbeiten",
       "title": "In Gedankengeschwindigkeit arbeiten",
       "subtitle": "Keyboard-first, überall",
       "paletteLabel": "Befehlspalette",
-      "paletteShortcut": "<f>Drücken Sie</f> <mod></mod> <m>+</m> <k></k> <m>überall</m>",
+      "paletteShortcut": "<f>Drücken Sie</f> <mod>{{mod}}</mod> <m>+</m> <k>K</k> <m>überall</m>",
       "paletteBody": "Projekte wechseln, Spec-Befehle ausführen, zu jeder Seite springen und letzte Jobs finden – alles mit Fuzzy-Suche.",
       "terminalLabel": "Terminal-Panel",
-      "terminalBody": "Umschalten mit <mod></mod> <j></j>.",
+      "terminalBody": "Umschalten mit <mod>{{mod}}</mod> <j>J</j>.",
       "shortcutsLabel": "Alle Shortcuts",
-      "shortcutsBody": "Drücken Sie <q></q> für die vollständige Übersicht.",
+      "shortcutsBody": "Drücken Sie <q>?</q> für die vollständige Übersicht.",
       "chatLabel": "Chat-Seitenleiste",
-      "chatBody": "Rechte Seitenleiste umschalten mit <mod></mod> <bkey></bkey>.",
+      "chatBody": "Rechte Seitenleiste umschalten mit <mod>{{mod}}</mod> <bkey>B</bkey>.",
       "projectsLabel": "Projekt-Seitenleiste",
-      "projectsBody": "Linke Arc-Seitenleiste umschalten mit <alt></alt> <mod></mod> <bkey></bkey>.",
+      "projectsBody": "Linke Arc-Seitenleiste umschalten mit <alt>{{alt}}</alt> <mod>{{mod}}</mod> <bkey>B</bkey>.",
       "outro": "<b>Das war die Tour.</b> Fügen Sie über die linke Seitenleiste ein Projekt hinzu und liefern Sie Ihre erste Spec aus. Diese Tour lässt sich jederzeit über die Einstellungen erneut öffnen."
     }
   }

--- a/client/src/locales/en/settings.json
+++ b/client/src/locales/en/settings.json
@@ -152,6 +152,13 @@
     "budgetHelper": "Cap on `surface=file-summary` spend per calendar month. User-initiated regenerations can override."
   },
   "appearance": {
+    "taglines": {
+      "dracula": "The original — dark purple-tinted with vivid neon accents",
+      "aurora-light": "Premium light — Linear-inspired indigo on warm off-white",
+      "obsidian-dark": "Premium dark — near-black blue-tinted with electric accents",
+      "matrix": "Phosphor terminal — soft mint on green-tinted near-black",
+      "specrails": "Brand theme — deep navy-indigo with saturated cyan accents"
+    },
     "heading": "Appearance",
     "themeGroupLabel": "Theme",
     "currentlyActive": "Currently active",

--- a/client/src/locales/en/setup.json
+++ b/client/src/locales/en/setup.json
@@ -166,6 +166,20 @@
       "developer": "Developer",
       "reviewer": "Reviewer"
     },
+    "language": {
+      "nav": "Language",
+      "title": "Choose your language",
+      "subtitle": "Specrails speaks your language",
+      "intro": "Pick the language you want the interface in. It applies instantly — this tour included.",
+      "note": "You can change it any time in Settings → Language."
+    },
+    "theme": {
+      "nav": "Theme",
+      "title": "Pick your look",
+      "subtitle": "Built-in themes, applied instantly",
+      "intro": "Choose how Specrails should look — the theme applies the moment you click.",
+      "note": "You can change it any time in Settings → Appearance."
+    },
     "welcome": {
       "nav": "Welcome",
       "title": "Welcome to Specrails",
@@ -248,7 +262,7 @@
       "title": "Make it your workspace",
       "subtitle": "Everything you need without leaving the window",
       "terminalLabel": "Terminal panel",
-      "terminalBody": "A real VS-Code-style terminal at the bottom (<mod></mod> <j></j>) — WebGL rendering, search, inline images, drag-drop paths and shell integration. Up to 10 sessions per project.",
+      "terminalBody": "A real VS-Code-style terminal at the bottom (<mod>{{mod}}</mod> <j>J</j>) — WebGL rendering, search, inline images, drag-drop paths and shell integration. Up to 10 sessions per project.",
       "codeLabel": "Code explorer",
       "codeBody": "A read-only file tree and Monaco viewer with plain-language AI summaries and “touched by AI” provenance chips, so anyone can follow what changed and why.",
       "integrationsLabel": "Integrations",
@@ -260,21 +274,35 @@
       "desktopLabel": "Desktop or browser",
       "desktopBody": "Run Specrails in your browser, or grab the signed desktop app (macOS & Windows) that bundles its own server and runtimes."
     },
+    "companion": {
+      "nav": "Mobile app",
+      "title": "Take Specrails with you",
+      "subtitle": "SpecRails Companion — your pipelines, on your phone",
+      "intro": "<b>SpecRails Companion</b> is the free mobile app for iPhone and Android that pairs with this desktop over your local network. Browse the specs board, launch and stop rails, follow live job logs and glance at analytics — straight from your phone.",
+      "localLabel": "100% local, like everything else",
+      "localBody": "The app talks directly to this computer over your Wi-Fi — QR pairing with pinned TLS. No cloud relay, no account, and your code never leaves home.",
+      "downloadLabel": "Get the app",
+      "downloadHint": "Scan a code with your phone's camera, or open the link.",
+      "ios": "Download for iPhone",
+      "android": "Download for Android",
+      "pairLabel": "Pairing takes ten seconds",
+      "pairBody": "Once installed, go to Settings → Mobile companion → Pair device and scan the QR code shown there."
+    },
     "moveFast": {
       "nav": "Move fast",
       "title": "Move at the speed of thought",
       "subtitle": "Keyboard-first, everywhere",
       "paletteLabel": "Command palette",
-      "paletteShortcut": "<f>Press</f> <mod></mod> <m>+</m> <k></k> <m>anywhere</m>",
+      "paletteShortcut": "<f>Press</f> <mod>{{mod}}</mod> <m>+</m> <k>K</k> <m>anywhere</m>",
       "paletteBody": "Switch projects, run spec commands, jump to any page and find recent jobs — all with fuzzy search.",
       "terminalLabel": "Terminal panel",
-      "terminalBody": "Toggle with <mod></mod> <j></j>.",
+      "terminalBody": "Toggle with <mod>{{mod}}</mod> <j>J</j>.",
       "shortcutsLabel": "All shortcuts",
-      "shortcutsBody": "Press <q></q> to see the full cheat-sheet.",
+      "shortcutsBody": "Press <q>?</q> to see the full cheat-sheet.",
       "chatLabel": "Chat sidebar",
-      "chatBody": "Toggle the right sidebar with <mod></mod> <bkey></bkey>.",
+      "chatBody": "Toggle the right sidebar with <mod>{{mod}}</mod> <bkey>B</bkey>.",
       "projectsLabel": "Projects sidebar",
-      "projectsBody": "Toggle the left Arc sidebar with <alt></alt> <mod></mod> <bkey></bkey>.",
+      "projectsBody": "Toggle the left Arc sidebar with <alt>{{alt}}</alt> <mod>{{mod}}</mod> <bkey>B</bkey>.",
       "outro": "<b>That's the tour.</b> Add a project from the left sidebar and ship your first spec. You can reopen this walkthrough anytime from Settings."
     }
   }

--- a/client/src/locales/es/settings.json
+++ b/client/src/locales/es/settings.json
@@ -152,6 +152,13 @@
     "budgetHelper": "Tope de gasto de `surface=file-summary` por mes natural. Las regeneraciones iniciadas por el usuario pueden sobrepasarlo."
   },
   "appearance": {
+    "taglines": {
+      "dracula": "El original — oscuro con tinte púrpura y acentos neón vivos",
+      "aurora-light": "Claro premium — índigo inspirado en Linear sobre blanco cálido",
+      "obsidian-dark": "Oscuro premium — casi negro con tinte azul y acentos eléctricos",
+      "matrix": "Terminal de fósforo — menta suave sobre casi negro verdoso",
+      "specrails": "Tema de marca — azul marino-índigo profundo con acentos cian saturados"
+    },
     "heading": "Apariencia",
     "themeGroupLabel": "Tema",
     "currentlyActive": "Activo actualmente",

--- a/client/src/locales/es/setup.json
+++ b/client/src/locales/es/setup.json
@@ -166,6 +166,20 @@
       "developer": "Desarrollador",
       "reviewer": "Revisor"
     },
+    "language": {
+      "nav": "Idioma",
+      "title": "Elige tu idioma",
+      "subtitle": "Specrails habla tu idioma",
+      "intro": "Selecciona el idioma en el que quieres la interfaz. Se aplica al instante — este tour incluido.",
+      "note": "Puedes cambiarlo cuando quieras en Ajustes → Idioma."
+    },
+    "theme": {
+      "nav": "Tema",
+      "title": "Elige tu estilo",
+      "subtitle": "Temas integrados, aplicados al instante",
+      "intro": "Decide qué aspecto tendrá Specrails — el tema se aplica en cuanto haces clic.",
+      "note": "Puedes cambiarlo cuando quieras en Ajustes → Apariencia."
+    },
     "welcome": {
       "nav": "Bienvenida",
       "title": "Bienvenido a Specrails",
@@ -248,7 +262,7 @@
       "title": "Hazlo tu espacio de trabajo",
       "subtitle": "Todo lo que necesitas sin salir de la ventana",
       "terminalLabel": "Panel de terminal",
-      "terminalBody": "Un terminal real al estilo VS Code en la parte inferior (<mod></mod> <j></j>) — renderizado WebGL, búsqueda, imágenes inline, arrastrar y soltar rutas e integración con el shell. Hasta 10 sesiones por proyecto.",
+      "terminalBody": "Un terminal real al estilo VS Code en la parte inferior (<mod>{{mod}}</mod> <j>J</j>) — renderizado WebGL, búsqueda, imágenes inline, arrastrar y soltar rutas e integración con el shell. Hasta 10 sesiones por proyecto.",
       "codeLabel": "Explorador de código",
       "codeBody": "Un árbol de archivos de solo lectura y un visor Monaco con resúmenes de IA en lenguaje llano y chips de procedencia «tocado por IA», para que cualquiera pueda seguir qué cambió y por qué.",
       "integrationsLabel": "Integraciones",
@@ -260,21 +274,35 @@
       "desktopLabel": "Escritorio o navegador",
       "desktopBody": "Ejecuta Specrails en tu navegador o descarga la app de escritorio firmada (macOS y Windows), que incluye su propio servidor y runtimes."
     },
+    "companion": {
+      "nav": "App móvil",
+      "title": "Llévate Specrails contigo",
+      "subtitle": "SpecRails Companion — tus pipelines, en tu teléfono",
+      "intro": "<b>SpecRails Companion</b> es la app móvil gratuita para iPhone y Android que se empareja con este escritorio a través de tu red local. Navega por el tablero de specs, lanza y detén rails, sigue los logs de los jobs en directo y echa un vistazo a la analítica — directamente desde tu teléfono.",
+      "localLabel": "100 % local, como todo lo demás",
+      "localBody": "La app habla directamente con este ordenador a través de tu Wi-Fi — emparejamiento por QR con anclaje de certificado TLS. Sin servidores intermedios en la nube, sin cuentas, y tu código nunca sale de casa.",
+      "downloadLabel": "Consigue la app",
+      "downloadHint": "Escanea un código con la cámara de tu teléfono o abre el enlace.",
+      "ios": "Descargar para iPhone",
+      "android": "Descargar para Android",
+      "pairLabel": "Emparejar lleva diez segundos",
+      "pairBody": "Una vez instalada, ve a Ajustes → App móvil → Emparejar dispositivo y escanea el código QR que aparece ahí."
+    },
     "moveFast": {
       "nav": "Ve rápido",
       "title": "Muévete a la velocidad del pensamiento",
       "subtitle": "Teclado primero, en todas partes",
       "paletteLabel": "Paleta de comandos",
-      "paletteShortcut": "<f>Pulsa</f> <mod></mod> <m>+</m> <k></k> <m>en cualquier parte</m>",
+      "paletteShortcut": "<f>Pulsa</f> <mod>{{mod}}</mod> <m>+</m> <k>K</k> <m>en cualquier parte</m>",
       "paletteBody": "Cambia de proyecto, ejecuta comandos de spec, salta a cualquier página y encuentra jobs recientes — todo con búsqueda difusa.",
       "terminalLabel": "Panel de terminal",
-      "terminalBody": "Alterna con <mod></mod> <j></j>.",
+      "terminalBody": "Alterna con <mod>{{mod}}</mod> <j>J</j>.",
       "shortcutsLabel": "Todos los atajos",
-      "shortcutsBody": "Pulsa <q></q> para ver la chuleta completa.",
+      "shortcutsBody": "Pulsa <q>?</q> para ver la chuleta completa.",
       "chatLabel": "Barra lateral de chat",
-      "chatBody": "Alterna la barra lateral derecha con <mod></mod> <bkey></bkey>.",
+      "chatBody": "Alterna la barra lateral derecha con <mod>{{mod}}</mod> <bkey>B</bkey>.",
       "projectsLabel": "Barra lateral de proyectos",
-      "projectsBody": "Alterna la barra lateral Arc izquierda con <alt></alt> <mod></mod> <bkey></bkey>.",
+      "projectsBody": "Alterna la barra lateral Arc izquierda con <alt>{{alt}}</alt> <mod>{{mod}}</mod> <bkey>B</bkey>.",
       "outro": "<b>Fin del tour.</b> Añade un proyecto desde la barra lateral izquierda y publica tu primera spec. Puedes reabrir este recorrido cuando quieras desde Ajustes."
     }
   }

--- a/client/src/locales/fr/settings.json
+++ b/client/src/locales/fr/settings.json
@@ -152,6 +152,13 @@
     "budgetHelper": "Plafond de dépense `surface=file-summary` par mois calendaire. Les régénérations lancées par l'utilisateur peuvent le dépasser."
   },
   "appearance": {
+    "taglines": {
+      "dracula": "L'original — sombre teinté de violet aux accents néon éclatants",
+      "aurora-light": "Clair premium — indigo inspiré de Linear sur blanc cassé chaleureux",
+      "obsidian-dark": "Sombre premium — presque noir teinté de bleu aux accents électriques",
+      "matrix": "Terminal phosphore — menthe douce sur fond presque noir verdâtre",
+      "specrails": "Thème de la marque — bleu marine-indigo profond aux accents cyan saturés"
+    },
     "heading": "Apparence",
     "themeGroupLabel": "Thème",
     "currentlyActive": "Actuellement actif",

--- a/client/src/locales/fr/setup.json
+++ b/client/src/locales/fr/setup.json
@@ -166,6 +166,20 @@
       "developer": "Développeur",
       "reviewer": "Relecteur"
     },
+    "language": {
+      "nav": "Langue",
+      "title": "Choisissez votre langue",
+      "subtitle": "Specrails parle votre langue",
+      "intro": "Choisissez la langue de l'interface. Elle s'applique instantanément — cette visite comprise.",
+      "note": "Vous pouvez en changer à tout moment dans Paramètres → Langue."
+    },
+    "theme": {
+      "nav": "Thème",
+      "title": "Trouvez votre style",
+      "subtitle": "Des thèmes intégrés, appliqués instantanément",
+      "intro": "Choisissez l'apparence de Specrails — le thème s'applique dès que vous cliquez.",
+      "note": "Vous pouvez en changer à tout moment dans Paramètres → Apparence."
+    },
     "welcome": {
       "nav": "Bienvenue",
       "title": "Bienvenue dans Specrails",
@@ -248,7 +262,7 @@
       "title": "Faites-en votre espace de travail",
       "subtitle": "Tout ce qu'il vous faut sans quitter la fenêtre",
       "terminalLabel": "Panneau de terminal",
-      "terminalBody": "Un vrai terminal façon VS Code en bas (<mod></mod> <j></j>) — rendu WebGL, recherche, images inline, glisser-déposer de chemins et intégration shell. Jusqu'à 10 sessions par projet.",
+      "terminalBody": "Un vrai terminal façon VS Code en bas (<mod>{{mod}}</mod> <j>J</j>) — rendu WebGL, recherche, images inline, glisser-déposer de chemins et intégration shell. Jusqu'à 10 sessions par projet.",
       "codeLabel": "Explorateur de code",
       "codeBody": "Une arborescence de fichiers en lecture seule et un viewer Monaco avec des résumés IA en langage clair et des puces de provenance « touché par l'IA », pour que chacun puisse suivre ce qui a changé et pourquoi.",
       "integrationsLabel": "Intégrations",
@@ -260,21 +274,35 @@
       "desktopLabel": "Desktop ou navigateur",
       "desktopBody": "Lancez Specrails dans votre navigateur, ou prenez l'application desktop signée (macOS & Windows) qui embarque son propre serveur et ses runtimes."
     },
+    "companion": {
+      "nav": "App mobile",
+      "title": "Emportez Specrails avec vous",
+      "subtitle": "SpecRails Companion — vos pipelines, dans votre poche",
+      "intro": "<b>SpecRails Companion</b> est l'application mobile gratuite pour iPhone et Android qui s'appaire avec cet ordinateur via votre réseau local. Parcourez le tableau des specs, lancez et arrêtez des rails, suivez les logs des jobs en direct et jetez un œil aux analytics — directement depuis votre téléphone.",
+      "localLabel": "100 % local, comme tout le reste",
+      "localBody": "L'application dialogue directement avec cet ordinateur via votre Wi-Fi — appairage par QR avec TLS épinglé. Pas de relais cloud, pas de compte, et votre code ne sort jamais de chez vous.",
+      "downloadLabel": "Téléchargez l'application",
+      "downloadHint": "Scannez un code avec l'appareil photo de votre téléphone, ou ouvrez le lien.",
+      "ios": "Télécharger pour iPhone",
+      "android": "Télécharger pour Android",
+      "pairLabel": "L'appairage prend dix secondes",
+      "pairBody": "Une fois installée, allez dans Paramètres → Compagnon mobile → Appairer un appareil et scannez le code QR qui s'y affiche."
+    },
     "moveFast": {
       "nav": "Aller vite",
       "title": "Avancez à la vitesse de la pensée",
       "subtitle": "Le clavier d'abord, partout",
       "paletteLabel": "Palette de commandes",
-      "paletteShortcut": "<f>Appuyez sur</f> <mod></mod> <m>+</m> <k></k> <m>n'importe où</m>",
+      "paletteShortcut": "<f>Appuyez sur</f> <mod>{{mod}}</mod> <m>+</m> <k>K</k> <m>n'importe où</m>",
       "paletteBody": "Changez de projet, lancez des commandes de spec, sautez vers n'importe quelle page et retrouvez les jobs récents — le tout en recherche floue.",
       "terminalLabel": "Panneau de terminal",
-      "terminalBody": "Basculez avec <mod></mod> <j></j>.",
+      "terminalBody": "Basculez avec <mod>{{mod}}</mod> <j>J</j>.",
       "shortcutsLabel": "Tous les raccourcis",
-      "shortcutsBody": "Appuyez sur <q></q> pour voir l'antisèche complète.",
+      "shortcutsBody": "Appuyez sur <q>?</q> pour voir l'antisèche complète.",
       "chatLabel": "Barre latérale de chat",
-      "chatBody": "Basculez la barre latérale droite avec <mod></mod> <bkey></bkey>.",
+      "chatBody": "Basculez la barre latérale droite avec <mod>{{mod}}</mod> <bkey>B</bkey>.",
       "projectsLabel": "Barre latérale des projets",
-      "projectsBody": "Basculez la barre latérale Arc de gauche avec <alt></alt> <mod></mod> <bkey></bkey>.",
+      "projectsBody": "Basculez la barre latérale Arc de gauche avec <alt>{{alt}}</alt> <mod>{{mod}}</mod> <bkey>B</bkey>.",
       "outro": "<b>La visite est terminée.</b> Ajoutez un projet depuis la barre latérale gauche et livrez votre première spec. Vous pouvez rouvrir cette visite à tout moment depuis les Paramètres."
     }
   }

--- a/client/src/locales/it/settings.json
+++ b/client/src/locales/it/settings.json
@@ -152,6 +152,13 @@
     "budgetHelper": "Tetto alla spesa `surface=file-summary` per mese di calendario. Le rigenerazioni avviate dall'utente possono superarlo."
   },
   "appearance": {
+    "taglines": {
+      "dracula": "L'originale — scuro con sfumature viola e vividi accenti neon",
+      "aurora-light": "Chiaro premium — indaco ispirato a Linear su bianco caldo",
+      "obsidian-dark": "Scuro premium — quasi nero con sfumature blu e accenti elettrici",
+      "matrix": "Terminale al fosforo — menta tenue su quasi nero verdastro",
+      "specrails": "Tema del brand — blu navy-indaco profondo con accenti ciano saturi"
+    },
     "heading": "Aspetto",
     "themeGroupLabel": "Tema",
     "currentlyActive": "Attualmente attivo",

--- a/client/src/locales/it/setup.json
+++ b/client/src/locales/it/setup.json
@@ -166,6 +166,20 @@
       "developer": "Developer",
       "reviewer": "Reviewer"
     },
+    "language": {
+      "nav": "Lingua",
+      "title": "Scegli la tua lingua",
+      "subtitle": "Specrails parla la tua lingua",
+      "intro": "Seleziona la lingua in cui vuoi usare l'interfaccia. Si applica all'istante — questo tour incluso.",
+      "note": "Puoi cambiarla in qualsiasi momento da Impostazioni → Lingua."
+    },
+    "theme": {
+      "nav": "Tema",
+      "title": "Scegli il tuo stile",
+      "subtitle": "Temi integrati, applicati all'istante",
+      "intro": "Scegli l'aspetto di Specrails — il tema si applica appena fai clic.",
+      "note": "Puoi cambiarlo in qualsiasi momento da Impostazioni → Aspetto."
+    },
     "welcome": {
       "nav": "Benvenuto",
       "title": "Benvenuto in Specrails",
@@ -248,7 +262,7 @@
       "title": "Rendilo il tuo workspace",
       "subtitle": "Tutto ciò che ti serve senza lasciare la finestra",
       "terminalLabel": "Pannello terminale",
-      "terminalBody": "Un vero terminale in stile VS Code in basso (<mod></mod> <j></j>) — rendering WebGL, ricerca, immagini inline, trascinamento di percorsi e integrazione con la shell. Fino a 10 sessioni per progetto.",
+      "terminalBody": "Un vero terminale in stile VS Code in basso (<mod>{{mod}}</mod> <j>J</j>) — rendering WebGL, ricerca, immagini inline, trascinamento di percorsi e integrazione con la shell. Fino a 10 sessioni per progetto.",
       "codeLabel": "Esploratore di codice",
       "codeBody": "Un albero dei file in sola lettura e un visualizzatore Monaco con riassunti IA in linguaggio semplice e chip di provenienza “toccato dall'IA”, così chiunque può seguire cosa è cambiato e perché.",
       "integrationsLabel": "Integrazioni",
@@ -260,21 +274,35 @@
       "desktopLabel": "Desktop o browser",
       "desktopBody": "Esegui Specrails nel browser, oppure scarica l'app desktop firmata (macOS e Windows) che include il proprio server e i runtime."
     },
+    "companion": {
+      "nav": "App mobile",
+      "title": "Porta Specrails con te",
+      "subtitle": "SpecRails Companion — le tue pipeline, sul tuo telefono",
+      "intro": "<b>SpecRails Companion</b> è l'app mobile gratuita per iPhone e Android che si associa a questo computer sulla tua rete locale. Sfoglia la board delle spec, lancia e ferma i rail, segui i log dei job in diretta e dai un'occhiata alle Analytics — direttamente dal telefono.",
+      "localLabel": "100% locale, come tutto il resto",
+      "localBody": "L'app dialoga direttamente con questo computer tramite il tuo Wi-Fi — associazione via QR con pinning TLS. Nessun relay cloud, nessun account, e il tuo codice non esce mai da casa.",
+      "downloadLabel": "Scarica l'app",
+      "downloadHint": "Scansiona un codice con la fotocamera del telefono, oppure apri il link.",
+      "ios": "Scarica per iPhone",
+      "android": "Scarica per Android",
+      "pairLabel": "L'associazione richiede dieci secondi",
+      "pairBody": "Una volta installata l'app, vai su Impostazioni → Companion mobile → Associa dispositivo e scansiona il codice QR che trovi lì."
+    },
     "moveFast": {
       "nav": "Vai veloce",
       "title": "Muoviti alla velocità del pensiero",
       "subtitle": "Keyboard-first, ovunque",
       "paletteLabel": "Palette dei comandi",
-      "paletteShortcut": "<f>Premi</f> <mod></mod> <m>+</m> <k></k> <m>ovunque</m>",
+      "paletteShortcut": "<f>Premi</f> <mod>{{mod}}</mod> <m>+</m> <k>K</k> <m>ovunque</m>",
       "paletteBody": "Cambia progetto, esegui comandi spec, salta a qualsiasi pagina e trova i job recenti — tutto con ricerca fuzzy.",
       "terminalLabel": "Pannello terminale",
-      "terminalBody": "Attiva/disattiva con <mod></mod> <j></j>.",
+      "terminalBody": "Attiva/disattiva con <mod>{{mod}}</mod> <j>J</j>.",
       "shortcutsLabel": "Tutte le scorciatoie",
-      "shortcutsBody": "Premi <q></q> per vedere il cheat-sheet completo.",
+      "shortcutsBody": "Premi <q>?</q> per vedere il cheat-sheet completo.",
       "chatLabel": "Sidebar della chat",
-      "chatBody": "Attiva/disattiva la sidebar destra con <mod></mod> <bkey></bkey>.",
+      "chatBody": "Attiva/disattiva la sidebar destra con <mod>{{mod}}</mod> <bkey>B</bkey>.",
       "projectsLabel": "Sidebar dei progetti",
-      "projectsBody": "Attiva/disattiva la sidebar Arc sinistra con <alt></alt> <mod></mod> <bkey></bkey>.",
+      "projectsBody": "Attiva/disattiva la sidebar Arc sinistra con <alt>{{alt}}</alt> <mod>{{mod}}</mod> <bkey>B</bkey>.",
       "outro": "<b>Il tour finisce qui.</b> Aggiungi un progetto dalla sidebar sinistra e rilascia la tua prima spec. Puoi riaprire questa guida in qualsiasi momento dalle Impostazioni."
     }
   }

--- a/client/src/locales/ja/settings.json
+++ b/client/src/locales/ja/settings.json
@@ -152,6 +152,13 @@
     "budgetHelper": "暦月ごとの `surface=file-summary` 支出の上限。ユーザーが開始した再生成は上限を超えられます。"
   },
   "appearance": {
+    "taglines": {
+      "dracula": "オリジナル — 紫がかったダークにネオンのアクセント",
+      "aurora-light": "プレミアムライト — Linear風のインディゴと温かみのあるオフホワイト",
+      "obsidian-dark": "プレミアムダーク — 青みがかった漆黒にエレクトリックなアクセント",
+      "matrix": "蛍光ターミナル — 緑がかった漆黒にソフトミント",
+      "specrails": "ブランドテーマ — 深いネイビーインディゴに鮮やかなシアン"
+    },
     "heading": "外観",
     "themeGroupLabel": "テーマ",
     "currentlyActive": "現在アクティブ",

--- a/client/src/locales/ja/setup.json
+++ b/client/src/locales/ja/setup.json
@@ -166,6 +166,20 @@
       "developer": "デベロッパー",
       "reviewer": "レビュアー"
     },
+    "language": {
+      "nav": "言語",
+      "title": "言語を選ぶ",
+      "subtitle": "Specrailsはあなたの言語に対応",
+      "intro": "インターフェースで使いたい言語を選んでください。即座に適用されます — このツアーも含めて。",
+      "note": "設定 → 言語でいつでも変更できます。"
+    },
+    "theme": {
+      "nav": "テーマ",
+      "title": "好みの見た目を選ぶ",
+      "subtitle": "内蔵テーマを即座に適用",
+      "intro": "Specrailsの見た目を選びましょう — テーマはクリックした瞬間に適用されます。",
+      "note": "設定 → 外観でいつでも変更できます。"
+    },
     "welcome": {
       "nav": "ようこそ",
       "title": "Specrails へようこそ",
@@ -248,7 +262,7 @@
       "title": "あなたのワークスペースに",
       "subtitle": "ウィンドウを離れずに必要なすべてを",
       "terminalLabel": "ターミナルパネル",
-      "terminalBody": "画面下部の本格的な VS Code スタイルのターミナル（<mod></mod> <j></j>）— WebGL レンダリング、検索、インライン画像、パスのドラッグ&ドロップ、シェル統合。プロジェクトごとに最大10セッション。",
+      "terminalBody": "画面下部の本格的な VS Code スタイルのターミナル（<mod>{{mod}}</mod> <j>J</j>）— WebGL レンダリング、検索、インライン画像、パスのドラッグ&ドロップ、シェル統合。プロジェクトごとに最大10セッション。",
       "codeLabel": "コードエクスプローラー",
       "codeBody": "読み取り専用のファイルツリーと Monaco ビューアに、平易な AI 要約と「AI が変更」の来歴チップが付き、誰でも何がなぜ変わったかを追えます。",
       "integrationsLabel": "インテグレーション",
@@ -260,21 +274,35 @@
       "desktopLabel": "デスクトップまたはブラウザ",
       "desktopBody": "ブラウザで Specrails を実行するか、サーバーとランタイムを同梱した署名済みデスクトップアプリ（macOS と Windows）を入手できます。"
     },
+    "companion": {
+      "nav": "モバイルアプリ",
+      "title": "Specrails を持ち歩く",
+      "subtitle": "SpecRails Companion — あなたのパイプラインを、スマートフォンで",
+      "intro": "<b>SpecRails Companion</b> は、ローカルネットワーク経由でこのデスクトップとペアリングする iPhone / Android 向けの無料モバイルアプリです。スペックボードの閲覧、レールの起動と停止、ジョブログのライブ追跡、分析のチェックまで — すべてスマートフォンから。",
+      "localLabel": "ほかのすべてと同じく 100% ローカル",
+      "localBody": "アプリは Wi-Fi 経由でこのコンピュータと直接通信します — QR ペアリングと TLS ピンニングで保護。クラウド中継なし、アカウント不要、コードが家の外に出ることはありません。",
+      "downloadLabel": "アプリを入手",
+      "downloadHint": "スマートフォンのカメラでコードをスキャンするか、リンクを開いてください。",
+      "ios": "iPhone 版をダウンロード",
+      "android": "Android 版をダウンロード",
+      "pairLabel": "ペアリングは10秒で完了",
+      "pairBody": "インストールしたら、設定 → モバイルコンパニオン → デバイスをペアリング と進み、表示される QR コードをスキャンしてください。"
+    },
     "moveFast": {
       "nav": "高速操作",
       "title": "思考のスピードで動く",
       "subtitle": "どこでもキーボードファースト",
       "paletteLabel": "コマンドパレット",
-      "paletteShortcut": "<f>どこでも</f> <mod></mod> <m>+</m> <k></k> <m>を押す</m>",
+      "paletteShortcut": "<f>どこでも</f> <mod>{{mod}}</mod> <m>+</m> <k>K</k> <m>を押す</m>",
       "paletteBody": "プロジェクトの切り替え、スペックコマンドの実行、任意のページへのジャンプ、最近のジョブの検索 — すべてあいまい検索で。",
       "terminalLabel": "ターミナルパネル",
-      "terminalBody": "<mod></mod> <j></j> で切り替え。",
+      "terminalBody": "<mod>{{mod}}</mod> <j>J</j> で切り替え。",
       "shortcutsLabel": "全ショートカット",
-      "shortcutsBody": "<q></q> を押すと完全なチートシートが表示されます。",
+      "shortcutsBody": "<q>?</q> を押すと完全なチートシートが表示されます。",
       "chatLabel": "チャットサイドバー",
-      "chatBody": "<mod></mod> <bkey></bkey> で右サイドバーを切り替え。",
+      "chatBody": "<mod>{{mod}}</mod> <bkey>B</bkey> で右サイドバーを切り替え。",
       "projectsLabel": "プロジェクトサイドバー",
-      "projectsBody": "<alt></alt> <mod></mod> <bkey></bkey> で左の Arc サイドバーを切り替え。",
+      "projectsBody": "<alt>{{alt}}</alt> <mod>{{mod}}</mod> <bkey>B</bkey> で左の Arc サイドバーを切り替え。",
       "outro": "<b>ツアーは以上です。</b>左サイドバーからプロジェクトを追加して、最初のスペックを出荷しましょう。このウォークスルーは設定からいつでも再表示できます。"
     }
   }

--- a/client/src/locales/pt/settings.json
+++ b/client/src/locales/pt/settings.json
@@ -152,6 +152,13 @@
     "budgetHelper": "Limite de gasto em `surface=file-summary` por mês de calendário. Regenerações iniciadas pelo utilizador podem ignorá-lo."
   },
   "appearance": {
+    "taglines": {
+      "dracula": "O original — escuro com tom púrpura e acentos néon vivos",
+      "aurora-light": "Claro premium — índigo inspirado no Linear sobre branco quente",
+      "obsidian-dark": "Escuro premium — quase preto com tom azulado e acentos elétricos",
+      "matrix": "Terminal de fósforo — menta suave sobre quase preto esverdeado",
+      "specrails": "Tema da marca — azul-marinho-índigo profundo com acentos ciano saturados"
+    },
     "heading": "Aspeto",
     "themeGroupLabel": "Tema",
     "currentlyActive": "Atualmente ativo",

--- a/client/src/locales/pt/setup.json
+++ b/client/src/locales/pt/setup.json
@@ -166,6 +166,20 @@
       "developer": "Developer",
       "reviewer": "Revisor"
     },
+    "language": {
+      "nav": "Idioma",
+      "title": "Escolha o seu idioma",
+      "subtitle": "O Specrails fala a sua língua",
+      "intro": "Escolha o idioma em que quer a interface. Aplica-se de imediato — incluindo este tour.",
+      "note": "Pode mudá-lo a qualquer momento em Definições → Idioma."
+    },
+    "theme": {
+      "nav": "Tema",
+      "title": "Escolha o seu visual",
+      "subtitle": "Temas incorporados, aplicados de imediato",
+      "intro": "Escolha o aspeto do Specrails — o tema aplica-se assim que clica.",
+      "note": "Pode mudá-lo a qualquer momento em Definições → Aspeto."
+    },
     "welcome": {
       "nav": "Boas-vindas",
       "title": "Bem-vindo ao Specrails",
@@ -248,7 +262,7 @@
       "title": "Faça dele o seu espaço de trabalho",
       "subtitle": "Tudo o que precisa sem sair da janela",
       "terminalLabel": "Painel de terminal",
-      "terminalBody": "Um terminal a sério ao estilo do VS Code na parte inferior (<mod></mod> <j></j>) — renderização WebGL, pesquisa, imagens inline, arrastar e largar caminhos e integração com a shell. Até 10 sessões por projeto.",
+      "terminalBody": "Um terminal a sério ao estilo do VS Code na parte inferior (<mod>{{mod}}</mod> <j>J</j>) — renderização WebGL, pesquisa, imagens inline, arrastar e largar caminhos e integração com a shell. Até 10 sessões por projeto.",
       "codeLabel": "Explorador de código",
       "codeBody": "Uma árvore de ficheiros só de leitura e um visualizador Monaco com resumos de IA em linguagem simples e chips de proveniência “tocado por IA”, para que qualquer pessoa acompanhe o que mudou e porquê.",
       "integrationsLabel": "Integrações",
@@ -260,21 +274,35 @@
       "desktopLabel": "Desktop ou browser",
       "desktopBody": "Use o Specrails no browser, ou descarregue a app desktop assinada (macOS e Windows) que inclui o seu próprio servidor e runtimes."
     },
+    "companion": {
+      "nav": "App móvel",
+      "title": "Leve o Specrails consigo",
+      "subtitle": "SpecRails Companion — os seus pipelines, no seu telemóvel",
+      "intro": "O <b>SpecRails Companion</b> é a app móvel gratuita para iPhone e Android que se emparelha com este desktop através da sua rede local. Navegue pelo quadro de specs, lance e pare rails, acompanhe os logs dos jobs em direto e espreite as analytics — diretamente do seu telemóvel.",
+      "localLabel": "100% local, como tudo o resto",
+      "localBody": "A app comunica diretamente com este computador através do seu Wi-Fi — emparelhamento por QR com certificado TLS fixado. Sem relay na cloud, sem conta, e o seu código nunca sai de casa.",
+      "downloadLabel": "Obtenha a app",
+      "downloadHint": "Leia um código com a câmara do seu telemóvel ou abra o link.",
+      "ios": "Descarregar para iPhone",
+      "android": "Descarregar para Android",
+      "pairLabel": "Emparelhar demora dez segundos",
+      "pairBody": "Depois de instalada, vá a Definições → Companion móvel → Emparelhar dispositivo e leia o código QR aí apresentado."
+    },
     "moveFast": {
       "nav": "Avançar depressa",
       "title": "Avance à velocidade do pensamento",
       "subtitle": "Primeiro o teclado, em todo o lado",
       "paletteLabel": "Paleta de comandos",
-      "paletteShortcut": "<f>Prima</f> <mod></mod> <m>+</m> <k></k> <m>em qualquer lado</m>",
+      "paletteShortcut": "<f>Prima</f> <mod>{{mod}}</mod> <m>+</m> <k>K</k> <m>em qualquer lado</m>",
       "paletteBody": "Mude de projeto, execute comandos de spec, salte para qualquer página e encontre jobs recentes — tudo com pesquisa difusa.",
       "terminalLabel": "Painel de terminal",
-      "terminalBody": "Alterne com <mod></mod> <j></j>.",
+      "terminalBody": "Alterne com <mod>{{mod}}</mod> <j>J</j>.",
       "shortcutsLabel": "Todos os atalhos",
-      "shortcutsBody": "Prima <q></q> para ver a folha de consulta completa.",
+      "shortcutsBody": "Prima <q>?</q> para ver a folha de consulta completa.",
       "chatLabel": "Barra lateral de chat",
-      "chatBody": "Alterne a barra lateral direita com <mod></mod> <bkey></bkey>.",
+      "chatBody": "Alterne a barra lateral direita com <mod>{{mod}}</mod> <bkey>B</bkey>.",
       "projectsLabel": "Barra lateral de projetos",
-      "projectsBody": "Alterne a barra lateral Arc esquerda com <alt></alt> <mod></mod> <bkey></bkey>.",
+      "projectsBody": "Alterne a barra lateral Arc esquerda com <alt>{{alt}}</alt> <mod>{{mod}}</mod> <bkey>B</bkey>.",
       "outro": "<b>E o tour fica por aqui.</b> Adicione um projeto na barra lateral esquerda e entregue a sua primeira spec. Pode reabrir esta apresentação a qualquer momento nas Definições."
     }
   }

--- a/client/src/locales/zh/settings.json
+++ b/client/src/locales/zh/settings.json
@@ -152,6 +152,13 @@
     "budgetHelper": "每个自然月 `surface=file-summary` 支出的上限。用户手动发起的重新生成可超出此限制。"
   },
   "appearance": {
+    "taglines": {
+      "dracula": "经典原版 — 紫色调暗色主题，霓虹色点缀鲜明",
+      "aurora-light": "高级浅色 — 受 Linear 启发的靛蓝配暖白底色",
+      "obsidian-dark": "高级深色 — 近黑蓝调配电光色点缀",
+      "matrix": "磷光终端 — 绿黑底色上的柔和薄荷绿",
+      "specrails": "品牌主题 — 深海军靛蓝配饱和青色点缀"
+    },
     "heading": "外观",
     "themeGroupLabel": "主题",
     "currentlyActive": "当前使用中",

--- a/client/src/locales/zh/setup.json
+++ b/client/src/locales/zh/setup.json
@@ -166,6 +166,20 @@
       "developer": "开发者",
       "reviewer": "评审员"
     },
+    "language": {
+      "nav": "语言",
+      "title": "选择你的语言",
+      "subtitle": "Specrails 支持你的语言",
+      "intro": "选择界面使用的语言，即刻生效——包括这个导览。",
+      "note": "你随时可以在设置 → 语言中更改。"
+    },
+    "theme": {
+      "nav": "主题",
+      "title": "挑选你的外观",
+      "subtitle": "内置主题，即点即用",
+      "intro": "选择 Specrails 的外观 — 主题在你点击的瞬间生效。",
+      "note": "你随时可以在设置 → 外观中更改。"
+    },
     "welcome": {
       "nav": "欢迎",
       "title": "欢迎使用 Specrails",
@@ -248,7 +262,7 @@
       "title": "打造你的工作区",
       "subtitle": "无需离开窗口即可完成一切",
       "terminalLabel": "终端面板",
-      "terminalBody": "底部一个真正的 VS Code 风格终端（<mod></mod> <j></j>）——WebGL 渲染、搜索、内联图片、拖放路径和 shell 集成。每个项目最多 10 个会话。",
+      "terminalBody": "底部一个真正的 VS Code 风格终端（<mod>{{mod}}</mod> <j>J</j>）——WebGL 渲染、搜索、内联图片、拖放路径和 shell 集成。每个项目最多 10 个会话。",
       "codeLabel": "代码浏览器",
       "codeBody": "只读文件树和 Monaco 查看器，配有通俗易懂的 AI 摘要和“由 AI 修改”的溯源标签，任何人都能看懂改了什么、为什么改。",
       "integrationsLabel": "集成",
@@ -260,21 +274,35 @@
       "desktopLabel": "桌面或浏览器",
       "desktopBody": "在浏览器中运行 Specrails，或下载已签名的桌面应用（macOS 和 Windows），它自带服务器与运行时。"
     },
+    "companion": {
+      "nav": "移动应用",
+      "title": "随身携带 Specrails",
+      "subtitle": "SpecRails Companion——你的流水线，尽在掌上",
+      "intro": "<b>SpecRails Companion</b> 是面向 iPhone 和 Android 的免费移动应用，通过本地网络与这台电脑配对。浏览 Spec 看板、启动或停止 rail、实时跟踪任务日志、随手查看分析数据——全部在手机上完成。",
+      "localLabel": "100% 本地，一如这里的一切",
+      "localBody": "应用经由你的 Wi-Fi 直接与这台电脑通信——二维码配对 + TLS 证书固定。没有云端中转、无需账号，你的代码绝不离开家门。",
+      "downloadLabel": "获取应用",
+      "downloadHint": "用手机相机扫码，或直接打开链接。",
+      "ios": "下载 iPhone 版",
+      "android": "下载 Android 版",
+      "pairLabel": "配对只需十秒",
+      "pairBody": "安装完成后，前往设置 → 移动伴侣 → 配对设备，扫描那里显示的二维码即可。"
+    },
     "moveFast": {
       "nav": "高效操作",
       "title": "以思维的速度移动",
       "subtitle": "键盘优先，无处不在",
       "paletteLabel": "命令面板",
-      "paletteShortcut": "<f>按下</f> <mod></mod> <m>+</m> <k></k> <m>随时随地</m>",
+      "paletteShortcut": "<f>按下</f> <mod>{{mod}}</mod> <m>+</m> <k>K</k> <m>随时随地</m>",
       "paletteBody": "切换项目、运行 spec 命令、跳转任意页面、查找最近任务——全部支持模糊搜索。",
       "terminalLabel": "终端面板",
-      "terminalBody": "用 <mod></mod> <j></j> 切换。",
+      "terminalBody": "用 <mod>{{mod}}</mod> <j>J</j> 切换。",
       "shortcutsLabel": "全部快捷键",
-      "shortcutsBody": "按 <q></q> 查看完整速查表。",
+      "shortcutsBody": "按 <q>?</q> 查看完整速查表。",
       "chatLabel": "聊天侧边栏",
-      "chatBody": "用 <mod></mod> <bkey></bkey> 切换右侧边栏。",
+      "chatBody": "用 <mod>{{mod}}</mod> <bkey>B</bkey> 切换右侧边栏。",
       "projectsLabel": "项目侧边栏",
-      "projectsBody": "用 <alt></alt> <mod></mod> <bkey></bkey> 切换左侧 Arc 侧边栏。",
+      "projectsBody": "用 <alt>{{alt}}</alt> <mod>{{mod}}</mod> <bkey>B</bkey> 切换左侧 Arc 侧边栏。",
       "outro": "<b>导览到此结束。</b>从左侧边栏添加一个项目，交付你的第一个 spec。你随时可以在设置中重新打开本导览。"
     }
   }


### PR DESCRIPTION
## What

Grows the first-run **OnboardingWizard** from 7 → 10 steps:

1. **Language** (step 1) — 8-language picker grid (native names). Hot-switches the rest of the tour instantly.
2. **Theme** (step 2) — 5 theme cards with live preview swatches; applied on click with server persistence + revert-on-failure.
3. **Mobile app** (step 9) — promotes **SpecRails Companion** with scannable iOS/Android QR codes + links, and the local-first LAN-pairing pitch. Points to Settings → Mobile companion for the actual pairing.

The theme/language card grids are extracted from `AppearanceSection` / `LanguageSection` into shared `components/pickers/{Theme,Language}PickerGrid.tsx`, so Settings and the wizard share one implementation (testids and a11y semantics preserved).

## Companion store links — needs web-side follow-up

The Companion app is **not published to the App Store / Play Store yet**. Download links point to `https://specrails.dev/companion/ios|android` (constants in `client/src/lib/companion.ts`) — **redirect paths the web controls, so going live needs no app re-release**. ⚠️ Those redirects don't exist on specrails.dev yet; they must be created when the store listings publish. iOS bundle id `com.specrails.specrailsCompanion`, Android applicationId `com.specrails.specrails_companion`.

## Drive-by fix: empty `<Kbd>` shortcut chips

Pre-existing i18n bug (broken in **every** locale incl. English): empty markup tags like `<mod></mod>`, `<j></j>` rendered blank chips because `Trans` drops component children when the tag body is empty. Switched platform keys to `{{interpolation}}` + `values`, literal letters for the rest, across all 8 locales. Regression test added.

<img width="400" alt="before: blank keyboard chips" src="N/A — see issue screenshot" />

## Adversarial review fixes (13-agent cloud review)

- **(medium)** Dialog scroll chain never engaged (`max-h-[88vh]` + unbounded child) → with 10 steps and the tall companion step, Back/Get-Started were clipped & unreachable at 600–690px window heights. Fixed: `flex flex-col` Content + `shrink-0` accent bar + scrollable nav.
- Theme taglines were hardcoded English → moved to `appearance.taglines.<id>`, translated in all 8 locales, descriptor fallback keeps the "add a theme without touching components" contract.
- Subtitles reworded to drop hardcoded registry counts ("eight languages" / "five themes") that would rot against the zero-change registries.
- Theme copy promised "watch the window behind this dialog" but the opaque overlay hides it → reworded.
- `aria-current` on mobile dots, `aria-label` on download links.

## i18n

New `onboarding.{language,theme,companion}.*` + per-theme `appearance.taglines.*` keys translated into all 8 locales (es/fr/de/pt/it/zh/ja), reusing each locale's established terminology. Locale-parity test green.

## Verification

- Root typecheck ✓
- Client: 207 files / 2509 tests ✓ · coverage 84.7% lines (>80) / 71.4% funcs (>70) ✓
- Server: 118 files ✓ · over thresholds ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)