### PR TITLE
feat(jobs): honest live Job Detail metrics (no fake numbers)

### DIFF
--- a/client/src/components/JobStatusPanel.tsx
+++ b/client/src/components/JobStatusPanel.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useReducer, useRef, useState } from 'react'
-import { CheckCircle2, ChevronDown, Loader2, XCircle } from 'lucide-react'
+import { CheckCircle2, ChevronDown, Clock, Loader2, XCircle } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '../lib/utils'
-import type { EventRow, JobSummary } from '../types'
+import type { EventRow, JobSummary, PhaseDefinition } from '../types'
 
 function formatWallClock(startedAt: string, finishedAt: string | number): string {
   const endMs = typeof finishedAt === 'number' ? finishedAt : new Date(finishedAt).getTime()
@@ -32,6 +32,10 @@ interface JobStatusPanelProps {
   events: EventRow[]
   defaultOpen?: boolean
   pipelineTotals?: PipelineTotals
+  /** Live pipeline phase states (key → state); used to label the activity pill. */
+  phases?: Record<string, string>
+  /** Phase definitions (key → human label) paired with `phases`. */
+  phaseDefinitions?: PhaseDefinition[]
 }
 
 function extractModifiedFiles(events: EventRow[]): string[] {
@@ -52,68 +56,142 @@ function extractModifiedFiles(events: EventRow[]): string[] {
   return Array.from(files).slice(0, 20)
 }
 
-interface LiveAggregate {
-  turns: number
-  tokens: number
+// ─── Activity derivation (HONEST live signal) ────────────────────────────────
+//
+// While a job runs we show ONLY real facts: a wall-clock duration (elsewhere)
+// and an activity line built from streamed frames we already broadcast. We
+// deliberately do NOT count tokens or cost here — those are unknowable until
+// exit and shown as a pending state. `steps` is a count of concrete observed
+// actions (real), labelled "pasos" — never "turnos" — so it can move freely
+// without masquerading as the final num_turns.
+
+const ARG_ACTIONS = new Set(['editing', 'writing', 'reading', 'searching', 'running'])
+
+function clip(s: string): string {
+  return s.length > 40 ? `${s.slice(0, 39)}…` : s
+}
+
+function basename(p: unknown): string {
+  if (typeof p !== 'string' || p.length === 0) return ''
+  const seg = p.replace(/\\/g, '/').split('/').filter(Boolean).pop() ?? ''
+  return clip(seg)
+}
+
+function firstToken(c: unknown): string {
+  if (typeof c !== 'string' || c.length === 0) return ''
+  return clip(c.trim().split(/\s+/)[0] ?? '')
+}
+
+interface FrameActivity {
+  step: boolean
+  actionKey?: string
+  actionArg?: string
+}
+
+function mapTool(name: unknown, input: Record<string, unknown> | undefined): FrameActivity {
+  const inp = input ?? {}
+  const file = basename(inp.file_path ?? inp.path)
+  switch (name) {
+    case 'Edit':
+    case 'MultiEdit':
+    case 'NotebookEdit':
+    case 'Update':
+      return { step: true, actionKey: 'editing', actionArg: file }
+    case 'Write':
+    case 'create':
+      return { step: true, actionKey: 'writing', actionArg: file }
+    case 'Read':
+      return { step: true, actionKey: 'reading', actionArg: file }
+    case 'Grep':
+    case 'Glob':
+    case 'search':
+      return { step: true, actionKey: 'searching', actionArg: clip(String(inp.pattern ?? inp.query ?? '')) }
+    case 'Bash':
+    case 'shell':
+      return { step: true, actionKey: 'running', actionArg: firstToken(inp.command) }
+    default:
+      return { step: true, actionKey: 'working' }
+  }
+}
+
+function deriveFrameActivity(ev: EventRow): FrameActivity {
+  const t = ev.event_type
+  let parsed: Record<string, unknown> = {}
+  try {
+    parsed = JSON.parse(ev.payload) as Record<string, unknown>
+  } catch {
+    parsed = {}
+  }
+
+  // ── Claude stream-json ──
+  if (t === 'assistant') {
+    const message = parsed.message as { content?: Array<Record<string, unknown>> } | undefined
+    const content = message?.content
+    if (Array.isArray(content)) {
+      const tool = [...content].reverse().find((c) => c?.type === 'tool_use')
+      if (tool) return mapTool(tool.name, tool.input as Record<string, unknown> | undefined)
+      if (content.some((c) => c?.type === 'text')) return { step: true, actionKey: 'thinking' }
+    }
+    return { step: true }
+  }
+  if (t === 'tool_use') {
+    return mapTool(parsed.name, parsed.input as Record<string, unknown> | undefined)
+  }
+
+  // ── Codex exec --json ──
+  if (t === 'item.completed') {
+    const item = parsed.item as Record<string, unknown> | undefined
+    const it = item?.type
+    if (it === 'agent_message') return { step: true, actionKey: 'thinking' }
+    if (it === 'agent_reasoning') return { step: true, actionKey: 'reasoning' }
+    if (it === 'function_call' || it === 'local_shell_call' || it === 'command_execution') {
+      const arg = firstToken(item?.command) || (typeof item?.name === 'string' ? clip(item.name) : '') ||
+        (it === 'local_shell_call' ? 'shell' : '')
+      return { step: true, actionKey: 'running', actionArg: arg }
+    }
+    return { step: true }
+  }
+
+  return { step: false }
+}
+
+interface ActivityState {
+  steps: number
+  actionKey: string
+  actionArg: string
   lastSeenIdx: number
 }
 
-const INITIAL_AGG: LiveAggregate = { turns: 0, tokens: 0, lastSeenIdx: 0 }
+const INITIAL_ACTIVITY: ActivityState = { steps: 0, actionKey: '', actionArg: '', lastSeenIdx: 0 }
 
-type AggAction =
-  | { type: 'reset' }
-  | { type: 'consume'; events: EventRow[] }
+type ActivityAction = { type: 'reset' } | { type: 'consume'; events: EventRow[] }
 
-function aggReducer(state: LiveAggregate, action: AggAction): LiveAggregate {
-  if (action.type === 'reset') return INITIAL_AGG
+function activityReducer(state: ActivityState, action: ActivityAction): ActivityState {
+  if (action.type === 'reset') return INITIAL_ACTIVITY
   if (action.type === 'consume') {
     const { events } = action
     if (events.length <= state.lastSeenIdx) return state
-    let { turns, tokens } = state
+    let { steps, actionKey, actionArg } = state
     for (let i = state.lastSeenIdx; i < events.length; i++) {
-      const ev = events[i]
-      if (ev.event_type !== 'assistant') continue
-      turns += 1
-      try {
-        const payload = JSON.parse(ev.payload) as
-          | {
-              message?: {
-                usage?: {
-                  input_tokens?: number
-                  output_tokens?: number
-                  cache_read_input_tokens?: number
-                  cache_creation_input_tokens?: number
-                }
-              }
-            }
-          | undefined
-        const usage = payload?.message?.usage
-        const n = (v: unknown): number => (typeof v === 'number' ? v : 0)
-        // NOTE: this is a deliberately rough LIVE indicator — per-frame usage
-        // re-includes the re-sent context each turn, so summing over-counts.
-        // It is labelled approximate in the UI and is replaced by the
-        // authoritative job.tokens_* totals at exit.
-        tokens +=
-          n(usage?.input_tokens) +
-          n(usage?.output_tokens) +
-          n(usage?.cache_read_input_tokens) +
-          n(usage?.cache_creation_input_tokens)
-      } catch {
-        // unparseable assistant payload — count the turn, skip token math
+      const d = deriveFrameActivity(events[i])
+      if (d.step) steps += 1
+      if (d.actionKey) {
+        actionKey = d.actionKey
+        actionArg = d.actionArg ?? ''
       }
     }
-    return { turns, tokens, lastSeenIdx: events.length }
+    return { steps, actionKey, actionArg, lastSeenIdx: events.length }
   }
   return state
 }
-
-const TERMINAL_STATUSES = new Set(['completed', 'failed', 'canceled', 'zombie_terminated', 'skipped'])
 
 export function JobStatusPanel({
   job,
   events,
   defaultOpen = true,
   pipelineTotals,
+  phases,
+  phaseDefinitions,
 }: JobStatusPanelProps) {
   const { t } = useTranslation('jobs')
   const [open, setOpen] = useState(defaultOpen)
@@ -121,9 +199,8 @@ export function JobStatusPanel({
 
   const isRunning = job.status === 'running'
   const isSuccess = job.status === 'completed'
-  const isTerminal = TERMINAL_STATUSES.has(job.status)
 
-  // Live duration tick (every 1s) while running.
+  // Live duration tick (every 1s) while running — the ONLY genuinely live number.
   const [now, setNow] = useState(() => Date.now())
   useEffect(() => {
     if (!isRunning) return
@@ -131,8 +208,8 @@ export function JobStatusPanel({
     return () => window.clearInterval(id)
   }, [isRunning])
 
-  // Incremental Turns/Tokens accumulator. Reset on job.id change.
-  const [agg, dispatch] = useReducer(aggReducer, INITIAL_AGG)
+  // Incremental activity accumulator (steps + current action). Reset on job change.
+  const [activity, dispatch] = useReducer(activityReducer, INITIAL_ACTIVITY)
   const lastJobIdRef = useRef<string>(job.id)
   useEffect(() => {
     if (lastJobIdRef.current !== job.id) {
@@ -142,32 +219,50 @@ export function JobStatusPanel({
     dispatch({ type: 'consume', events })
   }, [job.id, events])
 
-  // Authoritative values once available; live values otherwise.
-  const liveTurns = job.num_turns ?? (isTerminal ? null : agg.turns)
-  // Real total tokens = fresh input + output + cache-read + cache-create. The
-  // cache tiers (especially cache_read) typically dominate agentic Claude runs,
-  // so omitting them understated the figure by an order of magnitude.
-  const liveTokens =
-    job.tokens_in != null
-      ? (job.tokens_in ?? 0) +
-        (job.tokens_out ?? 0) +
-        (job.tokens_cache_read ?? 0) +
-        (job.tokens_cache_create ?? 0)
-      : isTerminal
-        ? null
-        : agg.tokens
-  // Live (still-running) figures are rough: tokens sum per-frame usage (which
-  // re-includes re-sent context) and turns count assistant frames, not CLI
-  // turns. Both are replaced by authoritative server values at job exit; mark
-  // them with a ~ while live so the visible jump at exit is not surprising.
-  const tokensApproximate = job.tokens_in == null && !isTerminal && liveTokens != null
-  const turnsApproximate = job.num_turns == null && !isTerminal && liveTurns != null
+  // Auto-hiding explainer (first 8s of a running job).
+  const [showExplainer, setShowExplainer] = useState(true)
+  useEffect(() => {
+    if (!isRunning) return
+    setShowExplainer(true)
+    const id = window.setTimeout(() => setShowExplainer(false), 8000)
+    return () => window.clearTimeout(id)
+  }, [isRunning, job.id])
 
   const durationDisplay = job.finished_at
     ? formatWallClock(job.started_at, job.finished_at)
     : isRunning
       ? formatWallClock(job.started_at, now)
       : '—'
+
+  // Authoritative figures — only meaningful at exit. Never approximated live.
+  const costEstimated = !!job.total_cost_usd_estimated
+  const costValue =
+    job.total_cost_usd != null ? `${costEstimated ? '~' : ''}$${job.total_cost_usd.toFixed(4)}` : null
+  const turnsValue = job.num_turns != null ? String(job.num_turns) : null
+  const tokensTotal =
+    job.tokens_in != null
+      ? (job.tokens_in ?? 0) +
+        (job.tokens_out ?? 0) +
+        (job.tokens_cache_read ?? 0) +
+        (job.tokens_cache_create ?? 0)
+      : null
+  const tokensValue = tokensTotal != null ? `${(tokensTotal / 1000).toFixed(1)}k` : null
+
+  // Activity line.
+  const runningPhaseLabel = useMemo(() => {
+    if (!phases || !phaseDefinitions) return null
+    const def = phaseDefinitions.find((d) => phases[d.key] === 'running')
+    return def?.label ?? null
+  }, [phases, phaseDefinitions])
+
+  const effectiveActionKey =
+    isRunning && activity.steps === 0 ? 'connecting' : activity.actionKey || 'thinking'
+  const actionLabel = ARG_ACTIONS.has(effectiveActionKey)
+    ? t(`statusPanel.activity.${effectiveActionKey}`, { arg: activity.actionArg })
+    : t(`statusPanel.activity.${effectiveActionKey}`)
+  const pillLabel =
+    runningPhaseLabel ?? (isRunning && activity.steps === 0 ? t('statusPanel.activity.starting') : null)
+  const stepsLabel = activity.steps > 0 ? t('statusPanel.steps', { count: activity.steps }) : null
 
   const headerLabel = isRunning
     ? t('statusPanel.inProgress')
@@ -188,15 +283,8 @@ export function JobStatusPanel({
       ? 'w-4 h-4 text-emerald-400 shrink-0'
       : 'w-4 h-4 text-red-400 shrink-0'
 
-  // Codex (and any non-native-cost provider) cost is a pricing-table estimate;
-  // prefix `~` so it is never read as a provider-billed figure.
-  const costEstimated = !!job.total_cost_usd_estimated
-  const costDisplay =
-    job.total_cost_usd != null ? `${costEstimated ? '~' : ''}$${job.total_cost_usd.toFixed(4)}` : '—'
-  const costDimmed = job.total_cost_usd == null
-
   return (
-    <div className={cn('mx-4 my-2 rounded-xl border', frameClass)}>
+    <div className={cn('mx-4 my-2 rounded-xl border transition-colors duration-500', frameClass)}>
       {/* Header — always visible */}
       <button
         type="button"
@@ -206,18 +294,18 @@ export function JobStatusPanel({
         <HeaderIcon className={headerIconClass} aria-hidden="true" />
         <span className="text-sm font-semibold flex-1 text-left">{headerLabel}</span>
 
-        {/* Quick stat chips */}
+        {/* Quick stat chips — running: duration + pasos (NO cost). terminal: duration + cost + files. */}
         <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
           <span className="tabular-nums">{durationDisplay}</span>
-          {!costDimmed ? (
-            <span className="tabular-nums text-yellow-400">{costDisplay}</span>
+          {isRunning ? (
+            stepsLabel && <span className="tabular-nums">{stepsLabel}</span>
           ) : (
-            <span className="tabular-nums">—</span>
-          )}
-          {modifiedFiles.length > 0 && (
-            <span>
-              {t('statusPanel.filesCount', { count: modifiedFiles.length })}
-            </span>
+            <>
+              {costValue && <span className="tabular-nums text-yellow-400">{costValue}</span>}
+              {modifiedFiles.length > 0 && (
+                <span>{t('statusPanel.filesCount', { count: modifiedFiles.length })}</span>
+              )}
+            </>
           )}
         </div>
 
@@ -232,64 +320,142 @@ export function JobStatusPanel({
       {/* Expandable detail */}
       {open && (
         <div className="px-4 pb-4 space-y-3 border-t border-border/20">
-          {/* Metric cards grid */}
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 pt-3">
-            <SummaryMetric label={t('statusPanel.duration')} value={durationDisplay} />
-            <SummaryMetric
-              label={t('statusPanel.cost')}
-              value={costDisplay}
-              valueClass={costDimmed ? 'text-muted-foreground' : 'text-yellow-400'}
-            />
-            <SummaryMetric
-              label={t('statusPanel.turns')}
-              value={liveTurns != null ? `${turnsApproximate ? '~' : ''}${liveTurns}` : '—'}
-            />
-            <SummaryMetric
-              label={t('statusPanel.tokens')}
-              value={liveTokens != null ? `${tokensApproximate ? '~' : ''}${(liveTokens / 1000).toFixed(1)}k` : '—'}
-            />
-          </div>
-
-          {/* Pipeline total */}
-          {pipelineTotals && (
-            <div>
-              <p className="text-[10px] text-muted-foreground/50 uppercase tracking-wider mb-1.5">
-                {t('statusPanel.pipelineTotal', { count: pipelineTotals.jobCount })}
+          {isRunning ? (
+            <>
+              {/* ── ZONE 1 · EN CURSO (real facts only) ───────────────────── */}
+              <p className="pt-3 text-[10px] text-muted-foreground/50 uppercase tracking-wider">
+                {t('statusPanel.zoneInProgress')}
               </p>
-              <div className="grid grid-cols-2 gap-2">
-                <SummaryMetric
-                  label={t('statusPanel.totalCost')}
-                  value={`$${pipelineTotals.totalCostUsd.toFixed(4)}`}
+              <div className="flex flex-col sm:flex-row gap-3 sm:items-stretch">
+                {/* Live duration card */}
+                <div className="bg-muted/20 rounded-lg px-3 py-2 sm:w-44 shrink-0">
+                  <p className="flex items-center gap-1.5 text-[10px] text-muted-foreground/50 uppercase tracking-wider">
+                    {t('statusPanel.duration')}
+                    <span
+                      className="inline-block w-1.5 h-1.5 rounded-full bg-accent-info animate-pulse"
+                      title={t('statusPanel.liveTooltip')}
+                      aria-label={t('statusPanel.liveTooltip')}
+                    />
+                  </p>
+                  <p className="text-sm font-semibold tabular-nums mt-0.5 text-accent-info">
+                    {durationDisplay}
+                  </p>
+                </div>
+                {/* Activity strip */}
+                <div className="flex-1 flex items-center gap-2 bg-muted/10 rounded-lg px-3 py-2 min-w-0">
+                  <Loader2 className="w-3.5 h-3.5 text-accent-info shrink-0 animate-spin" aria-hidden="true" />
+                  {pillLabel && (
+                    <span className="text-[11px] font-medium px-1.5 py-0.5 rounded bg-accent-info/15 text-accent-info shrink-0">
+                      {pillLabel}
+                    </span>
+                  )}
+                  <span className="text-xs text-muted-foreground truncate flex-1 min-w-0">
+                    {actionLabel}
+                  </span>
+                  {stepsLabel && (
+                    <span className="text-[11px] text-muted-foreground/60 tabular-nums shrink-0">
+                      · {stepsLabel}
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              {showExplainer && (
+                <p className="text-[11px] text-muted-foreground/40 leading-snug">
+                  {t('statusPanel.explainer')}
+                </p>
+              )}
+
+              {/* ── ZONE 2 · RESUMEN FINAL — se calcula al terminar ───────── */}
+              <p className="pt-1 text-[10px] text-muted-foreground/50 uppercase tracking-wider border-t border-accent-info/10 mt-1">
+                {t('statusPanel.zoneFinalPending')}
+              </p>
+              <div className="grid grid-cols-3 gap-2">
+                <PendingMetric
+                  label={t('statusPanel.cost')}
+                  caption={t('statusPanel.pendingCaption')}
+                  tooltip={t('statusPanel.costTooltip')}
+                />
+                <PendingMetric
+                  label={t('statusPanel.turns')}
+                  caption={t('statusPanel.pendingCaption')}
+                  tooltip={t('statusPanel.pendingTooltip')}
+                />
+                <PendingMetric
+                  label={t('statusPanel.tokens')}
+                  caption={t('statusPanel.pendingCaption')}
+                  tooltip={t('statusPanel.pendingTooltip')}
+                />
+              </div>
+            </>
+          ) : (
+            <>
+              {/* ── RESUMEN FINAL (authoritative reveal) ──────────────────── */}
+              <p className="pt-3 text-[10px] text-muted-foreground/50 uppercase tracking-wider">
+                {t('statusPanel.zoneFinal')}
+              </p>
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                <SummaryMetric label={t('statusPanel.duration')} value={durationDisplay} />
+                <FinalMetric
+                  label={t('statusPanel.cost')}
+                  value={costValue}
                   valueClass="text-yellow-400"
+                  naCaption={t('statusPanel.notAvailable')}
                 />
-                <SummaryMetric
-                  label={t('statusPanel.totalTokens')}
-                  value={`${((pipelineTotals.totalTokensIn +
-                    pipelineTotals.totalTokensOut +
-                    pipelineTotals.totalTokensCacheRead +
-                    pipelineTotals.totalTokensCacheCreate) / 1000).toFixed(1)}k`}
+                <FinalMetric
+                  label={t('statusPanel.turns')}
+                  value={turnsValue}
+                  naCaption={t('statusPanel.notAvailable')}
+                />
+                <FinalMetric
+                  label={t('statusPanel.tokens')}
+                  value={tokensValue}
+                  naCaption={t('statusPanel.notAvailable')}
                 />
               </div>
-            </div>
-          )}
 
-          {/* Modified files list */}
-          {modifiedFiles.length > 0 && (
-            <div>
-              <p className="text-[10px] text-muted-foreground/50 uppercase tracking-wider mb-1.5">
-                {t('statusPanel.filesModified')}
-              </p>
-              <div className="flex flex-wrap gap-1.5">
-                {modifiedFiles.map((f) => (
-                  <code
-                    key={f}
-                    className="text-[10px] font-mono bg-muted/30 px-2 py-0.5 rounded text-cyan-400/80"
-                  >
-                    {f}
-                  </code>
-                ))}
-              </div>
-            </div>
+              {/* Pipeline total */}
+              {pipelineTotals && (
+                <div>
+                  <p className="text-[10px] text-muted-foreground/50 uppercase tracking-wider mb-1.5">
+                    {t('statusPanel.pipelineTotal', { count: pipelineTotals.jobCount })}
+                  </p>
+                  <div className="grid grid-cols-2 gap-2">
+                    <SummaryMetric
+                      label={t('statusPanel.totalCost')}
+                      value={`$${pipelineTotals.totalCostUsd.toFixed(4)}`}
+                      valueClass="text-yellow-400"
+                    />
+                    <SummaryMetric
+                      label={t('statusPanel.totalTokens')}
+                      value={`${((pipelineTotals.totalTokensIn +
+                        pipelineTotals.totalTokensOut +
+                        pipelineTotals.totalTokensCacheRead +
+                        pipelineTotals.totalTokensCacheCreate) / 1000).toFixed(1)}k`}
+                    />
+                  </div>
+                </div>
+              )}
+
+              {/* Modified files list */}
+              {modifiedFiles.length > 0 && (
+                <div>
+                  <p className="text-[10px] text-muted-foreground/50 uppercase tracking-wider mb-1.5">
+                    {t('statusPanel.filesModified')}
+                  </p>
+                  <div className="flex flex-wrap gap-1.5">
+                    {modifiedFiles.map((f) => (
+                      <code
+                        key={f}
+                        className="text-[10px] font-mono bg-muted/30 px-2 py-0.5 rounded text-cyan-400/80"
+                      >
+                        {f}
+                      </code>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </>
           )}
         </div>
       )}
@@ -310,6 +476,63 @@ function SummaryMetric({
     <div className="bg-muted/20 rounded-lg px-3 py-2">
       <p className="text-[10px] text-muted-foreground/50 uppercase tracking-wider">{label}</p>
       <p className={cn('text-sm font-semibold tabular-nums mt-0.5', valueClass)}>{value}</p>
+    </div>
+  )
+}
+
+/** Terminal card whose authoritative value may legitimately be null (rare
+ *  provider gap) — shows an em-dash + "No disponible" instead of a fake 0. */
+function FinalMetric({
+  label,
+  value,
+  valueClass,
+  naCaption,
+}: {
+  label: string
+  value: string | null
+  valueClass?: string
+  naCaption: string
+}) {
+  return (
+    <div className="bg-muted/20 rounded-lg px-3 py-2">
+      <p className="text-[10px] text-muted-foreground/50 uppercase tracking-wider">{label}</p>
+      <p
+        className={cn(
+          'text-sm font-semibold tabular-nums mt-0.5',
+          value != null ? valueClass : 'text-muted-foreground',
+        )}
+      >
+        {value ?? '—'}
+      </p>
+      {value == null && (
+        <p className="text-[10px] text-muted-foreground/30 mt-0.5">{naCaption}</p>
+      )}
+    </div>
+  )
+}
+
+/** Running-state card for a metric that is unknowable until exit. Never a fake
+ *  number — a held em-dash + a clock + "Se calcula al terminar". */
+function PendingMetric({
+  label,
+  caption,
+  tooltip,
+}: {
+  label: string
+  caption: string
+  tooltip: string
+}) {
+  return (
+    <div
+      className="bg-muted/20 rounded-lg px-3 py-2 ring-1 ring-accent-info/10"
+      title={tooltip}
+    >
+      <p className="flex items-center gap-1 text-[10px] text-muted-foreground/50 uppercase tracking-wider">
+        {label}
+        <Clock className="w-2.5 h-2.5 text-muted-foreground/30" aria-hidden="true" />
+      </p>
+      <p className="text-sm font-semibold tabular-nums mt-0.5 text-muted-foreground/40">—</p>
+      <p className="text-[10px] text-muted-foreground/30 mt-0.5">{caption}</p>
     </div>
   )
 }

--- a/client/src/components/__tests__/JobStatusPanel.test.tsx
+++ b/client/src/components/__tests__/JobStatusPanel.test.tsx
@@ -2,13 +2,13 @@ import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '../../test-utils'
 import { JobStatusPanel } from '../JobStatusPanel'
-import type { JobSummary, EventRow } from '../../types'
+import type { JobSummary, EventRow, PhaseDefinition } from '../../types'
 
 const completedJob: JobSummary = {
   id: 'job-1',
   command: '/specrails:implement --spec SPEA-001',
   started_at: '2024-03-21T10:00:00Z',
-  finished_at: '2024-03-21T10:01:02Z',  // 62s wall-clock
+  finished_at: '2024-03-21T10:01:02Z', // 62s wall-clock
   status: 'completed',
   duration_ms: 62000,
   total_cost_usd: 0.0234,
@@ -31,34 +31,10 @@ const failedJob: JobSummary = {
 }
 
 const eventsWithFiles: EventRow[] = [
-  {
-    id: 1,
-    job_id: 'job-1',
-    event_type: 'log',
-    payload: JSON.stringify({ line: 'Writing file: src/components/MyComponent.tsx' }),
-    created_at: '2024-03-21T10:01:00Z',
-  },
-  {
-    id: 2,
-    job_id: 'job-1',
-    event_type: 'log',
-    payload: JSON.stringify({ line: 'Editing src/hooks/useHook.ts' }),
-    created_at: '2024-03-21T10:02:00Z',
-  },
-  {
-    id: 3,
-    job_id: 'job-1',
-    event_type: 'log',
-    payload: '{ invalid json }', // Should be skipped gracefully
-    created_at: '2024-03-21T10:03:00Z',
-  },
-  {
-    id: 4,
-    job_id: 'job-1',
-    event_type: 'phase', // Not a log event — should be skipped
-    payload: JSON.stringify({ phase: 'developer' }),
-    created_at: '2024-03-21T10:04:00Z',
-  },
+  { id: 1, job_id: 'job-1', seq: 1, event_type: 'log', payload: JSON.stringify({ line: 'Writing file: src/components/MyComponent.tsx' }), timestamp: '2024-03-21T10:01:00Z' },
+  { id: 2, job_id: 'job-1', seq: 2, event_type: 'log', payload: JSON.stringify({ line: 'Editing src/hooks/useHook.ts' }), timestamp: '2024-03-21T10:02:00Z' },
+  { id: 3, job_id: 'job-1', seq: 3, event_type: 'log', payload: '{ invalid json }', timestamp: '2024-03-21T10:03:00Z' },
+  { id: 4, job_id: 'job-1', seq: 4, event_type: 'phase', payload: JSON.stringify({ phase: 'developer' }), timestamp: '2024-03-21T10:04:00Z' },
 ]
 
 describe('JobStatusPanel', () => {
@@ -66,9 +42,12 @@ describe('JobStatusPanel', () => {
     vi.clearAllMocks()
   })
 
-  it('renders "Job completed" for completed status', () => {
+  // ── Terminal (completed / failed) ──────────────────────────────────────────
+
+  it('renders "Job completed" with the Final summary zone', () => {
     render(<JobStatusPanel job={completedJob} events={[]} />)
     expect(screen.getByText('Job completed')).toBeInTheDocument()
+    expect(screen.getByText('Final summary')).toBeInTheDocument()
   })
 
   it('renders "Job failed" for failed status', () => {
@@ -76,62 +55,28 @@ describe('JobStatusPanel', () => {
     expect(screen.getByText('Job failed')).toBeInTheDocument()
   })
 
-  it('renders duration chip in header for completed job', () => {
+  it('renders duration chip + card for completed job', () => {
     render(<JobStatusPanel job={completedJob} events={[]} />)
-    // Wall-clock: 10:00:00 → 10:01:02 = 62s → "1m 2s" — appears in both header chip AND metric card
-    const durationTexts = screen.getAllByText('1m 2s')
-    expect(durationTexts.length).toBeGreaterThanOrEqual(1)
+    // Wall-clock 10:00:00 → 10:01:02 = 62s → "1m 2s" (header chip + metric card)
+    expect(screen.getAllByText('1m 2s').length).toBeGreaterThanOrEqual(1)
   })
 
   it('renders cost chip in header for completed job', () => {
     render(<JobStatusPanel job={completedJob} events={[]} />)
-    // $0.0234 appears in both header chip AND metric card
-    const costTexts = screen.getAllByText('$0.0234')
-    expect(costTexts.length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('$0.0234').length).toBeGreaterThanOrEqual(1)
   })
 
-  it('does not render duration chip when finished_at is null', () => {
-    render(<JobStatusPanel job={failedJob} events={[]} />)
-    expect(screen.queryByText(/\ds$/)).not.toBeInTheDocument()
+  it('prefixes ~ for an estimated (codex) cost', () => {
+    render(<JobStatusPanel job={{ ...completedJob, total_cost_usd_estimated: 1 }} events={[]} />)
+    expect(screen.getAllByText('~$0.0234').length).toBeGreaterThanOrEqual(1)
   })
 
-  it('does not render cost chip when total_cost_usd is null', () => {
-    render(<JobStatusPanel job={failedJob} events={[]} />)
-    expect(screen.queryByText(/^\$/)).not.toBeInTheDocument()
-  })
-
-  it('renders expanded content by default (defaultOpen=true)', () => {
+  it('renders the four metric labels in the terminal grid', () => {
     render(<JobStatusPanel job={completedJob} events={[]} />)
     expect(screen.getByText('Duration')).toBeInTheDocument()
     expect(screen.getByText('Cost')).toBeInTheDocument()
     expect(screen.getByText('Turns')).toBeInTheDocument()
     expect(screen.getByText('Tokens')).toBeInTheDocument()
-  })
-
-  it('collapses content when defaultOpen=false', () => {
-    render(<JobStatusPanel job={completedJob} events={[]} defaultOpen={false} />)
-    expect(screen.queryByText('Duration')).not.toBeInTheDocument()
-  })
-
-  it('toggles open/closed when header button is clicked', () => {
-    render(<JobStatusPanel job={completedJob} events={[]} />)
-    // Initially open
-    expect(screen.getByText('Duration')).toBeInTheDocument()
-
-    // Click to close
-    fireEvent.click(screen.getByRole('button'))
-    expect(screen.queryByText('Duration')).not.toBeInTheDocument()
-
-    // Click to re-open
-    fireEvent.click(screen.getByRole('button'))
-    expect(screen.getByText('Duration')).toBeInTheDocument()
-  })
-
-  it('renders metric values in expanded state', () => {
-    render(<JobStatusPanel job={completedJob} events={[]} />)
-    // Wall-clock duration in metric card: 10:00:00 → 10:01:02 = "1m 2s"
-    const durationValues = screen.getAllByText('1m 2s')
-    expect(durationValues.length).toBeGreaterThanOrEqual(1)
   })
 
   it('renders turns value', () => {
@@ -141,12 +86,11 @@ describe('JobStatusPanel', () => {
 
   it('renders tokens value in k format', () => {
     render(<JobStatusPanel job={completedJob} events={[]} />)
-    // tokens_in: 5000 + tokens_out: 3000 = 8000 → 8.0k
+    // 5000 + 3000 = 8000 → 8.0k
     expect(screen.getByText('8.0k')).toBeInTheDocument()
   })
 
   it('includes cache tokens in the authoritative Tokens total', () => {
-    // Real total = in + out + cache_read + cache_create (cache dominates).
     const cacheHeavy: JobSummary = {
       ...completedJob,
       tokens_in: 5000,
@@ -155,39 +99,50 @@ describe('JobStatusPanel', () => {
       tokens_cache_create: 2_000,
     }
     render(<JobStatusPanel job={cacheHeavy} events={[]} />)
-    // 5000 + 3000 + 90000 + 2000 = 100000 → 100.0k (NOT 8.0k)
     expect(screen.getByText('100.0k')).toBeInTheDocument()
     expect(screen.queryByText('8.0k')).not.toBeInTheDocument()
   })
 
-  it('renders "—" for null metric values', () => {
+  it('shows em-dash + "Not available" for null terminal metrics', () => {
     render(<JobStatusPanel job={failedJob} events={[]} />)
-    const dashes = screen.getAllByText('—')
-    expect(dashes.length).toBeGreaterThanOrEqual(3) // duration, cost, turns, tokens all null
+    // duration —, cost —, turns —, tokens — = 4 em-dashes
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(4)
+    // cost/turns/tokens each carry a "Not available" caption (duration does not)
+    expect(screen.getAllByText('Not available').length).toBe(3)
   })
+
+  it('does not render a cost chip when total_cost_usd is null', () => {
+    render(<JobStatusPanel job={failedJob} events={[]} />)
+    expect(screen.queryByText(/^\$/)).not.toBeInTheDocument()
+  })
+
+  // ── Expand / collapse ───────────────────────────────────────────────────────
+
+  it('collapses content when defaultOpen=false', () => {
+    render(<JobStatusPanel job={completedJob} events={[]} defaultOpen={false} />)
+    expect(screen.queryByText('Final summary')).not.toBeInTheDocument()
+  })
+
+  it('toggles open/closed when the header button is clicked', () => {
+    render(<JobStatusPanel job={completedJob} events={[]} />)
+    expect(screen.getByText('Duration')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.queryByText('Duration')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getByText('Duration')).toBeInTheDocument()
+  })
+
+  // ── Modified files (terminal) ───────────────────────────────────────────────
 
   it('extracts modified files from log events', () => {
     render(<JobStatusPanel job={completedJob} events={eventsWithFiles} />)
-    // The regex extracts the full path like "src/components/MyComponent.tsx"
     expect(screen.getByText('src/components/MyComponent.tsx')).toBeInTheDocument()
+    expect(screen.getByText('src/hooks/useHook.ts')).toBeInTheDocument()
   })
 
-  it('shows files count chip in header when files are extracted', () => {
+  it('shows files count chip when files are extracted', () => {
     render(<JobStatusPanel job={completedJob} events={eventsWithFiles} />)
-    // 2 files extracted → "2 files" chip
     expect(screen.getByText('2 files')).toBeInTheDocument()
-  })
-
-  it('shows singular "file" when only 1 file modified', () => {
-    const singleFileEvents: EventRow[] = [{
-      id: 1,
-      job_id: 'job-1',
-      event_type: 'log',
-      payload: JSON.stringify({ line: 'Writing index.ts' }),
-      created_at: '2024-03-21T10:00:00Z',
-    }]
-    render(<JobStatusPanel job={completedJob} events={singleFileEvents} />)
-    expect(screen.getByText('1 file')).toBeInTheDocument()
   })
 
   it('does not show files section when no files extracted', () => {
@@ -195,55 +150,41 @@ describe('JobStatusPanel', () => {
     expect(screen.queryByText('Files modified')).not.toBeInTheDocument()
   })
 
-  it('renders modified file paths in expanded state', () => {
-    render(<JobStatusPanel job={completedJob} events={eventsWithFiles} />)
-    expect(screen.getByText('src/components/MyComponent.tsx')).toBeInTheDocument()
-    expect(screen.getByText('src/hooks/useHook.ts')).toBeInTheDocument()
-  })
-
-  it('skips non-log event types when extracting files', () => {
-    // Only the log event should be processed
-    const nonLogEvents: EventRow[] = [{
-      id: 1,
-      job_id: 'job-1',
-      event_type: 'phase',
-      payload: JSON.stringify({ line: 'Writing fake.ts' }),
-      created_at: '2024-03-21T10:00:00Z',
-    }]
-    render(<JobStatusPanel job={completedJob} events={nonLogEvents} />)
-    expect(screen.queryByText('fake.ts')).not.toBeInTheDocument()
-    expect(screen.queryByText('Files modified')).not.toBeInTheDocument()
-  })
-
-  it('skips events with invalid JSON payload', () => {
-    const badEvents: EventRow[] = [{
-      id: 1,
-      job_id: 'job-1',
-      event_type: 'log',
-      payload: 'not valid json at all',
-      created_at: '2024-03-21T10:00:00Z',
-    }]
-    // Should not throw
+  it('skips non-log events and invalid JSON when extracting files', () => {
+    const badEvents: EventRow[] = [
+      { id: 1, job_id: 'job-1', seq: 1, event_type: 'phase', payload: JSON.stringify({ line: 'Writing fake.ts' }), timestamp: '' },
+      { id: 2, job_id: 'job-1', seq: 2, event_type: 'log', payload: 'not valid json', timestamp: '' },
+    ]
     render(<JobStatusPanel job={completedJob} events={badEvents} />)
     expect(screen.queryByText('Files modified')).not.toBeInTheDocument()
   })
 
-  describe('running', () => {
-    function makeAssistantEvent(seq: number, input?: number, output?: number): EventRow {
-      const message =
-        input == null && output == null
-          ? {}
-          : { usage: { input_tokens: input ?? 0, output_tokens: output ?? 0 } }
-      return {
-        id: seq,
-        job_id: 'job-running',
-        seq,
-        event_type: 'assistant',
-        payload: JSON.stringify({ message }),
-        timestamp: new Date(2024, 0, 1, 10, 0, seq).toISOString(),
-      } as EventRow
-    }
+  // ── Pipeline totals ─────────────────────────────────────────────────────────
 
+  it('renders the pipeline total block when provided', () => {
+    render(
+      <JobStatusPanel
+        job={completedJob}
+        events={[]}
+        pipelineTotals={{
+          totalCostUsd: 1.2,
+          totalTokensIn: 100_000,
+          totalTokensOut: 50_000,
+          totalTokensCacheRead: 800_000,
+          totalTokensCacheCreate: 50_000,
+          jobCount: 3,
+        }}
+      />,
+    )
+    expect(screen.getByText('Pipeline total (3 phases)')).toBeInTheDocument()
+    expect(screen.getByText('$1.2000')).toBeInTheDocument()
+    // 1,000,000 tokens → 1000.0k
+    expect(screen.getByText('1000.0k')).toBeInTheDocument()
+  })
+
+  // ── Running (HONEST live state) ─────────────────────────────────────────────
+
+  describe('running', () => {
     const runningJob: JobSummary = {
       id: 'job-running',
       command: '/specrails:implement #24',
@@ -257,69 +198,153 @@ describe('JobStatusPanel', () => {
       num_turns: null,
     }
 
-    it('renders "Job in progress" header with spinner', () => {
+    function assistantTool(seq: number, name: string, input: Record<string, unknown>): EventRow {
+      return { id: seq, job_id: 'job-running', seq, event_type: 'assistant', payload: JSON.stringify({ message: { content: [{ type: 'tool_use', name, input }] } }), timestamp: '' }
+    }
+    function assistantText(seq: number): EventRow {
+      return { id: seq, job_id: 'job-running', seq, event_type: 'assistant', payload: JSON.stringify({ message: { content: [{ type: 'text', text: 'hello' }] } }), timestamp: '' }
+    }
+    function codexItem(seq: number, item: Record<string, unknown>): EventRow {
+      return { id: seq, job_id: 'job-running', seq, event_type: 'item.completed', payload: JSON.stringify({ item }), timestamp: '' }
+    }
+
+    it('renders "Job in progress" with the In progress + pending zones', () => {
       render(<JobStatusPanel job={runningJob} events={[]} />)
       expect(screen.getByText('Job in progress')).toBeInTheDocument()
+      expect(screen.getByText('In progress')).toBeInTheDocument()
+      expect(screen.getByText('Final summary — calculated when finished')).toBeInTheDocument()
     })
 
-    it('shows em-dash for Cost while running', () => {
+    it('NEVER shows a live/approximate cost, turns or tokens number while running', () => {
+      const events = [assistantTool(1, 'Edit', { file_path: 'a.ts' }), assistantTool(2, 'Write', { file_path: 'b.ts' })]
+      render(<JobStatusPanel job={runningJob} events={events} />)
+      // Pending cards hold em-dashes, never numbers, and carry the honest caption.
+      expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(3)
+      expect(screen.getAllByText('Calculated when finished').length).toBe(3)
+      // No tilde-prefixed approximate numbers anywhere.
+      expect(screen.queryByText(/^~/)).not.toBeInTheDocument()
+      // No cost chip in the running header.
+      expect(screen.queryByText(/^\$/)).not.toBeInTheDocument()
+    })
+
+    it('shows the connecting state before any frame arrives', () => {
       render(<JobStatusPanel job={runningJob} events={[]} />)
-      // The Cost cell renders inside the metric grid.
-      const costLabel = screen.getByText('Cost')
-      const valueEl = costLabel.parentElement?.querySelector('p:last-child')
-      expect(valueEl?.textContent).toBe('—')
+      expect(screen.getByText('Connecting to the agent…')).toBeInTheDocument()
     })
 
-    it('aggregates Turns and Tokens from streamed assistant events', () => {
-      const events: EventRow[] = [
-        makeAssistantEvent(1, 100, 50),
-        makeAssistantEvent(2, 200, 75),
-        makeAssistantEvent(3, 300, 100),
+    it('counts steps and labels the current claude tool action', () => {
+      const events = [
+        assistantTool(1, 'Read', { file_path: 'src/x.ts' }),
+        assistantTool(2, 'Edit', { file_path: 'src/queue-manager.ts' }),
       ]
       render(<JobStatusPanel job={runningJob} events={events} />)
-      // Live (still-running) values are marked approximate with a ~ prefix.
-      expect(screen.getByText('~3')).toBeInTheDocument() // Turns
-      // (100+50) + (200+75) + (300+100) = 825 → "~0.8k"
-      expect(screen.getByText('~0.8k')).toBeInTheDocument()
+      expect(screen.getByText('Editing queue-manager.ts')).toBeInTheDocument()
+      expect(screen.getByText('2 steps')).toBeInTheDocument()
     })
 
-    it('tolerates missing or partial usage fields without NaN', () => {
-      const events: EventRow[] = [
-        makeAssistantEvent(1, 100, 50),
-        makeAssistantEvent(2), // no usage
-        { ...makeAssistantEvent(3, 50, 25), payload: JSON.stringify({ message: { usage: { input_tokens: 50 } } }) },
+    it('shows the steps chip (singular) in the running header', () => {
+      render(<JobStatusPanel job={runningJob} events={[assistantText(1)]} />)
+      expect(screen.getByText('1 step')).toBeInTheDocument()
+    })
+
+    it('labels a bare assistant text frame as Thinking', () => {
+      render(<JobStatusPanel job={runningJob} events={[assistantText(1)]} />)
+      expect(screen.getByText('Thinking…')).toBeInTheDocument()
+    })
+
+    it('maps Bash to a Running action with the first command token', () => {
+      render(<JobStatusPanel job={runningJob} events={[assistantTool(1, 'Bash', { command: 'npm test --silent' })]} />)
+      expect(screen.getByText('Running: npm')).toBeInTheDocument()
+    })
+
+    it('maps Grep to a Searching action', () => {
+      render(<JobStatusPanel job={runningJob} events={[assistantTool(1, 'Grep', { pattern: 'TODO' })]} />)
+      expect(screen.getByText('Searching “TODO”')).toBeInTheDocument()
+    })
+
+    it('falls back to Working for an unknown tool', () => {
+      render(<JobStatusPanel job={runningJob} events={[assistantTool(1, 'SomeMcpTool', {})]} />)
+      expect(screen.getByText('Working…')).toBeInTheDocument()
+    })
+
+    it('derives activity from codex item.completed frames', () => {
+      const events = [
+        codexItem(1, { type: 'agent_reasoning' }),
+        codexItem(2, { type: 'local_shell_call', command: 'cargo test' }),
       ]
       render(<JobStatusPanel job={runningJob} events={events} />)
-      expect(screen.getByText('~3')).toBeInTheDocument()
-      // 100+50 + 0 + 50 = 200 → "~0.2k"
-      expect(screen.getByText('~0.2k')).toBeInTheDocument()
+      expect(screen.getByText('Running: cargo')).toBeInTheDocument()
+      expect(screen.getByText('2 steps')).toBeInTheDocument()
     })
 
-    it('aggregator scales to thousands of events without NaN', () => {
-      const events: EventRow[] = []
-      let expectedTokens = 0
-      for (let i = 1; i <= 1000; i++) {
-        const inT = i % 7 === 0 ? undefined : 10 + (i % 5)
-        const outT = i % 11 === 0 ? undefined : 5 + (i % 3)
-        events.push(makeAssistantEvent(i, inT, outT))
-        expectedTokens += (inT ?? 0) + (outT ?? 0)
-      }
+    it('labels a codex agent_message as Thinking and counts unknown items as steps', () => {
+      const events = [
+        codexItem(1, { type: 'agent_message', text: 'hi' }),
+        codexItem(2, { type: 'something_else' }),
+      ]
       render(<JobStatusPanel job={runningJob} events={events} />)
-      expect(screen.getByText('~1000')).toBeInTheDocument()
-      const expectedDisplay = `~${(expectedTokens / 1000).toFixed(1)}k`
-      expect(screen.getByText(expectedDisplay)).toBeInTheDocument()
+      expect(screen.getByText('Thinking…')).toBeInTheDocument()
+      expect(screen.getByText('2 steps')).toBeInTheDocument()
     })
 
-    it('switches header from running to completed on status change without remount', () => {
-      const startedAt = new Date(Date.now() - 5000).toISOString()
-      const events: EventRow[] = [makeAssistantEvent(1, 100, 50)]
-      const { rerender } = render(
+    it('tolerates unparseable frames without throwing', () => {
+      const events: EventRow[] = [
+        { id: 1, job_id: 'job-running', seq: 1, event_type: 'assistant', payload: '{ not json', timestamp: '' },
+        { id: 2, job_id: 'job-running', seq: 2, event_type: 'result', payload: '{}', timestamp: '' },
+      ]
+      render(<JobStatusPanel job={runningJob} events={events} />)
+      // The assistant frame still counts as a step; result does not.
+      expect(screen.getByText('1 step')).toBeInTheDocument()
+    })
+
+    it('shows the phase pill from the running phase definition', () => {
+      const phaseDefinitions: PhaseDefinition[] = [
+        { key: 'arch', label: 'Architect', description: '' },
+        { key: 'dev', label: 'Developer', description: '' },
+      ]
+      render(
         <JobStatusPanel
-          job={{ ...runningJob, started_at: startedAt }}
-          events={events}
+          job={runningJob}
+          events={[assistantText(1)]}
+          phases={{ arch: 'done', dev: 'running' }}
+          phaseDefinitions={phaseDefinitions}
         />,
       )
+      expect(screen.getByText('Developer')).toBeInTheDocument()
+    })
+
+    it('shows the Starting pill when no phase is running and no frames yet', () => {
+      render(
+        <JobStatusPanel
+          job={runningJob}
+          events={[]}
+          phases={{ dev: 'idle' }}
+          phaseDefinitions={[{ key: 'dev', label: 'Developer', description: '' }]}
+        />,
+      )
+      expect(screen.getByText('Starting…')).toBeInTheDocument()
+    })
+
+    it('renders the auto-hiding explainer line', () => {
+      render(<JobStatusPanel job={runningJob} events={[]} />)
+      expect(screen.getByText(/the provider's real figures and appear when the job finishes/i)).toBeInTheDocument()
+    })
+
+    it('resets the step accumulator when the job id changes', () => {
+      const { rerender } = render(<JobStatusPanel job={runningJob} events={[assistantText(1), assistantText(2)]} />)
+      expect(screen.getByText('2 steps')).toBeInTheDocument()
+      const otherJob = { ...runningJob, id: 'job-other' }
+      rerender(<JobStatusPanel job={otherJob} events={[assistantText(1)]} />)
+      expect(screen.getByText('1 step')).toBeInTheDocument()
+    })
+
+    it('reveals authoritative metrics on running → completed without remount', () => {
+      const startedAt = new Date(Date.now() - 5000).toISOString()
+      const events = [assistantTool(1, 'Edit', { file_path: 'a.ts' })]
+      const { rerender } = render(<JobStatusPanel job={{ ...runningJob, started_at: startedAt }} events={events} />)
       expect(screen.getByText('Job in progress')).toBeInTheDocument()
+      // While running there is no real cost shown.
+      expect(screen.queryByText('$0.4200')).not.toBeInTheDocument()
 
       const completed: JobSummary = {
         ...runningJob,
@@ -333,8 +358,9 @@ describe('JobStatusPanel', () => {
       }
       rerender(<JobStatusPanel job={completed} events={events} />)
       expect(screen.getByText('Job completed')).toBeInTheDocument()
-      // Cost appears in both the header chip and the metric grid.
+      // The real numbers resolve at exit (header chip + grid card).
       expect(screen.getAllByText('$0.4200').length).toBeGreaterThan(0)
+      expect(screen.getByText('Final summary')).toBeInTheDocument()
     })
   })
 })

--- a/client/src/locales/de/jobs.json
+++ b/client/src/locales/de/jobs.json
@@ -78,7 +78,30 @@
     "pipelineTotal": "Pipeline gesamt ({{count}} Phasen)",
     "totalCost": "Gesamtkosten",
     "totalTokens": "Tokens gesamt",
-    "filesModified": "Geänderte Dateien"
+    "filesModified": "Geänderte Dateien",
+    "zoneInProgress": "Läuft",
+    "zoneFinal": "Endabrechnung",
+    "zoneFinalPending": "Endabrechnung — wird am Ende berechnet",
+    "pendingCaption": "Wird am Ende berechnet",
+    "pendingTooltip": "Dies ist der reale Wert des Anbieters; er erscheint, wenn der Job endet.",
+    "costTooltip": "Die realen Kosten werden vom Anbieter beim Abschluss des Jobs berechnet.",
+    "liveTooltip": "Live",
+    "explainer": "Kosten, Runden und Tokens sind die realen Werte des Anbieters und erscheinen am Ende.",
+    "notAvailable": "Nicht verfügbar",
+    "steps_one": "{{count}} Schritt",
+    "steps_other": "{{count}} Schritte",
+    "activity": {
+      "editing": "Bearbeite {{arg}}",
+      "writing": "Schreibe {{arg}}",
+      "reading": "Lese {{arg}}",
+      "searching": "Suche „{{arg}}“",
+      "running": "Führe aus: {{arg}}",
+      "thinking": "Denkt nach…",
+      "reasoning": "Überlegt…",
+      "working": "Arbeitet…",
+      "connecting": "Verbinde mit dem Agenten…",
+      "starting": "Startet…"
+    }
   },
   "ticketHeader": {
     "showMore": "+ {{count}} weitere",

--- a/client/src/locales/en/jobs.json
+++ b/client/src/locales/en/jobs.json
@@ -78,7 +78,30 @@
     "pipelineTotal": "Pipeline total ({{count}} phases)",
     "totalCost": "Total cost",
     "totalTokens": "Total tokens",
-    "filesModified": "Files modified"
+    "filesModified": "Files modified",
+    "zoneInProgress": "In progress",
+    "zoneFinal": "Final summary",
+    "zoneFinalPending": "Final summary — calculated when finished",
+    "pendingCaption": "Calculated when finished",
+    "pendingTooltip": "This is the provider's real figure; it appears when the job finishes.",
+    "costTooltip": "The real cost is billed by the provider when the job closes.",
+    "liveTooltip": "Live",
+    "explainer": "Cost, turns and tokens are the provider's real figures and appear when the job finishes.",
+    "notAvailable": "Not available",
+    "steps_one": "{{count}} step",
+    "steps_other": "{{count}} steps",
+    "activity": {
+      "editing": "Editing {{arg}}",
+      "writing": "Writing {{arg}}",
+      "reading": "Reading {{arg}}",
+      "searching": "Searching “{{arg}}”",
+      "running": "Running: {{arg}}",
+      "thinking": "Thinking…",
+      "reasoning": "Reasoning…",
+      "working": "Working…",
+      "connecting": "Connecting to the agent…",
+      "starting": "Starting…"
+    }
   },
   "ticketHeader": {
     "showMore": "+ {{count}} more",

--- a/client/src/locales/es/jobs.json
+++ b/client/src/locales/es/jobs.json
@@ -78,7 +78,30 @@
     "pipelineTotal": "Total del pipeline ({{count}} fases)",
     "totalCost": "Coste total",
     "totalTokens": "Tokens totales",
-    "filesModified": "Archivos modificados"
+    "filesModified": "Archivos modificados",
+    "zoneInProgress": "En curso",
+    "zoneFinal": "Resumen final",
+    "zoneFinalPending": "Resumen final — se calcula al terminar",
+    "pendingCaption": "Se calcula al terminar",
+    "pendingTooltip": "Esta cifra es la real del proveedor; aparece al terminar el job.",
+    "costTooltip": "El coste real lo factura el proveedor al cerrar el job.",
+    "liveTooltip": "En vivo",
+    "explainer": "Las cifras de coste, turnos y tokens son las reales del proveedor y aparecen al terminar.",
+    "notAvailable": "No disponible",
+    "steps_one": "{{count}} paso",
+    "steps_other": "{{count}} pasos",
+    "activity": {
+      "editing": "Editando {{arg}}",
+      "writing": "Escribiendo {{arg}}",
+      "reading": "Leyendo {{arg}}",
+      "searching": "Buscando “{{arg}}”",
+      "running": "Ejecutando: {{arg}}",
+      "thinking": "Pensando…",
+      "reasoning": "Razonando…",
+      "working": "Trabajando…",
+      "connecting": "Conectando con el agente…",
+      "starting": "Iniciando…"
+    }
   },
   "ticketHeader": {
     "showMore": "+ {{count}} más",

--- a/client/src/locales/fr/jobs.json
+++ b/client/src/locales/fr/jobs.json
@@ -78,7 +78,30 @@
     "pipelineTotal": "Total du pipeline ({{count}} phases)",
     "totalCost": "Coût total",
     "totalTokens": "Total des tokens",
-    "filesModified": "Fichiers modifiés"
+    "filesModified": "Fichiers modifiés",
+    "zoneInProgress": "En cours",
+    "zoneFinal": "Résumé final",
+    "zoneFinalPending": "Résumé final — calculé à la fin",
+    "pendingCaption": "Calculé à la fin",
+    "pendingTooltip": "C'est le chiffre réel du fournisseur ; il apparaît à la fin du job.",
+    "costTooltip": "Le coût réel est facturé par le fournisseur à la clôture du job.",
+    "liveTooltip": "En direct",
+    "explainer": "Le coût, les tours et les tokens sont les chiffres réels du fournisseur et apparaissent à la fin.",
+    "notAvailable": "Non disponible",
+    "steps_one": "{{count}} étape",
+    "steps_other": "{{count}} étapes",
+    "activity": {
+      "editing": "Édition de {{arg}}",
+      "writing": "Écriture de {{arg}}",
+      "reading": "Lecture de {{arg}}",
+      "searching": "Recherche de « {{arg}} »",
+      "running": "Exécution : {{arg}}",
+      "thinking": "Réflexion…",
+      "reasoning": "Raisonnement…",
+      "working": "Travail en cours…",
+      "connecting": "Connexion à l'agent…",
+      "starting": "Démarrage…"
+    }
   },
   "ticketHeader": {
     "showMore": "+ {{count}} de plus",

--- a/client/src/locales/it/jobs.json
+++ b/client/src/locales/it/jobs.json
@@ -78,7 +78,30 @@
     "pipelineTotal": "Totale pipeline ({{count}} fasi)",
     "totalCost": "Costo totale",
     "totalTokens": "Token totali",
-    "filesModified": "File modificati"
+    "filesModified": "File modificati",
+    "zoneInProgress": "In corso",
+    "zoneFinal": "Riepilogo finale",
+    "zoneFinalPending": "Riepilogo finale — calcolato al termine",
+    "pendingCaption": "Calcolato al termine",
+    "pendingTooltip": "Questa è la cifra reale del provider; appare al termine del job.",
+    "costTooltip": "Il costo reale viene fatturato dal provider alla chiusura del job.",
+    "liveTooltip": "In diretta",
+    "explainer": "Costo, turni e token sono le cifre reali del provider e appaiono al termine.",
+    "notAvailable": "Non disponibile",
+    "steps_one": "{{count}} passo",
+    "steps_other": "{{count}} passi",
+    "activity": {
+      "editing": "Modifica di {{arg}}",
+      "writing": "Scrittura di {{arg}}",
+      "reading": "Lettura di {{arg}}",
+      "searching": "Ricerca di «{{arg}}»",
+      "running": "Esecuzione: {{arg}}",
+      "thinking": "Sta pensando…",
+      "reasoning": "Sta ragionando…",
+      "working": "Al lavoro…",
+      "connecting": "Connessione all'agente…",
+      "starting": "Avvio…"
+    }
   },
   "ticketHeader": {
     "showMore": "+ altri {{count}}",

--- a/client/src/locales/ja/jobs.json
+++ b/client/src/locales/ja/jobs.json
@@ -78,7 +78,30 @@
     "pipelineTotal": "パイプライン合計（{{count}} フェーズ）",
     "totalCost": "合計コスト",
     "totalTokens": "合計トークン",
-    "filesModified": "変更ファイル"
+    "filesModified": "変更ファイル",
+    "zoneInProgress": "進行中",
+    "zoneFinal": "最終サマリー",
+    "zoneFinalPending": "最終サマリー — 完了時に計算",
+    "pendingCaption": "完了時に計算",
+    "pendingTooltip": "これはプロバイダーの実際の数値です。ジョブ完了時に表示されます。",
+    "costTooltip": "実際のコストはジョブ終了時にプロバイダーが請求します。",
+    "liveTooltip": "ライブ",
+    "explainer": "コスト・ターン・トークンはプロバイダーの実際の数値で、完了時に表示されます。",
+    "notAvailable": "利用不可",
+    "steps_one": "{{count}} ステップ",
+    "steps_other": "{{count}} ステップ",
+    "activity": {
+      "editing": "{{arg}} を編集中",
+      "writing": "{{arg}} を書き込み中",
+      "reading": "{{arg}} を読み込み中",
+      "searching": "「{{arg}}」を検索中",
+      "running": "実行中: {{arg}}",
+      "thinking": "思考中…",
+      "reasoning": "推論中…",
+      "working": "作業中…",
+      "connecting": "エージェントに接続中…",
+      "starting": "起動中…"
+    }
   },
   "ticketHeader": {
     "showMore": "+ 他 {{count}} 件",

--- a/client/src/locales/pt/jobs.json
+++ b/client/src/locales/pt/jobs.json
@@ -78,7 +78,30 @@
     "pipelineTotal": "Total do pipeline ({{count}} fases)",
     "totalCost": "Custo total",
     "totalTokens": "Total de tokens",
-    "filesModified": "Ficheiros modificados"
+    "filesModified": "Ficheiros modificados",
+    "zoneInProgress": "Em andamento",
+    "zoneFinal": "Resumo final",
+    "zoneFinalPending": "Resumo final — calculado ao terminar",
+    "pendingCaption": "Calculado ao terminar",
+    "pendingTooltip": "Este é o valor real do provedor; aparece ao terminar o job.",
+    "costTooltip": "O custo real é cobrado pelo provedor ao encerrar o job.",
+    "liveTooltip": "Ao vivo",
+    "explainer": "Custo, turnos e tokens são os valores reais do provedor e aparecem ao terminar.",
+    "notAvailable": "Indisponível",
+    "steps_one": "{{count}} passo",
+    "steps_other": "{{count}} passos",
+    "activity": {
+      "editing": "Editando {{arg}}",
+      "writing": "Escrevendo {{arg}}",
+      "reading": "Lendo {{arg}}",
+      "searching": "Buscando “{{arg}}”",
+      "running": "Executando: {{arg}}",
+      "thinking": "Pensando…",
+      "reasoning": "Raciocinando…",
+      "working": "Trabalhando…",
+      "connecting": "Conectando ao agente…",
+      "starting": "Iniciando…"
+    }
   },
   "ticketHeader": {
     "showMore": "+ {{count}} mais",

--- a/client/src/locales/zh/jobs.json
+++ b/client/src/locales/zh/jobs.json
@@ -78,7 +78,30 @@
     "pipelineTotal": "流水线合计（{{count}} 个阶段）",
     "totalCost": "总成本",
     "totalTokens": "总 token 数",
-    "filesModified": "修改的文件"
+    "filesModified": "修改的文件",
+    "zoneInProgress": "进行中",
+    "zoneFinal": "最终汇总",
+    "zoneFinalPending": "最终汇总 — 完成后计算",
+    "pendingCaption": "完成后计算",
+    "pendingTooltip": "这是提供方的真实数字；任务完成后显示。",
+    "costTooltip": "真实费用由提供方在任务结束时计费。",
+    "liveTooltip": "实时",
+    "explainer": "费用、轮次和令牌是提供方的真实数字，将在任务完成后显示。",
+    "notAvailable": "不可用",
+    "steps_one": "{{count}} 步",
+    "steps_other": "{{count}} 步",
+    "activity": {
+      "editing": "正在编辑 {{arg}}",
+      "writing": "正在写入 {{arg}}",
+      "reading": "正在读取 {{arg}}",
+      "searching": "正在搜索“{{arg}}”",
+      "running": "正在执行：{{arg}}",
+      "thinking": "正在思考…",
+      "reasoning": "正在推理…",
+      "working": "正在处理…",
+      "connecting": "正在连接代理…",
+      "starting": "正在启动…"
+    }
   },
   "ticketHeader": {
     "showMore": "+ 还有 {{count}} 个",

--- a/client/src/pages/JobDetailPage.tsx
+++ b/client/src/pages/JobDetailPage.tsx
@@ -130,6 +130,22 @@ export default function JobDetailPage() {
         initPhases[def.key] = ((msg.phases as Record<string, string>)?.[def.key] as PhaseState) ?? 'idle'
       }
       setPhases(initPhases)
+    } else if (msg.type === 'event' && msg.jobId === id) {
+      // Live stream frames (assistant / item.completed / turn.completed …). The
+      // server broadcasts every parsed JSONL line here; the JobStatusPanel
+      // activity signal is built from them. Without this branch the panel froze
+      // at the open-time snapshot. Mirrors JobDetailModal's handler.
+      const eventRow: EventRow = {
+        id: Date.now(),
+        job_id: id ?? '',
+        seq: (msg.seq as number) ?? 0,
+        event_type: msg.event_type as string,
+        source: msg.source as string,
+        payload: msg.payload as string,
+        timestamp: msg.timestamp as string,
+      }
+      pendingEventsRef.current.push(eventRow)
+      if (!rafIdRef.current) rafIdRef.current = requestAnimationFrame(flushEvents)
     } else if (msg.type === 'log' && msg.processId === id) {
       const syntheticEvent: EventRow = {
         id: Date.now(),
@@ -417,6 +433,8 @@ export default function JobDetailPage() {
           events={events}
           defaultOpen={job.status === 'completed' || job.status === 'running'}
           pipelineTotals={pipelineTotals ?? undefined}
+          phases={phases}
+          phaseDefinitions={phaseDefinitions}
         />
       )}
 


### PR DESCRIPTION
## Problem

While a job runs, the Job Detail panel showed **misleading** live figures:
- **Tokens**: `aggReducer` summed per-frame usage, which re-includes the re-sent context each turn → ~10× over-count (the code itself documented this).
- **Turns**: counted `assistant` frames, not the final `num_turns`.
- **Cost**: simply `—` the whole run, then everything jumped at exit.
- **Codex**: the aggregator only understood claude's `message.usage` shape, so codex live turns/tokens were always 0.
- Root plumbing bug: `JobDetailPage.handleMessage` **dropped** the `type:'event'` WS frames the server already broadcasts, so even the activity stream never reached the panel.

The user rejected approximate/estimated live numbers as **dishonest**.

## Approach — honest two-zone panel

`JobStatusPanel` is reworked so the real-time feel comes from **real facts only**:

**Zona «En curso»** (running)
- Live wall-clock **Duración** (`● vivo`).
- **Activity strip**: phase pill + current action (`Editando queue-manager.ts`, `Ejecutando: cargo test`, `Pensando…`) + `N pasos`. Driven by a new `activityReducer` that parses claude `assistant`/`tool_use` and codex `item.completed` frames — **zero token/cost math**.

**Zona «Resumen final — se calcula al terminar»** (running → pending)
- Coste / Turnos / Tokens held in a pending state (em-dash + clock + caption), never a fake number, resolving to the authoritative values at exit. Null-at-exit → `No disponible`, never `$0`.

Deletes the dishonest `aggReducer`, the `~`-prefixed approximate values, and the live-cost machinery (unnecessary under this model — deletes more than it adds).

## Changes
- `JobStatusPanel.tsx` — full rewrite (two zones, `activityReducer`, pending/final metric cards).
- `JobDetailPage.tsx` — **S1**: consume `type:'event'` WS frames (previously dropped); thread `phases`/`phaseDefinitions`.
- 8 locales — new `statusPanel.*` / `statusPanel.activity.*` keys (parity test green).
- `JobStatusPanel.test.tsx` — rewritten (35 cases).

## Scope / safety
- **No server changes.** The mobile/companion frozen wire contract is untouched (verified: the gateway forwards `type:'event'` with the payload stripped, `server/mobile/mobile-ws.ts:218-219`).
- Deferred (not in scope): mounting the panel in `JobDetailModal` + its missing refetch (S3); dashboard/rail live metrics (S5).

## Verification
- Client typecheck ✅ · Server typecheck ✅
- Client tests ✅ 207 files / 2517 tests
- Client coverage ✅ 84.84% lines/statements, 71.49% functions (≥ thresholds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)