### PR TITLE
fix(add-spec): enable developer-approved MCP servers in Add Spec (Quick + Explore)

### DIFF
--- a/client/src/components/ContextScopeChecks.tsx
+++ b/client/src/components/ContextScopeChecks.tsx
@@ -59,7 +59,6 @@ function CheckRow({ id, label, hint, checked, disabled, tooltip, onChange }: Che
 
 export function ContextScopeChecks({
   scope,
-  mode,
   onChange,
   defaultOpen = false,
   label,
@@ -67,8 +66,12 @@ export function ContextScopeChecks({
 }: Props) {
   const { t } = useTranslation('addspec')
   const effectiveLabel = label ?? t('contextScope.defaultLabel')
-  const mcpDisabled = mode === 'quick'
-  const userMcpDisabled = mode === 'quick'
+  // MCP toggles are available in both Quick and Explore. Project `.mcp.json`
+  // (mcp) is discovered natively in both; "My approved MCPs" (userMcp) loads
+  // the developer's user-scope/plugin/connector servers via the server's
+  // loadUserEnv path.
+  const mcpDisabled = false
+  const userMcpDisabled = false
   const [open, setOpen] = useState(defaultOpen)
   const activeScopes = [
     scope.specrails && t('contextScope.tags.specrails'),

--- a/client/src/components/ProposeSpecModal.tsx
+++ b/client/src/components/ProposeSpecModal.tsx
@@ -363,6 +363,7 @@ export function ProposeSpecModal({ open, onClose, tickets, onExploreLaunch }: Pr
               openspec: scope.openspec,
               full: scope.full,
               mcp: scope.mcp,
+              userMcp: scope.userMcp,
               contractRefine: scope.contractRefine,
             },
             contractRefine: scope.contractRefine,

--- a/client/src/components/__tests__/ContextScopeChecks.test.tsx
+++ b/client/src/components/__tests__/ContextScopeChecks.test.tsx
@@ -23,30 +23,32 @@ describe('ContextScopeChecks', () => {
     expect(screen.getByLabelText('Enrich with Contract Layer')).toBeInTheDocument()
   })
 
-  it('My approved MCPs toggle is disabled in Quick mode, enabled in Explore', () => {
+  it('My approved MCPs toggle is enabled in both Quick and Explore', () => {
     const { rerender } = render(<ContextScopeChecks scope={baseScope} mode="quick" onChange={() => {}} defaultOpen />)
-    expect((screen.getByLabelText('My approved MCPs') as HTMLButtonElement).disabled).toBe(true)
+    expect((screen.getByLabelText('My approved MCPs') as HTMLButtonElement).disabled).toBe(false)
     rerender(<ContextScopeChecks scope={baseScope} mode="explore" onChange={() => {}} defaultOpen />)
     expect((screen.getByLabelText('My approved MCPs') as HTMLButtonElement).disabled).toBe(false)
   })
 
-  it('emits userMcp partial when the My approved MCPs toggle is clicked', () => {
+  it('emits userMcp partial when the My approved MCPs toggle is clicked (Explore)', () => {
     const onChange = vi.fn()
     render(<ContextScopeChecks scope={baseScope} mode="explore" onChange={onChange} defaultOpen />)
     fireEvent.click(screen.getByLabelText('My approved MCPs'))
     expect(onChange).toHaveBeenLastCalledWith({ ...baseScope, userMcp: true })
   })
 
-  it('MCPs toggle is disabled in Quick mode', () => {
-    render(<ContextScopeChecks scope={baseScope} mode="quick" onChange={() => {}} defaultOpen />)
-    const mcp = screen.getByLabelText('Project MCPs') as HTMLButtonElement
-    expect(mcp.disabled).toBe(true)
+  it('emits userMcp partial when the My approved MCPs toggle is clicked (Quick)', () => {
+    const onChange = vi.fn()
+    render(<ContextScopeChecks scope={baseScope} mode="quick" onChange={onChange} defaultOpen />)
+    fireEvent.click(screen.getByLabelText('My approved MCPs'))
+    expect(onChange).toHaveBeenLastCalledWith({ ...baseScope, userMcp: true })
   })
 
-  it('MCPs toggle is enabled in Explore mode', () => {
-    render(<ContextScopeChecks scope={baseScope} mode="explore" onChange={() => {}} defaultOpen />)
-    const mcp = screen.getByLabelText('Project MCPs') as HTMLButtonElement
-    expect(mcp.disabled).toBe(false)
+  it('Project MCPs toggle is enabled in both Quick and Explore', () => {
+    const { rerender } = render(<ContextScopeChecks scope={baseScope} mode="quick" onChange={() => {}} defaultOpen />)
+    expect((screen.getByLabelText('Project MCPs') as HTMLButtonElement).disabled).toBe(false)
+    rerender(<ContextScopeChecks scope={baseScope} mode="explore" onChange={() => {}} defaultOpen />)
+    expect((screen.getByLabelText('Project MCPs') as HTMLButtonElement).disabled).toBe(false)
   })
 
   it('emits the correct partial when toggled independently', () => {
@@ -58,11 +60,11 @@ describe('ContextScopeChecks', () => {
     expect(onChange).toHaveBeenLastCalledWith({ ...baseScope, full: true })
   })
 
-  it('does not flip mcp in Quick mode even if scope says true', () => {
+  it('reflects mcp scope in Quick mode (toggle is now active in both modes)', () => {
     const scope: ContextScope = { specrails: false, openspec: false, full: false, mcp: true, contractRefine: false }
     render(<ContextScopeChecks scope={scope} mode="quick" onChange={() => {}} defaultOpen />)
     const mcp = screen.getByLabelText('Project MCPs')
-    expect(mcp).toHaveAttribute('aria-checked', 'false')
+    expect(mcp).toHaveAttribute('aria-checked', 'true')
   })
 
   it('shows summary chip when collapsed', () => {

--- a/server/chat-manager.ts
+++ b/server/chat-manager.ts
@@ -613,6 +613,10 @@ export class ChatManager {
       sessionId: conversation.session_id ?? undefined,
       maxTurns: options?.maxTurns,
       extraArgs: scopeFlags,
+      // "My approved MCPs" (scope.userMcp) loads the developer's user-scope,
+      // plugin, and connector MCP servers — which require the `user` setting
+      // source. Claude-only (codex reads ~/.codex natively, ignores this).
+      loadUserEnv: adapter.id === 'claude' && !!conversationScope?.userMcp,
     })
     if (conversationScope) {
       console.log(`[chat-manager] scope=${JSON.stringify(conversationScope)} flags=${scopeFlags.join(' ')} promptBytes=${Buffer.byteLength(systemPrompt)}`)

--- a/server/project-router.ts
+++ b/server/project-router.ts
@@ -1855,10 +1855,13 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
       specrails: typeof rawScope?.specrails === 'boolean' ? rawScope.specrails : false,
       openspec: typeof rawScope?.openspec === 'boolean' ? rawScope.openspec : false,
       full: typeof rawScope?.full === 'boolean' ? rawScope.full : false,
-      mcp: false,
+      // Quick spawns from project.path, so project `.mcp.json` (the `mcp`
+      // toggle) is discovered natively. `userMcp` additionally loads the
+      // developer's user-scope/plugin/connector MCP servers via the claude
+      // adapter's `loadUserEnv` (see below).
+      mcp: typeof rawScope?.mcp === 'boolean' ? rawScope.mcp : false,
       contractRefine: quickContractRefine,
-      // Quick mode never injects MCPs (user MCP is an Explore-only toggle).
-      userMcp: false,
+      userMcp: typeof rawScope?.userMcp === 'boolean' ? rawScope.userMcp : false,
     }
     // Persist Quick mode Contract Refine choice (per-project last value).
     setQuickContractRefineLast(ctx(req).db, quickContractRefine)
@@ -1930,6 +1933,10 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
       model: resolvedModel,
       maxTurns: provider === 'claude' ? claudeMaxTurns : undefined,
       extraArgs: provider === 'claude' ? [...toolFlags.args, ...imageFlags] : undefined,
+      // "My approved MCPs" (scope.userMcp) loads the developer's user-scope,
+      // plugin, and connector MCP servers (claude-only). Quick already spawns
+      // from project.path so project `.mcp.json` is discovered without a flag.
+      loadUserEnv: provider === 'claude' && quickScope.userMcp,
     })
     const binary = adapter.binary
 

--- a/server/providers/claude-adapter.test.ts
+++ b/server/providers/claude-adapter.test.ts
@@ -101,6 +101,34 @@ describe('claudeAdapter.buildArgs', () => {
     ])
   })
 
+  it('emits isolated --setting-sources project,local by default (no loadUserEnv)', () => {
+    const args = claudeAdapter.buildArgs('chat-turn', { prompt: 'x', model: 'sonnet' })
+    const i = args.indexOf('--setting-sources')
+    expect(i).toBeGreaterThan(-1)
+    expect(args[i + 1]).toBe('project,local')
+  })
+
+  it('emits --setting-sources user,project,local when loadUserEnv is set (My approved MCPs)', () => {
+    const args = claudeAdapter.buildArgs('chat-turn', {
+      prompt: 'x',
+      model: 'sonnet',
+      loadUserEnv: true,
+    })
+    const i = args.indexOf('--setting-sources')
+    expect(i).toBeGreaterThan(-1)
+    expect(args[i + 1]).toBe('user,project,local')
+    // exactly one --setting-sources flag (no duplicate from COMMON_FLAGS)
+    expect(args.filter((a) => a === '--setting-sources')).toHaveLength(1)
+  })
+
+  it('loadUserEnv flows through rail-job and spec-gen actions too', () => {
+    for (const action of ['rail-job', 'spec-gen'] as const) {
+      const args = claudeAdapter.buildArgs(action, { prompt: 'x', model: 'sonnet', loadUserEnv: true })
+      const i = args.indexOf('--setting-sources')
+      expect(args[i + 1], `${action} setting-sources`).toBe('user,project,local')
+    }
+  })
+
   it('chat-turn honours maxTurns and extraArgs', () => {
     const args = claudeAdapter.buildArgs('chat-turn', {
       prompt: 'hello',

--- a/server/providers/claude-adapter.ts
+++ b/server/providers/claude-adapter.ts
@@ -47,30 +47,49 @@ function normaliseModel(model: string | null | undefined): string {
   }
 }
 
-/** Default arg block every claude spawn shares. */
+/** Default arg block every claude spawn shares. `--setting-sources` is appended
+ *  separately per-spawn (see `commonFlagsFor`) because its value depends on
+ *  whether the caller opted into loading the user's full Claude environment. */
 const COMMON_FLAGS = [
   '--dangerously-skip-permissions',
   '--tools', 'default',
   '--output-format', 'stream-json',
   '--verbose',
-  // Isolate app-spawned claude from the *user's* global Claude config. Without
-  // this, the child loads ~/.claude (user CLAUDE.md memory, plugins like
-  // claude-mem, SessionStart hooks). That bled cross-project memory into
-  // Explore turns (e.g. an unrelated "fighting game" surfaced for a fresh
-  // project) and inflated spec-gen tool usage past --max-turns. `project,local`
-  // still loads the target repo's own .claude settings + CLAUDE.md, which is
-  // exactly the context an app run should see.
-  '--setting-sources', 'project,local',
 ] as const
+
+/**
+ * COMMON_FLAGS + the `--setting-sources` value for this spawn.
+ *
+ * Default (`project,local`) isolates app-spawned claude from the *user's*
+ * global Claude config. Without this, the child loads ~/.claude (user CLAUDE.md
+ * memory, plugins like claude-mem, SessionStart hooks). That bled cross-project
+ * memory into Explore turns (e.g. an unrelated "fighting game" surfaced for a
+ * fresh project) and inflated spec-gen tool usage past --max-turns.
+ *
+ * When `opts.loadUserEnv` is set (the Add Spec "My approved MCPs" toggle), we
+ * switch to `user,project,local` so the developer's user-scope, plugin-bundled,
+ * and connector MCP servers are discovered. This is the ONLY way those MCP
+ * servers load (verified empirically against claude 2.1.177 — plugin MCP
+ * servers are gated by the `user` setting source); it also re-loads user
+ * CLAUDE.md + hooks, which is the user's explicit opt-in via the toggle.
+ */
+function commonFlagsFor(opts: SpawnOptions): string[] {
+  return [
+    ...COMMON_FLAGS,
+    '--setting-sources',
+    opts.loadUserEnv ? 'user,project,local' : 'project,local',
+  ]
+}
 
 function buildClaudeArgs(action: SpawnAction, opts: SpawnOptions): string[] {
   const args: string[] = []
   const model = normaliseModel(opts.model)
+  const commonFlags = commonFlagsFor(opts)
 
   switch (action) {
     case 'chat-turn': {
       args.push('--model', model)
-      args.push(...COMMON_FLAGS)
+      args.push(...commonFlags)
       if (opts.systemPrompt) args.push('--system-prompt', opts.systemPrompt)
       args.push('-p', opts.prompt)
       if (opts.maxTurns != null) args.push('--max-turns', String(opts.maxTurns))
@@ -82,7 +101,7 @@ function buildClaudeArgs(action: SpawnAction, opts: SpawnOptions): string[] {
         throw new Error('chat-resume requires sessionId')
       }
       args.push('--model', model)
-      args.push(...COMMON_FLAGS)
+      args.push(...commonFlags)
       if (opts.systemPrompt) args.push('--system-prompt', opts.systemPrompt)
       args.push('--resume', opts.sessionId)
       args.push('-p', opts.prompt)
@@ -94,7 +113,7 @@ function buildClaudeArgs(action: SpawnAction, opts: SpawnOptions): string[] {
       // QueueManager spawns with `--append-system-prompt` (not `--system-prompt`)
       // because the slash command in the prompt brings its own system prompt;
       // we ADD to it rather than overwrite.
-      args.push(...COMMON_FLAGS)
+      args.push(...commonFlags)
       args.push('--model', model)
       if (opts.systemPrompt) args.push('--append-system-prompt', opts.systemPrompt)
       args.push('-p', opts.prompt)
@@ -102,7 +121,7 @@ function buildClaudeArgs(action: SpawnAction, opts: SpawnOptions): string[] {
       return args
     }
     case 'spec-gen': {
-      args.push(...COMMON_FLAGS)
+      args.push(...commonFlags)
       args.push('--model', model)
       if (opts.maxTurns != null) args.push('--max-turns', String(opts.maxTurns))
       // Caller passes --tools override via extraArgs when scoped; otherwise
@@ -113,7 +132,7 @@ function buildClaudeArgs(action: SpawnAction, opts: SpawnOptions): string[] {
       return args
     }
     case 'agent-refine': {
-      args.push(...COMMON_FLAGS)
+      args.push(...commonFlags)
       if (opts.sessionId) args.push('--resume', opts.sessionId)
       args.push('-p', opts.prompt)
       if (opts.extraArgs) args.push(...opts.extraArgs)
@@ -121,7 +140,7 @@ function buildClaudeArgs(action: SpawnAction, opts: SpawnOptions): string[] {
     }
     case 'setup-enrich': {
       args.push('-p', opts.prompt)
-      args.push(...COMMON_FLAGS)
+      args.push(...commonFlags)
       if (opts.extraArgs) args.push(...opts.extraArgs)
       return args
     }
@@ -130,13 +149,13 @@ function buildClaudeArgs(action: SpawnAction, opts: SpawnOptions): string[] {
         throw new Error('setup-enrich-resume requires sessionId')
       }
       args.push('--resume', opts.sessionId)
-      args.push(...COMMON_FLAGS)
+      args.push(...commonFlags)
       args.push('-p', opts.prompt)
       if (opts.extraArgs) args.push(...opts.extraArgs)
       return args
     }
     case 'auto-title': {
-      args.push(...COMMON_FLAGS)
+      args.push(...commonFlags)
       args.push('-p', opts.prompt)
       return args
     }

--- a/server/providers/types.ts
+++ b/server/providers/types.ts
@@ -30,6 +30,16 @@ export interface SpawnOptions {
   attachmentTextBlocks?: string[]
   /** Additional argv to forward verbatim (provider-specific extras). */
   extraArgs?: string[]
+  /**
+   * Load the user's full Claude environment for this spawn (claude only).
+   * When true the claude adapter emits `--setting-sources user,project,local`
+   * instead of the isolated `project,local`, so the developer's user-scope,
+   * plugin-bundled, and connector MCP servers (the ones `claude mcp add` /
+   * plugins register) are discovered. Gated behind the Add Spec "My approved
+   * MCPs" toggle — it also re-loads user CLAUDE.md memory + hooks, which the
+   * isolated default intentionally excludes.
+   */
+  loadUserEnv?: boolean
 }
 
 export type AdapterEvent =


### PR DESCRIPTION
## Problem

Activar **"My approved MCPs"** (o "Project MCPs") en el fine-tune de Add Spec **no habilitaba** los MCP aprobados por el desarrollador con Claude — ni en Quick ni en Explore. En particular, los servidores MCP de **plugins** (p.ej. `claude-mem`) y de **conectores** (`claude.ai`) nunca llegaban a la generación de specs.

## Causa raíz (verificada empíricamente contra claude 2.1.177)

Capturando el evento `system/init` (`tools` + `mcp_servers`) con los flags exactos de la app:

1. **`--setting-sources project,local`** (en `COMMON_FLAGS`) aísla el spawn del entorno global del usuario. Ese aislamiento **también descarta los MCP de plugins/conectores** (cargan vía el source `user`). Quitarlo → `claude-mem` aparece con sus tools `mcp__plugin_claude-mem_*`.
2. **`buildUserMcpArgs`** (`--mcp-config`) sólo lee `~/.claude.json` top-level `mcpServers` → no puede ver MCP de plugins/conectores.
3. El whitelist **`--tools Read,Grep,Glob` NO bloquea** las tools `mcp__*` (aparecen junto a las built-in) — descartada como causa.
4. **Quick** tenía `mcp`/`userMcp` **hardcodeados a `false`** y el UI los **deshabilitaba**.

## Fix

- **`loadUserEnv`** nuevo en `SpawnOptions`. Cuando el usuario activa **"My approved MCPs"** (`scope.userMcp`), el adapter claude emite **`--setting-sources user,project,local`** → descubre los MCP user-scope, de plugins y de conectores (confirmado: carga `claude-mem` + sus tools). Opt-in explícito vía toggle (también recarga CLAUDE.md/hooks del usuario, por eso off por defecto).
- **Quick**: se dejan de forzar `mcp`/`userMcp` a false y se reenvía `userMcp` en el request → los MCP aprobados funcionan en **Quick y Explore**.

## Cambios
- `server/providers/types.ts` — `SpawnOptions.loadUserEnv`
- `server/providers/claude-adapter.ts` — `--setting-sources` condicional (`commonFlagsFor`)
- `server/chat-manager.ts` — pasa `loadUserEnv` en `scope.userMcp` (Explore)
- `server/project-router.ts` — Quick: lee `mcp`/`userMcp`, pasa `loadUserEnv`
- client `ContextScopeChecks` — habilita ambos toggles MCP en Quick
- client `ProposeSpecModal` — envía `userMcp` en el request de Quick

## Verificación
- Empírica: `--setting-sources user,project,local` carga `plugin:claude-mem:mcp-search` + `mcp__plugin_claude-mem_*` ✅
- Server typecheck ✅ · coverage ✅ (82.87% stmts / 84.69% lines, 2856 tests)
- Client typecheck ✅ · coverage ✅ (84.72% lines/stmts / 71.39% functions, 2509 tests)
- Tests de adapter (`--setting-sources` por defecto vs `loadUserEnv`) y de `ContextScopeChecks` (toggles activos en ambos modos) añadidos/actualizados.

## Nota
El default sigue aislado (`project,local`) — sin cambios de comportamiento salvo al activar el toggle. Trade-off del opt-in (recarga CLAUDE.md/hooks del usuario) confirmado con el usuario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)