### PR TITLE
chore(hardening): security + robustness quick wins (verified defects)

### DIFF
--- a/client/src/components/ShellErrorBoundary.tsx
+++ b/client/src/components/ShellErrorBoundary.tsx
@@ -1,0 +1,94 @@
+import { Component, type ReactNode, type ErrorInfo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { RefreshCw, X } from 'lucide-react'
+
+interface Props {
+  children: ReactNode
+  /** Dismiss the crashed shell and return to the board. */
+  onClose?: () => void
+}
+
+interface State {
+  hasError: boolean
+  error: Error | null
+}
+
+// Function-component fallback so it can use i18n hooks (and re-render on a hot
+// language switch) while the boundary itself stays a class.
+function ShellErrorFallback({
+  errorMessage,
+  onRetry,
+  onClose,
+}: {
+  errorMessage: string | null
+  onRetry: () => void
+  onClose?: () => void
+}) {
+  const { t } = useTranslation('nav')
+  return (
+    <div className="flex flex-col items-center justify-center h-full gap-4 p-8">
+      <div className="text-center space-y-2">
+        <h2 className="text-base font-semibold">{t('errorBoundary.title')}</h2>
+        {errorMessage && (
+          <p className="text-xs text-muted-foreground/60 font-mono max-w-md break-words">{errorMessage}</p>
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onRetry}
+          className="flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+        >
+          <RefreshCw className="w-3.5 h-3.5" />
+          {t('common:actions.retry')}
+        </button>
+        {onClose && (
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium border border-border hover:bg-muted/40 transition-colors"
+          >
+            <X className="w-3.5 h-3.5" />
+            {t('common:actions.close')}
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/// Catches a render/effect crash inside the large interactive overlays
+/// (Explore Spec, AI Edit) so a thrown error shows a Retry/Close recovery UI
+/// instead of silently unmounting the shell and losing the user's in-progress
+/// reply.
+export class ShellErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { hasError: false, error: null }
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('[ShellErrorBoundary]', error, info.componentStack)
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false, error: null })
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <ShellErrorFallback
+          errorMessage={this.state.error?.message ?? null}
+          onRetry={this.handleRetry}
+          onClose={this.props.onClose}
+        />
+      )
+    }
+    return this.props.children
+  }
+}

--- a/client/src/components/SpecsBoard.tsx
+++ b/client/src/components/SpecsBoard.tsx
@@ -18,6 +18,7 @@ import { applySpecSort } from '../lib/spec-sort'
 import type { SpecSortMode, SpecSortDir } from '../types/spec-sort'
 import { ProposeSpecModal, type ExploreLaunchPayload } from './ProposeSpecModal'
 import { ExploreSpecShell } from './explore-spec/ExploreSpecShell'
+import { ShellErrorBoundary } from './ShellErrorBoundary'
 import { useMinimizedChats, usePendingRestore } from '../context/MinimizedChatsContext'
 import { useDesktop } from '../hooks/useDesktop'
 import i18n from '../lib/i18n'
@@ -728,6 +729,7 @@ export function SpecsBoard({
       />
 
       {explore && activeProjectId && (
+        <ShellErrorBoundary onClose={() => setExplore(null)}>
         <ExploreSpecShell
           // Bind component identity to the session so restoring a different
           // chip remounts the shell from scratch — without this, internal
@@ -779,6 +781,7 @@ export function SpecsBoard({
             onTicketCreated?.(ticket)
           }}
         />
+        </ShellErrorBoundary>
       )}
     </div>
   )

--- a/client/src/components/__tests__/ShellErrorBoundary.test.tsx
+++ b/client/src/components/__tests__/ShellErrorBoundary.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '../../test-utils'
+import { ShellErrorBoundary } from '../ShellErrorBoundary'
+
+function Boom({ crash }: { crash: boolean }) {
+  if (crash) throw new Error('kaboom-detail')
+  return <div>shell content</div>
+}
+
+describe('ShellErrorBoundary', () => {
+  it('renders a recovery fallback on a child crash, then recovers on Retry', () => {
+    const { rerender } = render(
+      <ShellErrorBoundary>
+        <Boom crash />
+      </ShellErrorBoundary>,
+    )
+    // Fallback shown; the crashing child is not rendered, and the error surfaces.
+    expect(screen.queryByText('shell content')).not.toBeInTheDocument()
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+    expect(screen.getByText('kaboom-detail')).toBeInTheDocument()
+
+    // Fix the underlying cause, then Retry → the boundary resets and renders it.
+    rerender(
+      <ShellErrorBoundary>
+        <Boom crash={false} />
+      </ShellErrorBoundary>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(screen.getByText('shell content')).toBeInTheDocument()
+  })
+
+  it('offers a Close action that calls onClose', () => {
+    const onClose = vi.fn()
+    render(
+      <ShellErrorBoundary onClose={onClose}>
+        <Boom crash />
+      </ShellErrorBoundary>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes children through untouched when nothing throws', () => {
+    render(
+      <ShellErrorBoundary>
+        <Boom crash={false} />
+      </ShellErrorBoundary>,
+    )
+    expect(screen.getByText('shell content')).toBeInTheDocument()
+    expect(screen.queryByText('Something went wrong')).not.toBeInTheDocument()
+  })
+})

--- a/client/src/components/agents/AgentsCatalogTab.tsx
+++ b/client/src/components/agents/AgentsCatalogTab.tsx
@@ -7,6 +7,7 @@ import { Input } from '../ui/input'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '../ui/dialog'
 import { AgentStudio } from './AgentStudio'
 import { AiRefineOverlay } from './AiRefineOverlay'
+import { ShellErrorBoundary } from '../ShellErrorBoundary'
 import { AGENT_TEMPLATES, ALL_TEMPLATE_CATEGORIES, type AgentTemplateCategory } from './agentTemplates'
 import { useMinimizedChats, usePendingRestore } from '../../context/MinimizedChatsContext'
 import { useDesktop } from '../../hooks/useDesktop'
@@ -189,6 +190,7 @@ export function AgentsCatalogTab() {
   // AI Refine overlay view
   if (refine.kind === 'open') {
     return (
+      <ShellErrorBoundary onClose={() => setRefine({ kind: 'closed' })}>
       <AiRefineOverlay
         // Per-session key — switching to a different refine session must
         // remount so useAgentRefine state and the composer don't leak.
@@ -229,6 +231,7 @@ export function AgentsCatalogTab() {
           setStudio({ kind: 'edit', agentId: refine.agentId, draftFromRefine: refineId })
         }}
       />
+      </ShellErrorBoundary>
     )
   }
 

--- a/server/command-resolver.test.ts
+++ b/server/command-resolver.test.ts
@@ -119,6 +119,22 @@ Do this: $ARGUMENTS`
     expect(result).toBe('Do this:')
   })
 
+  it('rejects path-traversal segments and never reads outside the commands dir', () => {
+    const dir = createTempDir()
+    fs.writeFileSync(path.join(dir, 'secret.md'), 'TOP SECRET', 'utf-8')
+    // Without the guard, `..:..:secret` joins to <dir>/.claude/commands/../../secret.md = <dir>/secret.md
+    const malicious = '/..:..:secret arg'
+    const result = resolveCommand(malicious, dir)
+    expect(result).toBe(malicious) // unresolved — guard refused to traverse
+    expect(result).not.toContain('TOP SECRET')
+  })
+
+  it('rejects a segment containing a path separator', () => {
+    const dir = createTempDir()
+    const result = resolveCommand('/specrails:sub/evil hi', dir)
+    expect(result).toBe('/specrails:sub/evil hi')
+  })
+
   it('commands directory takes priority over skills directory', () => {
     const dir = createTempDir()
     writeCommandFile(

--- a/server/command-resolver.ts
+++ b/server/command-resolver.ts
@@ -53,6 +53,16 @@ ${commandArgs}`.trim()
 }
 
 /**
+ * A `:`-separated command segment is safe iff it is a plain identifier: no path
+ * separators, no `.`/`..`, no NUL. Anything else could escape the
+ * commands/skills directory once joined into the lookup path.
+ */
+function isSafeSegment(seg: string): boolean {
+  if (seg.length === 0 || seg === '.' || seg === '..') return false
+  return !/[/\\\0]/.test(seg)
+}
+
+/**
  * Try to find a command/skill .md file for the given command path parts
  * within the given base directory. Returns the resolved path or null.
  */
@@ -85,6 +95,13 @@ export function resolveCommand(command: string, cwd: string): string {
 
   const builtIn = builtInCommand(commandPath, commandArgs)
   if (builtIn) return builtIn
+
+  // Path-traversal guard: each segment is joined verbatim into
+  // `<baseDir>/.claude/commands/<...parts>.md`, so a segment like `..`, one
+  // containing a path separator, or an absolute fragment would escape the
+  // commands/skills directory and read an arbitrary file. Reject and leave the
+  // command unresolved (defense-in-depth even though the input is user-typed).
+  if (!parts.every(isSafeSegment)) return command
 
   // 1. Check the project directory
   let resolvedPath = findCommandFile(cwd, parts)

--- a/server/db.test.ts
+++ b/server/db.test.ts
@@ -54,6 +54,12 @@ describe('db', () => {
       expect(names).toContain('schema_migrations')
     })
 
+    it('sets busy_timeout and journal_size_limit for concurrent-write resilience', () => {
+      const db = makeDb()
+      expect(db.pragma('busy_timeout', { simple: true })).toBe(5000)
+      expect(db.pragma('journal_size_limit', { simple: true })).toBe(10000000)
+    })
+
     it('creates the rail_meta table (migration 28) with rail_index + name', () => {
       const db = makeDb()
       const cols = (db.prepare('PRAGMA table_info(rail_meta)').all() as { name: string }[]).map((c) => c.name)

--- a/server/db.ts
+++ b/server/db.ts
@@ -643,6 +643,12 @@ export function initDb(dbPath: string): DbInstance {
   const db = new Database(dbPath)
   db.pragma('journal_mode = WAL')
   db.pragma('foreign_keys = ON')
+  // Under load, QueueManager / ChatManager / FileSummaryManager write the same
+  // per-project DB concurrently with /analytics reads. Wait up to 5s on a lock
+  // instead of throwing SQLITE_BUSY, and cap the WAL so a long checkpoint can't
+  // grow it without bound.
+  db.pragma('busy_timeout = 5000')
+  db.pragma('journal_size_limit = 10000000') // ~10 MB
 
   applyMigrations(db)
 

--- a/server/desktop-db.ts
+++ b/server/desktop-db.ts
@@ -340,6 +340,9 @@ export function initDesktopDb(dbPath: string = getDesktopDbPath()): DbInstance {
   const db = new Database(dbPath)
   db.pragma('journal_mode = WAL')
   db.pragma('foreign_keys = ON')
+  // Wait up to 5s on a lock instead of throwing SQLITE_BUSY, and cap the WAL.
+  db.pragma('busy_timeout = 5000')
+  db.pragma('journal_size_limit = 10000000') // ~10 MB
 
   applyDesktopMigrations(db)
 

--- a/server/mobile/mobile-auth.test.ts
+++ b/server/mobile/mobile-auth.test.ts
@@ -80,4 +80,21 @@ describe('mobile-auth', () => {
     }
     expect(lastStatus).toBe(429)
   })
+
+  it('sweeps stale per-IP tracking once the window elapses (bounds the map)', () => {
+    createDevice(db, { name: 'A', platform: 'ios', tokenHash: hashToken('tok'), certFingerprint: 'fp' })
+    let now = 1000
+    const mw = createMobileAuthMiddleware({ db, currentFingerprint: () => 'fp', ratePerMinute: 2, clock: () => now })
+    const fire = (ip: string): number => {
+      const { res, captured } = fakeRes()
+      mw(fakeReq({ headers: { authorization: 'Bearer tok' }, remoteAddress: ip }), res, () => { captured.status = 200 })
+      return captured.status
+    }
+    fire('9.9.9.9'); fire('9.9.9.9')
+    expect(fire('9.9.9.9')).toBe(429) // window exhausted
+    // Advance past the 60s window → the next request runs the sweep (evicting
+    // the now-stale '9.9.9.9' entry) and the IP gets a fresh window.
+    now += 61_000
+    expect(fire('9.9.9.9')).toBe(200)
+  })
 })

--- a/server/mobile/mobile-auth.ts
+++ b/server/mobile/mobile-auth.ts
@@ -57,6 +57,10 @@ export function createMobileAuthMiddleware(opts: MobileAuthOptions) {
   const clock = opts.clock ?? (() => Date.now())
   const lastTouch = new Map<string, number>()
   const ipHits = new Map<string, number[]>()
+  // Periodically evict stale keys so these maps can't grow unbounded under a
+  // multi-source flood (each per-IP timestamp array self-bounds to the 60s
+  // window, but the Map KEYS would otherwise live forever, one per distinct IP).
+  let lastSweep = clock()
 
   return function mobileAuth(req: Request, res: Response, next: NextFunction): void {
     // 1. Refuse browser-origin requests outright.
@@ -68,6 +72,16 @@ export function createMobileAuthMiddleware(opts: MobileAuthOptions) {
     // 2. Coarse per-IP rate limit.
     const ip = req.socket?.remoteAddress ?? 'unknown'
     const now = clock()
+    // Sweep stale tracking at most once per window (cheap, amortized O(1)).
+    if (now - lastSweep > 60_000) {
+      lastSweep = now
+      for (const [k, v] of ipHits) {
+        if (v.length === 0 || now - v[v.length - 1] >= 60_000) ipHits.delete(k)
+      }
+      for (const [k, t] of lastTouch) {
+        if (now - t >= 3_600_000) lastTouch.delete(k) // drop device touch-cache after 1h idle
+      }
+    }
     const hits = (ipHits.get(ip) ?? []).filter((t) => now - t < 60_000)
     hits.push(now)
     ipHits.set(ip, hits)


### PR DESCRIPTION
Batch de quick wins de un escaneo de mejora del código. **Cada uno es un defecto verificado contra el fuente**, con test propio y sin cambio arquitectónico.

## Fixes

| # | Defecto | Evidencia | Sev |
|---|---------|-----------|-----|
| 1 | **Path traversal** en command-resolver | `command-resolver.ts:84` — `commandPath.split(':')` se une verbatim a `<baseDir>/.claude/commands/<...parts>.md`; `/..:..:secret` lee un fichero arbitrario. Guard: rechaza segmentos `.`/`..`/separador/NUL → deja el comando sin resolver. | Alto |
| 2 | **Map sin cota** en mobile-auth | `mobile-auth.ts:59` — `ipHits` acumula una entrada por IP distinta para siempre (OOM bajo flood multi-fuente). Sweep una-vez-por-ventana de `ipHits`/`lastTouch`. | Alto |
| 3 | **SQLite sin `busy_timeout`** | `db.ts:644` + `desktop-db.ts:341` — sólo `journal_mode=WAL`; añade `busy_timeout=5000` (espera en vez de `SQLITE_BUSY` cuando QueueManager/ChatManager/FileSummaryManager escriben durante lecturas de `/analytics`) y `journal_size_limit=10MB`. | Medio |
| 4 | **Sin ErrorBoundary** en los overlays grandes | `ShellErrorBoundary` envuelve `ExploreSpecShell` y `AiRefineOverlay` → un crash de render muestra Retry/Close en vez de desmontar en silencio y perder la respuesta a medio escribir. | Medio |

## Verificado que NO eran defectos (el escáner se equivocó)
- `profile.json`/`plugins.json` snapshots **ya** son chmod 400 (`profile-manager.ts:381`, `rail-integration.test.ts:82`).
- El fallo del snapshot de provenance **ya** se loguea (`queue-manager.ts:977`).

## Verificación
- `npm run typecheck` (server + client): limpio
- Server coverage: **2860 tests**, 82.87% stmts / 84.7% lines / 87.85% func / 73.16% branches
- Client coverage: **2525 tests**, 84.84% lines/stmts / 71.51% func / 80.99% branches
- Ambos gates (80% server / 80% client / 70% global) ✅

## Fuera de alcance (deliberado)
Los **big bets** del roadmap (abstracción spawn-lifecycle, split de project-router, persistent-stdin Explore, edición in-app de Code Explorer) van en sus propias ramas/PRs — cada uno es una iniciativa grande que no debe bundlearse aquí.

🤖 Generated with [Claude Code](https://claude.com/claude-code)