### PR TITLE
fix: persist SpecsBoard filters across project switch and app restart

### DIFF
--- a/client/src/components/SpecsBoard.tsx
+++ b/client/src/components/SpecsBoard.tsx
@@ -19,6 +19,7 @@ import { SpecSortControl } from './SpecSortControl'
 import { SpecsViewTierToggle } from './SpecsViewTierToggle'
 import type { SpecsViewTier } from '../lib/specs-view-tier'
 import { applySpecSort } from '../lib/spec-sort'
+import { loadSpecFilters, saveSpecFilters } from '../lib/spec-filters'
 import { cn } from '../lib/utils'
 import type { SpecSortMode, SpecSortDir } from '../types/spec-sort'
 import { ProposeSpecModal, type ExploreLaunchPayload } from './ProposeSpecModal'
@@ -208,10 +209,12 @@ export function SpecsBoard({
   )
   const [proposeOpen, setProposeOpen] = useState(false)
   const [explore, setExplore] = useState<ExploreState | null>(null)
-  const [activeLabels, setActiveLabels] = useState<Set<string>>(new Set())
-  const [activeEpic, setActiveEpic] = useState<string | null>(null)
-  const [activeSprint, setActiveSprint] = useState<string | null>(null)
   const { activeProjectId } = useDesktop()
+  // Filters persist per-project (and across app restarts) — restored from
+  // localStorage on mount and on every project switch (see the effect below).
+  const [activeLabels, setActiveLabels] = useState<Set<string>>(() => loadSpecFilters(activeProjectId).labels)
+  const [activeEpic, setActiveEpic] = useState<string | null>(() => loadSpecFilters(activeProjectId).epic)
+  const [activeSprint, setActiveSprint] = useState<string | null>(() => loadSpecFilters(activeProjectId).sprint)
   const [statusFilter, setStatusFilter] = useState<SpecStatusFilterValue>(() => loadStatusTab(activeProjectId))
   const handleStatusTabChange = useCallback((v: SpecStatusFilterValue) => {
     setStatusFilter(v)
@@ -242,16 +245,31 @@ export function SpecsBoard({
     if (parent) onTicketClick(parent)
   }, [ticketsById, onTicketClick])
 
+  // On project switch, restore THIS project's saved filters (not a reset) so
+  // the bug where switching projects wiped the filter bar is gone — and the
+  // same restore runs on mount, so a close/reopen lands on the same filters.
   useEffect(() => {
-    setActiveLabels(new Set())
-    setActiveEpic(null)
-    setActiveSprint(null)
+    const f = loadSpecFilters(activeProjectId)
+    setActiveLabels(f.labels)
+    setActiveEpic(f.epic)
+    setActiveSprint(f.sprint)
     setStatusFilter(loadStatusTab(activeProjectId))
   }, [activeProjectId])
 
   const handleLabelsChange = useCallback((next: Set<string>) => {
     setActiveLabels(next)
-  }, [])
+    saveSpecFilters(activeProjectId, { labels: next, epic: activeEpic, sprint: activeSprint })
+  }, [activeProjectId, activeEpic, activeSprint])
+
+  const handleEpicChange = useCallback((next: string | null) => {
+    setActiveEpic(next)
+    saveSpecFilters(activeProjectId, { labels: activeLabels, epic: next, sprint: activeSprint })
+  }, [activeProjectId, activeLabels, activeSprint])
+
+  const handleSprintChange = useCallback((next: string | null) => {
+    setActiveSprint(next)
+    saveSpecFilters(activeProjectId, { labels: activeLabels, epic: activeEpic, sprint: next })
+  }, [activeProjectId, activeLabels, activeEpic])
 
   const matchesFilters = useCallback(
     (t: LocalTicket): boolean => {
@@ -520,14 +538,14 @@ export function SpecsBoard({
           <SpecEpicFilterDropdown
             tickets={[...tickets, ...doneTickets]}
             active={activeEpic}
-            onChange={setActiveEpic}
+            onChange={handleEpicChange}
           />
         )}
         {hasSprints && (
           <SpecSprintFilterDropdown
             tickets={[...tickets, ...doneTickets]}
             active={activeSprint}
-            onChange={setActiveSprint}
+            onChange={handleSprintChange}
           />
         )}
 

--- a/client/src/components/__tests__/SpecsBoardFilterPersistence.test.tsx
+++ b/client/src/components/__tests__/SpecsBoardFilterPersistence.test.tsx
@@ -1,0 +1,114 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '../../test-utils'
+import type { LocalTicket } from '../../types'
+
+// Control the active project id the board sees, so we can simulate switches
+// and remounts (app close/reopen) while localStorage persists between them.
+const h = vi.hoisted(() => ({ activeId: 'proj-A' as string | null }))
+vi.mock('../../hooks/useDesktop', () => ({
+  useDesktop: () => ({
+    projects: [],
+    activeProjectId: h.activeId,
+    setActiveProjectId: () => {},
+    addProject: async () => null,
+    removeProject: async () => {},
+    isLoading: false,
+    isSwitchingProject: false,
+    setupProjectIds: new Set(),
+    startSetupWizard: () => {},
+    completeSetupWizard: () => {},
+  }),
+}))
+
+vi.mock('@dnd-kit/core', () => ({ useDroppable: () => ({ isOver: false, setNodeRef: vi.fn() }) }))
+vi.mock('@dnd-kit/sortable', () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  verticalListSortingStrategy: vi.fn(),
+  useSortable: () => ({ attributes: {}, listeners: {}, setNodeRef: vi.fn(), transform: null, transition: undefined, isDragging: false }),
+}))
+vi.mock('@dnd-kit/utilities', () => ({ CSS: { Transform: { toString: () => '' }, Translate: { toString: () => '' } } }))
+vi.mock('../ProposeSpecModal', () => ({ ProposeSpecModal: () => null }))
+
+import { SpecsBoard } from '../SpecsBoard'
+
+function makeTicket(id: number, title: string, epicKey?: string, epicName?: string): LocalTicket {
+  return {
+    id, title, description: '', status: 'todo', priority: 'medium', labels: [], assignee: null,
+    prerequisites: [], metadata: {}, created_at: '2024-01-01T00:00:00Z', updated_at: '2024-01-01T00:00:00Z',
+    created_by: 'tester', source: epicKey ? 'jira' : 'manual',
+    ...(epicKey ? { jira_epic_key: epicKey, jira_epic_name: epicName ?? epicKey } : {}),
+  }
+}
+
+const tickets = [
+  makeTicket(1, 'Auth spec', 'PROJ-100', 'Authentication'),
+  makeTicket(2, 'Billing spec', 'PROJ-200', 'Billing'),
+]
+
+const onTicketClick = vi.fn()
+
+function renderBoard() {
+  return render(<SpecsBoard tickets={tickets} doneTickets={[]} isLoading={false} onTicketClick={onTicketClick} />)
+}
+
+describe('SpecsBoard filter persistence', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    h.activeId = 'proj-A'
+  })
+
+  it('restores the epic filter after a remount (app close/reopen)', () => {
+    renderBoard()
+    // Pick the Authentication epic → Billing disappears.
+    fireEvent.click(screen.getByTestId('spec-epic-filter-dropdown'))
+    fireEvent.click(screen.getByRole('option', { name: /Authentication/ }))
+    expect(screen.queryByText('Billing spec')).toBeNull()
+
+    // Simulate app close/reopen: unmount + fresh mount, same project.
+    cleanup()
+    renderBoard()
+
+    // Filter survived: still scoped to Authentication.
+    expect(screen.getByText('Auth spec')).toBeInTheDocument()
+    expect(screen.queryByText('Billing spec')).toBeNull()
+  })
+
+  it('persisted the filter to a per-project localStorage key', () => {
+    renderBoard()
+    fireEvent.click(screen.getByTestId('spec-epic-filter-dropdown'))
+    fireEvent.click(screen.getByRole('option', { name: /Authentication/ }))
+    expect(localStorage.getItem('specrails-desktop:spec-filters:proj-A')).toContain('PROJ-100')
+  })
+
+  it('keeps filters separate per project on switch', () => {
+    const { rerender } = renderBoard()
+    // Filter proj-A to Authentication.
+    fireEvent.click(screen.getByTestId('spec-epic-filter-dropdown'))
+    fireEvent.click(screen.getByRole('option', { name: /Authentication/ }))
+    expect(screen.queryByText('Billing spec')).toBeNull()
+
+    // Switch to proj-B (no saved filter) → all specs visible.
+    h.activeId = 'proj-B'
+    rerender(<SpecsBoard tickets={tickets} doneTickets={[]} isLoading={false} onTicketClick={onTicketClick} />)
+    expect(screen.getByText('Auth spec')).toBeInTheDocument()
+    expect(screen.getByText('Billing spec')).toBeInTheDocument()
+
+    // Switch back to proj-A → its filter is restored.
+    h.activeId = 'proj-A'
+    rerender(<SpecsBoard tickets={tickets} doneTickets={[]} isLoading={false} onTicketClick={onTicketClick} />)
+    expect(screen.getByText('Auth spec')).toBeInTheDocument()
+    expect(screen.queryByText('Billing spec')).toBeNull()
+  })
+
+  it('clearing the filter removes the persisted key', () => {
+    renderBoard()
+    fireEvent.click(screen.getByTestId('spec-epic-filter-dropdown'))
+    fireEvent.click(screen.getByRole('option', { name: /Authentication/ }))
+    expect(localStorage.getItem('specrails-desktop:spec-filters:proj-A')).not.toBeNull()
+    // Re-open and choose "All epics".
+    fireEvent.click(screen.getByTestId('spec-epic-filter-dropdown'))
+    fireEvent.click(screen.getByTestId('spec-epic-filter-all'))
+    expect(localStorage.getItem('specrails-desktop:spec-filters:proj-A')).toBeNull()
+  })
+})

--- a/client/src/lib/__tests__/spec-filters.test.ts
+++ b/client/src/lib/__tests__/spec-filters.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  loadSpecFilters,
+  saveSpecFilters,
+  isEmptySpecFilters,
+  EMPTY_SPEC_FILTERS,
+  type SpecFilters,
+} from '../spec-filters'
+
+const KEY = (p: string) => `specrails-desktop:spec-filters:${p}`
+
+function mk(partial: Partial<SpecFilters> = {}): SpecFilters {
+  return { labels: new Set(), epic: null, sprint: null, ...partial }
+}
+
+describe('spec-filters', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('returns empty filters when projectId is null', () => {
+    const f = loadSpecFilters(null)
+    expect(f.labels.size).toBe(0)
+    expect(f.epic).toBeNull()
+    expect(f.sprint).toBeNull()
+  })
+
+  it('returns empty filters when nothing stored', () => {
+    const f = loadSpecFilters('p1')
+    expect(isEmptySpecFilters(f)).toBe(true)
+  })
+
+  it('round-trips labels', () => {
+    saveSpecFilters('p1', mk({ labels: new Set(['bug', 'ui']) }))
+    const f = loadSpecFilters('p1')
+    expect([...f.labels].sort()).toEqual(['bug', 'ui'])
+    expect(f.epic).toBeNull()
+    expect(f.sprint).toBeNull()
+  })
+
+  it('round-trips epic + sprint', () => {
+    saveSpecFilters('p1', mk({ epic: 'PROJ-100', sprint: '42' }))
+    const f = loadSpecFilters('p1')
+    expect(f.epic).toBe('PROJ-100')
+    expect(f.sprint).toBe('42')
+  })
+
+  it('round-trips all three together', () => {
+    saveSpecFilters('p1', { labels: new Set(['x']), epic: 'E-1', sprint: 'S-1' })
+    const f = loadSpecFilters('p1')
+    expect([...f.labels]).toEqual(['x'])
+    expect(f.epic).toBe('E-1')
+    expect(f.sprint).toBe('S-1')
+  })
+
+  it('scopes storage per projectId', () => {
+    saveSpecFilters('p1', mk({ epic: 'A' }))
+    saveSpecFilters('p2', mk({ epic: 'B' }))
+    expect(loadSpecFilters('p1').epic).toBe('A')
+    expect(loadSpecFilters('p2').epic).toBe('B')
+  })
+
+  it('removes the key (and reads as empty) when all filters cleared', () => {
+    saveSpecFilters('p1', mk({ epic: 'A', labels: new Set(['l']) }))
+    expect(localStorage.getItem(KEY('p1'))).not.toBeNull()
+    saveSpecFilters('p1', EMPTY_SPEC_FILTERS)
+    expect(localStorage.getItem(KEY('p1'))).toBeNull()
+    expect(isEmptySpecFilters(loadSpecFilters('p1'))).toBe(true)
+  })
+
+  it('save no-ops when projectId is null', () => {
+    saveSpecFilters(null, mk({ epic: 'A' }))
+    expect(localStorage.length).toBe(0)
+  })
+
+  it('returns empty on malformed JSON', () => {
+    localStorage.setItem(KEY('p1'), '{not json')
+    expect(isEmptySpecFilters(loadSpecFilters('p1'))).toBe(true)
+  })
+
+  it('returns empty when stored value is not an object', () => {
+    localStorage.setItem(KEY('p1'), '"a string"')
+    expect(isEmptySpecFilters(loadSpecFilters('p1'))).toBe(true)
+  })
+
+  it('ignores non-string labels and non-string epic/sprint', () => {
+    localStorage.setItem(
+      KEY('p1'),
+      JSON.stringify({ labels: ['ok', 3, null], epic: 5, sprint: { x: 1 } }),
+    )
+    const f = loadSpecFilters('p1')
+    expect([...f.labels]).toEqual(['ok'])
+    expect(f.epic).toBeNull()
+    expect(f.sprint).toBeNull()
+  })
+
+  it('treats empty-string epic/sprint as null', () => {
+    localStorage.setItem(KEY('p1'), JSON.stringify({ labels: [], epic: '', sprint: '' }))
+    const f = loadSpecFilters('p1')
+    expect(f.epic).toBeNull()
+    expect(f.sprint).toBeNull()
+  })
+
+  it('survives localStorage throwing on read', () => {
+    const orig = Storage.prototype.getItem
+    Storage.prototype.getItem = () => {
+      throw new Error('denied')
+    }
+    try {
+      expect(isEmptySpecFilters(loadSpecFilters('p1'))).toBe(true)
+    } finally {
+      Storage.prototype.getItem = orig
+    }
+  })
+
+  it('survives localStorage throwing on write', () => {
+    const orig = Storage.prototype.setItem
+    Storage.prototype.setItem = () => {
+      throw new Error('quota')
+    }
+    try {
+      expect(() => saveSpecFilters('p1', mk({ epic: 'A' }))).not.toThrow()
+    } finally {
+      Storage.prototype.setItem = orig
+    }
+  })
+
+  it('isEmptySpecFilters reflects each field', () => {
+    expect(isEmptySpecFilters(mk())).toBe(true)
+    expect(isEmptySpecFilters(mk({ labels: new Set(['a']) }))).toBe(false)
+    expect(isEmptySpecFilters(mk({ epic: 'E' }))).toBe(false)
+    expect(isEmptySpecFilters(mk({ sprint: 'S' }))).toBe(false)
+  })
+})

--- a/client/src/lib/spec-filters.ts
+++ b/client/src/lib/spec-filters.ts
@@ -1,0 +1,75 @@
+// Per-project persistence for the SpecsBoard filter bar (labels + Jira
+// epic/sprint). Mirrors the spec-sort / specs-view-tier helpers: one
+// localStorage key per project so a project switch — and an app
+// close/reopen — restores the exact filter the user left active.
+//
+// Epic/sprint are Jira-only (null on non-Jira projects); labels apply to
+// every project. The whole filter set lives under a single JSON key.
+
+export interface SpecFilters {
+  /** Active label filter (OR-match). Empty set = no label filter. */
+  labels: Set<string>
+  /** Active Jira epic key, or null for "all epics". */
+  epic: string | null
+  /** Active Jira sprint id, or null for "all sprints". */
+  sprint: string | null
+}
+
+export const EMPTY_SPEC_FILTERS: SpecFilters = {
+  labels: new Set<string>(),
+  epic: null,
+  sprint: null,
+}
+
+const KEY = (projectId: string) => `specrails-desktop:spec-filters:${projectId}`
+
+/** True when no filter is active (board shows every spec). */
+export function isEmptySpecFilters(f: SpecFilters): boolean {
+  return f.labels.size === 0 && f.epic === null && f.sprint === null
+}
+
+function asStringOrNull(v: unknown): string | null {
+  return typeof v === 'string' && v.length > 0 ? v : null
+}
+
+export function loadSpecFilters(projectId: string | null): SpecFilters {
+  if (!projectId) return { ...EMPTY_SPEC_FILTERS, labels: new Set() }
+  try {
+    const raw = localStorage.getItem(KEY(projectId))
+    if (!raw) return { labels: new Set(), epic: null, sprint: null }
+    const parsed = JSON.parse(raw) as unknown
+    if (!parsed || typeof parsed !== 'object') {
+      return { labels: new Set(), epic: null, sprint: null }
+    }
+    const obj = parsed as Record<string, unknown>
+    const labels = Array.isArray(obj.labels)
+      ? new Set(obj.labels.filter((l): l is string => typeof l === 'string'))
+      : new Set<string>()
+    return { labels, epic: asStringOrNull(obj.epic), sprint: asStringOrNull(obj.sprint) }
+  } catch {
+    // Malformed JSON / private mode / quota — fail to "no filter".
+    return { labels: new Set(), epic: null, sprint: null }
+  }
+}
+
+export function saveSpecFilters(projectId: string | null, filters: SpecFilters): void {
+  if (!projectId) return
+  try {
+    // Keep storage tidy: clearing every filter removes the key entirely so a
+    // stale "no filter" blob never lingers.
+    if (isEmptySpecFilters(filters)) {
+      localStorage.removeItem(KEY(projectId))
+      return
+    }
+    localStorage.setItem(
+      KEY(projectId),
+      JSON.stringify({
+        labels: [...filters.labels],
+        epic: filters.epic,
+        sprint: filters.sprint,
+      }),
+    )
+  } catch {
+    /* private mode / quota — best-effort */
+  }
+}


### PR DESCRIPTION
## Problem

When switching projects (notably on Jira-connected projects), the SpecsBoard filter bar was wiped. Label / Jira-epic / Jira-sprint filters lived only in component `useState`, and the `activeProjectId`-change effect **reset them to empty** on every switch. They were never written to storage, so filters were also lost on app close/reopen. Only status-tab / sort / view-tier were persisted.

## Fix

- **New `client/src/lib/spec-filters.ts`** — per-project persistence under `specrails-desktop:spec-filters:<projectId>`, mirroring the existing `spec-sort.ts` / `specs-view-tier.ts` helpers. Stores `{ labels[], epic, sprint }` as JSON; removes the key when all filters clear; throw-safe (private mode / quota).
- **`SpecsBoard.tsx`**:
  - init filters from `loadSpecFilters(activeProjectId)` instead of empty
  - the project-switch effect now **restores** the saved filters (instead of clearing) — and because it also runs on mount, close/reopen restores too
  - filter-change handlers (`handleLabelsChange` + new `handleEpicChange` / `handleSprintChange`) persist on every change; epic/sprint dropdowns wired to them

Pure client-side localStorage change — zero server impact. Per-project keyed, so filters never bleed between projects.

## Tests

- `spec-filters.test.ts` (15): round-trip labels/epic/sprint, per-project scoping, key-removal on clear, malformed-JSON / non-object / non-string resilience, null projectId no-op, localStorage throw on read/write.
- `SpecsBoardFilterPersistence.test.tsx` (4): restore after remount (close/reopen), persisted to per-project key, per-project isolation on switch, clearing removes the key.

## Verification

- Full client suite: **2673 passed**
- Coverage gate met: **85.2% lines/statements** (≥80), **72.5% funcs** (≥70); `spec-filters.ts` 95.8% stmts / 100% funcs
- `npm run typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)