### PR TITLE
refactor(providers): generalize provider-id types ahead of a 3rd provider

### DIFF
--- a/client/src/components/ChatInput.tsx
+++ b/client/src/components/ChatInput.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Button } from './ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip'
 import { cn } from '../lib/utils'
+import type { ProviderId } from '../lib/provider-capabilities'
 
 const CLAUDE_MODEL_OPTIONS = [
   { value: 'opus', label: 'Opus' },
@@ -22,7 +23,7 @@ interface ChatInputProps {
   model: string
   hasMessages: boolean
   isStreaming: boolean
-  provider?: 'claude' | 'codex'
+  provider?: ProviderId
   onSend: (conversationId: string, text: string) => void
   onAbort: (conversationId: string) => void
   onModelChange: (model: string) => void

--- a/client/src/components/ModelSelector.tsx
+++ b/client/src/components/ModelSelector.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import { cn } from '../lib/utils'
+import type { ProviderId } from '../lib/provider-capabilities'
 import {
   Select,
   SelectContent,
@@ -30,15 +31,23 @@ export const CODEX_MODELS = [
   { value: 'gpt-5.3-codex', label: 'GPT-5.3 Codex' },
 ]
 
-// Preset → default model per provider (matches specrails-core MODEL_PRESETS)
-export const PRESET_DEFAULTS: Record<ModelPreset, { claude: string; codex: string }> = {
+// Per-provider model catalog. Lookup keyed by provider id (not a branch) — a new
+// provider adds one entry, with no edit to consumers. Fallback is Claude's list.
+const PROVIDER_MODELS: Record<string, { value: string; label: string }[]> = {
+  claude: CLAUDE_MODELS,
+  codex: CODEX_MODELS,
+}
+
+// Preset → default model per provider (matches specrails-core MODEL_PRESETS).
+// Inner maps are keyed by provider id; an unknown provider falls back to Claude.
+export const PRESET_DEFAULTS: Record<ModelPreset, Record<string, string>> = {
   balanced: { claude: 'sonnet', codex: 'gpt-5.5' },
   budget: { claude: 'haiku', codex: 'gpt-5.4-mini' },
   max: { claude: 'sonnet', codex: 'gpt-5.5' },
 }
 
 // "max" preset: Opus for architect + PM, Sonnet for rest (matches specrails-core)
-const MAX_OVERRIDES: Record<string, { claude: string; codex: string }> = {
+const MAX_OVERRIDES: Record<string, Record<string, string>> = {
   'sr-architect': { claude: 'opus', codex: 'gpt-5.3-codex' },
   'sr-product-manager': { claude: 'opus', codex: 'gpt-5.3-codex' },
 }
@@ -46,19 +55,20 @@ const MAX_OVERRIDES: Record<string, { claude: string; codex: string }> = {
 export function getDefaultModel(
   agentId: string,
   preset: ModelPreset,
-  provider: 'claude' | 'codex'
+  provider: ProviderId
 ): string {
+  const presetDefaults = PRESET_DEFAULTS[preset]
   if (preset === 'max' && MAX_OVERRIDES[agentId]) {
-    return MAX_OVERRIDES[agentId][provider]
+    return MAX_OVERRIDES[agentId][provider] ?? presetDefaults[provider] ?? presetDefaults.claude
   }
-  return PRESET_DEFAULTS[preset][provider]
+  return presetDefaults[provider] ?? presetDefaults.claude
 }
 
 // ─── ModelSelector ────────────────────────────────────────────────────────────
 
 interface ModelSelectorProps {
   agents: AgentDef[]
-  provider: 'claude' | 'codex'
+  provider: ProviderId
   preset: ModelPreset
   overrides: ModelOverrides
   onPresetChange: (preset: ModelPreset) => void
@@ -77,7 +87,7 @@ export function ModelSelector({
   onOverrideChange,
 }: ModelSelectorProps) {
   const { t } = useTranslation('addspec')
-  const models = provider === 'claude' ? CLAUDE_MODELS : CODEX_MODELS
+  const models = PROVIDER_MODELS[provider] ?? CLAUDE_MODELS
 
   function getEffectiveModel(agentId: string): string {
     return overrides[agentId] ?? getDefaultModel(agentId, preset, provider)

--- a/client/src/components/ProposeSpecModal.tsx
+++ b/client/src/components/ProposeSpecModal.tsx
@@ -14,7 +14,7 @@ import { AiEngineSelector } from './AiEngineSelector'
 import type { LocalTicket, TicketPriority } from '../types'
 import { ContextScopeChecks } from './ContextScopeChecks'
 import { ContextScopeSlider } from './ContextScopeSlider'
-import { isSmashCapable } from '../lib/provider-capabilities'
+import { isSmashCapable, type ProviderId } from '../lib/provider-capabilities'
 import { getLastEngine, setLastEngine } from '../lib/last-engine'
 import { useContextScope } from '../hooks/useContextScope'
 import { useContextBudget } from '../hooks/useContextBudget'
@@ -62,7 +62,7 @@ export interface ExploreLaunchPayload {
   model: string
   /** AI engine picked at Add Spec (multi-provider). Undefined → project primary.
    *  Forwarded to the ExploreSpecShell so the conversation runs on it. */
-  provider?: 'claude' | 'codex'
+  provider?: ProviderId
   /** Add Spec context scope frozen at launch time. Forwarded to the
    *  ExploreSpecShell so the server-side conversation row carries it. */
   contextScope: ContextScope
@@ -119,7 +119,7 @@ export function ProposeSpecModal({ open, onClose, tickets, onExploreLaunch }: Pr
   // AI Engine (multi-provider). null until the first fetch resolves the
   // project's providers; then initialised to the last-used engine (default =
   // primary). Single-provider projects never render the selector.
-  const [engine, setEngine] = useState<'claude' | 'codex' | null>(null)
+  const [engine, setEngine] = useState<ProviderId | null>(null)
 
   // Model picker — fetched on each open. Locked for the whole flow once the
   // user submits; no downstream surface changes it. See spec
@@ -134,7 +134,7 @@ export function ProposeSpecModal({ open, onClose, tickets, onExploreLaunch }: Pr
     setEngine(getLastEngine(activeProjectId, providers, provider ?? 'claude'))
   }, [open, engine, providers, provider, activeProjectId])
 
-  const handleEngineChange = useCallback((next: 'claude' | 'codex') => {
+  const handleEngineChange = useCallback((next: ProviderId) => {
     setEngine(next)
     setLastEngine(activeProjectId, next)
   }, [activeProjectId])

--- a/client/src/components/explore-spec/SpecModelPicker.tsx
+++ b/client/src/components/explore-spec/SpecModelPicker.tsx
@@ -9,6 +9,7 @@ import {
   SelectValue,
 } from '../ui/select'
 import { getApiBase } from '../../lib/api'
+import type { ProviderId } from '../../lib/provider-capabilities'
 
 export interface SpecModelOption {
   value: string
@@ -17,10 +18,10 @@ export interface SpecModelOption {
 
 export interface DefaultSpecModelResponse {
   model: string
-  provider: 'claude' | 'codex'
+  provider: ProviderId
   allowed: SpecModelOption[]
   /** All providers installed for the project (multi-provider AI Engine selector). */
-  providers?: ('claude' | 'codex')[]
+  providers?: (ProviderId)[]
 }
 
 interface SpecModelPickerProps {
@@ -73,12 +74,12 @@ export function useDefaultSpecModel(
   enabled: boolean,
   /** Optional engine override (multi-provider). When set, the endpoint returns
    *  that provider's default model + allow-list. Refetches when it changes. */
-  providerOverride?: 'claude' | 'codex' | null,
+  providerOverride?: ProviderId | null,
 ) {
   const [model, setModel] = useState<string | null>(null)
   const [allowed, setAllowed] = useState<SpecModelOption[]>([])
-  const [provider, setProvider] = useState<'claude' | 'codex' | null>(null)
-  const [providers, setProviders] = useState<('claude' | 'codex')[]>([])
+  const [provider, setProvider] = useState<ProviderId | null>(null)
+  const [providers, setProviders] = useState<(ProviderId)[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 

--- a/client/src/components/terminal/BottomPanel.tsx
+++ b/client/src/components/terminal/BottomPanel.tsx
@@ -11,6 +11,7 @@ import { openExternalUrl } from '../../lib/tauri-shell'
 import { DEFAULT_TERMINAL_SETTINGS, type TerminalSettings } from '../../lib/terminal-settings-types'
 import { TERMINAL_SETTINGS_UPDATED_EVENT, type TerminalSettingsUpdatedEventDetail } from '../../lib/terminal-settings-events'
 import { registerTauriDragDrop } from '../../lib/tauri-drag-drop'
+import type { ProviderId } from '../../lib/provider-capabilities'
 import { ShortcutContextMenu } from './ShortcutContextMenu'
 import { CliLaunchMenu } from './CliLaunchMenu'
 import { TerminalTopBar } from './TerminalTopBar'
@@ -23,7 +24,7 @@ interface BottomPanelProps {
   projectId: string
   /** Project's primary CLI provider — drives the Sparkles shortcut label when a
    *  single provider is installed (claude vs codex). */
-  provider?: 'claude' | 'codex'
+  provider?: ProviderId
   /** All installed providers. When >1, the Sparkles shortcut opens a picker. */
   providers?: readonly string[]
   state: ProjectPanelState

--- a/client/src/components/terminal/TerminalTopBar.tsx
+++ b/client/src/components/terminal/TerminalTopBar.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { cn } from '../../lib/utils'
 import { PanelChevronButton } from './PanelChevronButton'
 import type { PanelVisibility } from '../../context/TerminalsContext'
+import type { ProviderId } from '../../lib/provider-capabilities'
 
 interface TerminalTopBarProps {
   visibility: PanelVisibility
@@ -10,7 +11,7 @@ interface TerminalTopBarProps {
   hasActive: boolean
   /** CLI to launch from the Sparkles shortcut: 'claude' (default) or 'codex'.
    *  Used for the button label when only one provider is installed. */
-  provider?: 'claude' | 'codex'
+  provider?: ProviderId
   /** All installed providers. When >1, clicking the Sparkles shortcut opens a
    *  picker (anchored at the click) instead of launching directly. */
   providers?: readonly string[]

--- a/client/src/hooks/useDesktop.tsx
+++ b/client/src/hooks/useDesktop.tsx
@@ -10,6 +10,7 @@ import {
   type ReactNode,
 } from 'react'
 import { API_ORIGIN } from '../lib/origin'
+import type { ProviderId } from '../lib/provider-capabilities'
 import { toast } from 'sonner'
 import i18n from '../lib/i18n'
 import { useSharedWebSocket } from './useSharedWebSocket'
@@ -22,17 +23,17 @@ export interface DesktopProject {
   path: string
   db_path: string
   /** Primary / default provider (first selected at install). */
-  provider: 'claude' | 'codex'
+  provider: ProviderId
   /** All providers installed for this project. Always contains `provider`.
    *  Optional for forward-compat: older server payloads omit it, callers fall
    *  back to `[provider]`. */
-  providers?: ('claude' | 'codex')[]
+  providers?: ProviderId[]
   added_at: string
   last_seen_at: string
 }
 
 /** Installed providers for a project, tolerant of legacy payloads w/o `providers`. */
-export function projectProviders(p: Pick<DesktopProject, 'provider' | 'providers'>): ('claude' | 'codex')[] {
+export function projectProviders(p: Pick<DesktopProject, 'provider' | 'providers'>): ProviderId[] {
   return p.providers && p.providers.length > 0 ? p.providers : [p.provider]
 }
 
@@ -45,7 +46,7 @@ interface DesktopContextValue {
   projects: DesktopProject[]
   activeProjectId: string | null
   setActiveProjectId: (id: string | null) => void
-  addProject: (path: string, name?: string, providers?: ('claude' | 'codex')[]) => Promise<AddProjectResult | null>
+  addProject: (path: string, name?: string, providers?: ProviderId[]) => Promise<AddProjectResult | null>
   removeProject: (id: string) => Promise<void>
   isLoading: boolean
   /** True briefly after switching active project — triggers the loading bar */
@@ -169,7 +170,7 @@ export function DesktopProvider({ children }: { children: ReactNode }) {
     return () => unregisterHandler('desktop')
   }, [handleMessage, registerHandler, unregisterHandler])
 
-  const addProject = useCallback(async (projectPath: string, name?: string, providers: ('claude' | 'codex')[] = ['claude']): Promise<AddProjectResult | null> => {
+  const addProject = useCallback(async (projectPath: string, name?: string, providers: ProviderId[] = ['claude']): Promise<AddProjectResult | null> => {
     try {
       const list = providers.length > 0 ? providers : ['claude']
       const body: Record<string, unknown> = { path: projectPath, providers: list }

--- a/client/src/lib/provider-capabilities.ts
+++ b/client/src/lib/provider-capabilities.ts
@@ -7,7 +7,11 @@
  * See openspec/changes/hide-smash-codex-explore.
  */
 
-export type ProviderId = 'claude' | 'codex'
+// Open provider id. The set of valid ids is owned by the server's provider
+// registry (surfaced via /available-providers and each project's `providers`),
+// not this union — adding a provider needs no edit here. Capability/label
+// helpers below already accept `string | null | undefined` and fall back safely.
+export type ProviderId = string
 
 /**
  * Returns true when the given provider supports SMASH (Spec decomposition via

--- a/docs/gemini-cli-provider-study.md
+++ b/docs/gemini-cli-provider-study.md
@@ -1,0 +1,301 @@
+# Estudio de implementación — Gemini CLI como tercer proveedor de specrails-desktop
+
+> Documento de planificación (no contrato final). Generado 2026-06-16 mediante auditoría multi-agente del código real + investigación de fuentes primarias de `github.com/google-gemini/gemini-cli` (HEAD `5624a3b`, v0.48.0-nightly). Listón de referencia: el adapter de Codex (no-nativo con puentes). Las citas `file:line` provienen de la auditoría del código; las flags/campos de Gemini en `verbatim` de la investigación. Lo marcado `[UNCERTAIN]` se señala con su plan de resolución.
+
+---
+
+## 1. Resumen ejecutivo y alcance
+
+**Veredicto: viable y de bajo riesgo arquitectónico.** El core de spawn/detect/cost/registry ya está generalizado por id de proveedor (`server/providers/registry.ts` es un `Map<ProviderId,adapter>`, `core-compat.ts` recorre `listAdapters()`, `pricing.ts` usa claves `'<id>:<model>'`, `result-event.ts` `finaliseInvocationResult` y `provider-selection.ts` son membership-based). El contrato promete *"un fichero + una entrada de registro"* y eso se cumple para el camino de compilación mínimo. El resto del trabajo es **ensanchar uniones literales `'claude'|'codex'`** y **rellenar branches `=== 'codex'` que no tienen hermano gemini**.
+
+Gemini supera a Codex en dos capacidades clave verificadas:
+- **OTEL nativo** (`[confirmed]`): emite OTLP por env (`GEMINI_TELEMETRY_*`), igual que claude → `nativeOtelEnv: true`, **no necesita bridge sintético**.
+- **System-prompt nativo** (`[confirmed]`): `GEMINI_SYSTEM_MD=<path>` reemplaza el system prompt por env de proceso → soporte de system-prompt (con matiz, ver §3).
+
+**Entra en v1 (PR-B beta-gated):** jobs/rails básicos, Explore Spec multi-turno (spawn-per-turn con `--resume`), Quick spec, Analytics/coste vía rate-card, OTEL nativo, terminal CLI launch, detección + prerequisitos, selección de modelo, multi-provider per project.
+
+**NO entra en v1 (paridad Codex, se ocultan por intersección de capacidades):** Agent Profiles, SMASH, Contract Refine, Ultracode (+interactivo), plugins/Serena, persistent-stdin de Explore. Gemini se comporta byte-idéntico a Codex en estas superficies **siempre que declare las capacidades correctas y se ensanchen los tipos** — cero código nuevo en esas superficies.
+
+**Diferido a follow-up explícito (decisiones tomadas, no implementadas en v1):** generalizar `provider-capabilities.ts` para *otorgar* a Gemini features hoy claude-only; bridge Windows multi-line argv; traducción slash-command para rails funcionales en Gemini (esto último es **bloqueante para rails reales**, ver §6).
+
+---
+
+## 2. Modelos a ofrecer
+
+Decisión: **pinear ids GA concretos, no alias ni ids preview**, porque los ids `gemini-3-*-preview` rotan (la API ya movió Pro a `gemini-3.1-pro-preview`) y el CLI acepta ids inválidos sin validar (`issue #21391`). `ai_invocations.model` y la clave de pricing necesitan un id concreto y estable → el `modelCatalog()` ofrece ids GA concretos como `value`, que son los que se pasan a `--model` y se almacenan; se evita el churn de los preview.
+
+**Catálogo curado (4 entradas):**
+
+| value (`--model` / `ai_invocations.model`) | label | default |
+|---|---|---|
+| `gemini-2.5-pro` | Gemini 2.5 Pro | **sí** |
+| `gemini-2.5-flash` | Gemini 2.5 Flash | no |
+| `gemini-2.5-flash-lite` | Gemini 2.5 Flash Lite | no |
+| `gemini-3.1-pro-preview` | Gemini 3 Pro (preview) | no |
+
+- **Default = `gemini-2.5-pro`**: GA, no-preview, es el `DEFAULT_GEMINI_MODEL` hardcoded del propio CLI, pricing estable. Evita anclar el producto a un id preview que rotará.
+- **Se ofrece `gemini-3.1-pro-preview`** como cuarta opción de calidad (el único Pro de Gemini-3 *con precio publicado*; `gemini-3-pro` no existe como modelo con precio). Etiquetado "preview" para señalar volatilidad.
+- **Se omiten `gemini-3-flash-preview` / `gemini-3.5-flash` / `gemini-3.1-flash-lite`**: preview de precio movible; con `flash`/`flash-lite` 2.5 ya cubrimos el tier rápido/barato con GA estable. Añadirlos luego es trivial (solo filas de pricing + catálogo).
+- **Se omite pasar alias `auto`/`pro`/`flash`**: el routing `auto` impide stampear un id concreto en `ai_invocations.model`, rompiendo la atribución de coste. Pinneamos ids.
+
+`[UNCERTAIN]`: el mapping alias→id-concreto no está byte-documentado; se resuelve NO usando alias.
+
+**Filas para `server/pricing.ts` (clave `'gemini:<model>'`, USD por 1M tokens, Standard paid tier):**
+
+```ts
+// Gemini (Google). Ref: ai.google.dev/gemini-api/docs/pricing (fetched 2026-06-16).
+// nativeCostUsd:false → estas tarifas son la ÚNICA fuente de coste.
+'gemini:gemini-2.5-pro':         { inputPer1M: 1.25, outputPer1M: 10.00, cacheReadPer1M: 0.125, lastReviewedAt: '2026-06-16' },
+'gemini:gemini-2.5-flash':       { inputPer1M: 0.30, outputPer1M: 2.50,  cacheReadPer1M: 0.03,  lastReviewedAt: '2026-06-16' },
+'gemini:gemini-2.5-flash-lite':  { inputPer1M: 0.10, outputPer1M: 0.40,  cacheReadPer1M: 0.01,  lastReviewedAt: '2026-06-16' },
+'gemini:gemini-3.1-pro-preview': { inputPer1M: 2.00, outputPer1M: 12.00, cacheReadPer1M: 0.20,  lastReviewedAt: '2026-06-16' },
+```
+
+Notas de tiering y caché (decisiones explícitas):
+- **`gemini-2.5-pro` y `gemini-3.1-pro-preview` son context-tiered** (>200k tokens duplica precio: pro $2.50/$15.00; 3.1-pro $4.00/$18.00). `PriceEntry` no soporta tiering por tamaño de prompt. **Decisión v1: usar el tier ≤200k** (la mayoría de jobs caen ahí). El coste de prompts >200k se **infra-estima** — aceptable y honesto (Analytics ya marca `estimated=true`). Fidelidad = follow-up que ensancha `PriceEntry` con tiering (toca también codex pro). No bloqueante.
+- **Free tier**: existe (OAuth 60 RPM/1000 RPD; API key free 10 RPM/250 RPD, solo Flash). **No se modela en pricing** — el rate-card es para coste estimado, no para gating de cuota (coherente con codex).
+- **Caché**: `cacheReadPer1M` asume (como OpenAI/codex) que los cached tokens son un *subconjunto* de `tokens_in`. Gemini reporta `cachedContentTokenCount` separado → `[UNCERTAIN]` **resolución**: en `extractResult` mapear `cached` a `tokens_cache_read` y NO restarlo de `tokens_in` (mismo patrón que codex `cached_input_tokens`); el test de pricing fija el contrato.
+
+---
+
+## 3. El adapter `server/providers/gemini-adapter.ts`
+
+Estructura espejo de `codex-adapter.ts`. Constantes `GEMINI_MODELS`, `GEMINI_MIN_VERSION`, helper `fold()` (igual que codex-adapter.ts:49-52), `WHICH_CMD`, `compareSemver`.
+
+### Propiedades readonly
+
+| Miembro | Valor Gemini | Razón |
+|---|---|---|
+| `id` | `'gemini'` | clave de registro; igual a `projects.providers[]` y al param `aiEngine`. |
+| `displayName` | `'Gemini CLI'` | etiqueta UI pura. |
+| `binary` | `'gemini'` | ejecutable en PATH. |
+| `minCliVersion` | `'0.11.0'` | piso donde stream-json (PR #10883) + resume están validados. <0.6 no tiene `--output-format`; <0.11 no tiene stream-json. |
+| `projectDirName` | `'.gemini'` | dir de settings del CLI (`.gemini/settings.json`). |
+| `instructionsFilename` | `'GEMINI.md'` | el CLI lee GEMINI.md por defecto; plugin/explore-cwd escriben aquí. **Mejor que codex**: nativo, sin config extra. |
+| `mcpRegistration` | `'project-json'` | Gemini registra MCP en `.gemini/settings.json` `mcpServers`. `gemini mcp add -s project` escribe al settings.json. |
+
+### `capabilities` (8 campos)
+
+| Campo | Valor | Por qué |
+|---|---|---|
+| `nativeResume` | `true` | `--resume <uuid\|index\|latest>` headless wired en non-interactive (`nonInteractiveCli.ts:236-242`, `resumeChat`). El host pre-asigna UUID con `--session-id` y resume con `--resume <uuid>`. |
+| `nativeStreamJson` | `true` | `--output-format stream-json` emite NDJSON (`init/message/tool_use/tool_result/error/result`). |
+| `nativeCostUsd` | `false` | NO hay campo cost/usd en ningún evento (grep confirmado). → rate-card en pricing.ts (igual codex). |
+| `nativeOtelEnv` | `true` | **MEJOR que codex**: emite OTLP nativo por `GEMINI_TELEMETRY_*` env. No necesita bridge sintético (ver §4). |
+| `profileEnvSupport` | `true` (vestigial) | Igual que codex: rails fuerzan profile=null para non-claude (`rails-router.ts:250`); valor irrelevante funcionalmente; `true` por paridad. |
+| `systemPromptArg` | `false` (v1) | **Matiz**: Gemini SÍ soporta override de system-prompt, pero por **env `GEMINI_SYSTEM_MD=<path>`**, NO por flag de argv. El contrato `systemPromptArg` significa "¿hay un *flag* `--system-prompt`?" → no lo hay. **v1: `false`** y foldear systemPrompt en el prompt (como codex, fold()). El path env es follow-up. |
+| `persistentStdin` | omitido (`false`) | El CLI requiere el follow-up prompt vía `-p`/`--prompt` en resume headless (issue #14180), no soporta stdin stream-json long-lived documentado. → Explore cae al spawn-per-turn legacy (sin pérdida vs default, que es OFF). |
+
+**Nota sobre `systemPromptArg=false` pese a soporte nativo**: el contrato solo modela "flag de argv". Como Gemini usa env (`GEMINI_SYSTEM_MD`), la vía limpia v1 es foldear (codex-parity). Un follow-up puede inyectar `GEMINI_SYSTEM_MD` en el env de spawn — pero eso es un reemplazo *completo* del system prompt (no merge), y los managers asumen append; foldear es más seguro en v1.
+
+### `buildArgs(action, opts)` — switch de los 9 SpawnActions
+
+Flags base: `--output-format stream-json`, `--model <opts.model>`. Headless se dispara con `-p <prompt>`. Jobs autónomos: `--approval-mode yolo`. Acciones read-only de spec/explore: `--approval-mode plan`. `opts.extraArgs` siempre se appendea verbatim.
+
+```
+chat-turn (Explore):     gemini -p <fold(sys,prompt)> --model <m> --output-format stream-json --session-id <hostUUID>
+chat-resume:             gemini -p <fold(sys,prompt)> --model <m> --output-format stream-json --resume <opts.sessionId>
+                         // throw si !opts.sessionId  (igual codex)
+chat-stream:             throw  // persistentStdin no soportado (igual codex)
+rail-job:                gemini -p <command> --model <m> --output-format stream-json --approval-mode yolo --session-id <hostUUID>
+                         // NB: el command slash /specrails:X NO lo entiende Gemini → §6 (bloqueante rails reales)
+spec-gen:                gemini -p <fold(sys,prompt)> --model <m> --output-format stream-json --approval-mode plan
+agent-refine:            gemini -p <fold(sys,prompt)> --model <m> --output-format stream-json --approval-mode yolo
+setup-enrich:            gemini -p <fold(sys,prompt)> --model <m> --output-format stream-json
+setup-enrich-resume:     gemini -p <fold(sys,prompt)> --model <m> --output-format stream-json --resume <opts.sessionId>
+                         // throw si !opts.sessionId
+auto-title:              gemini -p <fold(sys,prompt)> --model <m> --output-format stream-json
+```
+
+Detalles:
+- **`--session-id <hostUUID>` en turno 1** (chat-turn, rail-job): el host mintea un UUID propio y lo pre-asigna, así no depende de parsear `init.session_id` (que es post-2025-12-04). Resume luego con `--resume <eseUUID>`. Robustez de versión.
+- **Resume requiere prompt vía `-p`** (no stdin/positional) — issue #14180, workaround estable documentado.
+- **`opts.maxTurns`**: Gemini lo mapea a `maxSessionTurns` (settings.json, default 100), NO hay flag `--max-turns`. Ignorar `maxTurns` en buildArgs (como codex); el cap sale por exit code 53.
+- **cwd**: todos los spawns desde `project.path` (o explore-cwd) — el resume está scopeado por hash de cwd (`getProjectHash(process.cwd())`). El host ya fija `cwd=project.path` por manager.
+
+### `parseStreamLine(line)` — mapeo evento-gemini → AdapterEvent[]
+
+`JSON.parse` por línea; `null` en línea vacía o parse-fail (igual codex):
+
+| Evento Gemini | AdapterEvent | Mapeo |
+|---|---|---|
+| `init` `{session_id,model}` | `session-started{sessionId: e.session_id}` | **session_id sale del evento `init`** (único sitio). |
+| `message` `{role:'assistant',content,delta}` | `text-delta{text: e.content}` | acumular chunks con `role==='assistant'`. `role:'user'` (echo) → ignorar. |
+| `tool_use` `{tool_name,tool_id,parameters}` | `tool-use{name: e.tool_name, inputPreview: ...slice(0,200)}` | preview 200 chars (igual codex). |
+| `tool_result` `{tool_id,status,output,error}` | `other{type:'tool_result',raw}` | no hay variant dedicado; codex tampoco lo usa. |
+| `result` `{status,stats}` | `result{payload: e}` | terminal; `stats` queda en payload para `extractResult`. |
+| `error` `{severity,message}` | `other{type:'error',raw}` | no-fatal; los fatales van a stderr+exit. |
+| desconocido | `other{type,raw}` | |
+
+**session_id**: del evento `init.session_id`. Como además pre-asignamos `--session-id`, el host ya lo conoce sin parsear (doble seguridad).
+
+### `extractResult(events)` — suma de tokens
+
+Lee el último `result.payload.stats` (StreamStats, flat):
+- `tokens_in ← stats.input_tokens`
+- `tokens_out ← stats.output_tokens` (Gemini stream-json **descarta** `thoughts`/`tool` tokens; no hay reasoning separado que foldear)
+- `tokens_cache_read ← stats.cached`
+- `tokens_cache_create ← undefined`
+- `num_turns ←` contar eventos `result` (1 por turno)
+- `session_id ←` último `session-started.sessionId`
+- `total_cost_usd ← undefined` → `finaliseInvocationResult` (`result-event.ts:48-89`) aplica `estimateCostUsd('gemini', model, usage)` contra `pricing.ts`. Sin filas → coste NULL + warn (`result-event.ts:81`).
+
+### `detectInstalled()` — espejo exacto de codex (contrato cap 3s, types.ts:131-132)
+
+`which/where gemini` → si ausente `{installed:false,executable:false}`. Si presente: `gemini --version` con `timeout:3000`, regex `\d+\.\d+\.\d+`, `compareSemver` vs `GEMINI_MIN_VERSION='0.11.0'` → `meetsMinimum` + string de error/upgrade. Fallo del probe → `{installed:true,executable:false}`. Corre al startup y en `/setup-prerequisites`.
+
+### `baselineAgents()` → `['sr-architect','sr-developer','sr-reviewer']` (vestigial — rails fuerzan profile=null).
+
+### `registration` (`server/providers/index.ts:11-14,17`)
+```ts
+import { geminiAdapter } from './gemini-adapter'
+register(geminiAdapter)
+export { claudeAdapter, codexAdapter, geminiAdapter }
+```
+
+---
+
+## 4. OTEL: nativo (NO bridge)
+
+**Decisión: `nativeOtelEnv: true` — Gemini va por el path de claude (env-injection), NO por el bridge sintético de codex.** Evidencia `[confirmed]`: `packages/core/src/telemetry/config.ts` (PR #9113) lee de `process.env` con precedencia env>settings, emitiendo OTLP nativo de traces+metrics+logs.
+
+**Cómo se inyecta** — en `server/queue-manager.ts`, con `nativeOtelEnv:true` el bloque del bridge (`queue-manager.ts:1197-1205`, gated `!adapter.capabilities.nativeOtelEnv`) **se salta automáticamente**, y Gemini fluye por `buildTelemetryEnv` (`queue-manager.ts:1042,1105`). El adapter/queue inyecta:
+```
+GEMINI_TELEMETRY_ENABLED=true
+GEMINI_TELEMETRY_TARGET=local
+GEMINI_TELEMETRY_OTLP_ENDPOINT=<app OTLP receiver>
+GEMINI_TELEMETRY_OTLP_PROTOCOL=grpc           # grpc:4317, evita el bug OTLP/HTTP #15581
+GEMINI_TELEMETRY_TRACES_ENABLED=true          # spans (off por defecto)
+```
+
+**Qué cambia respecto a claude en queue-manager**: `buildTelemetryEnv` hardcodea `CLAUDE_CODE_ENABLE_TELEMETRY:'1'` (`queue-manager.ts:52-60`), claude-específico. Gemini necesita SU enable-flag. **Cambio requerido (solo si telemetry está ON para un job gemini)**: parametrizar el enable-var por adapter — p.ej. `adapter.nativeOtelEnvVars()` que devuelva `{CLAUDE_CODE_ENABLE_TELEMETRY:'1'}` para claude y el bloque `GEMINI_TELEMETRY_*` para gemini. Los `OTEL_EXPORTER_OTLP_*` estándar siguen neutrales. **No bloqueante** salvo que se active telemetry.
+
+**Caveat de correlación `[UNCERTAIN]`**: el receptor OTLP del app rutea por `specrails.job_id` + `specrails.project_id` en `resource.attributes`. Gemini emite sus propios `session.id`/`installation.id`, NO los de specrails. Si Gemini honra `OTEL_RESOURCE_ATTRIBUTES` (estándar OTEL SDK, **no documentado en telemetry.md**), inyectar `OTEL_RESOURCE_ATTRIBUTES=specrails.job_id=<id>,specrails.project_id=<id>` resuelve la correlación. **Resolución**: probar empíricamente antes de confiar; fallback = correlacionar por `session.id` de spawn-time (lo conocemos vía `--session-id`). Telemetry es opt-in OFF por defecto → no bloquea v1.
+
+**El bridge `codex-otel-bridge.ts` NO se toca** para Gemini (se bypassa por capability).
+
+---
+
+## 5. Change-list exacto por fichero (dos PRs)
+
+### PR-A — Generalización previa (ensanchar tipos, desramificar; sin Gemini todavía)
+
+Mergeable independiente, no cambia comportamiento observable.
+
+| Fichero:línea | Cambio | Bloq |
+|---|---|---|
+| `server/desktop-db.ts:10,50,167,268,388` | `CliProvider = 'claude'\|'codex'` → ensanchar a incluir `'gemini'` (o alias a `ProviderId`/string). Tipo DB central; todos heredan. `DEFAULT 'claude'` se mantiene. | **sí** |
+| `server/spec-models.ts:1-37` | `SpecProvider` union + reemplazar ternario `provider==='codex'?CODEX:CLAUDE` en `getModelsForProvider` por **lookup `Record<provider, SpecModelOption[]>`** (fallback `adapter.defaultModel()`/`[]`). `PROVIDER_DEFAULT_MODEL` → record extensible. | **sí** |
+| `server/desktop-router.ts:158-168` (`GET /available-providers`) | Dejar de destructurar `{claude,codex}` fijo; `detectAvailableCLIs()` ya devuelve `Record<string,boolean>` → **devolver el map entero (spread)**. `if(providers.claude\|\|providers.codex)` → `Object.values(providers).some(Boolean)`. | **sí** |
+| `server/desktop-router.ts:265-266` | casts `as 'claude'\|'codex'` en addProject → ensanchar (registry valida con `hasAdapter`). | **sí** |
+| `server/project-registry.ts:116` | `AddProjectInput.providers?: ('claude'\|'codex')[]` → `ProviderId[]`/`string[]`. | **sí** |
+| `client/src/hooks/useDesktop.tsx:29,35,48,172` | 4 anotaciones `('claude'\|'codex')[]` → `string[]`/`ProviderId`. | **sí** |
+| `client/src/lib/provider-capabilities.ts:11` | `ProviderId = 'claude'\|'codex'` → añadir `'gemini'`/string. | **sí** |
+| `client/src/components/ModelSelector.tsx:20-55,80` | ternario `provider==='claude'?CLAUDE:CODEX` → map por id; `PRESET_DEFAULTS`/`MAX_OVERRIDES` literal → `Record<string,string>`; ensanchar prop union. **Bloqueante funcional**: sin esto Gemini mostraría modelos de Codex. | **sí** |
+| `client/src/components/ChatInput.tsx:7-18,25` | selección por id-keyed map; ensanchar `provider?: 'claude'\|'codex'`. | **sí** |
+| `client/src/components/AddProjectDialog.tsx:28,31,37,41,67-79,96,141,235-236` | `availableProviders` de `{claude;codex}` fijo → `Record<string,boolean>` iterado sobre `/available-providers`; `!claude && !codex` → iterar keys. | **sí** |
+| `client/src/components/{AiEngineSelector:40,53, RailEngineSelector:33,38, CliLaunchMenu:52,55, explore-spec/SpecModelPicker:23,81, SetupWizard:563}` | casts inline `as 'claude'\|'codex'` → ensanchar union. Listas data-driven, Gemini aparece solo. | **sí** |
+| `server/util/cli-prompt.ts:178-191` | `spawnAiCli` ya cae a `spawnCli` genérico para binarios desconocidos → **POSIX funciona sin cambio**. Windows multi-line argv (`transformClaudeArgsForWindows`/`transformCodexArgsForWindows`) NO cubre gemini. | cosmético (POSIX) / bloq Windows |
+
+### PR-B — El adapter Gemini + branches y catálogos
+
+| Fichero:línea | Cambio | Bloq |
+|---|---|---|
+| `server/providers/gemini-adapter.ts` (nuevo) | El adapter completo (§3). | **sí** |
+| `server/providers/index.ts:11-14,17` | import + `register(geminiAdapter)` + re-export. | **sí** |
+| `server/pricing.ts:44-50` | 4 filas `'gemini:<model>'` (§2). Sin ellas coste=NULL. | **sí** |
+| `server/project-router-tickets.ts:1540-1556` (ai-edit) | dispatch hardcoded `if(provider==='codex'){binary='codex'...} else {binary='claude'...}` → **un proyecto gemini spawnearía 'claude' (binario equivocado)**. Reemplazar por `adapter.binary` + `adapter.buildArgs` (patrón ya usado en quick-spec línea 341). | **sí** |
+| `server/project-router-tickets.ts:420,610,1022,1148` | bloques `if(provider==='codex')` sin hermano gemini → generalizar o añadir arm gemini. | **sí** |
+| `server/setup-manager.ts:697-700,1306-1307` | regex allow-list `m[1]==='claude'\|\|m[1]==='codex'` **descarta 'gemini' silenciosamente** → install-config cae a claude. Añadir `'gemini'`. **Fallo silencioso de alto riesgo.** | **sí** |
+| `server/setup-manager.ts:495-503` | `computeSummary` branch codex → hermano gemini si el summary difiere. | menor |
+| `server/setup-prerequisites.ts:405-423` | switch de install-hint: añadir `case 'gemini':` (URL/comando install Gemini CLI). | menor |
+| `server/agent-refine-manager.ts:73,79` | ensanchar `provider?: 'claude'\|'codex'`. (validateAgentBody ya skip non-claude). | **sí** (compile) |
+| `server/chat-manager.ts:124,132,332` | ensanchar `provider?: 'claude'\|'codex'` ctor + cast persistido. Gates `adapter.id==='claude'` (scope/userMcp) ya rutean gemini como codex (OK). | **sí** (compile) |
+| `server/result-event.ts:98-117` | `normaliseResultEvent` legacy shim: gemini cae al branch codex `else` (mis-parsea usage). **Preferir `adapter.extractResult`** (path moderno). Ensanchar union por si se usa. | menor |
+| `client/src/types/context-scope.ts:62-67` | añadir filas de coste gemini (cliente). | menor |
+| `client/src/components/analytics/ProviderBreakdownCard.tsx:9-17` | `PROVIDER_LABEL`/`PROVIDER_ACCENT`: añadir `gemini` (label + accent, p.ej. `bg-accent-success`). | menor |
+| `client/src/components/Navbar.tsx:26-43` | badge: añadir `=== 'gemini'` (label/color), sino cae a 'no CLI' rojo. | menor |
+| `client/src/components/SetupWizard.tsx:63-76` | heurísticas modelId sonnet/haiku/opus son claude-specific → branch gemini si el configure debe mostrar modelo. | menor |
+| `server/desktop-router.ts:28-35,155-157,229-234` | gate beta: añadir `SPECRAILS_GEMINI_BETA` paralelo a `SPECRAILS_CODEX_BETA`. Generalizar el refuse hardcoded `providers.includes('codex')` (línea 229). | menor (necesario para el gate) |
+| `docs/adding-a-provider.md` (**no existe en disco**) | **Crearlo** — CLAUDE.md lo referencia pero falta. Documentar el patrón "un fichero + una entrada" usando gemini como ejemplo. | menor |
+
+**NO tocar (verificado, evitar over-edit):** `core-compat.ts` (registry-driven), `provider-selection.ts` (membership; solo necesita `CliProvider` ensanchado), `spawn-lifecycle.ts` (adapter-driven, cero literales), `result-event.ts` `finaliseInvocationResult` (id-driven), `registry.ts`, `queue-manager._resolveJobAdapter`, `COALESCE(provider,'claude')` en ai-invocations/spending/db (solo backfill de NULLs legacy), `contract-refine-runner.ts`/`smash-runner.ts` (claude-only intencional).
+
+---
+
+## 6. Matriz de feature-parity
+
+| Feature | ¿Gemini lo soporta? | Qué haría falta para paridad |
+|---|---|---|
+| **Jobs/rails (compila + corre)** | **Degradado/Bloqueado** | Compila vía adapter. **BLOQUEANTE para rails reales**: `queue-manager.ts:976-981` pasa el slash `/specrails:implement #N` crudo a Gemini en el `else` final — Gemini NO entiende slash-commands de Claude (Codex los traduce a `$skill`). Paridad: branch gemini que mapee slash→forma que entiendan las skills de specrails-core en Gemini. |
+| **Explore Spec (multi-turno)** | **Nativo (degradado)** | `--resume` headless + `--session-id` pre-asignado funcionan. Spawn-per-turn con `-p`. Sin pérdida básica. |
+| **— persistent-stdin Explore** | **Bloqueado** | `persistentStdin:false` → spawn-per-turn (default OFF de todas formas). Requiere stdin stream-json long-lived que Gemini no documenta. |
+| **— tool-gating (Explore/Quick scope)** | **Degradado (default-safe)** | Gates `adapter.id==='claude'` → gemini recibe args vacíos (sin restricción; usa su propio `--approval-mode plan/yolo`). Paridad: branch gemini en `toolFlagsForScope` (`context-scope.ts`) mapeando ContextScope → flags Gemini. |
+| **— MCP per-spec (`.mcp.json`)** | **Degradado** | Gemini usa `.gemini/settings.json` `mcpServers`, NO el `.mcp.json` de claude ni `--mcp-config` inline. Paridad: escribir `.gemini/settings.json` en la cwd o `--allowed-mcp-server-names`. |
+| **— user-MCP (My approved MCPs)** | **Degradado (default-safe)** | `buildUserMcpArgs` devuelve `[]` para non-claude. Gemini lee su MCP global desde `~/.gemini/settings.json` (como codex con `~/.codex`) → no-op correcto, sin pérdida. |
+| **Quick spec** | **Nativo** | spawn one-shot vía adapter; coste por rate-card. |
+| **Agent profiles** | **Bloqueado (paridad codex)** | `CLAUDE_ONLY_SECTIONS=['agents']`, `profileEnvSupport` vestigial. Oculto por intersección. Paridad: soporte por sección en `provider-capabilities.ts:44-71` + `projectSupportsProfiles` por-provider. |
+| **Integrations/plugins (MCP/Serena)** | **Bloqueado (paridad codex)** | Manifest Serena omite `providerSupport` → claude-only. Paridad: añadir `'gemini'` a `providerSupport` + entry MCP bajo `.gemini/settings.json`. |
+| **SMASH** | **Bloqueado (paridad codex)** | `isSmashCapable→'claude'`. `smash-runner.ts` spawnea `claude` directo sin adapter. Paridad: reescribir runner sobre `getAdapter()` + prompt/parser Gemini + flip del gate. |
+| **Contract Refine** | **Bloqueado (inherentemente anthropic en su forma actual)** | `--resume` a sesión Claude + slash `/specrails:contract-refine`. Paridad parcial vía el path no-resume (re-seed por system prompt, como `runContractRefineForQuick`) + de-hardcodear `getAdapter('claude')`. |
+| **Ultracode interactivo** | **Bloqueado (paridad codex)** | `mode==='ultracode' && provider!=='claude'→400`; `isUltracode=adapter.id==='claude'`. Paridad: quitar el 400 para gemini, generalizar el branch ultracode-prompt, `persistentStdin:true` para el interactivo. Mecanismo no-anthropic; factible. |
+| **Analytics/coste** | **Nativo (estimado)** | `nativeCostUsd:false` + filas pricing → coste estimado, `estimated=true`. Filtros engine ya data-driven. |
+| **OTEL/telemetry** | **Nativo (MEJOR que codex)** | `nativeOtelEnv:true` → env-injection (no bridge). Solo parametrizar el enable-var en `buildTelemetryEnv`. Caveat correlación (§4). |
+| **Terminal CLI launch** | **Nativo** | `CliLaunchMenu` itera providers; aparece tras ensanchar union + wiring binario. |
+
+**Problema de la intersección binaria `=== 'claude'`**: `sectionVisibleForProviders` **oculta una sección si CUALQUIER proveedor instalado no la soporta**. En un proyecto mixto claude+gemini, Agents/SMASH/etc. desaparecen porque gemini no las declara — igual que codex hoy. **Si se generalizara `provider-capabilities.ts`** (soporte por-sección por-proveedor en vez del `Set` claude-only), Gemini *ganaría*: Agent Profiles (solo env `SPECRAILS_PROFILE_PATH`, agnóstico), tool-gating, user-MCP, file-summary cheap-model — todas mecanismo-dependientes. Solo Contract Refine es inherentemente anthropic. **Decisión v1**: paridad-codex (ocultar), generalización diferida a follow-up.
+
+---
+
+## 7. Riesgos y mitigaciones
+
+| Riesgo | Mitigación |
+|---|---|
+| **Pin de versión pre-1.0** (cambia a diario; nightly 0.48) | `minCliVersion='0.11.0'` (piso validado de stream-json). `detectInstalled` surface meetsMinimum + upgrade hint. Documentar que los ids preview rotan. |
+| **Drift del stream-json** (bugs #9281/#11184/#9009) | Esos bugs son del `--output-format json` (single-object `response`), **NO del stream-json** (usa message deltas, sin `response`). #9009 (flag desconocida) cerrado, afecta <0.6 — el pin 0.11 lo evita. **Golden-snapshot test**: fixtures NDJSON bajo `__fixtures__/` verbatim del `stream-json-formatter.test.ts` upstream, aserción `toEqual` sobre el AdapterEvent[]. |
+| **Scope por cwd-hash en resume** | Sesiones scopeadas por `getProjectHash(cwd)`. **Siempre spawn desde `project.path`** (ya lo hace el host). Resume cross-cwd no encuentra la sesión → host-controllable. Pre-asignar `--session-id <UUID>` para no depender de parsear init en builds <2025-12-04. |
+| **Exit code 53** (turn limit, no quota) | Mapear 53 = "cap de turnos `maxSessionTurns`" distinto de error general. 42 = bad input/args. Resto non-zero → tratar como exit 1 (general/API). Quota/429/403 colapsan a exit 1. |
+| **Auth headless** | **Presetear `GEMINI_API_KEY`** en el env de spawn → `getAuthTypeFromEnv()` devuelve `USE_GEMINI`, `validateAuthMethod` pasa, sin browser. Alt CI: `GOOGLE_GENAI_USE_VERTEXAI=true`+`GOOGLE_CLOUD_PROJECT`+`GOOGLE_CLOUD_LOCATION`+`GOOGLE_APPLICATION_CREDENTIALS`. **No setear `security.auth.enforcedType`** conflictivo. Sin var de auth → `process.exit(FATAL_AUTHENTICATION_ERROR)` (no browser). El host necesita un flujo para que el usuario provea la API key (Settings/AddProject). |
+| **Drift OTEL** (correlación `session.id` vs `specrails.job_id`) | Telemetry OFF por defecto → no bloquea v1. Al activar: validar si Gemini propaga `OTEL_RESOURCE_ATTRIBUTES`; fallback correlación por `--session-id` de spawn-time. |
+| **Bug OTLP/HTTP #15581** (POST a `/` no `/v1/{signal}`) | Usar `GEMINI_TELEMETRY_OTLP_PROTOCOL=grpc` (default :4317, well-tested), evitar HTTP. |
+| **Coste >200k tokens infra-estimado** | Aceptado en v1 (tier ≤200k). Analytics marca `estimated`. Follow-up: tiering en `PriceEntry`. |
+
+---
+
+## 8. Plan de tests + coverage
+
+CI exige **80% server** (lines/functions/statements, 70% branches) y **80% client** (lines/statements, 70% functions). Cada fichero tocado debe llegar.
+
+**Tests nuevos server:**
+- `server/providers/gemini-adapter.test.ts` (espejo de `codex-adapter.test.ts`):
+  - `capabilities` exactos (8 campos).
+  - `buildArgs` por cada uno de los 9 SpawnActions (línea exacta; resume throw si `!sessionId`; chat-stream throw; fold cuando `systemPromptArg=false`; `extraArgs` appendeado).
+  - `parseStreamLine`: fixtures NDJSON bajo `server/providers/__fixtures__/gemini-*.ndjson` (init/message/tool_use/tool_result/error/result/línea-vacía/parse-fail), aserción del AdapterEvent[].
+  - `extractResult`: stats → tokens_in/out/cache_read, num_turns, session_id, `total_cost_usd` undefined.
+  - `detectInstalled`: mock de `execSync` (no instalado / version OK / version < min / probe-fail / timeout >3s → installed:false).
+- `server/pricing.test.ts`: 4 filas `gemini:*`, `estimateCostUsd('gemini',model,usage)` correcto; clave ausente → null; semántica cached (no doble-conteo).
+- `server/provider-selection.test.ts`: `isProviderEnabled`/`resolveProvider`/`validateRequestedProvider` aceptan `'gemini'`; multi-provider claude+gemini.
+- `server/providers/registry.test.ts`: `getAdapter('gemini')`/`hasAdapter`/`listAdapters` incluye gemini tras import de index.
+
+**Tests nuevos client:**
+- `ModelSelector`/`ChatInput`: provider `'gemini'` muestra `GEMINI_MODELS` (no Codex).
+- `AddProjectDialog`: checkbox gemini cuando `/available-providers` lo devuelve; `noProviderAvailable` iterado.
+- `provider-capabilities.test.ts`: `providerLabel('gemini')`, `sectionVisibleForProviders` oculta Agents/SMASH en proyecto con gemini (paridad codex).
+- `ProviderBreakdownCard`/`Navbar`: label+accent gemini.
+
+**Gate `SPECRAILS_GEMINI_BETA`**: test en `desktop-router.test.ts` — con `=0`, `/available-providers` devuelve `gemini:false` y `POST /projects` con `providers:['gemini']` se rechaza; default/`1` → habilitado. Espejo de `SPECRAILS_CODEX_BETA`.
+
+**Cumplir 80%**: el adapter es lógica pura (sin I/O salvo `detectInstalled` mockeado) → fácil 100%. Cubrir los 9 cases de `buildArgs` garantiza branch coverage. Las filas pricing y los branches `=== 'codex'` generalizados necesitan un test que ejercite el path gemini (ai-edit con provider gemini → `adapter.binary='gemini'`). Excluir solo lo Tauri-only inalcanzable en jsdom, documentando inline; **nunca para enmascarar tests faltantes**.
+
+---
+
+## 9. Rollout por fases
+
+1. **PR-A (generalización previa)** — ensanchar `CliProvider`/`ProviderId`/las ~12 uniones `('claude'|'codex')[]`, desramificar `/available-providers` y `spec-models.ts`/`ModelSelector`/`ChatInput` a lookups por id. **Sin Gemini todavía**; comportamiento idéntico. Mergeable y testeable solo. Reduce el blast-radius del PR-B.
+2. **PR-B (el adapter)** — `gemini-adapter.ts` + `register` + filas pricing + branches gemini (ai-edit dispatch, setup-manager regex, install-hint) + labels/accents + `SPECRAILS_GEMINI_BETA`. **Gemini detrás del gate beta**, default ON con kill-switch.
+3. **Beta-gated validation** — probar end-to-end: detect, add-project con gemini, Quick spec, Explore multi-turno (resume), Analytics coste, terminal launch. Validar exit 53/42, auth `GEMINI_API_KEY`. **NO** habilitar rails reales hasta resolver la traducción slash-command (§6, bloqueante) — gemini sirve para spec/explore/quick en esta fase.
+4. **Docs** — crear `docs/adding-a-provider.md` (falta) con gemini como ejemplo, y `docs/gemini.md` (espejo de `docs/codex.md`) con setup de API key.
+
+**Primer commit recomendado:** PR-A paso atómico — ensanchar `server/desktop-db.ts:10` `CliProvider` para incluir `'gemini'` y convertir el ternario de `server/spec-models.ts:1-37` `getModelsForProvider` en lookup `Record<provider, SpecModelOption[]>`. Desbloquea la cadena de tipos sin tocar comportamiento y deja la base lista para registrar el adapter.
+
+**Puntos `[UNCERTAIN]` pendientes (no inventados):** (a) `OTEL_RESOURCE_ATTRIBUTES` propagation en Gemini — validar empíricamente antes de confiar para correlación job/project; (b) semántica de `cachedContentTokenCount` como subconjunto de input — fijar por test de pricing; (c) `mcpRegistration` exacto en la versión bundleada — verificado que escribe a settings.json (`project-json`), confirmar en build. Ninguno bloquea v1 (spec/explore/quick); todos tienen fallback.

--- a/server/agent-refine-manager.ts
+++ b/server/agent-refine-manager.ts
@@ -7,7 +7,7 @@ import { testCustomAgent } from './agent-generator'
 import { recordInvocation } from './ai-invocations'
 import { finaliseInvocationResult } from './result-event'
 import { runAiCliInvocation } from './spawn-lifecycle'
-import { getAdapter, type ProviderAdapter, type AdapterEvent } from './providers'
+import { getAdapter, type ProviderAdapter, type AdapterEvent, type ProviderId } from './providers'
 import type { DbInstance } from './db'
 import type {
   WsMessage,
@@ -70,7 +70,7 @@ export class AgentRefineManager {
     db: DbInstance,
     projectPath: string,
     projectId?: string,
-    provider?: 'claude' | 'codex',
+    provider?: ProviderId,
   ) {
     this._broadcast = broadcast
     this._db = db

--- a/server/chat-manager.ts
+++ b/server/chat-manager.ts
@@ -12,7 +12,7 @@ import { finaliseInvocationResult } from './result-event'
 import { randomUUID } from 'crypto'
 import { parseSpecDraftBlocks, applyBlocks, type ConversationDraftState } from './spec-draft-parser'
 import { attachmentManager, USER_ATTACHMENT_SYSTEM_NOTE } from './attachment-manager'
-import { getAdapter, type ProviderAdapter, type AdapterEvent } from './providers'
+import { getAdapter, type ProviderAdapter, type AdapterEvent, type ProviderId } from './providers'
 import {
   buildScopedSystemPromptPrefix, toolFlagsForScope, normalizeContextScope,
   defaultBootScope, type ContextScope,
@@ -121,7 +121,7 @@ export class ChatManager {
     db: DbInstance,
     cwd?: string,
     projectName?: string,
-    provider?: 'claude' | 'codex',
+    provider?: ProviderId,
     projectId?: string,
     projectSlug?: string,
   ) {
@@ -329,7 +329,7 @@ export class ChatManager {
         slug: this._projectSlug,
         projectPath: this._cwd,
         projectName: this._projectName,
-        provider: (providerId ?? this._adapter.id) as 'claude' | 'codex',
+        provider: providerId ?? this._adapter.id,
       })
       console.log(`[chat-manager] explore spawn cwd=${cwd} (mcp=off)`)
       return cwd

--- a/server/desktop-db.ts
+++ b/server/desktop-db.ts
@@ -3,11 +3,16 @@ import path from 'path'
 import os from 'os'
 import Database from 'better-sqlite3'
 import type { DbInstance } from './db'
+import type { ProviderId } from './providers/types'
 import { secureDir, secureDbFile } from './util/secure-fs'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-export type CliProvider = 'claude' | 'codex'
+// Provider id for a project. Open by design: the set of valid ids is owned by
+// the provider registry (`server/providers`), not this union — adding a provider
+// is one adapter file + one `register()` call, with no type edit here. Runtime
+// validation of an actual value goes through `hasAdapter` / `validateRequestedProvider`.
+export type CliProvider = ProviderId
 
 export interface ProjectRow {
   id: string

--- a/server/desktop-router.ts
+++ b/server/desktop-router.ts
@@ -159,13 +159,13 @@ export function createDesktopRouter(
     const providers = detectAvailableCLIs()
     // tiers: quick install is always available (app-driven config); full requires an AI CLI
     const tiers: ('quick' | 'full')[] = ['quick']
-    if (providers.claude || providers.codex) tiers.push('full')
-    const codexBetaOff = isCodexBetaDisabled()
-    res.json({
-      claude: providers.claude,
-      codex: codexBetaOff ? false : providers.codex,
-      tiers,
-    })
+    if (Object.values(providers).some(Boolean)) tiers.push('full')
+    // Return the full detected map (registry-driven) so a newly-registered
+    // provider surfaces here with no edit. Apply per-provider beta gates: codex
+    // is forced unavailable when SPECRAILS_CODEX_BETA=0 (emergency rollback).
+    const gated: Record<string, boolean> = { ...providers }
+    if (isCodexBetaDisabled()) gated.codex = false
+    res.json({ ...gated, tiers })
   })
 
   router.get('/setup-prerequisites', (req, res) => {
@@ -262,8 +262,8 @@ export function createDesktopRouter(
         slug,
         name: derivedName,
         path: canonicalPath,
-        provider: providers[0] as 'claude' | 'codex',
-        providers: providers as ('claude' | 'codex')[],
+        provider: providers[0],
+        providers,
       })
       broadcast({
         type: 'desktop.project_added',

--- a/server/explore-cwd-manager.ts
+++ b/server/explore-cwd-manager.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import { getAdapter } from './providers'
-import type { ProviderAdapter } from './providers/types'
+import type { ProviderAdapter, ProviderId } from './providers/types'
 
 /**
  * ExploreCwdManager owns the per-project app-managed cwd used to spawn the
@@ -92,7 +92,7 @@ export interface ExploreCwdInput {
   projectName: string
   /** Provider id from the project row. Defaults to claude for backwards
    *  compatibility with callers that haven't been threaded the project yet. */
-  provider?: 'claude' | 'codex'
+  provider?: ProviderId
 }
 
 /**

--- a/server/project-registry.ts
+++ b/server/project-registry.ts
@@ -36,6 +36,7 @@ import {
   clearAgentJob,
   getDesktopSetting,
   type ProjectRow,
+  type CliProvider,
 } from './desktop-db'
 import { getConfig } from './config'
 
@@ -112,8 +113,8 @@ export class ProjectRegistry {
     slug: string
     name: string
     path: string
-    provider?: 'claude' | 'codex'
-    providers?: ('claude' | 'codex')[]
+    provider?: CliProvider
+    providers?: CliProvider[]
   }): ProjectContext {
     const row = addProjectToDesktopDb(this._desktopDb, opts)
     return this._loadProjectContext(row)

--- a/server/queue-manager.ts
+++ b/server/queue-manager.ts
@@ -22,7 +22,7 @@ import {
 } from './file-provenance'
 import { finaliseInvocationResult } from './result-event'
 import { randomUUID } from 'crypto'
-import { getAdapter, type ProviderAdapter, type AdapterEvent } from './providers'
+import { getAdapter, type ProviderAdapter, type AdapterEvent, type ProviderId } from './providers'
 import { createCodexOtelBridge, type CodexOtelBridge } from './codex-otel-bridge'
 import { createJob, finishJob, appendEvent, skipJob, getProjectSettings, getUltracodePrePrompt, DEFAULT_ULTRACODE_PRE_PROMPT, finalizeInteractiveJob } from './db'
 import type { JobResult } from './db'
@@ -133,7 +133,7 @@ export interface EnqueueOptions {
   /** Per-job AI engine override (multi-provider projects). When omitted the
    *  job runs with the project's primary provider (this._adapter). Validated by
    *  the route layer against the project's installed providers. */
-  provider?: 'claude' | 'codex'
+  provider?: ProviderId
   /** Per-job model override (e.g. ultracode rails let the user pick
    *  haiku/sonnet/opus per launch). For claude this becomes the `--model`
    *  value, taking precedence over the project orchestrator model. In-memory
@@ -189,7 +189,7 @@ export class QueueManager {
   /** Pending per-job provider override keyed by jobId — read at spawn time.
    *  In-memory only (mirrors _jobProfileSelection): a queued job that survives a
    *  restart falls back to the project's primary provider. */
-  private _jobProviderSelection: Map<string, 'claude' | 'codex'>
+  private _jobProviderSelection: Map<string, ProviderId>
   /** Pending per-job model override keyed by jobId — read at spawn time.
    *  In-memory only (mirrors _jobProviderSelection). */
   private _jobModelSelection: Map<string, string>
@@ -212,7 +212,7 @@ export class QueueManager {
       zombieTimeoutMs?: number
       getCostAlertThreshold?: () => number | null
       getDesktopDailyBudget?: () => { budget: number | null; totalSpend: number }
-      provider?: 'claude' | 'codex'
+      provider?: ProviderId
       /** Effective model for codex spawns. If omitted, falls back to 'gpt-5.5'. */
       resolvedModel?: string
       onJobFinished?: (jobId: string, status: Job['status'], costUsd?: number) => void

--- a/server/result-event.ts
+++ b/server/result-event.ts
@@ -17,7 +17,7 @@
 // Spec: openspec/specs/multi-provider-architecture/spec.md
 // Spec: openspec/changes/add-multi-provider-support/specs/project-spending/spec.md
 
-import type { AdapterEvent, NormalisedResult, ProviderAdapter } from './providers/types'
+import type { AdapterEvent, NormalisedResult, ProviderAdapter, ProviderId } from './providers/types'
 import { estimateCostUsd } from './pricing'
 
 export type { NormalisedResult } from './providers/types'
@@ -97,7 +97,7 @@ export function finaliseInvocationResult(
 
 export function normaliseResultEvent(
   event: Record<string, unknown> | null | undefined,
-  provider: 'claude' | 'codex' = 'claude',
+  provider: ProviderId = 'claude',
 ): NormalisedResult {
   if (!event) return {}
   if (provider === 'claude') {

--- a/server/setup-manager.ts
+++ b/server/setup-manager.ts
@@ -11,7 +11,7 @@ import { spawnCli } from './util/win-spawn'
 import { formatMissingSetupPrerequisites } from './setup-prerequisites'
 import { CORE_PACKAGE_SPEC } from './core-package'
 import { getAdapter } from './providers'
-import type { ProviderAdapter, SpawnAction } from './providers/types'
+import type { ProviderAdapter, SpawnAction, ProviderId } from './providers/types'
 
 /**
  * specrails-core's installer (Node-native from v4.2.0 onward, bash
@@ -837,7 +837,7 @@ export class SetupManager {
 
   // ─── Enrich: claude -p "/specrails:enrich --from-config" ────────────────────
 
-  startEnrich(projectId: string, projectPath: string, provider?: 'claude' | 'codex', projectName?: string): void {
+  startEnrich(projectId: string, projectPath: string, provider?: ProviderId, projectName?: string): void {
     if (this._setupProcesses.has(projectId)) {
       console.warn(`[SetupManager] enrich already running for ${projectId}`)
       return
@@ -875,11 +875,11 @@ export class SetupManager {
   }
 
   /** @deprecated Use startEnrich() instead */
-  startSetup(projectId: string, projectPath: string, provider?: 'claude' | 'codex'): void {
+  startSetup(projectId: string, projectPath: string, provider?: ProviderId): void {
     return this.startEnrich(projectId, projectPath, provider)
   }
 
-  resumeEnrich(projectId: string, projectPath: string, sessionId: string, userMessage: string, provider?: 'claude' | 'codex'): void {
+  resumeEnrich(projectId: string, projectPath: string, sessionId: string, userMessage: string, provider?: ProviderId): void {
     if (this._setupProcesses.has(projectId)) {
       console.warn(`[SetupManager] enrich already running for ${projectId}`)
       return
@@ -887,7 +887,7 @@ export class SetupManager {
 
     if (provider) this._projectProviders.set(projectId, provider)
 
-    const resolvedProvider = (provider ?? this._projectProviders.get(projectId)) as 'claude' | 'codex' | undefined
+    const resolvedProvider = (provider ?? this._projectProviders.get(projectId)) as ProviderId | undefined
     const adapter = getAdapter(resolvedProvider ?? 'claude')
 
     // Synthetic codex session ids (from before §10) can't be resumed against
@@ -919,7 +919,7 @@ export class SetupManager {
   }
 
   /** @deprecated Use resumeEnrich() instead */
-  resumeSetup(projectId: string, projectPath: string, sessionId: string, userMessage: string, provider?: 'claude' | 'codex'): void {
+  resumeSetup(projectId: string, projectPath: string, sessionId: string, userMessage: string, provider?: ProviderId): void {
     return this.resumeEnrich(projectId, projectPath, sessionId, userMessage, provider)
   }
 
@@ -956,7 +956,7 @@ export class SetupManager {
       action: 'setup-enrich' | 'setup-enrich-resume'
       prompt: string
       sessionId?: string
-      provider?: 'claude' | 'codex'
+      provider?: ProviderId
     },
   ): void {
     const resolvedProvider = opts.provider ?? detectCLISync()

--- a/server/spec-models.test.ts
+++ b/server/spec-models.test.ts
@@ -32,4 +32,12 @@ describe('spec-models', () => {
     expect(getModelsForProvider('claude')).toBe(CLAUDE_MODELS)
     expect(getModelsForProvider('codex')).toBe(CODEX_MODELS)
   })
+
+  it('falls back to claude for an unknown / not-yet-registered provider id', () => {
+    // The provider id type is open (registry-owned). An id without an explicit
+    // catalog entry resolves to Claude's list/default rather than throwing —
+    // the safe behaviour for a provider added before its rows are filled in.
+    expect(getModelsForProvider('gemini')).toBe(CLAUDE_MODELS)
+    expect(getProviderDefault('gemini')).toBe(getProviderDefault('claude'))
+  })
 })

--- a/server/spec-models.ts
+++ b/server/spec-models.ts
@@ -1,4 +1,9 @@
-export type SpecProvider = 'claude' | 'codex'
+import type { ProviderId } from './providers/types'
+
+// Open provider id (see desktop-db `CliProvider`). The per-provider model
+// catalog below is a data-driven lookup, not a closed union — a new provider
+// adds one entry to `PROVIDER_MODELS` + `PROVIDER_DEFAULT_MODEL`, no branching.
+export type SpecProvider = ProviderId
 
 export interface SpecModelOption {
   value: string
@@ -18,13 +23,19 @@ export const CODEX_MODELS: SpecModelOption[] = [
   { value: 'gpt-5.3-codex', label: 'GPT-5.3 Codex' },
 ]
 
-export const PROVIDER_DEFAULT_MODEL: Record<SpecProvider, string> = {
+/** Per-provider model catalog. Lookup, not a branch — fallback is Claude's. */
+const PROVIDER_MODELS: Record<string, SpecModelOption[]> = {
+  claude: CLAUDE_MODELS,
+  codex: CODEX_MODELS,
+}
+
+export const PROVIDER_DEFAULT_MODEL: Record<string, string> = {
   claude: 'sonnet',
   codex: 'gpt-5.5',
 }
 
 export function getModelsForProvider(provider: SpecProvider): SpecModelOption[] {
-  return provider === 'codex' ? CODEX_MODELS : CLAUDE_MODELS
+  return PROVIDER_MODELS[provider] ?? CLAUDE_MODELS
 }
 
 export function isValidModelForProvider(model: unknown, provider: SpecProvider): model is string {
@@ -33,5 +44,5 @@ export function isValidModelForProvider(model: unknown, provider: SpecProvider):
 }
 
 export function getProviderDefault(provider: SpecProvider): string {
-  return PROVIDER_DEFAULT_MODEL[provider]
+  return PROVIDER_DEFAULT_MODEL[provider] ?? PROVIDER_DEFAULT_MODEL.claude
 }


### PR DESCRIPTION
## What

Prerequisite refactor (**PR-A of 2**) for adding a third AI provider (Gemini CLI). Widens the canonical provider-id types to the registry-owned open `ProviderId` and makes the provider-enumerating surfaces data-driven, so a future adapter is *one file + one registry entry* instead of a scattered edit across ~50 literal-union sites.

**No behaviour change.** Byte-identical for `claude`/`codex`; no new provider id is introduced anywhere.

## Server
- `CliProvider` / `SpecProvider` → `= ProviderId` (open string; runtime validation stays in the registry via `hasAdapter`).
- `getModelsForProvider` / `PROVIDER_DEFAULT_MODEL` → data-driven lookups with a Claude fallback instead of a `codex?:claude` ternary (+ a test exercising the unknown-provider fallback).
- `GET /available-providers` returns the full `detectAvailableCLIs()` registry map (codex beta-gate preserved) instead of a hardcoded `{claude, codex}`.
- Dropped `as 'claude'|'codex'` casts; widened manager signatures (queue / chat / setup / agent-refine / result-event / explore-cwd) to `ProviderId`.

## Client
- `provider-capabilities.ProviderId` → `string`; widened `useDesktop` (`DesktopProject`, `projectProviders`, `addProject`).
- De-branched `ModelSelector` per-provider maps; widened cascade roots (`BottomPanel`, `ChatInput`, `ProposeSpecModal`, `SpecModelPicker`, `TerminalTopBar`).

## Deferred to PR-B (the adapter)
Typecheck-guided once the provider actually exists: the data-driven `AddProjectDialog` rewrite (still hardcodes the `{claude, codex}` checkboxes) and the remaining cosmetic inline `'claude'|'codex'` annotations in the engine selectors. They compile today and break only when a third provider id flows.

## Verification
- `npm run typecheck` (server + CLI + client): ✅ exit 0
- Server tests: 3601/3602 (the 1 is a flaky `setup-prerequisites` exec-probe timeout — passes in isolation)
- Server coverage: ✅ exit 0 (83.6 stmt / 74.6 br / 87.2 fn / 85.3 ln)
- Client tests: 2674/2674 ✅
- Client coverage: ✅ exit 0 (84.9 / 81.2 / 72.4 / 84.9)

Design rationale: `docs/gemini-cli-provider-study.md` (added here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)