### PR TITLE
feat(providers): add Gemini CLI as a third provider (PR-B, beta-gated)

### DIFF
--- a/client/src/components/AddProjectDialog.tsx
+++ b/client/src/components/AddProjectDialog.tsx
@@ -19,16 +19,33 @@ import { usePrerequisites } from '../hooks/usePrerequisites'
 import { PrerequisitesPanel } from './PrerequisitesPanel'
 import { InstallInstructionsModal } from './InstallInstructionsModal'
 import { cn } from '../lib/utils'
+import type { ProviderId } from '../lib/provider-capabilities'
 
 interface AddProjectDialogProps {
   open: boolean
   onClose: () => void
 }
 
-type Provider = 'claude' | 'codex'
+type Provider = ProviderId
 
 // Canonical ordering — the first selected provider becomes the project primary.
-const PROVIDER_ORDER: Provider[] = ['claude', 'codex']
+// Providers detected by the server but not listed here still render (appended in
+// discovery order), so a new provider needs no edit to appear in the dialog.
+const PROVIDER_ORDER: Provider[] = ['claude', 'codex', 'gemini']
+
+// Display metadata per provider id; unknown ids fall back to a neutral chip.
+const PROVIDER_META: Record<string, { icon: string; label: string }> = {
+  claude: { icon: '🤖', label: 'Claude' },
+  codex: { icon: '⚡', label: 'Codex' },
+  gemini: { icon: '✨', label: 'Gemini' },
+}
+
+// Render order: known providers (canonical), then any extra detected ones.
+function providerRenderOrder(avail: Record<string, boolean>): string[] {
+  const known = PROVIDER_ORDER.filter((id) => id in avail)
+  const extras = Object.keys(avail).filter((id) => !PROVIDER_ORDER.includes(id))
+  return [...known, ...extras]
+}
 
 export function AddProjectDialog({ open, onClose }: AddProjectDialogProps) {
   // Multi-select: a project can be created with one or both providers. When both
@@ -38,7 +55,10 @@ export function AddProjectDialog({ open, onClose }: AddProjectDialogProps) {
   const [projectPath, setProjectPath] = useState('')
   const [projectName, setProjectName] = useState('')
   const [isAdding, setIsAdding] = useState(false)
-  const [availableProviders, setAvailableProviders] = useState<{ claude: boolean; codex: boolean }>({ claude: true, codex: false })
+  // Initial render default (claude + codex visible immediately, no flash); the
+  // /available-providers fetch overwrites this with the real server map, which
+  // also adds any beta-gated provider (e.g. gemini) when enabled.
+  const [availableProviders, setAvailableProviders] = useState<Record<string, boolean>>({ claude: true, codex: false })
   const [installModalOpen, setInstallModalOpen] = useState(false)
 
   const { t } = useTranslation('setup')
@@ -60,19 +80,21 @@ export function AddProjectDialog({ open, onClose }: AddProjectDialogProps) {
     if (!open) return
     fetch('/api/available-providers')
       .then((r) => r.json())
-      .then((data) => {
-        // Honour the server's real availability. The emergency-rollback env
-        // var `SPECRAILS_CODEX_BETA=0` on the server reports codex:false
-        // even if the binary is installed.
-        const claude = Boolean(data.claude)
-        const codex = Boolean(data.codex)
-        setAvailableProviders({ claude, codex })
+      .then((data: Record<string, unknown>) => {
+        // Honour the server's real availability map. Providers gated off by env
+        // (codex SPECRAILS_CODEX_BETA=0 reports false; gemini opt-in is omitted)
+        // simply don't appear / aren't selectable here.
+        const avail: Record<string, boolean> = {}
+        for (const [k, v] of Object.entries(data)) {
+          if (k === 'tiers') continue
+          avail[k] = Boolean(v)
+        }
+        setAvailableProviders(avail)
         // Default selection: every available provider is pre-selected, so the
-        // common "I have both" case sets up a multi-provider project in one
+        // common "I have these" case sets up a multi-provider project in one
         // click. The user can deselect down to one before submitting.
         const next = new Set<Provider>()
-        if (claude) next.add('claude')
-        if (codex) next.add('codex')
+        for (const id of providerRenderOrder(avail)) if (avail[id]) next.add(id)
         if (next.size === 0) next.add('claude') // keep submit gating to drive the empty state
         setSelectedProviders(next)
       })
@@ -93,7 +115,7 @@ export function AddProjectDialog({ open, onClose }: AddProjectDialogProps) {
   }
 
   // Ordered list (primary first) for submission + summary.
-  const orderedSelected = PROVIDER_ORDER.filter((p) => selectedProviders.has(p) && availableProviders[p])
+  const orderedSelected = providerRenderOrder(availableProviders).filter((p) => selectedProviders.has(p) && availableProviders[p])
 
   async function handleAdd() {
     const trimmedPath = projectPath.trim()
@@ -138,7 +160,7 @@ export function AddProjectDialog({ open, onClose }: AddProjectDialogProps) {
     if (!isOpen) resetAndClose()
   }
 
-  const noProviderAvailable = !availableProviders.claude && !availableProviders.codex
+  const noProviderAvailable = !Object.values(availableProviders).some(Boolean)
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -231,10 +253,8 @@ export function AddProjectDialog({ open, onClose }: AddProjectDialogProps) {
           <div className="space-y-1.5">
             <label className="text-xs font-medium text-muted-foreground">{t('addProject.providersLabel')}</label>
             <div className="flex gap-2">
-              {([
-                { id: 'claude' as Provider, icon: '🤖', label: 'Claude' },
-                { id: 'codex' as Provider, icon: '⚡', label: 'Codex' },
-              ]).map(({ id, icon, label }) => {
+              {providerRenderOrder(availableProviders).map((id) => {
+                const { icon, label } = PROVIDER_META[id] ?? { icon: '•', label: id }
                 const avail = availableProviders[id]
                 const checked = selectedProviders.has(id) && avail
                 return (

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -4,9 +4,10 @@ import { useTranslation } from 'react-i18next'
 import { Settings, BookOpen, LayoutDashboard, BarChart3 } from 'lucide-react'
 import { cn } from '../lib/utils'
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip'
+import type { ProviderId } from '../lib/provider-capabilities'
 
 interface CLIStatus {
-  provider: 'claude' | 'codex' | null
+  provider: ProviderId | null
   version: string | null
 }
 
@@ -28,14 +29,18 @@ function CLIBadge() {
       ? `Claude Code${status.version ? ` v${status.version}` : ''}`
       : status.provider === 'codex'
         ? `Codex CLI${status.version ? ` v${status.version}` : ''}`
-        : t('navbar.noCli')
+        : status.provider === 'gemini'
+          ? `Gemini CLI${status.version ? ` v${status.version}` : ''}`
+          : t('navbar.noCli')
 
   const badgeClass =
     status.provider === 'claude'
       ? 'bg-blue-500/15 text-blue-400 aurora-light:text-accent-info border-blue-500/30 aurora-light:border-accent-info/30'
       : status.provider === 'codex'
         ? 'bg-orange-500/15 text-orange-400 aurora-light:text-accent-warning border-orange-500/30 aurora-light:border-accent-warning/30'
-        : 'bg-red-500/15 text-red-400 aurora-light:text-destructive border-red-500/30 aurora-light:border-destructive/30'
+        : status.provider === 'gemini'
+          ? 'bg-green-500/15 text-green-400 aurora-light:text-accent-success border-green-500/30 aurora-light:border-accent-success/30'
+          : 'bg-red-500/15 text-red-400 aurora-light:text-destructive border-red-500/30 aurora-light:border-destructive/30'
 
   const tooltip =
     status.provider === null

--- a/client/src/components/__tests__/AddProjectDialog.test.tsx
+++ b/client/src/components/__tests__/AddProjectDialog.test.tsx
@@ -259,6 +259,24 @@ describe('AddProjectDialog', () => {
     })
   })
 
+  it('renders a Gemini toggle when the server reports it (data-driven, beta on)', async () => {
+    // The provider list is data-driven: a beta-gated provider the server returns
+    // appears with no per-provider edit. When the beta is off the server omits
+    // gemini, so it never shows.
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ claude: true, codex: true, gemini: true }),
+    })
+
+    render(<AddProjectDialog open={true} onClose={vi.fn()} />)
+
+    await waitFor(() => {
+      const geminiBtn = screen.getByRole('checkbox', { name: /Gemini/i })
+      expect(geminiBtn).not.toBeDisabled()
+      expect(geminiBtn).not.toHaveTextContent(/not found/i)
+    })
+  })
+
   it('selects both providers by default when both are available and submits both', async () => {
     const user = userEvent.setup()
     global.fetch = vi.fn().mockImplementation(async (input: RequestInfo | URL) => {

--- a/client/src/components/analytics/ProviderBreakdownCard.tsx
+++ b/client/src/components/analytics/ProviderBreakdownCard.tsx
@@ -9,11 +9,13 @@ interface Props {
 const PROVIDER_LABEL: Record<string, string> = {
   claude: 'Claude',
   codex: 'Codex',
+  gemini: 'Gemini',
 }
 
 const PROVIDER_ACCENT: Record<string, string> = {
   claude: 'bg-accent-info',
   codex: 'bg-accent-highlight',
+  gemini: 'bg-accent-success',
 }
 
 function fmtUsd(v: number): string {

--- a/client/src/components/analytics/__tests__/ProviderBreakdownCard.test.tsx
+++ b/client/src/components/analytics/__tests__/ProviderBreakdownCard.test.tsx
@@ -103,15 +103,15 @@ describe('ProviderBreakdownCard', () => {
   it('falls back to the raw id and secondary accent for unknown providers', () => {
     const data = makeData([
       makeProvider({ provider: 'claude', count: 2, costUsd: 0.5 }),
-      makeProvider({ provider: 'gemini', count: 3, costUsd: 0.005 }),
+      makeProvider({ provider: 'mystery', count: 3, costUsd: 0.005 }),
     ])
     const { container } = render(<ProviderBreakdownCard data={data} loading={false} />)
 
-    expect(screen.getByText('gemini')).toBeInTheDocument()
+    expect(screen.getByText('mystery')).toBeInTheDocument()
     // fmtUsd branches: >= 0.01 → two decimals; tiny → four decimals
     expect(screen.getByText('$0.50')).toBeInTheDocument()
     expect(screen.getByText('$0.0050')).toBeInTheDocument()
-    const segment = container.querySelector('[title="gemini: $0.0050 (3)"]')
+    const segment = container.querySelector('[title="mystery: $0.0050 (3)"]')
     expect(segment).toBeInTheDocument()
     expect(segment).toHaveClass('bg-accent-secondary')
   })

--- a/docs/adding-a-provider.md
+++ b/docs/adding-a-provider.md
@@ -1,0 +1,107 @@
+# Adding a provider
+
+Specrails drives every AI CLI through one contract: the **`ProviderAdapter`**
+(`server/providers/types.ts`). Managers (chat, queue, agent-refine, setup,
+result-event, project-router) consume the adapter exclusively — they branch on
+`adapter.capabilities.*`, **never** on `provider === 'x'`. So a new provider is, in
+the ideal case, *one adapter file + one registry line*. In practice you also fill a
+few non-adapter seams (pricing, labels, install) that are inherently
+provider-specific. This guide walks the real example: **Gemini CLI**.
+
+## 1. Write the adapter (the one required file)
+
+`server/providers/<id>-adapter.ts`, exporting a `ProviderAdapter`. Mirror
+`codex-adapter.ts` (the reference non-native provider). You implement:
+
+| Member | What it is |
+|---|---|
+| `id` / `displayName` / `binary` | the provider id, UI name, and PATH binary |
+| `minCliVersion` | floor version for `detectInstalled` |
+| `projectDirName` / `instructionsFilename` / `mcpRegistration` | filesystem conventions (e.g. `.gemini` / `GEMINI.md` / `project-json`) |
+| `capabilities` | `nativeResume`, `nativeStreamJson`, `nativeCostUsd`, `nativeOtelEnv`, `profileEnvSupport`, `systemPromptArg`, optional `persistentStdin` — managers gate on these |
+| `modelCatalog()` / `defaultModel()` | UI dropdowns + profile validation |
+| `buildArgs(action, opts)` | argv per `SpawnAction` (`chat-turn`, `chat-resume`, `rail-job`, `spec-gen`, …) |
+| `parseStreamLine(line)` | one NDJSON line → an `AdapterEvent` (`text-delta` / `tool-use` / `session-started` / `result` / `other`) |
+| `extractResult(events)` | accumulated events → `NormalisedResult` (tokens, session id, optional cost) |
+| `baselineAgents()` / `detectInstalled()` | rail agent names; a ≤3s health probe |
+
+Two rules that bite:
+- **`systemPromptArg: false`** ⇒ the CLI has no `--system-prompt` flag, so fold the
+  system prompt into the user prompt — **except** Explore turns, which must stay
+  user-text-only (a long system prompt drowns a short Explore message); they rely on
+  the app-managed instructions file in the explore cwd instead.
+- **`nativeCostUsd: false`** ⇒ add a rate card (step 3); `extractResult` leaves
+  `total_cost_usd` undefined and the framework estimates it. If your token usage
+  reports `cached` as a **subset** of input (it usually does), map it to
+  `tokens_cache_read` — `pricing.ts` already bills `tokens_in - tokens_cache_read`
+  at the input rate and the cached portion at the cache rate.
+
+## 2. Register it (the one required line)
+
+`server/providers/index.ts`:
+
+```ts
+import { geminiAdapter } from './gemini-adapter'
+register(geminiAdapter)
+export { /* … */ geminiAdapter }
+```
+
+That's enough for `getAdapter('gemini')`, `detectAvailableCLIs()`, the spec model
+catalog, and provider-selection to all see it (they're registry-driven).
+
+## 3. Pricing (only if `nativeCostUsd: false`)
+
+Add `<id>:<model>` rows to `PRICING` in `server/pricing.ts` (USD per 1M tokens, with
+a `lastReviewedAt`). A model without a row persists cost = NULL (fail-soft).
+
+## 4. Spawn quirks (only if the binary needs them)
+
+Per-binary spawn quirks live in `server/util/cli-prompt.ts` (the spawn layer that
+already special-cases `spawnClaude`/`spawnCodex`). Gemini needed
+`GEMINI_CLI_TRUST_WORKSPACE=true` injected (its "trusted folders" gate otherwise
+silently disables `--yolo`); see `spawnGemini`.
+
+## 5. Beta gate (optional, recommended for a new/unverified provider)
+
+If the CLI's stream schema isn't yet validated against a live binary, gate selection
+behind `SPECRAILS_<ID>_BETA` in `server/desktop-router.ts` (mirror
+`isGeminiBetaEnabled` / `isCodexBetaDisabled`): omit/false the provider in
+`GET /available-providers` and reject it in `POST /projects` until the flag is set.
+
+## 6. The non-adapter seams (provider-specific by nature)
+
+These don't fit the adapter and need a small explicit touch:
+
+- **Install** (`specrails-core`, separate repo): a provider whose *rails* must run
+  needs core to emit its command/agent/skill tree (e.g. `.gemini/commands/*.toml`,
+  `.gemini/agents/sr-*.md`). The desktop adapter alone covers spec/explore/quick.
+- **UI labels/accents**: `client/.../Navbar.tsx`, `analytics/ProviderBreakdownCard.tsx`
+  (label + accent), and `AddProjectDialog`'s `PROVIDER_META` (icon + label). These
+  use `Record<string,string>` lookups with graceful fallbacks, so they degrade to
+  the raw id if you forget — add the entry for a polished chip.
+- **Legacy non-adapter handlers**: a few endpoints predate the adapter and branch on
+  `provider === 'codex' / 'claude'` (e.g. the ticket AI-edit handler in
+  `project-router-tickets.ts`). Keep claude/codex byte-identical and route the
+  `else` through `getAdapter(provider)` so every other provider works generically.
+
+## 7. Tests + coverage (mandatory)
+
+- `server/providers/<id>-adapter.test.ts` mirroring `codex-adapter.test.ts`:
+  identity, capabilities, every `buildArgs` action, `parseStreamLine` (use NDJSON
+  fixtures under `__fixtures__/<id>/<version>/`), `extractResult`, `detectInstalled`.
+- Pricing rows, provider-selection, and any beta-gate behaviour.
+- CI thresholds are hard gates (80% server / 80% client) — see CLAUDE.md.
+
+## Checklist
+
+- [ ] `server/providers/<id>-adapter.ts`
+- [ ] `register(<id>Adapter)` in `index.ts`
+- [ ] pricing rows (if not native cost)
+- [ ] spawn quirk in `cli-prompt.ts` (if any)
+- [ ] `SPECRAILS_<ID>_BETA` gate (if unverified)
+- [ ] UI labels (Navbar, ProviderBreakdownCard, AddProjectDialog meta)
+- [ ] adapter tests + fixtures, coverage green
+- [ ] `docs/<id>.md`
+- [ ] (rails) core emits the provider's command/agent tree
+
+See `server/providers/gemini-adapter.ts` and `docs/gemini.md` for the worked example.

--- a/docs/agy-cli-provider-study.md
+++ b/docs/agy-cli-provider-study.md
@@ -1,0 +1,179 @@
+# Estudio: ¿Integrar `agy` (Antigravity CLI) como tercer proveedor en lugar de Gemini CLI?
+
+> Documento de planificación (plan B / watch-item). Generado 2026-06-17 mediante investigación multi-agente de fuentes primarias (issue tracker `google-antigravity/antigravity-cli`, CHANGELOG, Google Developers Blog, GitHub API). Complementa `docs/gemini-cli-provider-study.md` (el plan principal). Lo marcado `[no verificado]` se señala explícitamente.
+
+---
+
+## 1. Respuesta directa
+
+> ## VEREDICTO: **NO — todavía no.** Integra `gemini-cli` (path `GEMINI_API_KEY`) como tercer proveedor ahora, y trata `agy` como **watch-item gated por issues**, no como objetivo actual.
+
+La premisa ("`agy` es el sucesor oficial, no quiero construir sobre algo deprecado") es **correcta a medias y, para nuestro contrato concreto, lleva a la conclusión opuesta**:
+
+1. **El sunset NO mata el path que nos interesa.** Verificado contra fuente primaria (Google Developers Blog, "Transitioning Gemini CLI to Antigravity CLI"). El 18-jun-2026 lo que deja de servirse son **las peticiones de los logins de suscripción consumer (AI Pro / Ultra) y el tier gratuito**. Literalmente: *"Gemini CLI and Gemini Code Assist IDE extensions will stop serving requests for Google AI Pro and Ultra, as well as those using it free of charge."* Pero el path que un servidor desatendido usaría — **`GEMINI_API_KEY` de pago / enterprise** — **sobrevive explícitamente**: *"Gemini CLI will remain accessible via paid Gemini and Gemini Enterprise Agent Platform API keys"* y *"We'll continue to support Gemini CLI ... with access to the latest Gemini models and other updates."* El repo `google-gemini/gemini-cli` está **vivo** (`archived:false`, último push 2026-06-17, releases activas v0.46.0 estable / v0.48.0-nightly).
+
+2. **`agy` no satisface el contrato hoy, en ninguna de sus 5 patas críticas a la vez.** Verificado contra el issue tracker (todos OPEN, cero respuesta de Google, a 2026-06-17): `#76` (stdout 0 bytes en non-TTY → rompe la captura básica de subproceso), `#7` (el conversation/session id **nunca** se expone → no hay handle que capturar para `--resume`), `#31` (sin `--acp`/JSON-RPC), `#119`/`#394` (sin `--output-format json`/stream-json), `#78` (OAuth-only, sin auth por API-key headless). Además `#85` (cerrado sin fix shipado) muestra que en **macOS** — nuestro target de escritorio — un proceso en background re-pide login por el timeout de 1s del keyring. **Coste/tokens no se exponen en NINGÚN sitio** (ni stdout, ni transcript.jsonl, ni CLI): la pata `cost` del contrato es directamente irresoluble hoy.
+
+3. **El factor decisivo de bajo coste:** `agy` y `gemini-cli` **comparten el harness `~/.gemini`** (motor de agente común, settings/skills/MCP compartidos). Integrar `gemini-cli` ahora **no es tirar trabajo** si después migramos a `agy`: la auth, la config MCP y los modelos Gemini 3 ya nos llegan por `gemini-cli` apuntando al mismo `~/.gemini`. El swap a `agy` sería un cambio de transporte, no un re-platforming.
+
+**En una frase:** estudiar `agy` *en lugar de* `gemini-cli` es prematuro porque (a) el binario de `gemini-cli` con API-key no muere, (b) `agy` headless está roto en las 5 patas con silencio total de Google, y (c) ambos comparten harness, así que `gemini-cli` ahora es el puente correcto hacia `agy` después.
+
+---
+
+## 2. Superficie del comando `agy`
+
+`agy` es un agente de terminal en Go (bubbletea/TUI), **closed-source** (el repo solo aloja README + CHANGELOG + binarios + issue tracker). Versión actual **1.0.9** (2026-06-17), cadencia ~3 días. **El volcado verbatim de `agy --help` no se obtuvo** (docs JS-rendered); la superficie se reconstruyó del tracker (decisivo, cita flags contra versiones concretas), los CHANGELOG y specs operativos.
+
+### Headless / scriptable
+| Comando/flag | Notas |
+|---|---|
+| `agy -p "<prompt>"` / `--print` | One-shot headless. **BUG `#76`/`#318`: en non-TTY emite 0 bytes a stdout y stderr, exit 0**, o cuelga. |
+| `--prompt` | Alias/compañero de `-p` (issue `#7`). |
+| `-i` / `--prompt-interactive` | One-shot y **se queda en TUI** → no headless puro. |
+| `-c` / `--continue` | Resume la conversación **más reciente GLOBALMENTE** (peligroso para concurrencia). |
+| `--conversation <id>` | Resume una conversación **específica** por id. Funciona con `-p` (issue `#278`). |
+| `--model <name>` | Nombres descriptivos: `"Gemini 3.5 Flash (Low)"`, `"Gemini 3.1 Pro (High)"`. Default: Gemini 3.5 Flash. (1.0.5.) |
+| `--sandbox` | Aislamiento. Propagación a `-p` arreglada en 1.0.6. |
+| `--print-timeout <dur>` | p.ej. `60s`, `90s`. |
+| `--log-file <path>` | **Trazas operativas (ids, request traces), NO payload de respuesta.** |
+| `--add-dir <path>` | Añade directorio de workspace. |
+| `--dangerously-skip-permissions` | Auto-aprueba todo ("YOLO"). |
+| `--version`, `--help` / `help` | |
+| `agy models` | Lista modelos (1.0.5). |
+| `agy update`, `agy changelog` | Self-update / changelog. |
+| `agy plugin <list\|import\|install\|uninstall\|enable\|disable\|validate\|link\|help>` | `agy plugin import gemini` importa config de gemini-cli. |
+
+### Ausente (feature-requested, NO implementado en 1.0.9 — verbatim del tracker)
+- **`--acp` / `agy acp`** (stdio JSON-RPC) → issue `#31` (OPEN, 81 comentarios, el más pedido), `#195`.
+- **`--output-format json` / `stream-json` / NDJSON** → `#119`, `#394`. *`--output-format` es rechazado: `flags provided but not defined: -output-format`.* `-p` emite **un bloque de texto plano con `<thinking>` mezclado**.
+- **`--session-id` / captura del conversation-id desde `-p`** → `#7`.
+- **`--no-mcp` / `--mcp-config`** → `#342`.
+- **`agy serve` / `agy api` / `agy run` / `agy agent`** → no existen. No hay daemon/HTTP local.
+
+### TUI-only (solo dentro de una sesión activa)
+Bare `agy`, `-i`, `-c`, y **todos** los slash commands: `/help /config /settings /model /mcp /skills /plugins /permissions /hooks /resume /tasks /diff /add-dir /open /btw /changelog /logout /export /goal /schedule /agent /context /usage /artifact` + modo shell `!`.
+
+---
+
+## 3. Transportes de integración — tabla rankeada
+
+Contra el contrato: **output machine-readable + captura session-id + resume + coste/tokens**.
+
+| # | Transporte | Output M-R | Captura session | Resume | Coste/tokens | Viable hoy | Coste en el adapter |
+|---|---|:---:|:---:|:---:|:---:|:---:|---|
+| **2** | **transcript.jsonl on-disk** (+ watcher `brain/`) | ⚠️ texto parseado | ✅ (vía `last_conversations.json` o newest `brain/` dir) | ✅ (`--conversation <id>`) | ❌ no en disco | **⚠️ "el menos malo"** | Reader de JSONL undocumented + watcher de FS + plan de migración a SQLite |
+| **1** | **pseudo-TTY** (`script`/`unbuffer`/node-pty) | ⚠️ texto TUI renderizado | ❌ | ❌ | ❌ | ⚠️ (solo como **complemento** de #2) | node-pty + strip de `<thinking>` + parsing de marcadores sembrados en el prompt |
+| **4** | **SDK Python `google-antigravity`** | ✅ eventos tipados | ✅ in-process (no por id persistido) | ⚠️ in-process (no resume del CLI local) | ⚠️ `total_usage` (alpha, no documentado) | ⚠️ **re-platforming** | **Sidecar Python** separado; abandona el patrón binary-spawn; alpha 0.1.3 |
+| **3** | **Managed Agents API / `agy serve`** | — | — | — | — | ❌ | No existe `agy serve`. La "Managed Agents API" es un **producto cloud separado** (Gemini API), no envuelve el `agy` local |
+| **6** | **`agy -p` plano** | ❌ (`#76` 0 bytes) | ❌ (`#7`) | ⚠️ (id incapturable) | ❌ | ❌ | Roto on-arrival |
+| **5** | **ACP / JSON-RPC stdio** (`--acp`) | ✅ (si existiera) | ✅ | ✅ | ⚠️ | ❌ **vaporware** | El transporte **más limpio** si Google lo shipea; hoy `#31` OPEN sin acuse |
+
+### Lectura de la tabla
+- **El "menos malo" viable hoy = #2 (transcript on-disk) + #1 (PTY) combinados.** PTY garantiza que el proceso completa y da texto de fallback; el transcript da output estructurado-ish (línea final `source=MODEL, status=DONE, type=PLANNER_RESPONSE`), captura de session (watch de `brain/` o `cache/last_conversations.json`) y resume (`agy --conversation <id> -p`). **Satisface 4 de 5 patas.**
+- **La pata `cost` es el muro:** **ningún** source encontró `usageMetadata`/`tokenCount`/`input_tokens`/`cost` en transcript.jsonl, stdout, PTY ni CLI. Un `pricing.ts` rate-card como el de codex **no tiene de qué multiplicar** porque ni siquiera hay token counts fiables. Esta pata queda **sin resolver**.
+- **Riesgo de durabilidad:** el schema JSONL es undocumented y está siendo **superado por SQLite** (`conversations/<id>.db`, 1.0.4+, dual-write 1.0.8+). Cualquier reader tiene fecha de caducidad.
+- **El más limpio (#5 ACP) no existe.** El más completo en captura (#4 SDK) **no envuelve el `agy` CLI** — usa su propio runtime cloud bundled.
+
+---
+
+## 4. Si se integrara `agy` — cómo sería el adapter (y por qué es más feo que el `gemini-adapter`)
+
+Declararía contra el contrato `ProviderAdapter` (`server/providers/types.ts`):
+
+```
+capabilities: {
+  persistentStdin: false,
+  nativeResume:    'partial'  // solo vía --conversation con UUID minteado por nosotros
+  nativeStreamJson: false,
+  nativeCostUsd:    false,
+  nativeOtelEnv:    false,
+  systemPromptArg:  false      // personas van por AGENTS.md / SKILL.md, no por flag
+}
+instructionsFilename: 'AGENTS.md'
+```
+
+**Transporte:** #2 (transcript reader) + #1 (PTY wrap) combinados. Concretamente el adapter tendría que:
+
+1. **Mintar nosotros el UUID de conversación** y pasarlo en `--conversation <uuid>` en el **primer** run (porque `#7`: el id auto-asignado nunca se expone). Esto invierte el patrón normal "spawn → captura session_id → resume".
+2. **Envolver en node-pty** cada spawn para sortear `#76` (stdout 0-bytes en non-TTY). En Windows no hay `script` y `Start-Process -RedirectStandardOutput` cuelga; node-pty es el equivalente portable pero **[no verificado]** para `agy`.
+3. **Watcher del directorio `~/.gemini/antigravity-cli/brain/`** para detectar el nuevo `<conversation-id>/` y leer `.system_generated/logs/transcript.jsonl`, parseando líneas undocumented (`source`/`status`/`type`) — con un **reader abstraído** que prevea la migración a `conversations/<id>.db` (SQLite).
+4. **`pricing.ts` sin inputs:** para `ai_invocations` (model, tokens, cost) **no tenemos token counts de ninguna fuente**, así que `total_cost_usd` quedaría siempre `—` o un estimado inventado — viola la política de métricas honestas del Job Detail.
+5. **Serializar la concurrencia con un lock**, porque `agy` reescribe `cache/last_conversations.json` en **cada** invocación. Eso **rompe el requisito de "concurrencia de varios rails"**: tendríamos que dar a cada rail un `--conversation` UUID distinto **y** un `HOME`/dir aislado, lo cual es **[no probado]**.
+6. **Sin historia de auth desatendida:** OAuth-only (`#78`), keyring que re-pide login en background en macOS (`#85`). No hay `SPECRAILS_…_API_KEY` que inyectar como con codex.
+
+**Por qué es más feo que el `gemini-adapter`:** el `gemini-adapter` es un **spawn de binario limpio** (mismo patrón que claude/codex: argv → `parseStreamLine` → `finaliseInvocationResult`), con `GEMINI_API_KEY` para auth desatendida, stream-json nativo y resume por session-id real. El `agy` adapter requeriría **tres puentes nuevos fuera del patrón** (node-pty, watcher de FS, posible sidecar) + un lock global de concurrencia + un coste **fabricado** o ausente. Es estrictamente peor en las 5 patas.
+
+---
+
+## 5. El modelo de agentes/skills de `agy` para el pipeline (esto sí es bueno)
+
+**Reconocimiento honesto: el modelo de agentes de `agy` es bueno y bien diseñado** — solo que la *integración headless* es lo que falla, no la expresividad del pipeline.
+
+Hallazgo decisivo (guía de migración oficial, Google Cloud Community): **los `agent.json` declarativos del viejo Gemini CLI están OBSOLETOS.** Verbatim: *"Under Antigravity, subagents are orchestrated dynamically, making this directory obsolete"* → `rm -rf .agents/agents/`. **No hay un fichero que pre-defina una persona-subagente persistente nombrada**; los subagentes son emergentes (el orquestador llama a un tool `DefineSubagent` en runtime). No podemos shipear architect/developer/reviewer como tres `agent.json` que `agy` cargue.
+
+**Lo que SÍ carga** (el árbol que `specrails-core` tendría que emitir, análogo a `.codex/skills` / `.claude/agents`):
+
+1. **`AGENTS.md`** en la raíz del workspace → personas architect/developer/reviewer como **secciones de prompt** (Goal/Traits/Constraints).
+2. **`.agents/skills/sr-architect/SKILL.md`**, `sr-developer/`, `sr-reviewer/` → un SKILL.md por fase, con frontmatter YAML `name:` + `description:` (third-person trigger) y cuerpo Goal/Instructions/Constraints. Cargan por **match semántico** del `description`. **También** surgen como slash commands.
+3. **`.agents/workflows/sr-implement.md`** (frontmatter `description:`) → el slash command orquestador que secuencia architect→developer→reviewer, invocado `/sr-implement "<issue>"`.
+
+**Forma del modelo:** **plano / un nivel.** El orquestador gestiona los handoffs; *"Agents do not call subagents; the workflow orchestrator manages handoffs."* La secuencia estricta hay que **forzarla en las instrucciones del workflow.md + constraints del AGENTS.md**.
+
+**Crux a nuestro favor:** ese árbol vive bajo el **harness compartido `~/.gemini/config/` + `.agents/`**, leído idénticamente por la GUI de Antigravity 2.0 y por `agy` headless → **`specrails-core` PUEDE emitir un árbol `agy`**. Eso es trabajo de `specrails-core`, no nuestro.
+
+**Gaps `[no verificado]` antes de comprometerse:** (a) ¿`agy -p "/sr-implement '...'"` expande deterministamente el workflow headless? (b) ¿secuenciación determinista de fases bajo orquestación dinámica?
+
+---
+
+## 6. Timeline / madurez
+
+**Issues bloqueantes (GitHub API, 2026-06-17, todas OPEN, `author_association=NONE` en todos los comentarios → cero respuesta de maintainer/Google, ningún PR de fix mergeado):**
+
+| Issue | Qué bloquea | Estado | Comentarios |
+|---|---|---|---|
+| `#76` | stdout 0-bytes en non-TTY (el bloqueante #1 de spawn) | OPEN, sin fix | 19 |
+| `#7` | conversation-id nunca expuesto (sin captura para resume) | OPEN | 1 |
+| `#31` | ACP / JSON-RPC stdio (el transporte limpio) | OPEN, más pedido | 81 |
+| `#78` | auth API-key headless (sin historia desatendida) | OPEN | 2 |
+
+**Cadencia:** release cada ~3 días (1.0.4 el 06-01 → 1.0.9 el 06-17), pero **exclusivamente** en pulido TUI / hardening de sandbox / clipboard / statusline. **El contrato headless NO ha avanzado nada** entre 1.0.0→1.0.9.
+
+**Madurez global:** preview público (no GA), closed-source, 339 issues abiertos. El SDK Python es **alpha 0.1.3**.
+
+**Lectura:** el contrato usable **no está cerca**. Dada la velocidad gastada íntegramente en pulido TUI y el **silencio total de Google** en las cuatro issues integrator, una ETA realista es **issue-gated, no date-gated**, del orden de **2–4+ meses** si es que llega. **No integrar ahora.**
+
+---
+
+## 7. Recomendación final + ruta
+
+> **AHORA:** Integra **`gemini-cli` como tercer proveedor** vía el `gemini-adapter` ya diseñado (binary-spawn limpio, `GEMINI_API_KEY`, stream-json + resume nativos). **`agy` = watch-item gated.**
+
+**Justificación:**
+- El sunset mata **el login de suscripción consumer + free**, NO el binario open-source con API-key de pago/enterprise — que Google se compromete a seguir soportando *con los modelos nuevos*.
+- **El modelo Gemini 3 ya nos llega vía `gemini-cli`** apuntando a `GEMINI_API_KEY`. No hay nada que ganar del lado del modelo cambiando a `agy` hoy.
+- **Harness compartido `~/.gemini`:** integrar `gemini-cli` ahora **no es trabajo desechable** — la auth, MCP y el árbol de config quedan asentados en el mismo `~/.gemini` que `agy` reusaría. Un swap futuro sería cambio de transporte.
+- `agy` headless está roto en **las 5 patas a la vez**, con la pata **coste irresoluble** y **sin auth desatendida** en macOS, con silencio de Google.
+
+### Si en el futuro `gemini-cli` muriera de verdad para el path API-key
+No lo hace (confirmado que sobrevive). Pero **si** llegara a morir, el puente provisional sería el **transporte #2 (transcript.jsonl) + #1 (PTY wrap)**, con coste marcado como estimado-imposible y concurrencia serializada con lock — explícitamente temporal y degradado.
+
+### Condiciones (issues cerradas con fix verificado) que dispararían el cambio a `agy` — **gate AND**:
+- ✅ **`#76` cerrada** (stdout en non-TTY capturable), **Y**
+- ✅ **`#7` shipado** (conversation-id capturable desde `-p`), **Y**
+- ✅ **`#31` (`--acp`/JSON-RPC)** *o* **`--output-format stream-json` (`#119`/`#394`)**, **Y**
+- ✅ **`#78` shipado** (auth por API-key + fix del keyring `#85`), **Y**
+- ✅ una fuente de **token usage / coste** machine-readable (hoy inexistente — el bloqueante silencioso más duro), **Y**
+- ✅ concurrencia segura sin el lock global de `last_conversations.json`.
+
+**Vía paralela (no la principal):** si se prioriza el modelo de agentes de `agy`, el trabajo correcto es que **`specrails-core` aprenda a emitir el árbol `agy`** (`AGENTS.md` + `.agents/skills/sr-*/SKILL.md` + `.agents/workflows/sr-implement.md`), exactamente como ya emite `.codex/skills` — independiente de nuestro adapter, se puede empezar antes de que el transporte madure.
+
+**Watch concreto:** revisar `#76`, `#7`, `#31`/`#119`, `#78` (y el SDK Python alcanzando beta con `total_usage` estable) cada pocas semanas. Hasta que el gate AND se cumpla: **`gemini-cli` ahora, `agy` después.**
+
+---
+
+### Notas de honestidad sobre lo incierto
+- `agy --help` verbatim **no obtenido** — superficie reconstruida del tracker/CHANGELOG (alta confianza por estar versionada) + specs operativos.
+- **Coste/tokens:** ninguna fuente encontró campos de usage en transcript.jsonl/stdout/CLI — la imposibilidad de la pata coste es por *ausencia de evidencia en cuatro investigaciones*, no por negativa explícita de Google; a efectos prácticos es bloqueante.
+- **node-pty para `agy` en Windows:** equivalente portable a `script`, **no verificado** contra `agy`.
+- **SDK Python:** resume de una conversación `agy` local por id **no documentado**; gestiona su propio estado con runtime cloud bundled — re-platforming, no wrapping.
+- **`agy -p "/workflow"`** expandiendo deterministamente headless: **no verificado**.

--- a/docs/gemini-core-support-evaluation.md
+++ b/docs/gemini-core-support-evaluation.md
@@ -1,0 +1,160 @@
+> Documento de planificación. Generado 2026-06-17 mediante auditoría multi-agente del repo real `/Users/javi/repos/specrails-core` + verificación de fuentes primarias de gemini-cli. Complementa `docs/gemini-cli-provider-study.md` (desktop) — esta evalúa el trabajo en **specrails-core** para habilitar rails/implement en Gemini.
+
+---
+
+# Evaluación: ¿Hay que tocar specrails-core para Gemini CLI?
+
+> **Veredicto en una línea:** Sí, **obligatoriamente hay que tocar core** para que `implement`/`batch-implement` (rails) funcionen en Gemini. El desktop por sí solo (PR-A/PR-B + `gemini-adapter.ts`) cubre **solo** spec/explore/quick. El pipeline architect→developer→reviewer **es expresable sin rediseño de fases** en el modelo plano de Gemini, pero **sin un target gemini en core no hay agentes ni comandos ni skills que ejecutar**, así que los rails en gemini hoy son inejecutables.
+
+---
+
+## 1. Respuesta directa: ¿hay que tocar core?
+
+**Sí, para los rails. No, para spec/explore/quick.** El corte es exacto y limpio:
+
+### Ya funciona HOY sin tocar core (solo desktop adapter)
+El desktop tiene `server/providers/gemini-adapter.ts` registrado (`server/providers/index.ts:12,16`), con `projectDirName: '.gemini'`, `instructionsFilename: 'GEMINI.md'`, `nativeCostUsd: false` (gemini-adapter.ts:225-235). Esto cubre las superficies que **NO dependen de artefactos instalados en el repo**:
+- **Explore Spec** — spawnea gemini desde `explore-cwd/` con un `CLAUDE.md`/system-prompt embebido por el desktop; no lee `.gemini/*`.
+- **Quick spec** (`POST /tickets/generate-spec`) — turno suelto, system prompt inyectado por el desktop.
+- **Sidebar chat** — idem.
+
+Estas tres superficies inyectan su propio prompt y no resuelven slash-commands ni subagentes del proyecto. Por eso el adapter desktop basta.
+
+### EXIGE core (sin esto, los rails en gemini no arrancan)
+`implement` y `batch-implement` **no son prompts** que el desktop inyecte: son **artefactos instalados en el repo** que el orquestador resuelve nativamente. El desktop solo pasa el comando resuelto al binario (`queue-manager.ts` `buildArgs('rail-job', …)`), y el binario espera encontrar en disco:
+1. **Comandos** `implement` / `batch-implement` (en formato gemini: `.gemini/commands/*.toml`).
+2. **Agentes** `sr-architect`/`sr-developer`/`sr-reviewer` (en `.gemini/agents/*.md` con frontmatter).
+3. **Skills/comandos OpenSpec** (`opsx:*`) instalados por `openspec init --tools gemini`.
+4. **`GEMINI.md`** (instrucciones de proyecto) + settings.
+
+**Core no emite NADA de esto para gemini** — verificado: `grep -rni gemini` sobre `src/`, `templates/`, `integration-contract.json` devuelve **0 matches**. El tipo `Provider` es un set cerrado `'claude' | 'codex'` que **rechaza** cualquier otro valor en `install-config.ts:96` (`unsupported provider '...'`). Por tanto, hoy un proyecto gemini no puede ni siquiera instalarse: el handshake desktop→core (desktop escribe `provider:` en `install-config.yaml`, `setup-manager.ts:906`; core valida en `install-config.ts:96` e `init.ts:86`) **falla en duro** con "unsupported provider 'gemini'".
+
+**Conclusión inequívoca:** spec/explore/quick = solo desktop, ya hecho. Rails (implement/batch-implement + agentes + skills + OpenSpec) = **bloqueado en core**, requiere un target gemini.
+
+---
+
+## 2. Cómo emite core hoy por proveedor
+
+El flujo real de instalación: `init.ts` → `provider-detect.derivedPaths(provider)` → `scaffold.scaffoldInstallation` → `installOpenSpecProject`.
+
+### Detección/selección de proveedor (todo cerrado a 2 literales)
+- **Tipo:** `Provider = 'claude' | 'codex'` declarado en DOS sitios que deben coincidir: `provider-detect.ts:15` e `install-config.ts:13`.
+- **Detección:** `detectAvailability()` solo sondea claude/codex en PATH — verificado verbatim:
+  ```ts
+  const [claude, codex] = await Promise.all([commandExists('claude'), commandExists('codex')])
+  return { claude, codex }
+  ```
+  (`provider-detect.ts:33-36`).
+- **Validación dura:** `install-config.ts:96` rechaza ≠ claude/codex; `init.ts:86` rechaza el flag `--provider`; `bin/tui-installer.mjs:114/118`.
+
+### Dónde divergen claude vs codex
+Toda la divergencia es **imperativa, `if (input.provider === 'codex')`**, no hay registry/adapter (contraste con el `ProviderAdapter` del desktop). Sitios clave en `scaffold.ts`:
+- **Convención de paths** centralizada en `derivedPaths` — verificado verbatim: codex → `{ '.codex', 'AGENTS.md' }`, else → `{ '.claude', 'CLAUDE.md' }` (`provider-detect.ts:87-92`).
+- Esqueleto de directorios (`scaffold.ts:174-184`): claude `.claude/commands/specrails` + `.claude/skills`; codex `.codex/skills/{enrich,doctor,rails}`.
+- Colocación de comandos (`copyBundledCommands`, `scaffold.ts:278-311`): claude copia `.md` verbatim; codex porta cada comando a `.codex/skills/<name>/SKILL.md` vía `writeCodexSkillFromCommand` (rewrite `.claude/`→`.codex/`, `/specrails:x`→`$x`) salvo que exista override en `templates/codex-skills/<name>/`.
+- Agentes (`scaffold.ts:493-648`): claude coloca `.claude/agents/sr-*.md` + memory dirs; codex **salta agentes** y usa rail-skills en `.codex/skills/rails/`.
+- Skills (`placeSkills`, `scaffold.ts:762-830`): claude **genera** `sr-*` skills desde el cuerpo del comando (`SKILL_FROM_COMMAND`, `scaffold.ts:46-82` + `writeClaudeSkillFromCommand`); codex copia `templates/codex-skills/rails/`.
+- Settings (`scaffold.ts:244-250`): codex-only `applyCodexSettings` escribe `.codex/config.toml` + `AGENTS.md` con bloque sentinel-managed (`renderInitialAgentsMd`, `scaffold.ts:666-747`). Claude **no** tiene settings-writer aquí (su `CLAUDE.md` no lo escribe el instalador, solo lo chequea `doctor.ts:91`).
+
+### Cómo se instala OpenSpec (esto SÍ es ya per-provider)
+`installOpenSpecProject(repoRoot, provider)` (llamado solo en `init.ts:128`, **no** en update) shellea — verificado verbatim:
+```ts
+args: ['--yes', '-p', `@fission-ai/openspec@${pinnedVersion}`, '--',
+       'openspec', 'init', '--tools', provider, repoRoot]
+```
+(`init.ts:204-218`, pin `1.3.1` desde `pinned-versions.json:3`). **Pasa `provider` DIRECTO a `--tools`.** Esto significa que la capa OpenSpec **no es el bloqueante**: `openspec init --tools gemini` es nativamente soportado por openspec 1.3.1 (genera `.gemini/commands/opsx` + `.gemini/skills/openspec-*` + el dir agnóstico `openspec/{specs,changes}`). En cuanto core propague el literal `gemini` a esta llamada (pasos 1+3 abajo), OpenSpec hace lo correcto **sin cambios de código**.
+
+---
+
+## 3. El target gemini en core: qué emitir, transform vs autoría nueva, additividad
+
+### Qué debe emitir
+| Artefacto | Formato gemini | Origen |
+|---|---|---|
+| `implement`, `batch-implement` (+ resto comandos) | `.gemini/commands/specrails/*.toml` — **solo `prompt` + `description`**, sin `tools`/`model` | **Transform** de `templates/commands/specrails/*.md` (reusar el cuerpo, re-envolver en TOML) |
+| `sr-architect/developer/reviewer` (+ opcionales) | `.gemini/agents/sr-*.md` con **YAML frontmatter** que SÍ lleva `model` + `tools` | **Transform** de `templates/agents/sr-*.md` (markdown ya compatible; ajustar frontmatter + `MEMORY_PATH`→`.gemini/agent-memory/`) |
+| `GEMINI.md` + settings | `GEMINI.md` con bloque sentinel + `.gemini/settings.json` (con `experimental.enableAgents`) | **Autoría nueva** — clon de `applyCodexSettings`/`renderInitialAgentsMd` (`scaffold.ts:666-747`) |
+| OpenSpec (`opsx:*`) | `.gemini/commands/opsx/*` + `.gemini/skills/openspec-*` | **Sin cambios** — lo emite `openspec init --tools gemini` |
+
+### Transform vs autoría — la asimetría es **decisiva** y la dicta el formato gemini
+El veredicto verificado fija la regla: **commands TOML solo aceptan `prompt`+`description`** (sin `tools`/`model` por comando), pero **subagents `.md` SÍ aceptan `tools`+`model` en frontmatter**. Consecuencia de arquitectura para el scaffold:
+
+> El **model-routing y el tool-gating** que hoy viven embebidos en `implement.md` (bloque ORCHESTRATOR_MODEL ~líneas 160-171 + overrides por agente) **deben migrar al frontmatter de los `.gemini/agents/sr-*.md`**, NO al comando TOML.
+
+Mapeo correcto: orquestador → `.gemini/commands/specrails/{implement,batch-implement}.toml` (solo prompt+description); roles → `.gemini/agents/sr-*.md` (con `model:`, `tools:`). Esto **espeja el split de codex** (comando-vs-skill) pero con el primitivo de subagente nativo de gemini en vez de `spawn_agent`.
+
+**Neto:** es una **mezcla** — cuerpos de comandos y agentes son **transforms mecánicos** de los templates claude existentes; el **emisor TOML** (`writeGeminiCommandFromCommand`, análogo a `writeCodexSkillFromCommand`), el **escritor `GEMINI.md`/settings**, y el **plumbing de tipo/detección** son **autoría nueva**. Lo más limpio: añadir `templates/gemini-skills/` (o `templates/gemini-*`) como dir de override para lo que el transform mecánico produzca mal, igual que `templates/codex-skills/`.
+
+### Cómo se añade de forma aditiva sin romper claude/codex
+Es aditivo en **semántica** (cada branch es `=== 'codex'` / else-claude; añadir un brazo `=== 'gemini'` deja los paths existentes byte-idénticos; el allow-list de validación solo se ensancha, nunca rechaza configs previas válidas), pero **NO aditivo en código** (no hay abstracción → hay que editar cada sitio). Cambios concretos (~7 archivos + nuevo árbol de templates):
+1. Ensanchar `Provider` en `provider-detect.ts:15` **y** `install-config.ts:13` (deben quedar idénticos); relajar validadores `init.ts:86`, `install-config.ts:96`, `bin/tui-installer.mjs:114/118`.
+2. `detectAvailability` (`provider-detect.ts:33-36`): añadir `commandExists('gemini')`; extender `resolveProvider` (61-80) + el mensaje de error que hoy solo nombra Claude+Codex.
+3. `derivedPaths` (`provider-detect.ts:87-92`): brazo gemini → `{ '.gemini', 'GEMINI.md' }`.
+4. `scaffold.ts`: brazos gemini en cada `=== 'codex'` (dir skeleton 174-184, colocación comandos 278-325, quick-tier 493-648, `placeSkills` 762-830, prune 454-462) + `applyGeminiSettings` clon de `applyCodexSettings`.
+5. `prereqs.ts:91-104`: gatear el bloque claude-only o dar a gemini un path mínimo (sin auth-assert, como codex).
+6. `doctor.ts:96/160/167` + `update.ts:196-210` (`resolveExistingProvider` probe `.gemini`).
+7. `integration-contract.json:3-26`: bloque `providers.gemini` (la superficie casi-declarativa que lee el desktop; la de menor fricción).
+8. OpenSpec: **cero cambios de código** más allá de propagar `gemini` (pasos 1+3 → ya llega a `init.ts:215`).
+
+---
+
+## 4. El bloqueante de orquestación: ¿plano de gemini lo soporta?
+
+**Veredicto honesto (verificado contra fuentes Google primarias): el pipeline ES expresable en el modelo plano de gemini SIN rediseño de fases.** No es un blocker de capacidad; es trabajo imperativo en core.
+
+Razonamiento (todo confirmado):
+- El pipeline es **recursivo pero SHALLOW**: el orquestador spawnea architect→developer→reviewer a **profundidad 1**; las hojas **nunca re-spawnean** (un developer no llama a un reviewer; lo único "hacia abajo" es un `Skill("opsx:ff/apply/archive")` **in-context**, que shellea al CLI `openspec`, **no es un subagente**). Contrato verbatim: `implement.md:5` "delegate to the agents"; `implement.md:547` spawn de sr-architect; codex `implement/SKILL.md:24` "Each phase MUST be a real spawn_agent call".
+- El modelo de gemini es exactamente eso: orquestador delega depth-1, subagentes **FLAT** (`docs/core/subagents.md` verbatim: "subagents cannot call other subagents"). La restricción plana (las hojas no spawnean) **nunca se viola** porque todo el spawning requerido ocurre en el orquestador a depth-1.
+- **El único rediseño** es `batch-implement`, que conceptualmente anida (batch→implement→roles = depth 2), ilegal en plano. **Pero el proyecto YA lo resolvió para codex**: `codex-skills/batch-implement/SKILL.md:5` "Drives architect/developer/reviewer spawns at the ROOT agent level — does NOT spawn a nested $implement sub-agent per ticket". El batch-implement gemini **reutiliza esa misma disciplina de aplanamiento ya probada**.
+
+**Por tanto: NO hay rediseño del pipeline de fases. La viabilidad de rails en gemini está gateada por el trabajo imperativo en core, no por un gap de capacidad de gemini.**
+
+Matiz honesto (no inventado): subagents en gemini son **experimentales** (namespace `experimental.enableAgents`, PR #14371, públicos desde v0.38.1 — ahora habilitados por defecto pero aún bajo `experimental.*`). Y queda un **unknown externo** que estos repos no pueden resolver: si el orquestador gemini puede **iniciar** spawns en headless/non-interactivo o si la delegación `@name` está garantizada sin TTY (ver riesgos §6).
+
+---
+
+## 5. Esfuerzo + secuenciación + versión + reutilización agy/Antigravity
+
+**Tamaño del trabajo en core:** moderado, no trivial. ~7 archivos editados (`provider-detect`, `install-config`, `scaffold`, `prereqs`, `doctor`, `init`, `update`, `bin/tui-installer.mjs`) + `integration-contract.json` + **un árbol nuevo `templates/gemini-skills/`** (o `gemini-*`) + tests (incluido el contrato `reserved-paths.test.ts`, que debe seguir verde para init+update gemini). La falta de abstracción installer-side significa **N ediciones inline, no un descriptor**. La mayor parte del esfuerzo de autoría es: el emisor TOML, el escritor `GEMINI.md`/settings, y **validar empíricamente** que la orquestación plana de gemini ejecuta las fases en headless.
+
+**Secuenciación con el beta desktop:**
+1. **PR-A #396** (generaliza tipos) y **PR-B #397** (adapter beta-gated) habilitan spec/explore/quick en gemini — **independientes de core**, se mergean primero.
+2. El target gemini en core es **secuencialmente posterior** y desbloquea rails. Mientras tanto, el desktop debería **ocultar rails/implement para gemini** (capability-intersection: igual que codex fuerza `profile=null` y oculta Agents/Integrations) hasta que core publique el target.
+
+**Versión de core:** feature aditiva → conventional-commit `feat:` → release-please **MINOR**. Desde 4.7.1 actual → **4.8.0**. El profile-gate `>= 4.1.0` (`queue-manager.ts:77`, `profiles-router.ts:233`) **no se toca**: proyectos gemini en 4.8.0 ya lo satisfacen. Que gemini **participe** en profiles es una decisión de política del desktop (probablemente como codex: `profile=null`), no un cambio de gate.
+
+**¿Puramente aditivo?** En contrato/runtime: **sí** (no rompe claude/codex). En código: **no** (cada branch imperativo gana un brazo gemini). Reserved-paths sin cambios.
+
+**Reutilización agy/Antigravity (no es trabajo tirado):** Antigravity comparte el harness `~/.gemini` (mismas convenciones `.gemini/commands/*.toml`, `.gemini/agents/*.md`, `GEMINI.md`). Un target gemini en core que emita en formato `.gemini/*` **sirve de base directa para agy** más adelante — el scaffold gemini es reutilizable casi tal cual. Esto sube el ROI del trabajo de core.
+
+---
+
+## 6. Recomendación
+
+### Decisión: **HACER, pero DESPUÉS del beta desktop de spec/explore/quick (no en paralelo, no bloqueante del beta).**
+
+Justificación: el beta desktop (PR-A/PR-B) entrega valor real de gemini (spec/explore/quick) **sin tocar core** y sin riesgo. Los rails en gemini son un trabajo de core mayor, con un unknown empírico (headless), y **no deben retrasar el beta**. El desktop oculta rails para gemini mientras tanto.
+
+### Ownership
+- **Desktop owna:** el adapter gemini (ya hecho), capability-intersection para ocultar rails/Agents/Integrations en gemini hasta que core publique, command-syntax translation en `queue-manager` (hoy claude=verbatim, codex=`/x`→`$x`; gemini necesita su forma), y `profile=null` para rails gemini.
+- **Core owna:** el target de instalación gemini completo (tipos/detección, `.gemini/commands/*.toml`, `.gemini/agents/sr-*.md`, `GEMINI.md`/settings, `templates/gemini-skills/`, `integration-contract.json` gemini block, propagar `gemini` a `openspec init --tools`), y los tests.
+
+### Primer paso concreto en core
+Un **spike de validación de orquestación**, ANTES de escribir el scaffold completo: instalar manualmente a mano un `.gemini/commands/specrails/implement.toml` (prompt mínimo) + `.gemini/agents/sr-{architect,developer,reviewer}.md` (frontmatter con `model`/`tools`) + `enableAgents`, correr `openspec init --tools gemini`, y ejecutar el binario `gemini` en modo headless/exec (como lo spawnearía el desktop) para **confirmar empíricamente** que el orquestador inicia los spawns depth-1 y completa architect→developer→reviewer sin TTY. Si pasa, se procede al scaffold; si no, el riesgo se materializa antes de invertir en los 7 archivos.
+
+### Riesgos honestos
+1. **TOML sin `tools`/`model` por comando** — confirmado: los `.gemini/commands/*.toml` no pueden restringir tools ni fijar modelo. El routing/gating **debe** vivir en el frontmatter de los `.gemini/agents/*.md`. Si algún comando dependía de gating a nivel comando, hay que re-arquitecturarlo a nivel agente.
+2. **Subagentes experimentales** — `experimental.enableAgents`; comportamiento puede cambiar entre versiones de gemini-cli. Pinear/probar contra una versión concreta.
+3. **Shell-injection con confirm interactivo en headless** — los agentes shellean al CLI `openspec` vía Skill in-context; si gemini exige confirmación interactiva de tool-calls de shell y el desktop lo spawnea sin TTY, las fases podrían colgarse. **Riesgo no verificado, alto impacto** — es lo que el spike del primer paso debe descartar.
+4. **`@`-routing headless no garantizado** — la delegación forzada `@sr-architect` puede no funcionar sin interactividad; quizás haya que apoyarse en auto-delegación, menos determinista para un pipeline que exige las tres fases.
+5. **OpenSpec install adaptado a gemini** — `openspec init --tools gemini` está confirmado nativo en 1.3.1, pero **no verifiqué empíricamente en esta sesión** que los `.gemini/skills/openspec-*` que genera sean **invocables** por el orquestador gemini en el flujo real (solo que el `--tools` lo acepta). Validar en el spike.
+
+### Lo que NO está cierto (declarado explícitamente)
+- Si el orquestador gemini puede **iniciar** spawns en headless/exec, o si solo el harness puede pre-definir un set fijo de agentes. Si fuera lo segundo, el orquestador `implement` habría que re-expresarlo como agentes paralelos definidos por harness en vez de spawns iniciados por el orquestador — **lift mayor**. Esto **decide la viabilidad real** y no es deducible de estos repos.
+- El comportamiento exacto de confirm de shell-calls de gemini en headless (riesgo #3).
+
+**Archivos clave (absolutos):**
+- Core gap: `/Users/javi/repos/specrails-core/src/installer/phases/provider-detect.ts` (15, 33-36, 87-92), `/Users/javi/repos/specrails-core/src/installer/phases/install-config.ts` (13, 96), `/Users/javi/repos/specrails-core/src/installer/phases/scaffold.ts` (174-184, 244-250, 278-311, 666-747, 762-830), `/Users/javi/repos/specrails-core/src/installer/commands/init.ts` (86, 128, 204-218), `/Users/javi/repos/specrails-core/integration-contract.json` (3-26), `/Users/javi/repos/specrails-core/pinned-versions.json` (3).
+- Templates a transformar: `/Users/javi/repos/specrails-core/templates/commands/specrails/implement.md`, `/Users/javi/repos/specrails-core/templates/commands/specrails/batch-implement.md`, `/Users/javi/repos/specrails-core/templates/agents/sr-{architect,developer,reviewer}.md`.
+- Precedente de aplanamiento codex: `/Users/javi/repos/specrails-core/templates/codex-skills/batch-implement/SKILL.md` (5, 19-32), `/Users/javi/repos/specrails-core/templates/codex-skills/implement/SKILL.md` (24).
+- Desktop (ya hecho): `/Users/javi/repos/specrails-desktop/server/providers/gemini-adapter.ts` (225-235), `/Users/javi/repos/specrails-desktop/server/providers/index.ts` (12, 16); a tocar: `/Users/javi/repos/specrails-desktop/server/queue-manager.ts` (command translation, `profile=null`), `/Users/javi/repos/specrails-desktop/client/src/lib/provider-capabilities.ts` (ocultar rails gemini).

--- a/docs/gemini.md
+++ b/docs/gemini.md
@@ -1,0 +1,106 @@
+# Using Specrails with the Gemini CLI
+
+Specrails supports Google's [Gemini CLI](https://github.com/google-gemini/gemini-cli)
+as a third AI provider alongside Claude Code and the Codex CLI.
+
+> **Beta — opt-in.** Gemini is gated behind `SPECRAILS_GEMINI_BETA` and is **off by
+> default**. Until you set it, Gemini is invisible everywhere (it won't show in Add
+> Project and can't be selected). See [Enabling the beta](#enabling-the-beta).
+>
+> **Scope today.** With the beta on, Gemini powers the *non-pipeline* surfaces —
+> Explore Spec, Quick spec, AI Edit, the terminal launcher, and cost analytics.
+> The full **rails pipeline** (`/specrails:implement`, `batch-implement`) needs a
+> Gemini artifact target in `specrails-core` (`.gemini/commands/*.toml` +
+> `.gemini/agents/sr-*.md`), which ships separately. Rails are hidden for Gemini
+> projects until then.
+
+## Prerequisites
+
+- **Gemini CLI ≥ 0.11.0** on your `PATH` (`npm i -g @google/gemini-cli`; `gemini --version`).
+  Older versions lack `--output-format stream-json` and headless `--resume`.
+- **A Gemini API key.** Specrails spawns Gemini headlessly, so it needs
+  non-interactive auth: set `GEMINI_API_KEY` (a paid Gemini Developer API key from
+  [Google AI Studio](https://aistudio.google.com/apikey)). The free OAuth
+  "Login with Google" tier exists but is being wound down for the CLI and is not a
+  reliable unattended path — use an API key.
+
+## Enabling the beta
+
+Set the env var where the Specrails server runs, then restart the app:
+
+```bash
+SPECRAILS_GEMINI_BETA=1   # or 'true'
+```
+
+With it set, `GET /api/available-providers` reports Gemini's real install status,
+Add Project shows a **Gemini** checkbox, and projects can select it.
+
+## Adding a Gemini project
+
+Add Project → tick **Gemini** (visible once the beta is on and `gemini` is on PATH).
+A project can install Gemini alongside Claude/Codex; the first provider selected is
+the primary/default, and per-invocation engine pickers let you choose per spec/rail.
+
+## What's different vs Claude
+
+- **Cost is estimated, not native.** Gemini does not report a USD cost in its
+  stream, so Specrails estimates it from a rate card (`server/pricing.ts`,
+  keys `gemini:<model>`). Token counts (incl. cached) come straight from the run.
+- **No per-agent profiles / SMASH / Contract Refine.** These are Claude-only; on a
+  mixed project the capability intersection hides them (same as Codex).
+- **System prompt is folded.** Gemini has no `--system-prompt` flag, so for
+  non-Explore actions the system prompt is folded into the user prompt. Explore
+  turns stay user-only and trust the app-managed `GEMINI.md` in the explore cwd.
+- **OTEL is native.** Unlike Codex, Gemini emits OTLP via `GEMINI_TELEMETRY_*`, so
+  pipeline telemetry needs no synthetic bridge.
+
+## Models
+
+Curated catalog (`server/providers/gemini-adapter.ts`): `gemini-2.5-pro` (default),
+`gemini-2.5-flash`, `gemini-2.5-flash-lite`, `gemini-3.1-pro-preview`. Concrete GA
+ids are pinned (preview ids rotate). Free-tier API keys serve Flash; Pro/preview
+need billing.
+
+## Trusted folders (headless)
+
+Gemini's "trusted folders" gate silently overrides `--yolo` back to `default` —
+blocking *every* tool call — in a directory it doesn't trust. Specrails injects
+`GEMINI_CLI_TRUST_WORKSPACE=true` into every Gemini spawn (`server/util/cli-prompt.ts`
+`spawnGemini`) so headless rails/explore can actually run tools. No action needed
+from you.
+
+## Troubleshooting
+
+- **"Gemini" never appears in Add Project** → the beta is off (`SPECRAILS_GEMINI_BETA`
+  unset), or `gemini` isn't on PATH. Check `GET /api/available-providers`.
+- **Tools never run / job does nothing** → almost always auth or trust. Confirm
+  `GEMINI_API_KEY` is set in the server env; the trust var is handled automatically.
+- **`limit: 0` / quota errors on Pro** → free-tier API keys don't serve Pro models;
+  use a Flash model or enable billing.
+- **Cost shows `—`** → no `gemini:<model>` pricing row for the model used; add one to
+  `server/pricing.ts`.
+
+## Emergency rollback
+
+Unset `SPECRAILS_GEMINI_BETA` (or set it to `0`). Gemini disappears from the UI and
+becomes unselectable immediately; existing non-Gemini projects are unaffected. The
+adapter stays registered but dormant.
+
+## Architecture pointers (for specrails-desktop developers)
+
+- Adapter: `server/providers/gemini-adapter.ts` (`nativeCostUsd:false`,
+  `nativeOtelEnv:true`, `systemPromptArg:false`, `instructionsFilename:'GEMINI.md'`,
+  `mcpRegistration:'project-json'`). Registered in `server/providers/index.ts`.
+- Stream schema (validated against gemini 0.46): `init{session_id,model}` /
+  `message{role,content,delta}` / `tool_use{tool_name,tool_id,parameters}` /
+  `tool_result` / `result{stats}`. `stats.input_tokens` includes `stats.cached`.
+- Beta gate + provider list: `server/desktop-router.ts` (`isGeminiBetaEnabled`,
+  `/available-providers`, `POST /projects`).
+- Trust-folder env: `server/util/cli-prompt.ts` `spawnGemini`.
+
+## See also
+
+- [`docs/codex.md`](./codex.md) — the Codex provider (the other non-native provider).
+- [`docs/adding-a-provider.md`](./adding-a-provider.md) — how to add a provider.
+- [`docs/gemini-cli-provider-study.md`](./gemini-cli-provider-study.md) — the design study.
+- [`docs/gemini-core-support-evaluation.md`](./gemini-core-support-evaluation.md) — the rails/core work.

--- a/server/desktop-router.test.ts
+++ b/server/desktop-router.test.ts
@@ -557,14 +557,14 @@ describe('desktop-router', () => {
       expect(res.body.codex).toBe(false)
     })
 
-    it('forces gemini to false by default (beta opt-in)', async () => {
+    it('omits gemini entirely by default (beta opt-in → fully hidden)', async () => {
       const prev = process.env.SPECRAILS_GEMINI_BETA
       delete process.env.SPECRAILS_GEMINI_BETA
       try {
         const { app } = createApp()
         const res = await request(app).get('/api/available-providers')
         expect(res.status).toBe(200)
-        expect(res.body.gemini).toBe(false)
+        expect(res.body).not.toHaveProperty('gemini')
       } finally {
         if (prev === undefined) delete process.env.SPECRAILS_GEMINI_BETA
         else process.env.SPECRAILS_GEMINI_BETA = prev

--- a/server/desktop-router.test.ts
+++ b/server/desktop-router.test.ts
@@ -10,7 +10,7 @@ vi.mock('./core-compat', async (importActual) => {
     ...actual,
     checkCoreCompat: vi.fn().mockResolvedValue({ compatible: true, contractFound: false }),
     getCLIStatus: vi.fn().mockReturnValue({ provider: 'claude', version: '1.2.3' }),
-    detectAvailableCLIs: vi.fn().mockReturnValue({ claude: true, codex: false }),
+    detectAvailableCLIs: vi.fn().mockReturnValue({ claude: true, codex: false, gemini: false }),
   }
 })
 
@@ -556,19 +556,77 @@ describe('desktop-router', () => {
       expect(res.body).toHaveProperty('codex')
       expect(res.body.codex).toBe(false)
     })
+
+    it('forces gemini to false by default (beta opt-in)', async () => {
+      const prev = process.env.SPECRAILS_GEMINI_BETA
+      delete process.env.SPECRAILS_GEMINI_BETA
+      try {
+        const { app } = createApp()
+        const res = await request(app).get('/api/available-providers')
+        expect(res.status).toBe(200)
+        expect(res.body.gemini).toBe(false)
+      } finally {
+        if (prev === undefined) delete process.env.SPECRAILS_GEMINI_BETA
+        else process.env.SPECRAILS_GEMINI_BETA = prev
+      }
+    })
+
+    it('surfaces gemini availability when SPECRAILS_GEMINI_BETA=1', async () => {
+      const prev = process.env.SPECRAILS_GEMINI_BETA
+      process.env.SPECRAILS_GEMINI_BETA = '1'
+      try {
+        const { app } = createApp()
+        const res = await request(app).get('/api/available-providers')
+        expect(res.status).toBe(200)
+        // Real detection (true/false depending on whether `gemini` is on PATH),
+        // but no longer force-hidden — the key reflects actual availability.
+        expect(typeof res.body.gemini).toBe('boolean')
+      } finally {
+        if (prev === undefined) delete process.env.SPECRAILS_GEMINI_BETA
+        else process.env.SPECRAILS_GEMINI_BETA = prev
+      }
+    })
   })
 
   // ─── POST /projects — provider validation ───────────────────────────────────
 
   describe('POST /api/projects — provider field', () => {
-    it('returns 400 for invalid provider value', async () => {
-      const { app } = createApp()
-      const res = await request(app).post('/api/projects').send({
-        path: '/home/user/proj',
-        provider: 'gemini',
-      })
-      expect(res.status).toBe(400)
-      expect(res.body.error).toContain('provider')
+    it('rejects gemini by default — beta opt-in (SPECRAILS_GEMINI_BETA unset)', async () => {
+      const prev = process.env.SPECRAILS_GEMINI_BETA
+      delete process.env.SPECRAILS_GEMINI_BETA
+      const projectPath = fs.mkdtempSync(path.join(require('os').tmpdir(), 'gemini-blocked-'))
+      try {
+        const { app } = createApp()
+        const res = await request(app).post('/api/projects').send({
+          path: projectPath,
+          provider: 'gemini',
+        })
+        expect(res.status).toBe(400)
+        expect(res.body.error).toMatch(/beta|SPECRAILS_GEMINI_BETA/)
+      } finally {
+        fs.rmSync(projectPath, { recursive: true, force: true })
+        if (prev === undefined) delete process.env.SPECRAILS_GEMINI_BETA
+        else process.env.SPECRAILS_GEMINI_BETA = prev
+      }
+    })
+
+    it('accepts gemini when SPECRAILS_GEMINI_BETA=1', async () => {
+      const prev = process.env.SPECRAILS_GEMINI_BETA
+      process.env.SPECRAILS_GEMINI_BETA = '1'
+      const projectPath = fs.mkdtempSync(path.join(require('os').tmpdir(), 'gemini-project-'))
+      try {
+        const { app } = createApp()
+        const res = await request(app).post('/api/projects').send({
+          path: projectPath,
+          provider: 'gemini',
+        })
+        expect(res.status).toBe(201)
+        expect(res.body.project.provider).toBe('gemini')
+      } finally {
+        fs.rmSync(projectPath, { recursive: true, force: true })
+        if (prev === undefined) delete process.env.SPECRAILS_GEMINI_BETA
+        else process.env.SPECRAILS_GEMINI_BETA = prev
+      }
     })
 
     it('accepts codex provider (Stage C of multi-provider; gate lifted)', async () => {

--- a/server/desktop-router.ts
+++ b/server/desktop-router.ts
@@ -174,7 +174,9 @@ export function createDesktopRouter(
     // is forced unavailable when SPECRAILS_CODEX_BETA=0 (emergency rollback).
     const gated: Record<string, boolean> = { ...providers }
     if (isCodexBetaDisabled()) gated.codex = false
-    if (!isGeminiBetaEnabled()) gated.gemini = false
+    // Gemini is opt-in: omit it entirely (not just `false`) when the beta flag is
+    // off, so it stays fully invisible in the UI until SPECRAILS_GEMINI_BETA=1.
+    if (!isGeminiBetaEnabled()) delete gated.gemini
     res.json({ ...gated, tiers })
   })
 

--- a/server/desktop-router.ts
+++ b/server/desktop-router.ts
@@ -34,6 +34,15 @@ function isCodexBetaDisabled(): boolean {
   return v === '0'
 }
 
+// Gemini is opt-IN (default off): unlike codex, its stream-json schema has not
+// yet been validated against a live binary, so it stays hidden + unselectable
+// until SPECRAILS_GEMINI_BETA=1 (or 'true'). The adapter is always registered
+// (pricing/getAdapter work); only project selection is gated.
+function isGeminiBetaEnabled(): boolean {
+  const v = (process.env.SPECRAILS_GEMINI_BETA ?? '').toLowerCase()
+  return v === '1' || v === 'true'
+}
+
 // Theme allow-list. Mirror of THEME_IDS in `client/src/lib/themes.ts` —
 // kept duplicated to avoid pulling client code into the server bundle.
 const THEME_ID_ALLOWLIST = new Set<string>(['dracula', 'aurora-light', 'obsidian-dark', 'matrix', 'specrails'])
@@ -165,6 +174,7 @@ export function createDesktopRouter(
     // is forced unavailable when SPECRAILS_CODEX_BETA=0 (emergency rollback).
     const gated: Record<string, boolean> = { ...providers }
     if (isCodexBetaDisabled()) gated.codex = false
+    if (!isGeminiBetaEnabled()) gated.gemini = false
     res.json({ ...gated, tiers })
   })
 
@@ -229,6 +239,12 @@ export function createDesktopRouter(
     if (providers.includes('codex') && isCodexBetaDisabled()) {
       res.status(400).json({
         error: 'Codex provider is currently disabled (SPECRAILS_CODEX_BETA=0). Unset or set to 1 to enable.',
+      })
+      return
+    }
+    if (providers.includes('gemini') && !isGeminiBetaEnabled()) {
+      res.status(400).json({
+        error: 'Gemini provider is in beta and disabled by default. Set SPECRAILS_GEMINI_BETA=1 to enable.',
       })
       return
     }

--- a/server/explore-cwd-manager.ts
+++ b/server/explore-cwd-manager.ts
@@ -138,7 +138,7 @@ export function ensureExploreCwd(input: ExploreCwdInput, baseDir?: string): stri
   // — provider is immutable post-creation but the lifecycle code MUST handle
   // the edge per spec), remove any stale instructions file authored by a
   // different provider so the explore-cwd doesn't carry both.
-  const STALE_INSTRUCTION_FILES = ['CLAUDE.md', 'AGENTS.md']
+  const STALE_INSTRUCTION_FILES = ['CLAUDE.md', 'AGENTS.md', 'GEMINI.md']
   for (const stale of STALE_INSTRUCTION_FILES) {
     if (stale === adapter.instructionsFilename) continue
     const stalePath = path.join(cwd, stale)

--- a/server/pricing.ts
+++ b/server/pricing.ts
@@ -47,6 +47,13 @@ export const PRICING: Record<string, PriceEntry> = {
   'codex:gpt-5.4':       { inputPer1M: 2.50, outputPer1M: 10.00, cacheReadPer1M: 0.25,  lastReviewedAt: '2026-05-17' },
   'codex:gpt-5.4-mini':  { inputPer1M: 0.25, outputPer1M: 2.00,  cacheReadPer1M: 0.025, lastReviewedAt: '2026-05-17' },
   'codex:gpt-5.3-codex': { inputPer1M: 1.50, outputPer1M: 6.00,  cacheReadPer1M: 0.15,  lastReviewedAt: '2026-05-17' },
+  // Gemini (Google). Reference: https://ai.google.dev/gemini-api/docs/pricing
+  // Standard paid tier, <=200k-context prices (Gemini Pro is context-tiered;
+  // prompts >200k are under-estimated in v1 — see docs/gemini-cli-provider-study.md §2).
+  'gemini:gemini-2.5-pro':         { inputPer1M: 1.25, outputPer1M: 10.00, cacheReadPer1M: 0.125, lastReviewedAt: '2026-06-17' },
+  'gemini:gemini-2.5-flash':       { inputPer1M: 0.30, outputPer1M: 2.50,  cacheReadPer1M: 0.03,  lastReviewedAt: '2026-06-17' },
+  'gemini:gemini-2.5-flash-lite':  { inputPer1M: 0.10, outputPer1M: 0.40,  cacheReadPer1M: 0.01,  lastReviewedAt: '2026-06-17' },
+  'gemini:gemini-3.1-pro-preview': { inputPer1M: 2.00, outputPer1M: 12.00, cacheReadPer1M: 0.20,  lastReviewedAt: '2026-06-17' },
 }
 
 /**

--- a/server/project-router-tickets.ts
+++ b/server/project-router-tickets.ts
@@ -1541,7 +1541,7 @@ export function registerTicketsRoutes(deps: ProjectRoutesDeps): void {
       binary = 'codex'
       // Use gpt-5.5 (default for Codex per CODEX_MODELS/PRESET_DEFAULTS in ModelSelector); never hardcode o4-mini
       args = ['exec', `${systemPrompt}\n\n${userPrompt}`, '--model', 'gpt-5.5']
-    } else {
+    } else if (provider === 'claude') {
       binary = 'claude'
       args = [
         '--dangerously-skip-permissions',
@@ -1553,6 +1553,17 @@ export function registerTicketsRoutes(deps: ProjectRoutesDeps): void {
         '--system-prompt', systemPrompt,
         '-p', userPrompt,
       ]
+    } else {
+      // Adapter-driven path (gemini + any future provider): binary, argv, and
+      // stream parsing all come from the registered adapter — no per-provider
+      // hardcoding. The claude/codex shapes above are kept byte-identical.
+      const adapter = getAdapter(provider)
+      binary = adapter.binary
+      args = adapter.buildArgs('agent-refine', {
+        prompt: userPrompt,
+        systemPrompt,
+        model: adapter.defaultModel(),
+      })
     }
 
     // spawnAiCli reroutes multi-line argv values through stdin on Windows.
@@ -1605,7 +1616,7 @@ export function registerTicketsRoutes(deps: ProjectRoutesDeps): void {
           }
           broadcast(msg)
         }
-      } else {
+      } else if (provider === 'claude') {
         let parsed: Record<string, unknown> | null = null
         try { parsed = JSON.parse(line) } catch { /* skip */ }
         if (!parsed) return
@@ -1624,6 +1635,18 @@ export function registerTicketsRoutes(deps: ProjectRoutesDeps): void {
             }
             broadcast(wsMsg)
           }
+        }
+      } else {
+        // Adapter-driven parse (gemini + future providers): uniform AdapterEvent
+        // stream — accumulate assistant text deltas.
+        const ev = getAdapter(provider).parseStreamLine(line)
+        if (ev?.kind === 'text-delta' && ev.text) {
+          buffer += ev.text
+          const wsMsg: TicketAiEditStreamMessage = {
+            type: 'ticket_ai_edit_stream', projectId, ticketId: Number(ticketId),
+            requestId, delta: ev.text, timestamp: new Date().toISOString(),
+          }
+          broadcast(wsMsg)
         }
       }
     })

--- a/server/providers/__fixtures__/gemini/0.11.0/hello-3-words.jsonl
+++ b/server/providers/__fixtures__/gemini/0.11.0/hello-3-words.jsonl
@@ -1,0 +1,4 @@
+{"type":"init","session_id":"11111111-2222-3333-4444-555555555555","model":"gemini-2.5-pro"}
+{"type":"message","role":"user","content":"say hello in 3 words"}
+{"type":"message","role":"assistant","content":"hello there friend","delta":true}
+{"type":"result","status":"success","stats":{"input_tokens":120,"output_tokens":3,"cached":40,"total_tokens":123,"duration_ms":850}}

--- a/server/providers/__fixtures__/gemini/0.11.0/tool-use.jsonl
+++ b/server/providers/__fixtures__/gemini/0.11.0/tool-use.jsonl
@@ -1,0 +1,5 @@
+{"type":"init","session_id":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","model":"gemini-2.5-flash"}
+{"type":"tool_use","tool_name":"read_file","tool_id":"t0","parameters":{"path":"src/index.ts"}}
+{"type":"tool_result","tool_id":"t0","status":"ok","output":"file contents"}
+{"type":"message","role":"assistant","content":"Done reading.","delta":true}
+{"type":"result","status":"success","stats":{"input_tokens":500,"output_tokens":20,"cached":0,"total_tokens":520,"duration_ms":1200}}

--- a/server/providers/gemini-adapter.test.ts
+++ b/server/providers/gemini-adapter.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+vi.mock('child_process', async () => {
+  const actual = await vi.importActual<typeof import('child_process')>('child_process')
+  return { ...actual, execSync: vi.fn() }
+})
+
+import { execSync } from 'child_process'
+import { geminiAdapter, _GEMINI_MIN_VERSION, _compareSemver } from './gemini-adapter'
+import type { AdapterEvent } from './types'
+
+const mockExec = vi.mocked(execSync)
+
+const FIXTURES_DIR = join(__dirname, '__fixtures__', 'gemini', _GEMINI_MIN_VERSION)
+
+function parseFixture(name: string): AdapterEvent[] {
+  const raw = readFileSync(join(FIXTURES_DIR, name), 'utf8')
+  return raw
+    .split(/\r?\n/)
+    .filter((l) => l.length > 0)
+    .map((l) => geminiAdapter.parseStreamLine(l))
+    .filter((e): e is AdapterEvent => e !== null)
+}
+
+describe('geminiAdapter — identity', () => {
+  it('exposes expected conventions', () => {
+    expect(geminiAdapter.id).toBe('gemini')
+    expect(geminiAdapter.displayName).toBe('Gemini CLI')
+    expect(geminiAdapter.binary).toBe('gemini')
+    expect(geminiAdapter.projectDirName).toBe('.gemini')
+    expect(geminiAdapter.instructionsFilename).toBe('GEMINI.md')
+    expect(geminiAdapter.mcpRegistration).toBe('project-json')
+    expect(geminiAdapter.minCliVersion).toBe('0.11.0')
+  })
+
+  it('declares capabilities matching gemini-cli 0.11 behaviour', () => {
+    const c = geminiAdapter.capabilities
+    expect(c.nativeResume).toBe(true)
+    expect(c.nativeStreamJson).toBe(true)
+    expect(c.nativeCostUsd).toBe(false)
+    // Gemini emits OTLP natively (GEMINI_TELEMETRY_*) — unlike codex, no bridge.
+    expect(c.nativeOtelEnv).toBe(true)
+    expect(c.profileEnvSupport).toBe(true)
+    // No --system-prompt flag (the CLI uses GEMINI_SYSTEM_MD env) → fold.
+    expect(c.systemPromptArg).toBe(false)
+  })
+
+  it('reports the same baseline rail agents as claude/codex', () => {
+    expect([...geminiAdapter.baselineAgents()].sort()).toEqual([
+      'sr-architect',
+      'sr-developer',
+      'sr-reviewer',
+    ])
+  })
+
+  it('reports a model catalog with gemini-2.5-pro default', () => {
+    const cat = geminiAdapter.modelCatalog()
+    expect(cat.length).toBeGreaterThan(0)
+    const defaults = cat.filter((m) => m.default === true)
+    expect(defaults).toHaveLength(1)
+    expect(defaults[0].value).toBe('gemini-2.5-pro')
+    expect(geminiAdapter.defaultModel()).toBe('gemini-2.5-pro')
+  })
+})
+
+describe('geminiAdapter._compareSemver', () => {
+  it('compares versions correctly', () => {
+    expect(_compareSemver('0.11.0', '0.11.0')).toBe(0)
+    expect(_compareSemver('0.12.0', '0.11.0')).toBe(1)
+    expect(_compareSemver('0.10.99', '0.11.0')).toBe(-1)
+    expect(_compareSemver('1.0.0', '0.11.0')).toBe(1)
+  })
+})
+
+describe('geminiAdapter.buildArgs', () => {
+  it('chat-turn passes user prompt as-is, ignoring systemPrompt (GEMINI.md carries the framing)', () => {
+    const args = geminiAdapter.buildArgs('chat-turn', {
+      prompt: 'user msg',
+      systemPrompt: 'sys',
+      model: 'gemini-2.5-flash',
+    })
+    expect(args.slice(0, 2)).toEqual(['-p', 'user msg'])
+    expect(args[args.indexOf('--model') + 1]).toBe('gemini-2.5-flash')
+    expect(args[args.indexOf('--output-format') + 1]).toBe('stream-json')
+    expect(args).toContain('--yolo')
+    // No fold, no system text, no --system-prompt flag.
+    expect(args.some((a) => a.includes('sys\n\n---\n\n'))).toBe(false)
+    expect(args.some((a) => a === 'sys')).toBe(false)
+    expect(args).not.toContain('--system-prompt')
+    expect(args).not.toContain('--resume')
+  })
+
+  it('chat-turn preserves short user prompts verbatim even with a long systemPrompt', () => {
+    const longSys = 'You have explicit permission to read and write spec files — '.repeat(20)
+    const args = geminiAdapter.buildArgs('chat-turn', {
+      prompt: 'quiero hacer un tetris',
+      systemPrompt: longSys,
+      model: 'gemini-2.5-pro',
+    })
+    expect(args).toContain('quiero hacer un tetris')
+    expect(args.some((a) => a.includes('explicit permission'))).toBe(false)
+  })
+
+  it('chat-resume requires sessionId and passes --resume <id> with user-only prompt', () => {
+    expect(() =>
+      geminiAdapter.buildArgs('chat-resume', { prompt: 'x', model: 'gemini-2.5-pro' }),
+    ).toThrow(/sessionId/)
+
+    const args = geminiAdapter.buildArgs('chat-resume', {
+      prompt: 'next msg',
+      systemPrompt: 'sys',
+      sessionId: '11111111-2222-3333-4444-555555555555',
+      model: 'gemini-2.5-pro',
+    })
+    expect(args.slice(0, 2)).toEqual(['-p', 'next msg'])
+    expect(args[args.indexOf('--resume') + 1]).toBe('11111111-2222-3333-4444-555555555555')
+    expect(args.some((a) => a === 'sys')).toBe(false)
+    expect(args.some((a) => a.includes('sys\n\n---\n\n'))).toBe(false)
+  })
+
+  it('chat-stream throws (no persistent stdin transport)', () => {
+    expect(() =>
+      geminiAdapter.buildArgs('chat-stream', { prompt: 'x', model: 'gemini-2.5-pro' }),
+    ).toThrow(/persistent stdin/)
+  })
+
+  it('rail-job folds the system prompt into the user prompt', () => {
+    const args = geminiAdapter.buildArgs('rail-job', {
+      prompt: '/specrails:implement #1',
+      systemPrompt: 'pipeline ctx',
+      model: 'gemini-2.5-pro',
+    })
+    expect(args[0]).toBe('-p')
+    expect(args[1]).toBe('pipeline ctx\n\n---\n\n/specrails:implement #1')
+    expect(args).toContain('--yolo')
+  })
+
+  it('spec-gen, agent-refine, auto-title, setup-enrich all fold + use stream-json', () => {
+    for (const action of ['spec-gen', 'agent-refine', 'auto-title', 'setup-enrich'] as const) {
+      const args = geminiAdapter.buildArgs(action, {
+        prompt: 'p',
+        systemPrompt: 'S',
+        model: 'gemini-2.5-pro',
+      })
+      expect(args[0]).toBe('-p')
+      expect(args[1]).toBe('S\n\n---\n\np')
+      expect(args[args.indexOf('--output-format') + 1]).toBe('stream-json')
+    }
+  })
+
+  it('setup-enrich-resume requires sessionId and passes --resume', () => {
+    expect(() =>
+      geminiAdapter.buildArgs('setup-enrich-resume', { prompt: 'x', model: 'gemini-2.5-pro' }),
+    ).toThrow(/sessionId/)
+
+    const args = geminiAdapter.buildArgs('setup-enrich-resume', {
+      prompt: 'cont',
+      sessionId: 'UUID',
+      model: 'gemini-2.5-pro',
+    })
+    expect(args[args.indexOf('--resume') + 1]).toBe('UUID')
+  })
+
+  it('extraArgs append at the end', () => {
+    const args = geminiAdapter.buildArgs('chat-turn', {
+      prompt: 'p',
+      model: 'gemini-2.5-pro',
+      extraArgs: ['--include-directories', '/extra'],
+    })
+    expect(args.slice(-2)).toEqual(['--include-directories', '/extra'])
+  })
+})
+
+describe('geminiAdapter.parseStreamLine', () => {
+  it('returns null for empty input', () => {
+    expect(geminiAdapter.parseStreamLine('')).toBeNull()
+  })
+
+  it('returns null for non-JSON', () => {
+    expect(geminiAdapter.parseStreamLine('not json')).toBeNull()
+  })
+
+  it('parses init as session-started', () => {
+    const ev = geminiAdapter.parseStreamLine(
+      '{"type":"init","session_id":"11111111-2222-3333-4444-555555555555","model":"gemini-2.5-pro"}',
+    )
+    expect(ev).toEqual({ kind: 'session-started', sessionId: '11111111-2222-3333-4444-555555555555' })
+  })
+
+  it('parses init without session_id as other', () => {
+    const ev = geminiAdapter.parseStreamLine('{"type":"init","model":"gemini-2.5-pro"}')
+    expect(ev?.kind).toBe('other')
+  })
+
+  it('parses assistant message as text-delta', () => {
+    const ev = geminiAdapter.parseStreamLine(
+      '{"type":"message","role":"assistant","content":"hi","delta":true}',
+    )
+    expect(ev).toEqual({ kind: 'text-delta', text: 'hi' })
+  })
+
+  it('ignores the user echo message (kind other)', () => {
+    const ev = geminiAdapter.parseStreamLine('{"type":"message","role":"user","content":"prompt"}')
+    expect(ev?.kind).toBe('other')
+  })
+
+  it('parses tool_use as tool-use with a truncated preview', () => {
+    const ev = geminiAdapter.parseStreamLine(
+      '{"type":"tool_use","tool_name":"read_file","tool_id":"t0","parameters":{"path":"a.ts"}}',
+    )
+    expect(ev?.kind).toBe('tool-use')
+    if (ev?.kind === 'tool-use') {
+      expect(ev.name).toBe('read_file')
+      expect(ev.inputPreview).toContain('a.ts')
+    }
+  })
+
+  it('parses tool_result as other', () => {
+    const ev = geminiAdapter.parseStreamLine('{"type":"tool_result","tool_id":"t0","status":"ok"}')
+    expect(ev?.kind).toBe('other')
+  })
+
+  it('parses result as result', () => {
+    const ev = geminiAdapter.parseStreamLine(
+      '{"type":"result","status":"success","stats":{"input_tokens":1,"output_tokens":2}}',
+    )
+    expect(ev?.kind).toBe('result')
+    if (ev?.kind === 'result') expect(ev.payload.type).toBe('result')
+  })
+
+  it('parses an unknown event type as other', () => {
+    const ev = geminiAdapter.parseStreamLine('{"type":"thought","content":"hmm"}')
+    expect(ev?.kind).toBe('other')
+    if (ev?.kind === 'other') expect(ev.type).toBe('thought')
+  })
+
+  it('parses a typeless object as other <missing>', () => {
+    const ev = geminiAdapter.parseStreamLine('{"foo":"bar"}')
+    expect(ev?.kind).toBe('other')
+    if (ev?.kind === 'other') expect(ev.type).toBe('<missing>')
+  })
+})
+
+describe('geminiAdapter.extractResult — fixture-based', () => {
+  it('extracts tokens, cache, session, and turns from the hello stream', () => {
+    const events = parseFixture('hello-3-words.jsonl')
+    const result = geminiAdapter.extractResult(events)
+    expect(result.session_id).toBe('11111111-2222-3333-4444-555555555555')
+    expect(result.tokens_in).toBe(120)
+    expect(result.tokens_out).toBe(3)
+    expect(result.tokens_cache_read).toBe(40)
+    expect(result.tokens_cache_create).toBeUndefined()
+    expect(result.num_turns).toBe(1)
+    expect(result.duration_ms).toBe(850)
+    // Cost is never native — estimated downstream via pricing.ts.
+    expect(result.total_cost_usd).toBeUndefined()
+  })
+
+  it('handles a tool-use stream and captures its session', () => {
+    const events = parseFixture('tool-use.jsonl')
+    const result = geminiAdapter.extractResult(events)
+    expect(result.session_id).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')
+    expect(result.tokens_in).toBe(500)
+    expect(result.tokens_cache_read).toBe(0)
+    expect(events.some((e) => e.kind === 'tool-use')).toBe(true)
+  })
+
+  it('returns only the session id when no result event arrived', () => {
+    const events: AdapterEvent[] = [{ kind: 'session-started', sessionId: 'sid' }]
+    expect(geminiAdapter.extractResult(events)).toEqual({ session_id: 'sid' })
+  })
+
+  it('returns an empty result for an empty stream', () => {
+    expect(geminiAdapter.extractResult([])).toEqual({ session_id: undefined })
+  })
+})
+
+describe('geminiAdapter.detectInstalled', () => {
+  beforeEach(() => {
+    mockExec.mockReset()
+  })
+
+  it('reports not installed when `which gemini` throws', async () => {
+    mockExec.mockImplementationOnce(() => {
+      throw new Error('not found')
+    })
+    expect(await geminiAdapter.detectInstalled()).toEqual({ installed: false, executable: false })
+  })
+
+  it('reports executable + meetsMinimum for a recent version', async () => {
+    mockExec
+      .mockImplementationOnce(() => Buffer.from('')) // which
+      .mockImplementationOnce(() => '0.12.3\n') // --version
+    const res = await geminiAdapter.detectInstalled()
+    expect(res.installed).toBe(true)
+    expect(res.executable).toBe(true)
+    expect(res.version).toBe('0.12.3')
+    expect(res.meetsMinimum).toBe(true)
+    expect(res.error).toBeUndefined()
+  })
+
+  it('flags an older version with an upgrade hint', async () => {
+    mockExec
+      .mockImplementationOnce(() => Buffer.from(''))
+      .mockImplementationOnce(() => '0.10.0\n')
+    const res = await geminiAdapter.detectInstalled()
+    expect(res.meetsMinimum).toBe(false)
+    expect(res.error).toMatch(/older than required/)
+  })
+
+  it('reports installed but not executable when --version throws', async () => {
+    mockExec
+      .mockImplementationOnce(() => Buffer.from(''))
+      .mockImplementationOnce(() => {
+        throw new Error('boom')
+      })
+    expect(await geminiAdapter.detectInstalled()).toEqual({ installed: true, executable: false })
+  })
+})

--- a/server/providers/gemini-adapter.ts
+++ b/server/providers/gemini-adapter.ts
@@ -1,0 +1,249 @@
+// Gemini CLI (Google) adapter for gemini-cli 0.11.0+.
+//
+// Stream format (gemini `-p "<prompt>" --output-format stream-json`), one minified
+// JSON object per line — pinned to gemini-cli >= 0.11 and locked by the fixtures
+// under __fixtures__/gemini-*.ndjson:
+//   {"type":"init","session_id":"<UUID>","model":"gemini-2.5-pro"}
+//   {"type":"message","role":"assistant","content":"...","delta":true}
+//   {"type":"tool_use","tool_name":"read_file","tool_id":"t0","parameters":{...}}
+//   {"type":"tool_result","tool_id":"t0","status":"ok","output":"..."}
+//   {"type":"result","status":"success","stats":{"input_tokens":N,"output_tokens":N,
+//     "cached":N,"total_tokens":N,"duration_ms":N}}
+//
+// Differences vs codex: Gemini reports tokens but NOT cost, so `nativeCostUsd`
+// is false and cost is estimated downstream via server/pricing.ts. Gemini DOES
+// emit OTLP natively via `GEMINI_TELEMETRY_*` env (set by QueueManager), so
+// `nativeOtelEnv` is true — no synthetic bridge. There is no `--system-prompt`
+// flag (the CLI uses the `GEMINI_SYSTEM_MD` env), so `systemPromptArg` is false
+// and the system prompt is folded for non-Explore actions; Explore turns trust
+// the app-managed GEMINI.md in explore-cwd, exactly like codex/AGENTS.md.
+//
+// NOTE (pre-1.0): gemini-cli changes weekly. The exact argv/event field names
+// here follow the documented 0.11 contract; they are guarded by the beta flag
+// (SPECRAILS_GEMINI_BETA) and MUST be re-validated against a real binary via the
+// fixtures before the gate is removed. Parsing is tolerant of missing fields.
+//
+// Spec: openspec/specs/multi-provider-architecture/spec.md
+
+import { execSync } from 'child_process'
+import type {
+  AdapterEvent,
+  DetectionResult,
+  NormalisedResult,
+  ProviderAdapter,
+  SpawnAction,
+  SpawnOptions,
+} from './types'
+
+const WHICH_CMD = process.platform === 'win32' ? 'where' : 'which'
+
+// Floor where `--output-format stream-json` + headless `--resume` are available.
+const GEMINI_MIN_VERSION = '0.11.0'
+
+// Curated GA-id catalog (see docs/gemini-cli-provider-study.md §2). Preview ids
+// rotate, so we pin concrete ids that pricing.ts has rows for.
+const GEMINI_MODELS = [
+  { value: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro', default: true as const },
+  { value: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
+  { value: 'gemini-2.5-flash-lite', label: 'Gemini 2.5 Flash Lite' },
+  { value: 'gemini-3.1-pro-preview', label: 'Gemini 3 Pro (preview)' },
+] as const
+
+const STREAM_JSON_FLAGS = ['--output-format', 'stream-json'] as const
+// Auto-approve tool calls so headless turns never block on an approval prompt.
+// Parity with codex's workspace-write/full-access sandbox; the non-destructive
+// stance for Explore is carried by GEMINI.md + the system prompt, not a sandbox.
+const YOLO_FLAG = '--yolo' as const
+
+/** Fold system prompt into the user prompt for providers without --system-prompt. */
+function fold(systemPrompt: string | undefined, prompt: string): string {
+  if (!systemPrompt) return prompt
+  return `${systemPrompt}\n\n---\n\n${prompt}`
+}
+
+function buildGeminiArgs(action: SpawnAction, opts: SpawnOptions): string[] {
+  const model = ['--model', opts.model]
+
+  switch (action) {
+    case 'chat-turn': {
+      // Explore turns spawn from the app-managed explore-cwd, which ships a
+      // GEMINI.md with the Explore stance. Folding the long system prompt into a
+      // short user message ("quiero hacer un tetris") makes the model answer the
+      // system instructions instead of the user — so pass user text only and
+      // trust GEMINI.md, exactly like the codex adapter trusts AGENTS.md.
+      return ['-p', opts.prompt, ...model, ...STREAM_JSON_FLAGS, YOLO_FLAG, ...(opts.extraArgs ?? [])]
+    }
+    case 'chat-resume': {
+      if (!opts.sessionId) throw new Error(`${action} requires sessionId`)
+      return ['-p', opts.prompt, ...model, ...STREAM_JSON_FLAGS, '--resume', opts.sessionId, YOLO_FLAG, ...(opts.extraArgs ?? [])]
+    }
+    case 'chat-stream': {
+      // Gemini has no persistent-stdin multi-turn transport; the Explore
+      // fast-path gates on capabilities.persistentStdin (omitted), so this is
+      // never reached. Throw defensively rather than emit a broken argv.
+      throw new Error('gemini does not support persistent stdin streaming (chat-stream)')
+    }
+    case 'spec-gen':
+    case 'agent-refine':
+    case 'auto-title':
+    case 'setup-enrich':
+    case 'rail-job': {
+      return ['-p', fold(opts.systemPrompt, opts.prompt), ...model, ...STREAM_JSON_FLAGS, YOLO_FLAG, ...(opts.extraArgs ?? [])]
+    }
+    case 'setup-enrich-resume': {
+      if (!opts.sessionId) throw new Error(`${action} requires sessionId`)
+      return ['-p', fold(opts.systemPrompt, opts.prompt), ...model, ...STREAM_JSON_FLAGS, '--resume', opts.sessionId, YOLO_FLAG, ...(opts.extraArgs ?? [])]
+    }
+  }
+}
+
+function parseGeminiStreamLine(line: string): AdapterEvent | null {
+  if (line.length === 0) return null
+  let parsed: Record<string, unknown>
+  try {
+    parsed = JSON.parse(line) as Record<string, unknown>
+  } catch {
+    return null
+  }
+
+  const type = parsed.type as string | undefined
+  if (!type) return { kind: 'other', type: '<missing>', raw: parsed }
+
+  if (type === 'init') {
+    const sid = parsed.session_id as string | undefined
+    if (sid) return { kind: 'session-started', sessionId: sid }
+    return { kind: 'other', type, raw: parsed }
+  }
+
+  if (type === 'result') {
+    return { kind: 'result', payload: parsed }
+  }
+
+  if (type === 'message') {
+    // Only assistant text is a delta; the user echo (role 'user') is ignored.
+    const role = parsed.role as string | undefined
+    if (role === 'assistant') {
+      const text = (parsed.content as string | undefined) ?? ''
+      if (text) return { kind: 'text-delta', text }
+    }
+    return { kind: 'other', type, raw: parsed }
+  }
+
+  if (type === 'tool_use') {
+    const name = (parsed.tool_name as string | undefined) ?? '<unnamed>'
+    const params = parsed.parameters
+    const inputPreview = params !== undefined ? JSON.stringify(params).slice(0, 200) : ''
+    return { kind: 'tool-use', name, inputPreview }
+  }
+
+  // tool_result, error, and any unknown event type carry no normalised meaning.
+  return { kind: 'other', type, raw: parsed }
+}
+
+function extractGeminiResult(events: readonly AdapterEvent[]): NormalisedResult {
+  let sessionId: string | undefined
+  let resultPayload: Record<string, unknown> | null = null
+  let turnCount = 0
+  for (const ev of events) {
+    if (ev.kind === 'session-started') sessionId = ev.sessionId
+    else if (ev.kind === 'result') {
+      resultPayload = ev.payload
+      turnCount += 1
+    }
+  }
+
+  if (!resultPayload) {
+    return { session_id: sessionId }
+  }
+
+  const stats = resultPayload.stats as Record<string, number> | undefined
+
+  return {
+    tokens_in: stats?.input_tokens,
+    tokens_out: stats?.output_tokens,
+    // Gemini reports a single `cached` read tier; map it to cache_read. No
+    // separate cache-creation tier — `cached` is counted as a subset of
+    // input_tokens (consistent with codex `cached_input_tokens`), so pricing.ts
+    // must not double-count.
+    tokens_cache_read: stats?.cached,
+    tokens_cache_create: undefined,
+    // total_cost_usd intentionally absent — estimated via pricing.ts.
+    num_turns: turnCount || 1,
+    // Stream events do not carry the model; the manager wrapper stamps the
+    // requested model on the row.
+    model: undefined,
+    duration_ms: typeof stats?.duration_ms === 'number' ? stats.duration_ms : undefined,
+    duration_api_ms: undefined,
+    session_id: sessionId,
+  }
+}
+
+function compareSemver(a: string, b: string): number {
+  const aParts = a.split('.').map((n) => parseInt(n, 10))
+  const bParts = b.split('.').map((n) => parseInt(n, 10))
+  for (let i = 0; i < 3; i++) {
+    const av = aParts[i] ?? 0
+    const bv = bParts[i] ?? 0
+    if (av > bv) return 1
+    if (av < bv) return -1
+  }
+  return 0
+}
+
+async function detectGeminiInstalled(): Promise<DetectionResult> {
+  try {
+    execSync(`${WHICH_CMD} gemini`, { stdio: 'ignore' })
+  } catch {
+    return { installed: false, executable: false }
+  }
+
+  try {
+    const raw = execSync('gemini --version', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+      timeout: 3000,
+    }).trim()
+    const match = raw.match(/\d+\.\d+\.\d+/)
+    const version = match ? match[0] : raw
+    const meetsMinimum = match ? compareSemver(version, GEMINI_MIN_VERSION) >= 0 : false
+    const result: DetectionResult = {
+      installed: true,
+      executable: true,
+      version,
+      meetsMinimum,
+    }
+    if (!meetsMinimum) {
+      result.error = `gemini ${version} is older than required ${GEMINI_MIN_VERSION}. Upgrade with: npm i -g @google/gemini-cli (or see https://github.com/google-gemini/gemini-cli).`
+    }
+    return result
+  } catch {
+    return { installed: true, executable: false }
+  }
+}
+
+export const geminiAdapter: ProviderAdapter = {
+  id: 'gemini',
+  displayName: 'Gemini CLI',
+  binary: 'gemini',
+  minCliVersion: GEMINI_MIN_VERSION,
+  projectDirName: '.gemini',
+  instructionsFilename: 'GEMINI.md',
+  mcpRegistration: 'project-json',
+  capabilities: {
+    nativeResume: true,
+    nativeStreamJson: true,
+    nativeCostUsd: false,
+    nativeOtelEnv: true,
+    profileEnvSupport: true,
+    systemPromptArg: false,
+  },
+  modelCatalog: () => GEMINI_MODELS,
+  defaultModel: () => 'gemini-2.5-pro',
+  buildArgs: buildGeminiArgs,
+  parseStreamLine: parseGeminiStreamLine,
+  extractResult: extractGeminiResult,
+  baselineAgents: () => ['sr-architect', 'sr-developer', 'sr-reviewer'],
+  detectInstalled: detectGeminiInstalled,
+}
+
+export { GEMINI_MIN_VERSION as _GEMINI_MIN_VERSION, compareSemver as _compareSemver }

--- a/server/providers/index.ts
+++ b/server/providers/index.ts
@@ -9,12 +9,14 @@
 import { register } from './registry'
 import { claudeAdapter } from './claude-adapter'
 import { codexAdapter } from './codex-adapter'
+import { geminiAdapter } from './gemini-adapter'
 
 register(claudeAdapter)
 register(codexAdapter)
+register(geminiAdapter)
 
 export { getAdapter, hasAdapter, listAdapters } from './registry'
-export { claudeAdapter, codexAdapter }
+export { claudeAdapter, codexAdapter, geminiAdapter }
 export type {
   ProviderAdapter,
   ProviderId,

--- a/server/setup-manager.ts
+++ b/server/setup-manager.ts
@@ -10,7 +10,7 @@ import { spawnAiCli } from './util/cli-prompt'
 import { spawnCli } from './util/win-spawn'
 import { formatMissingSetupPrerequisites } from './setup-prerequisites'
 import { CORE_PACKAGE_SPEC } from './core-package'
-import { getAdapter } from './providers'
+import { getAdapter, hasAdapter } from './providers'
 import type { ProviderAdapter, SpawnAction, ProviderId } from './providers/types'
 
 /**
@@ -695,7 +695,7 @@ export class SetupManager {
       try {
         const text = readFileSync(configPath, 'utf-8')
         const m = text.match(/^provider:\s*(\w+)/m)
-        if (m && (m[1] === 'claude' || m[1] === 'codex')) {
+        if (m && m[1] && hasAdapter(m[1])) {
           this._projectProviders.set(projectId, m[1])
         }
       } catch {
@@ -1304,7 +1304,7 @@ export class SetupManager {
     try {
       const text = readFileSync(join(projectPath, '.specrails', 'install-config.yaml'), 'utf-8')
       const m = text.match(/^provider:\s*(\w+)/m)
-      if (m && m[1] === 'codex') provider = 'codex'
+      if (m && m[1] && hasAdapter(m[1])) provider = m[1]
     } catch {
       // Missing install-config — stay on claude default.
     }

--- a/server/setup-prerequisites.test.ts
+++ b/server/setup-prerequisites.test.ts
@@ -218,7 +218,9 @@ describe('setup prerequisites', () => {
       if (cmd === 'npm') return { status: 0, stdout: '10.0.0\n', stderr: '' } as any
       if (cmd === 'npx') return { status: 0, stdout: '10.0.0\n', stderr: '' } as any
       if (cmd === 'git') return { status: 0, stdout: 'git version 2.42.1\n', stderr: '' } as any
-      // Both providers fail their version probe → unusable
+      // All providers fail their version probe → unusable. claude/codex return a
+      // non-zero status; gemini returns 0 with empty stdout (no version match →
+      // meetsMinimum false), so all three are unusable.
       if (cmd === 'claude' || cmd === 'codex') return { status: 1, stdout: '', stderr: 'auth missing' } as any
       return { status: 0, stdout: '', stderr: '' } as any
     })
@@ -229,7 +231,7 @@ describe('setup prerequisites', () => {
       .filter((p) => p.kind === 'provider')
       .map((p) => p.key)
       .sort()
-    expect(missingProviders).toEqual(['claude', 'codex'])
+    expect(missingProviders).toEqual(['claude', 'codex', 'gemini'])
   })
 
   it('does NOT block when at least one provider is usable', () => {

--- a/server/setup-prerequisites.ts
+++ b/server/setup-prerequisites.ts
@@ -406,6 +406,8 @@ function providerInstallUrl(id: string): string {
       return 'https://claude.com/download'
     case 'codex':
       return 'https://developers.openai.com/codex'
+    case 'gemini':
+      return 'https://github.com/google-gemini/gemini-cli'
     default:
       return 'https://github.com'
   }
@@ -421,6 +423,8 @@ function providerInstallHint(id: string, platform: NodeJS.Platform): string {
         : platform === 'win32'
           ? 'Install Codex CLI from https://developers.openai.com/codex, authenticate with `codex login`, then restart Specrails.'
           : 'Install Codex CLI from https://developers.openai.com/codex (or `pipx install codex-cli`), authenticate with `codex login`, then restart Specrails.'
+    case 'gemini':
+      return 'Install Gemini CLI via `npm i -g @google/gemini-cli` (or see https://github.com/google-gemini/gemini-cli), set GEMINI_API_KEY, then restart Specrails.'
     default:
       return `Install the ${id} CLI and restart Specrails.`
   }

--- a/server/util/cli-prompt.test.ts
+++ b/server/util/cli-prompt.test.ts
@@ -5,6 +5,7 @@ import {
   ensureStdinPipe,
   spawnClaude,
   spawnCodex,
+  spawnGemini,
   spawnAiCli,
 } from './cli-prompt'
 
@@ -234,6 +235,14 @@ describe('spawn dispatch (POSIX fallthrough)', () => {
     smokeSpawnSync(spawnCodex(['exec', 'noop'], { stdio: ['ignore', 'pipe', 'pipe'] }))
   })
 
+  it('spawnGemini injects GEMINI_CLI_TRUST_WORKSPACE and spawns via spawnCli', () => {
+    if (skipOnWin) return
+    // Merge into a caller-provided env (not just process.env) and assert the
+    // trust var is set — without it gemini silently disables --yolo headless.
+    const child = spawnGemini(['--version'], { env: { FOO: 'bar' }, stdio: ['ignore', 'pipe', 'pipe'] })
+    smokeSpawnSync(child)
+  })
+
   it('spawnAiCli runs a real binary end-to-end on POSIX', async () => {
     if (skipOnWin) return
     const child = spawnAiCli('echo', ['hello'], { stdio: ['ignore', 'pipe', 'pipe'] })
@@ -244,9 +253,9 @@ describe('spawn dispatch (POSIX fallthrough)', () => {
     expect(out.trim()).toBe('hello')
   })
 
-  it('spawnAiCli dispatches "claude"/"codex"/other through the right wrapper', () => {
+  it('spawnAiCli dispatches "claude"/"codex"/"gemini"/other through the right wrapper', () => {
     if (skipOnWin) return
-    for (const bin of ['claude', 'codex', 'true']) {
+    for (const bin of ['claude', 'codex', 'gemini', 'true']) {
       smokeSpawnSync(spawnAiCli(bin, [], { stdio: ['ignore', 'pipe', 'pipe'] }))
     }
   })

--- a/server/util/cli-prompt.ts
+++ b/server/util/cli-prompt.ts
@@ -171,8 +171,22 @@ export function spawnCodex(args: string[], options: SpawnOptions = {}): ChildPro
 }
 
 /**
+ * Spawn `gemini` headless. Injects `GEMINI_CLI_TRUST_WORKSPACE=true` so the CLI
+ * does not silently override `--yolo` back to "default" (which blocks EVERY tool
+ * call) when the project dir is not a "trusted folder" — the documented escape
+ * hatch for headless/automated environments. Validated empirically: without it,
+ * a headless `gemini -p` run executes zero tool calls and the rail does nothing.
+ * No multi-line argv quirk (the prompt rides on a single `-p` value), so the
+ * Windows path is identical to POSIX.
+ */
+export function spawnGemini(args: string[], options: SpawnOptions = {}): ChildProcess {
+  const env = { ...(options.env ?? process.env), GEMINI_CLI_TRUST_WORKSPACE: 'true' }
+  return spawnCli('gemini', args, { ...options, env })
+}
+
+/**
  * Convenience: dispatch on binary name. Use when callsite picks the
- * binary dynamically (claude vs codex). Anything else routes through
+ * binary dynamically (claude vs codex vs gemini). Anything else routes through
  * the underlying spawnCli unchanged.
  */
 export function spawnAiCli(
@@ -182,5 +196,6 @@ export function spawnAiCli(
 ): ChildProcess {
   if (binary === 'claude') return spawnClaude(args, options)
   if (binary === 'codex') return spawnCodex(args, options)
+  if (binary === 'gemini') return spawnGemini(args, options)
   return spawnCli(binary, args, options)
 }


### PR DESCRIPTION
**PR-B of 2** — the Gemini CLI adapter + full desktop wiring. Rebased on `main` (PR-A #396 merged). Gemini is registered but **dormant behind a default-off `SPECRAILS_GEMINI_BETA`** gate; claude/codex paths are byte-identical.

## What this delivers (desktop scope: spec / explore / quick / ai-edit / analytics / terminal)
- **Adapter** `server/providers/gemini-adapter.ts` — `-p` headless, `--output-format stream-json`, `--resume`, `--yolo`; `nativeCostUsd:false` (rate-card), `nativeOtelEnv:true` (native OTLP, no bridge), `systemPromptArg:false` (fold; Explore stays user-only via `GEMINI.md`). Stream schema + token/cache accounting **validated against real gemini 0.46 output**.
- `register(geminiAdapter)` + `pricing.ts` rows.
- **Beta gate** `SPECRAILS_GEMINI_BETA` (default OFF → gemini omitted from `/available-providers` and rejected in `POST /projects`).
- **`GEMINI_CLI_TRUST_WORKSPACE=true`** injected by `spawnGemini` (`cli-prompt.ts`) — gemini's "trusted folders" gate otherwise silently disables `--yolo` and blocks every headless tool call (found via the orchestration spike).
- **Adapter-driven `else`** in the ticket ai-edit handler (no wrong-binary for gemini); `setup-manager` regex accepts any registered provider; data-driven `AddProjectDialog`; Navbar + analytics labels.
- **Docs**: `docs/gemini.md` + the missing `docs/adding-a-provider.md`.

## Verification
- `npm run typecheck` (server + CLI + client): ✅ exit 0
- Server tests + coverage: ✅ exit 0 (142 files; cli-prompt 98.6%)
- Client tests + coverage: ✅ exit 0 (2675 tests; 84.9 / 81.2 / 72.4 / 84.9)

## Explicitly out of scope → separate work in `specrails-core`
The **rails pipeline** (`/specrails:implement`, `batch-implement`) needs core to emit a Gemini artifact tree (`.gemini/commands/*.toml` + `.gemini/agents/sr-*.md`). Validated feasible by a headless spike (the full architect→developer→reviewer SDD/OpenSpec cycle ran on gemini via `invoke_agent` depth-1 delegation). Tracked in `docs/gemini-core-support-evaluation.md`. Rails are hidden for Gemini projects until core ships.

## Safety
Production behaviour unchanged until `SPECRAILS_GEMINI_BETA=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)