### PR TITLE
fix(mobile): chunk oversized WebRTC DataChannel messages

### DIFF
--- a/server/mobile/mobile-datachannel.test.ts
+++ b/server/mobile/mobile-datachannel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { DataChannelPeer, type DataChannelLike, type WelcomeResult } from './mobile-datachannel'
+import { DataChannelPeer, ChunkReassembler, type DataChannelLike, type WelcomeResult } from './mobile-datachannel'
 import { MobileWsBridge } from './mobile-ws'
 import type { WsMessage } from '../types'
 
@@ -113,6 +113,44 @@ describe('DataChannelPeer', () => {
     bridge.dispatch({ type: 'queue', projectId: 'p1', jobs: [], paused: false, activeJobId: null } as unknown as WsMessage)
 
     expect(ch.json().some((f) => f.type === 'queue' && f.projectId === 'p1')).toBe(true)
+  })
+
+  it('splits an oversized rpc_result into __chunk frames that reassemble to the original', async () => {
+    const ch = new FakeChannel()
+    const bridge = new MobileWsBridge()
+    const register = async () => ({ ok: true as const, deviceId: 'dev-1', token: 'tok-1', hubName: 'Mac', hubInstanceId: 'inst-1' })
+    // A big JIRA-style ticket list — well over the per-message size cap.
+    const tickets = Array.from({ length: 5000 }, (_, i) => ({ id: i, title: `Ticket ${i}`, status: i % 2 ? 'todo' : 'done' }))
+    new DataChannelPeer(ch, {
+      bridge,
+      registerDevice: register,
+      rpcDispatch: async () => ({ status: 200, json: { tickets } }),
+    })
+    ch.recv({ type: 'hello', sec: 'good', deviceName: 'iPhone', platform: 'web' })
+    await flush()
+    ch.sent.length = 0 // discard the welcome frame
+    ch.recv({ type: 'rpc', id: 'r1', method: 'GET', path: '/v1/projects/p1/tickets' })
+    await flush()
+
+    const frames = ch.json()
+    expect(frames.length).toBeGreaterThan(1) // it actually chunked
+    expect(frames.every((f) => f.type === '__chunk')).toBe(true)
+
+    // Reassembling the chunks yields the original rpc_result verbatim.
+    const reasm = new ChunkReassembler()
+    let full: string | null = null
+    for (const raw of ch.sent) full = reasm.push(raw) ?? full
+    expect(full).not.toBeNull()
+    const decoded = JSON.parse(full!) as { type: string; id: string; status: number; json: { tickets: unknown[] } }
+    expect(decoded.type).toBe('rpc_result')
+    expect(decoded.id).toBe('r1')
+    expect(decoded.json.tickets).toHaveLength(5000)
+  })
+
+  it('ChunkReassembler passes non-chunk frames straight through', () => {
+    const reasm = new ChunkReassembler()
+    const frame = JSON.stringify({ type: 'welcome', deviceId: 'd' })
+    expect(reasm.push(frame)).toBe(frame)
   })
 
   it('drops cleanly when the channel closes', async () => {

--- a/server/mobile/mobile-datachannel.ts
+++ b/server/mobile/mobile-datachannel.ts
@@ -16,6 +16,62 @@ import type { SocketLike } from './mobile-ws'
 const WS_OPEN = 1
 const WS_CLOSED = 3
 
+// WebRTC DataChannels carry an SCTP per-message size cap (werift advertises a
+// modest maxMessageSize; oversized sends throw). A large rpc_result — e.g. a
+// JIRA-backed project's full ticket list — easily exceeds it, and the throw was
+// swallowed silently, so the companion just timed out and rendered "0 tickets".
+// We split any oversized frame into ordered `__chunk` envelopes and reassemble
+// them on the far side. The channel is ordered+reliable, so chunks arrive in
+// order; `g` (group id) keeps concurrent large messages from interleaving.
+const CHUNK_SIZE = 16000
+let _chunkGroup = 0
+
+/** Send `data` over `ch`, splitting into `__chunk` frames when it exceeds the
+ *  safe per-message size. Small frames go out verbatim (no envelope overhead). */
+function framedSend(ch: DataChannelLike, data: string): void {
+  if (data.length <= CHUNK_SIZE) {
+    ch.send(data)
+    return
+  }
+  const g = _chunkGroup++
+  const n = Math.ceil(data.length / CHUNK_SIZE)
+  for (let i = 0; i < n; i++) {
+    const d = data.slice(i * CHUNK_SIZE, (i + 1) * CHUNK_SIZE)
+    ch.send(JSON.stringify({ type: '__chunk', g, i, n, d }))
+  }
+}
+
+/** Buffers inbound `__chunk` frames and yields the reassembled payload once a
+ *  group is complete. Non-chunk frames pass straight through. */
+export class ChunkReassembler {
+  private _groups = new Map<number, { n: number; parts: string[]; got: number }>()
+
+  /** Returns the string to handle (the frame itself, or a completed
+   *  reassembly), or null when more chunks of the group are still pending. */
+  push(data: string): string | null {
+    if (!data.startsWith('{"type":"__chunk"')) return data
+    let p: { g: number; i: number; n: number; d: string }
+    try {
+      p = JSON.parse(data)
+    } catch {
+      return data
+    }
+    if (!p || p.n == null) return data
+    let grp = this._groups.get(p.g)
+    if (!grp) {
+      grp = { n: p.n, parts: new Array(p.n).fill(''), got: 0 }
+      this._groups.set(p.g, grp)
+    }
+    if (grp.parts[p.i] === '' && grp.got < grp.n) {
+      grp.parts[p.i] = p.d
+      grp.got++
+    }
+    if (grp.got < grp.n) return null
+    this._groups.delete(p.g)
+    return grp.parts.join('')
+  }
+}
+
 /** Minimal structural view of a WebRTC DataChannel (werift RTCDataChannel or the
  *  browser type), so the wiring adapter and tests can both satisfy it. */
 export interface DataChannelLike {
@@ -39,7 +95,7 @@ export class DataChannelSocket implements SocketLike {
 
   send(data: string): void {
     try {
-      this._ch.send(data)
+      framedSend(this._ch, data)
     } catch {
       /* channel went away mid-send — onClose will reap it */
     }
@@ -126,11 +182,14 @@ export class DataChannelPeer {
   private _sock: DataChannelSocket
   private _authed = false
   private _token = ''
+  private _reasm = new ChunkReassembler()
 
   constructor(private _ch: DataChannelLike, private _deps: DataChannelPeerDeps) {
     this._sock = new DataChannelSocket(_ch)
     _ch.onMessage((data) => {
-      void this._onMessage(data)
+      const full = this._reasm.push(data)
+      if (full === null) return
+      void this._onMessage(full)
     })
     _ch.onClose(() => this._sock.closed())
   }
@@ -141,7 +200,7 @@ export class DataChannelPeer {
 
   private _send(obj: unknown): void {
     try {
-      this._ch.send(JSON.stringify(obj))
+      framedSend(this._ch, JSON.stringify(obj))
     } catch {
       /* ignore */
     }


### PR DESCRIPTION
werift's DataChannel enforces an SCTP per-message size cap; an oversized `rpc_result` (e.g. a Jira-backed project's full ticket list) exceeded it and the send threw silently, so the companion timed out and rendered "0 tickets".

`framedSend` splits any frame over `CHUNK_SIZE` into ordered `__chunk` envelopes; `ChunkReassembler` buffers + reassembles them on the far side (channel is ordered+reliable; a per-message group id prevents concurrent large messages from interleaving). Small frames go out verbatim.

Tests: oversized `rpc_result` chunks + reassembles to the original; non-chunk frames pass through. Server typecheck + the mobile-datachannel suite (8 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)