### PR TITLE
fix(providers): fix Gemini-confusion bugs across surfaces + refresh Gemini model catalog

### DIFF
--- a/client/src/components/AiEngineSelector.tsx
+++ b/client/src/components/AiEngineSelector.tsx
@@ -13,7 +13,7 @@ interface AiEngineSelectorProps {
   value: string
   /** Installed providers to choose from. */
   providers: readonly string[]
-  onChange: (next: 'claude' | 'codex') => void
+  onChange: (next: string) => void
   disabled?: boolean
   ariaLabel?: string
   className?: string
@@ -37,7 +37,7 @@ export function AiEngineSelector({
   return (
     <Select
       value={value}
-      onValueChange={(v) => onChange(v as 'claude' | 'codex')}
+      onValueChange={(v) => onChange(v)}
       disabled={disabled}
     >
       <SelectTrigger

--- a/client/src/components/ChatInput.tsx
+++ b/client/src/components/ChatInput.tsx
@@ -18,6 +18,20 @@ const CODEX_MODEL_OPTIONS = [
   { value: 'gpt-5.3-codex', label: 'GPT-5.3 Codex' },
 ]
 
+const GEMINI_MODEL_OPTIONS = [
+  { value: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
+  { value: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
+  { value: 'gemini-2.5-flash-lite', label: 'Gemini 2.5 Flash Lite' },
+  { value: 'gemini-3.1-pro-preview', label: 'Gemini 3 Pro (preview)' },
+]
+
+// Per-provider model options; unknown provider falls back to Claude's list.
+const MODEL_OPTIONS_BY_PROVIDER: Record<string, { value: string; label: string }[]> = {
+  claude: CLAUDE_MODEL_OPTIONS,
+  codex: CODEX_MODEL_OPTIONS,
+  gemini: GEMINI_MODEL_OPTIONS,
+}
+
 interface ChatInputProps {
   conversationId: string
   model: string
@@ -40,7 +54,7 @@ export function ChatInput({
   onModelChange,
 }: ChatInputProps) {
   const { t } = useTranslation('chat')
-  const MODEL_OPTIONS = provider === 'codex' ? CODEX_MODEL_OPTIONS : CLAUDE_MODEL_OPTIONS
+  const MODEL_OPTIONS = MODEL_OPTIONS_BY_PROVIDER[provider] ?? CLAUDE_MODEL_OPTIONS
   const [text, setText] = useState('')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 

--- a/client/src/components/ChatInput.tsx
+++ b/client/src/components/ChatInput.tsx
@@ -19,10 +19,10 @@ const CODEX_MODEL_OPTIONS = [
 ]
 
 const GEMINI_MODEL_OPTIONS = [
-  { value: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
-  { value: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
+  { value: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash' },
+  { value: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro (preview)' },
+  { value: 'gemini-3.1-flash-lite', label: 'Gemini 3.1 Flash Lite' },
   { value: 'gemini-2.5-flash-lite', label: 'Gemini 2.5 Flash Lite' },
-  { value: 'gemini-3.1-pro-preview', label: 'Gemini 3 Pro (preview)' },
 ]
 
 // Per-provider model options; unknown provider falls back to Claude's list.

--- a/client/src/components/ModelSelector.tsx
+++ b/client/src/components/ModelSelector.tsx
@@ -32,10 +32,10 @@ export const CODEX_MODELS = [
 ]
 
 export const GEMINI_MODELS = [
-  { value: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
-  { value: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
+  { value: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash' },
+  { value: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro (preview)' },
+  { value: 'gemini-3.1-flash-lite', label: 'Gemini 3.1 Flash Lite' },
   { value: 'gemini-2.5-flash-lite', label: 'Gemini 2.5 Flash Lite' },
-  { value: 'gemini-3.1-pro-preview', label: 'Gemini 3 Pro (preview)' },
 ]
 
 // Per-provider model catalog. Lookup keyed by provider id (not a branch) — a new
@@ -49,9 +49,9 @@ const PROVIDER_MODELS: Record<string, { value: string; label: string }[]> = {
 // Preset → default model per provider (matches specrails-core MODEL_PRESETS).
 // Inner maps are keyed by provider id; an unknown provider falls back to Claude.
 export const PRESET_DEFAULTS: Record<ModelPreset, Record<string, string>> = {
-  balanced: { claude: 'sonnet', codex: 'gpt-5.5', gemini: 'gemini-2.5-pro' },
+  balanced: { claude: 'sonnet', codex: 'gpt-5.5', gemini: 'gemini-3.5-flash' },
   budget: { claude: 'haiku', codex: 'gpt-5.4-mini', gemini: 'gemini-2.5-flash-lite' },
-  max: { claude: 'sonnet', codex: 'gpt-5.5', gemini: 'gemini-2.5-pro' },
+  max: { claude: 'sonnet', codex: 'gpt-5.5', gemini: 'gemini-3.5-flash' },
 }
 
 // "max" preset: top model for architect + PM, default for rest (matches specrails-core)
@@ -97,6 +97,23 @@ export function ModelSelector({
   const { t } = useTranslation('addspec')
   const models = PROVIDER_MODELS[provider] ?? CLAUDE_MODELS
 
+  // Provider-aware preset descriptions: interpolate the ACTUAL model labels for
+  // the selected provider so a gemini/codex project never reads "Sonnet for all
+  // agents". balanced/budget name one model ({{model}}); max names two
+  // ({{topModel}} for architect + PM, {{baseModel}} for the rest).
+  function modelLabel(value: string): string {
+    return models.find((m) => m.value === value)?.label ?? value
+  }
+  function presetDescriptionVars(p: ModelPreset): Record<string, string> {
+    if (p === 'max') {
+      return {
+        topModel: modelLabel(getDefaultModel('sr-architect', 'max', provider)),
+        baseModel: modelLabel(getDefaultModel('sr-developer', 'max', provider)),
+      }
+    }
+    return { model: modelLabel(getDefaultModel('sr-developer', p, provider)) }
+  }
+
   function getEffectiveModel(agentId: string): string {
     return overrides[agentId] ?? getDefaultModel(agentId, preset, provider)
   }
@@ -134,7 +151,7 @@ export function ModelSelector({
                 {t(`modelSelector.preset.${p}.label`)}
               </span>
               <span className="text-[9px] text-muted-foreground text-center leading-tight">
-                {t(`modelSelector.preset.${p}.description`)}
+                {t(`modelSelector.preset.${p}.description`, presetDescriptionVars(p))}
               </span>
             </button>
           ))}

--- a/client/src/components/ModelSelector.tsx
+++ b/client/src/components/ModelSelector.tsx
@@ -31,25 +31,33 @@ export const CODEX_MODELS = [
   { value: 'gpt-5.3-codex', label: 'GPT-5.3 Codex' },
 ]
 
+export const GEMINI_MODELS = [
+  { value: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
+  { value: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
+  { value: 'gemini-2.5-flash-lite', label: 'Gemini 2.5 Flash Lite' },
+  { value: 'gemini-3.1-pro-preview', label: 'Gemini 3 Pro (preview)' },
+]
+
 // Per-provider model catalog. Lookup keyed by provider id (not a branch) — a new
 // provider adds one entry, with no edit to consumers. Fallback is Claude's list.
 const PROVIDER_MODELS: Record<string, { value: string; label: string }[]> = {
   claude: CLAUDE_MODELS,
   codex: CODEX_MODELS,
+  gemini: GEMINI_MODELS,
 }
 
 // Preset → default model per provider (matches specrails-core MODEL_PRESETS).
 // Inner maps are keyed by provider id; an unknown provider falls back to Claude.
 export const PRESET_DEFAULTS: Record<ModelPreset, Record<string, string>> = {
-  balanced: { claude: 'sonnet', codex: 'gpt-5.5' },
-  budget: { claude: 'haiku', codex: 'gpt-5.4-mini' },
-  max: { claude: 'sonnet', codex: 'gpt-5.5' },
+  balanced: { claude: 'sonnet', codex: 'gpt-5.5', gemini: 'gemini-2.5-pro' },
+  budget: { claude: 'haiku', codex: 'gpt-5.4-mini', gemini: 'gemini-2.5-flash-lite' },
+  max: { claude: 'sonnet', codex: 'gpt-5.5', gemini: 'gemini-2.5-pro' },
 }
 
-// "max" preset: Opus for architect + PM, Sonnet for rest (matches specrails-core)
+// "max" preset: top model for architect + PM, default for rest (matches specrails-core)
 const MAX_OVERRIDES: Record<string, Record<string, string>> = {
-  'sr-architect': { claude: 'opus', codex: 'gpt-5.3-codex' },
-  'sr-product-manager': { claude: 'opus', codex: 'gpt-5.3-codex' },
+  'sr-architect': { claude: 'opus', codex: 'gpt-5.3-codex', gemini: 'gemini-3.1-pro-preview' },
+  'sr-product-manager': { claude: 'opus', codex: 'gpt-5.3-codex', gemini: 'gemini-3.1-pro-preview' },
 }
 
 export function getDefaultModel(

--- a/client/src/components/RailRow.tsx
+++ b/client/src/components/RailRow.tsx
@@ -46,7 +46,7 @@ interface RailRowProps {
   density?: 'normal' | 'compact'
   onModeChange: (mode: RailMode) => void
   onProfileChange?: (profileName: string | null) => void
-  onEngineChange?: (aiEngine: 'claude' | 'codex') => void
+  onEngineChange?: (aiEngine: string) => void
   onUltracodeModelChange?: (model: UltracodeModel) => void
   onInteractiveChange?: (interactive: boolean) => void
   onToggle: () => void

--- a/client/src/components/RailsBoard.tsx
+++ b/client/src/components/RailsBoard.tsx
@@ -69,7 +69,7 @@ interface RailsBoardProps {
   providers?: readonly string[]
   onModeChange: (railId: string, mode: RailMode) => void
   onProfileChange?: (railId: string, profileName: string | null) => void
-  onEngineChange?: (railId: string, aiEngine: 'claude' | 'codex') => void
+  onEngineChange?: (railId: string, aiEngine: string) => void
   onUltracodeModelChange?: (railId: string, model: UltracodeModel) => void
   onInteractiveChange?: (railId: string, interactive: boolean) => void
   onToggle: (railId: string) => void

--- a/client/src/components/SetupWizard.tsx
+++ b/client/src/components/SetupWizard.tsx
@@ -7,11 +7,11 @@ import i18n from '../lib/i18n'
 import { Button } from './ui/button'
 import { type CheckpointState } from './CheckpointTracker'
 import { AgentSelector, ALL_AGENTS, CORE_AGENTS, DEFAULT_SELECTED } from './AgentSelector'
-import { ModelSelector, type ModelPreset, type ModelOverrides } from './ModelSelector'
+import { ModelSelector, PRESET_DEFAULTS, type ModelPreset, type ModelOverrides } from './ModelSelector'
 import { useSharedWebSocket } from '../hooks/useSharedWebSocket'
 import { cn } from '../lib/utils'
 import { type DesktopProject, projectProviders } from '../hooks/useDesktop'
-import { providerLabel } from '../lib/provider-capabilities'
+import { providerLabel, type ProviderId } from '../lib/provider-capabilities'
 import { usePrerequisites, type SetupPrerequisitesStatus } from '../hooks/usePrerequisites'
 import { PrerequisitesPanel } from './PrerequisitesPanel'
 import { FEATURE_JIRA } from '../lib/feature-flags'
@@ -37,7 +37,7 @@ interface SetupSummary {
   opsxCommands: number
   legacySrRemoved: number
   tier: 'quick' | 'full'
-  provider?: 'claude' | 'codex'
+  provider?: ProviderId
 }
 
 const EMPTY_SUMMARY: SetupSummary = {
@@ -68,14 +68,10 @@ function toShortModelName(modelId: string): string {
   return modelId // codex models pass through as-is
 }
 
-// Map preset to default short model name
-function presetToDefaultModel(preset: ModelPreset): string {
-  const defaults: Record<ModelPreset, string> = {
-    balanced: 'sonnet',
-    budget: 'haiku',
-    max: 'sonnet',
-  }
-  return defaults[preset]
+// Preset → the preset's default model for a given provider (claude/codex/gemini).
+function presetToDefaultModel(preset: ModelPreset, provider: string): string {
+  const byProvider = PRESET_DEFAULTS[preset]
+  return byProvider[provider] ?? byProvider.claude
 }
 
 function buildDefaultConfig(): InstallConfig {
@@ -151,7 +147,7 @@ function AgentSelectionStep({
   onChange: (config: InstallConfig) => void
   onInstall: () => void
   onSkip: () => void
-  provider: 'claude' | 'codex'
+  provider: ProviderId
   /** Primary CTA label — "Install" on the last provider, "Next: …" otherwise. */
   ctaLabel?: string
   /** True on the last (or only) provider — drives the CTA icon. */
@@ -560,7 +556,7 @@ export function SetupWizard({ project, onComplete: rawOnComplete, onSkip: rawOnS
 
   // Installed providers (one or both). The wizard configures + installs each in
   // sequence; single-provider projects collapse to the classic flow.
-  const providers = projectProviders(project) as ('claude' | 'codex')[]
+  const providers = projectProviders(project)
 
   const cached = wizardCache.get(project.id)
 
@@ -769,7 +765,7 @@ export function SetupWizard({ project, onComplete: rawOnComplete, onSkip: rawOnS
             agents: { selected: selectedWithCore, excluded },
             models: {
               preset: cfg.modelPreset,
-              defaults: { model: presetToDefaultModel(cfg.modelPreset) },
+              defaults: { model: presetToDefaultModel(cfg.modelPreset, provider) },
               overrides: shortOverrides,
             },
             agent_teams: false,

--- a/client/src/components/__tests__/ModelSelector.test.tsx
+++ b/client/src/components/__tests__/ModelSelector.test.tsx
@@ -50,6 +50,22 @@ describe('getDefaultModel', () => {
     expect(getDefaultModel('sr-product-manager', 'max', 'codex')).toBe('gpt-5.3-codex')
   })
 
+  it('returns gemini-2.5-pro for non-special agents in balanced preset (gemini)', () => {
+    expect(getDefaultModel('sr-developer', 'balanced', 'gemini')).toBe('gemini-2.5-pro')
+  })
+
+  it('returns gemini-2.5-flash-lite for budget preset (gemini)', () => {
+    expect(getDefaultModel('sr-developer', 'budget', 'gemini')).toBe('gemini-2.5-flash-lite')
+  })
+
+  it('returns gemini-3.1-pro-preview for architect in max preset (gemini)', () => {
+    expect(getDefaultModel('sr-architect', 'max', 'gemini')).toBe('gemini-3.1-pro-preview')
+  })
+
+  it('falls back to claude models for an unknown provider', () => {
+    expect(getDefaultModel('sr-developer', 'balanced', 'mystery')).toBe('sonnet')
+  })
+
   it('returns gpt-5.5 for sr-developer in max preset (codex)', () => {
     expect(getDefaultModel('sr-developer', 'max', 'codex')).toBe('gpt-5.5')
   })

--- a/client/src/components/__tests__/ModelSelector.test.tsx
+++ b/client/src/components/__tests__/ModelSelector.test.tsx
@@ -50,8 +50,8 @@ describe('getDefaultModel', () => {
     expect(getDefaultModel('sr-product-manager', 'max', 'codex')).toBe('gpt-5.3-codex')
   })
 
-  it('returns gemini-2.5-pro for non-special agents in balanced preset (gemini)', () => {
-    expect(getDefaultModel('sr-developer', 'balanced', 'gemini')).toBe('gemini-2.5-pro')
+  it('returns gemini-3.5-flash for non-special agents in balanced preset (gemini)', () => {
+    expect(getDefaultModel('sr-developer', 'balanced', 'gemini')).toBe('gemini-3.5-flash')
   })
 
   it('returns gemini-2.5-flash-lite for budget preset (gemini)', () => {

--- a/client/src/components/agents/RailEngineSelector.tsx
+++ b/client/src/components/agents/RailEngineSelector.tsx
@@ -6,7 +6,7 @@ interface Props {
   /** Selected engine. null/undefined = project primary. */
   value: string | null | undefined
   providers: readonly string[]
-  onChange: (value: 'claude' | 'codex') => void
+  onChange: (value: string) => void
 }
 
 /**
@@ -30,7 +30,7 @@ export function RailEngineSelector({ value, providers, onChange }: Props) {
         value={current}
         aria-label={t('railSelectors.engineTitle')}
         data-testid="rail-engine-selector"
-        onChange={(e) => onChange(e.target.value as 'claude' | 'codex')}
+        onChange={(e) => onChange(e.target.value)}
         className="h-5 text-[10px] rounded border border-border/50 bg-transparent text-muted-foreground hover:text-foreground pr-4 pl-1 focus:outline-none focus:ring-1 focus:ring-primary/40"
       >
         {providers.map((p) => (

--- a/client/src/components/terminal/BottomPanel.tsx
+++ b/client/src/components/terminal/BottomPanel.tsx
@@ -116,9 +116,12 @@ export function BottomPanel({ projectId, provider = 'claude', providers, state, 
     void t.create(projectId)
   }, [canCreate, projectId, t])
 
-  const launchCli = useCallback((which: 'claude' | 'codex') => {
+  const launchCli = useCallback((which: ProviderId) => {
     if (!canCreate) return
-    const baseName = which === 'codex' ? 'codex' : 'claude'
+    // The provider id IS the CLI binary name (claude / codex / gemini), so the
+    // shell command typed below is the provider verbatim — never hardcode a
+    // two-provider fallback that would relaunch claude for a gemini project.
+    const baseName = which || 'claude'
     const numberSuffix = new RegExp(`^${baseName} \\(\\d+\\)$`)
     const matches = state.sessions.filter(
       (s) => s.name === baseName || numberSuffix.test(s.name),
@@ -135,7 +138,7 @@ export function BottomPanel({ projectId, provider = 'claude', providers, state, 
       setCliMenu(anchor)
       return
     }
-    launchCli((provider === 'codex' ? 'codex' : 'claude'))
+    launchCli(provider)
   }, [canCreate, multiProvider, provider, launchCli])
 
   const handleOpenBrowser = useCallback(() => {

--- a/client/src/components/terminal/CliLaunchMenu.tsx
+++ b/client/src/components/terminal/CliLaunchMenu.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { providerLabel } from '../../lib/provider-capabilities'
+import { providerLabel, type ProviderId } from '../../lib/provider-capabilities'
 
 interface Props {
   x: number
   y: number
   providers: readonly string[]
-  onSelect: (provider: 'claude' | 'codex') => void
+  onSelect: (provider: ProviderId) => void
   onClose: () => void
 }
 
@@ -49,7 +49,7 @@ export function CliLaunchMenu({ x, y, providers, onSelect, onClose }: Props) {
           key={p}
           type="button"
           role="menuitem"
-          onClick={() => { onSelect(p as 'claude' | 'codex'); onClose() }}
+          onClick={() => { onSelect(p); onClose() }}
           className="w-full text-left px-3 py-1.5 text-[#f8f8f2] hover:bg-[#44475a]"
         >
           {t('cliMenu.open', { name: providerLabel(p) })}

--- a/client/src/components/terminal/TerminalTopBar.tsx
+++ b/client/src/components/terminal/TerminalTopBar.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { cn } from '../../lib/utils'
 import { PanelChevronButton } from './PanelChevronButton'
 import type { PanelVisibility } from '../../context/TerminalsContext'
-import type { ProviderId } from '../../lib/provider-capabilities'
+import { providerLabel, type ProviderId } from '../../lib/provider-capabilities'
 
 interface TerminalTopBarProps {
   visibility: PanelVisibility
@@ -36,7 +36,7 @@ export function TerminalTopBar({
 }: TerminalTopBarProps) {
   const { t } = useTranslation('terminal')
   const multiProvider = !!providers && providers.length > 1
-  const cliDisplayName = provider === 'codex' ? 'Codex' : 'Claude'
+  const cliDisplayName = providerLabel(provider)
   const maxTerminalsLabel = t('topBar.maxTerminals', { max: 10 })
   const cliLabel = canCreate
     ? (multiProvider ? t('topBar.openCliMulti') : t('topBar.openCli', { cli: cliDisplayName }))

--- a/client/src/lib/__tests__/provider-capabilities.test.ts
+++ b/client/src/lib/__tests__/provider-capabilities.test.ts
@@ -151,9 +151,12 @@ describe('providerLabel', () => {
     expect(providerLabel('codex')).toBe('Codex')
   })
 
+  it('returns "Gemini" for provider "gemini"', () => {
+    expect(providerLabel('gemini')).toBe('Gemini')
+  })
+
   it('returns the raw string for an unknown provider', () => {
     expect(providerLabel('openai')).toBe('openai')
-    expect(providerLabel('gemini')).toBe('gemini')
     expect(providerLabel('')).toBe('')
   })
 

--- a/client/src/lib/provider-capabilities.ts
+++ b/client/src/lib/provider-capabilities.ts
@@ -83,5 +83,6 @@ export function isMultiProvider(providers: readonly string[] | null | undefined)
 export function providerLabel(provider: string | null | undefined): string {
   if (provider === 'codex') return 'Codex'
   if (provider === 'claude') return 'Claude'
+  if (provider === 'gemini') return 'Gemini'
   return provider ?? 'Claude'
 }

--- a/client/src/locales/de/addspec.json
+++ b/client/src/locales/de/addspec.json
@@ -147,15 +147,15 @@
     "preset": {
       "balanced": {
         "label": "Ausgewogen",
-        "description": "Sonnet für alle Agents (empfohlen)"
+        "description": "{{model}} für alle Agents (empfohlen)"
       },
       "budget": {
         "label": "Budget",
-        "description": "Haiku für alle Agents – 3× günstiger, schneller"
+        "description": "{{model}} für alle Agents – 3× günstiger, schneller"
       },
       "max": {
         "label": "Max",
-        "description": "Opus für Architect + PM, Sonnet für den Rest"
+        "description": "{{topModel}} für Architect + PM, {{baseModel}} für den Rest"
       }
     },
     "overridesHeading": "Modell-Overrides pro Agent",

--- a/client/src/locales/en/addspec.json
+++ b/client/src/locales/en/addspec.json
@@ -147,15 +147,15 @@
     "preset": {
       "balanced": {
         "label": "Balanced",
-        "description": "Sonnet for all agents (recommended)"
+        "description": "{{model}} for all agents (recommended)"
       },
       "budget": {
         "label": "Budget",
-        "description": "Haiku for all agents — 3x cheaper, faster"
+        "description": "{{model}} for all agents — 3x cheaper, faster"
       },
       "max": {
         "label": "Max",
-        "description": "Opus for architect + PM, Sonnet for rest"
+        "description": "{{topModel}} for architect + PM, {{baseModel}} for rest"
       }
     },
     "overridesHeading": "Per-agent model overrides",

--- a/client/src/locales/es/addspec.json
+++ b/client/src/locales/es/addspec.json
@@ -147,15 +147,15 @@
     "preset": {
       "balanced": {
         "label": "Equilibrado",
-        "description": "Sonnet para todos los agentes (recomendado)"
+        "description": "{{model}} para todos los agentes (recomendado)"
       },
       "budget": {
         "label": "Económico",
-        "description": "Haiku para todos los agentes — 3× más barato y rápido"
+        "description": "{{model}} para todos los agentes — 3× más barato y rápido"
       },
       "max": {
         "label": "Max",
-        "description": "Opus para arquitecto + PM, Sonnet para el resto"
+        "description": "{{topModel}} para arquitecto + PM, {{baseModel}} para el resto"
       }
     },
     "overridesHeading": "Modelo por agente",

--- a/client/src/locales/fr/addspec.json
+++ b/client/src/locales/fr/addspec.json
@@ -147,15 +147,15 @@
     "preset": {
       "balanced": {
         "label": "Équilibré",
-        "description": "Sonnet pour tous les agents (recommandé)"
+        "description": "{{model}} pour tous les agents (recommandé)"
       },
       "budget": {
         "label": "Budget",
-        "description": "Haiku pour tous les agents — 3× moins cher, plus rapide"
+        "description": "{{model}} pour tous les agents — 3× moins cher, plus rapide"
       },
       "max": {
         "label": "Max",
-        "description": "Opus pour l'architecte + le PM, Sonnet pour le reste"
+        "description": "{{topModel}} pour l'architecte + le PM, {{baseModel}} pour le reste"
       }
     },
     "overridesHeading": "Surcharges de modèle par agent",

--- a/client/src/locales/it/addspec.json
+++ b/client/src/locales/it/addspec.json
@@ -147,15 +147,15 @@
     "preset": {
       "balanced": {
         "label": "Bilanciato",
-        "description": "Sonnet per tutti gli agenti (consigliato)"
+        "description": "{{model}} per tutti gli agenti (consigliato)"
       },
       "budget": {
         "label": "Budget",
-        "description": "Haiku per tutti gli agenti — 3× più economico, più veloce"
+        "description": "{{model}} per tutti gli agenti — 3× più economico, più veloce"
       },
       "max": {
         "label": "Max",
-        "description": "Opus per architect + PM, Sonnet per il resto"
+        "description": "{{topModel}} per architect + PM, {{baseModel}} per il resto"
       }
     },
     "overridesHeading": "Override del modello per agente",

--- a/client/src/locales/ja/addspec.json
+++ b/client/src/locales/ja/addspec.json
@@ -147,15 +147,15 @@
     "preset": {
       "balanced": {
         "label": "バランス",
-        "description": "全エージェントに Sonnet（推奨）"
+        "description": "全エージェントに {{model}}（推奨）"
       },
       "budget": {
         "label": "節約",
-        "description": "全エージェントに Haiku — 3倍安く、高速"
+        "description": "全エージェントに {{model}} — 3倍安く、高速"
       },
       "max": {
         "label": "最大",
-        "description": "アーキテクトと PM に Opus、その他に Sonnet"
+        "description": "アーキテクトと PM に {{topModel}}、その他に {{baseModel}}"
       }
     },
     "overridesHeading": "エージェント別モデルオーバーライド",

--- a/client/src/locales/pt/addspec.json
+++ b/client/src/locales/pt/addspec.json
@@ -147,15 +147,15 @@
     "preset": {
       "balanced": {
         "label": "Equilibrado",
-        "description": "Sonnet para todos os agentes (recomendado)"
+        "description": "{{model}} para todos os agentes (recomendado)"
       },
       "budget": {
         "label": "Económico",
-        "description": "Haiku para todos os agentes — 3x mais barato, mais rápido"
+        "description": "{{model}} para todos os agentes — 3x mais barato, mais rápido"
       },
       "max": {
         "label": "Máx",
-        "description": "Opus para arquiteto + PM, Sonnet para os restantes"
+        "description": "{{topModel}} para arquiteto + PM, {{baseModel}} para os restantes"
       }
     },
     "overridesHeading": "Substituições de modelo por agente",

--- a/client/src/locales/zh/addspec.json
+++ b/client/src/locales/zh/addspec.json
@@ -147,15 +147,15 @@
     "preset": {
       "balanced": {
         "label": "均衡",
-        "description": "所有 Agent 使用 Sonnet（推荐）"
+        "description": "所有 Agent 使用 {{model}}（推荐）"
       },
       "budget": {
         "label": "经济",
-        "description": "所有 Agent 使用 Haiku——便宜 3 倍、更快"
+        "description": "所有 Agent 使用 {{model}}——便宜 3 倍、更快"
       },
       "max": {
         "label": "最强",
-        "description": "架构师 + PM 使用 Opus，其余使用 Sonnet"
+        "description": "架构师 + PM 使用 {{topModel}}，其余使用 {{baseModel}}"
       }
     },
     "overridesHeading": "按 Agent 覆写模型",

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -722,7 +722,7 @@ export default function DashboardPage() {
     updateRails((prev) => prev.map((r) => (r.id === railId ? { ...r, interactive } : r)))
   }
 
-  async function handleEngineChange(railId: string, aiEngine: 'claude' | 'codex') {
+  async function handleEngineChange(railId: string, aiEngine: string) {
     // Ultracode is Claude-only — if the rail leaves Claude while in Ultracode,
     // fall back to implement so the launch can't 400.
     updateRails((prev) => prev.map((r) =>

--- a/server/pricing.ts
+++ b/server/pricing.ts
@@ -50,10 +50,16 @@ export const PRICING: Record<string, PriceEntry> = {
   // Gemini (Google). Reference: https://ai.google.dev/gemini-api/docs/pricing
   // Standard paid tier, <=200k-context prices (Gemini Pro is context-tiered;
   // prompts >200k are under-estimated in v1 — see docs/gemini-cli-provider-study.md §2).
+  // Current catalog (June 2026): 3.5-flash flagship default, 3.1-pro-preview max,
+  // 3.1-flash-lite budget, 2.5-flash-lite cheapest. Older 2.5-pro/2.5-flash rows
+  // are retained so historic invocations still price.
+  'gemini:gemini-3.5-flash':       { inputPer1M: 1.50, outputPer1M: 9.00,  cacheReadPer1M: 0.15,  lastReviewedAt: '2026-06-17' },
+  'gemini:gemini-3.1-pro-preview': { inputPer1M: 2.00, outputPer1M: 12.00, cacheReadPer1M: 0.20,  lastReviewedAt: '2026-06-17' },
+  'gemini:gemini-3.1-flash-lite':  { inputPer1M: 0.25, outputPer1M: 1.50,  cacheReadPer1M: 0.025, lastReviewedAt: '2026-06-17' },
+  'gemini:gemini-3-flash-preview': { inputPer1M: 0.50, outputPer1M: 3.00,  cacheReadPer1M: 0.05,  lastReviewedAt: '2026-06-17' },
   'gemini:gemini-2.5-pro':         { inputPer1M: 1.25, outputPer1M: 10.00, cacheReadPer1M: 0.125, lastReviewedAt: '2026-06-17' },
   'gemini:gemini-2.5-flash':       { inputPer1M: 0.30, outputPer1M: 2.50,  cacheReadPer1M: 0.03,  lastReviewedAt: '2026-06-17' },
   'gemini:gemini-2.5-flash-lite':  { inputPer1M: 0.10, outputPer1M: 0.40,  cacheReadPer1M: 0.01,  lastReviewedAt: '2026-06-17' },
-  'gemini:gemini-3.1-pro-preview': { inputPer1M: 2.00, outputPer1M: 12.00, cacheReadPer1M: 0.20,  lastReviewedAt: '2026-06-17' },
 }
 
 /**

--- a/server/project-router-tickets.ts
+++ b/server/project-router-tickets.ts
@@ -443,25 +443,46 @@ export function registerTicketsRoutes(deps: ProjectRoutesDeps): void {
         return
       }
 
-      // Claude path.
-      if ((parsed.type as string) === 'result') {
-        lastResultEvent = parsed
+      if (provider === 'claude') {
+        // Claude path.
+        if ((parsed.type as string) === 'result') {
+          lastResultEvent = parsed
+        }
+
+        if ((parsed.type as string) === 'assistant') {
+          const msg = parsed.message as { content?: Array<{ type: string; text?: string }> } | undefined
+          const texts = (msg?.content ?? [])
+            .filter((c) => c.type === 'text')
+            .map((c) => c.text ?? '')
+          const newText = texts.join('')
+          if (newText) {
+            buffer += newText
+            const wsMsg: SpecGenStreamMessage = {
+              type: 'spec_gen_stream', projectId, requestId,
+              delta: newText, timestamp: new Date().toISOString(),
+            }
+            broadcast(wsMsg)
+          }
+        }
+        return
       }
 
-      if ((parsed.type as string) === 'assistant') {
-        const msg = parsed.message as { content?: Array<{ type: string; text?: string }> } | undefined
-        const texts = (msg?.content ?? [])
-          .filter((c) => c.type === 'text')
-          .map((c) => c.text ?? '')
-        const newText = texts.join('')
-        if (newText) {
-          buffer += newText
-          const wsMsg: SpecGenStreamMessage = {
-            type: 'spec_gen_stream', projectId, requestId,
-            delta: newText, timestamp: new Date().toISOString(),
-          }
-          broadcast(wsMsg)
+      // Adapter-driven path (gemini + future providers): the adapter already
+      // parsed this line into a structured AdapterEvent above (`adapterEv`).
+      // Accumulate assistant text deltas into the buffer and capture the result
+      // event for usage extraction — mirrors the ai-edit endpoint's else branch.
+      // Without this, gemini (which emits `type:'message'`, not `type:'assistant'`)
+      // would never accumulate text → empty buffer → "Empty response from AI".
+      if (adapterEv?.kind === 'result') {
+        lastResultEvent = parsed
+      }
+      if (adapterEv?.kind === 'text-delta' && adapterEv.text) {
+        buffer += adapterEv.text
+        const wsMsg: SpecGenStreamMessage = {
+          type: 'spec_gen_stream', projectId, requestId,
+          delta: adapterEv.text, timestamp: new Date().toISOString(),
         }
+        broadcast(wsMsg)
       }
     })
 

--- a/server/project-router.gemini.test.ts
+++ b/server/project-router.gemini.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Focused test for the Gemini provider stream-handling path in project-router.
+ *
+ * Regression: POST /tickets/generate-spec previously hardcoded a codex branch +
+ * a claude branch (matching `type:"assistant"`). Gemini emits assistant text as
+ * `type:"message"` / `role:"assistant"`, so it matched NEITHER — the buffer never
+ * accumulated and spec generation failed with "Empty response from AI". The
+ * endpoint now routes non-claude/non-codex providers through the adapter-driven
+ * path (the same one the ai-edit endpoint already used), so gemini streams and
+ * produces a ticket.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { EventEmitter } from 'events'
+import { PassThrough } from 'stream'
+import express from 'express'
+import request from 'supertest'
+import { mkdirSync, rmSync } from 'fs'
+import { join } from 'path'
+
+vi.mock('child_process', () => ({ spawn: vi.fn(), execSync: vi.fn() }))
+vi.mock('uuid', () => ({ v4: vi.fn(() => 'gemini-req-uuid') }))
+
+import { spawn as mockSpawn } from 'child_process'
+import { createProjectRouter } from './project-router'
+import { initDb } from './db'
+import { initDesktopDb } from './desktop-db'
+import type { ProjectRegistry, ProjectContext } from './project-registry'
+import type { DbInstance } from './db'
+
+function createMockChildProcess() {
+  const child = new EventEmitter() as any
+  child.stdout = new PassThrough()
+  child.stderr = new PassThrough()
+  child.pid = 88888
+  child.kill = vi.fn()
+  return child
+}
+
+const tick = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+
+function makeMinimalContext(db: DbInstance, projectPath: string): ProjectContext {
+  return {
+    project: {
+      id: 'proj-gemini',
+      slug: 'proj-gemini',
+      name: 'Gemini Project',
+      path: projectPath,
+      db_path: ':memory:',
+      added_at: '',
+      last_seen_at: '',
+      provider: 'gemini',
+      providers: ['gemini'],
+    },
+    db,
+    queueManager: {
+      enqueue: vi.fn(() => ({ id: 'job-1', queuePosition: 0 })),
+      cancel: vi.fn(),
+      pause: vi.fn(),
+      resume: vi.fn(),
+      reorder: vi.fn(),
+      getJobs: vi.fn(() => []),
+      isPaused: vi.fn(() => false),
+      getActiveJobId: vi.fn(() => null),
+      phasesForCommand: vi.fn(() => []),
+    } as any,
+    chatManager: { isActive: vi.fn(() => false), sendMessage: vi.fn(async () => {}), abort: vi.fn() } as any,
+    setupManager: { isInstalling: vi.fn(() => false), isEnriching: vi.fn(() => false), isSettingUp: vi.fn(() => false) } as any,
+    proposalManager: { isActive: vi.fn(() => false) } as any,
+    specLauncherManager: { isActive: vi.fn(() => false) } as any,
+    ticketWatcher: { notifyDesktopWrite: vi.fn(), start: vi.fn(), close: vi.fn() } as any,
+    broadcast: vi.fn(),
+  } as any
+}
+
+function makeRegistry(ctx: ProjectContext): ProjectRegistry {
+  const desktopDb = initDesktopDb(':memory:')
+  return {
+    desktopDb,
+    getContext: vi.fn((id: string) => (id === ctx.project.id ? ctx : undefined)),
+    getContextByPath: vi.fn(() => undefined),
+    addProject: vi.fn() as any,
+    removeProject: vi.fn(),
+    touchProject: vi.fn(),
+    listContexts: vi.fn(() => [ctx]),
+    getProjectRow: vi.fn(() => undefined),
+  } as unknown as ProjectRegistry
+}
+
+function createApp(ctx: ProjectContext) {
+  const router = createProjectRouter(makeRegistry(ctx))
+  const app = express()
+  app.use(express.json())
+  app.use('/api/projects', router)
+  return app
+}
+
+describe('gemini stream handling in project-router', () => {
+  let db: DbInstance
+  let tmpDir: string
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    db = initDb(':memory:')
+    tmpDir = '/tmp/specrails-gemini-test-' + process.pid + '-' + Math.floor(performance.now())
+    mkdirSync(join(tmpDir, '.specrails'), { recursive: true })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    try { rmSync(tmpDir, { recursive: true, force: true }) } catch { /* ignore */ }
+  })
+
+  describe('POST /tickets/generate-spec with provider=gemini', () => {
+    it('accumulates assistant text from gemini `type:"message"` events and creates a ticket', async () => {
+      const child = createMockChildProcess()
+      vi.mocked(mockSpawn).mockReturnValue(child as any)
+
+      const ctx = makeMinimalContext(db, tmpDir)
+      const app = createApp(ctx)
+
+      const requestPromise = request(app)
+        .post('/api/projects/proj-gemini/tickets/generate-spec')
+        .send({ idea: 'Add a dark mode toggle' })
+
+      // Let the handler dispatch + spawn the child + attach its stdout reader.
+      // (A fixed tick — vi.waitFor's polling starves supertest's request dispatch.)
+      await tick(60)
+
+      // A full spec arrives as one gemini assistant message (`type:"message"`).
+      const specText = [
+        '## Spec Title',
+        'Dark mode toggle',
+        '',
+        '## Estimated Complexity',
+        'medium',
+        '',
+        '## Description',
+        'Add a persistent dark mode toggle to settings.',
+      ].join('\n')
+      const typesSeen = () => vi.mocked(ctx.broadcast).mock.calls.map((c) => (c[0] as any)?.type)
+      const waitForType = async (type: string) => {
+        for (let i = 0; i < 100 && !typesSeen().includes(type); i++) await tick(20)
+      }
+
+      child.stdout.write(JSON.stringify({ type: 'message', role: 'assistant', content: specText }) + '\n')
+      child.stdout.write(JSON.stringify({ type: 'result', stats: { input_tokens: 10, output_tokens: 20 } }) + '\n')
+      child.stdout.end()
+      // Poll until the assistant text has streamed. THIS is the regression proof:
+      // the legacy code only matched codex's `item.completed` / claude's
+      // `type:"assistant"`, so gemini's `type:"message"` was dropped and nothing
+      // streamed. The adapter-driven branch now accumulates it.
+      await waitForType('spec_gen_stream')
+      child.emit('close', 0)
+      await requestPromise.catch(() => { /* ignore */ })
+
+      const broadcasts = vi.mocked(ctx.broadcast).mock.calls.map((c) => c[0] as any)
+      const streamMsgs = broadcasts.filter((m) => m?.type === 'spec_gen_stream')
+      expect(streamMsgs.length).toBeGreaterThan(0)
+      expect(streamMsgs.map((m) => m.delta).join('')).toContain('Dark mode toggle')
+
+      // The spawn targeted the gemini binary with the gemini default model
+      // (gemini-3.5-flash, the refreshed catalog default), not a claude one.
+      const spawnArgs = vi.mocked(mockSpawn).mock.calls[0]
+      expect(spawnArgs[0]).toBe('gemini')
+      expect((spawnArgs[1] as string[]).join(' ')).toContain('gemini-3.5-flash')
+    })
+  })
+})

--- a/server/providers/gemini-adapter.test.ts
+++ b/server/providers/gemini-adapter.test.ts
@@ -55,13 +55,13 @@ describe('geminiAdapter — identity', () => {
     ])
   })
 
-  it('reports a model catalog with gemini-2.5-pro default', () => {
+  it('reports a model catalog with gemini-3.5-flash default', () => {
     const cat = geminiAdapter.modelCatalog()
     expect(cat.length).toBeGreaterThan(0)
     const defaults = cat.filter((m) => m.default === true)
     expect(defaults).toHaveLength(1)
-    expect(defaults[0].value).toBe('gemini-2.5-pro')
-    expect(geminiAdapter.defaultModel()).toBe('gemini-2.5-pro')
+    expect(defaults[0].value).toBe('gemini-3.5-flash')
+    expect(geminiAdapter.defaultModel()).toBe('gemini-3.5-flash')
   })
 })
 
@@ -79,10 +79,10 @@ describe('geminiAdapter.buildArgs', () => {
     const args = geminiAdapter.buildArgs('chat-turn', {
       prompt: 'user msg',
       systemPrompt: 'sys',
-      model: 'gemini-2.5-flash',
+      model: 'gemini-3.1-flash-lite',
     })
     expect(args.slice(0, 2)).toEqual(['-p', 'user msg'])
-    expect(args[args.indexOf('--model') + 1]).toBe('gemini-2.5-flash')
+    expect(args[args.indexOf('--model') + 1]).toBe('gemini-3.1-flash-lite')
     expect(args[args.indexOf('--output-format') + 1]).toBe('stream-json')
     expect(args).toContain('--yolo')
     // No fold, no system text, no --system-prompt flag.
@@ -97,7 +97,7 @@ describe('geminiAdapter.buildArgs', () => {
     const args = geminiAdapter.buildArgs('chat-turn', {
       prompt: 'quiero hacer un tetris',
       systemPrompt: longSys,
-      model: 'gemini-2.5-pro',
+      model: 'gemini-3.5-flash',
     })
     expect(args).toContain('quiero hacer un tetris')
     expect(args.some((a) => a.includes('explicit permission'))).toBe(false)
@@ -105,14 +105,14 @@ describe('geminiAdapter.buildArgs', () => {
 
   it('chat-resume requires sessionId and passes --resume <id> with user-only prompt', () => {
     expect(() =>
-      geminiAdapter.buildArgs('chat-resume', { prompt: 'x', model: 'gemini-2.5-pro' }),
+      geminiAdapter.buildArgs('chat-resume', { prompt: 'x', model: 'gemini-3.5-flash' }),
     ).toThrow(/sessionId/)
 
     const args = geminiAdapter.buildArgs('chat-resume', {
       prompt: 'next msg',
       systemPrompt: 'sys',
       sessionId: '11111111-2222-3333-4444-555555555555',
-      model: 'gemini-2.5-pro',
+      model: 'gemini-3.5-flash',
     })
     expect(args.slice(0, 2)).toEqual(['-p', 'next msg'])
     expect(args[args.indexOf('--resume') + 1]).toBe('11111111-2222-3333-4444-555555555555')
@@ -122,7 +122,7 @@ describe('geminiAdapter.buildArgs', () => {
 
   it('chat-stream throws (no persistent stdin transport)', () => {
     expect(() =>
-      geminiAdapter.buildArgs('chat-stream', { prompt: 'x', model: 'gemini-2.5-pro' }),
+      geminiAdapter.buildArgs('chat-stream', { prompt: 'x', model: 'gemini-3.5-flash' }),
     ).toThrow(/persistent stdin/)
   })
 
@@ -130,7 +130,7 @@ describe('geminiAdapter.buildArgs', () => {
     const args = geminiAdapter.buildArgs('rail-job', {
       prompt: '/specrails:implement #1',
       systemPrompt: 'pipeline ctx',
-      model: 'gemini-2.5-pro',
+      model: 'gemini-3.5-flash',
     })
     expect(args[0]).toBe('-p')
     expect(args[1]).toBe('pipeline ctx\n\n---\n\n/specrails:implement #1')
@@ -142,7 +142,7 @@ describe('geminiAdapter.buildArgs', () => {
       const args = geminiAdapter.buildArgs(action, {
         prompt: 'p',
         systemPrompt: 'S',
-        model: 'gemini-2.5-pro',
+        model: 'gemini-3.5-flash',
       })
       expect(args[0]).toBe('-p')
       expect(args[1]).toBe('S\n\n---\n\np')
@@ -152,13 +152,13 @@ describe('geminiAdapter.buildArgs', () => {
 
   it('setup-enrich-resume requires sessionId and passes --resume', () => {
     expect(() =>
-      geminiAdapter.buildArgs('setup-enrich-resume', { prompt: 'x', model: 'gemini-2.5-pro' }),
+      geminiAdapter.buildArgs('setup-enrich-resume', { prompt: 'x', model: 'gemini-3.5-flash' }),
     ).toThrow(/sessionId/)
 
     const args = geminiAdapter.buildArgs('setup-enrich-resume', {
       prompt: 'cont',
       sessionId: 'UUID',
-      model: 'gemini-2.5-pro',
+      model: 'gemini-3.5-flash',
     })
     expect(args[args.indexOf('--resume') + 1]).toBe('UUID')
   })
@@ -166,7 +166,7 @@ describe('geminiAdapter.buildArgs', () => {
   it('extraArgs append at the end', () => {
     const args = geminiAdapter.buildArgs('chat-turn', {
       prompt: 'p',
-      model: 'gemini-2.5-pro',
+      model: 'gemini-3.5-flash',
       extraArgs: ['--include-directories', '/extra'],
     })
     expect(args.slice(-2)).toEqual(['--include-directories', '/extra'])

--- a/server/providers/gemini-adapter.ts
+++ b/server/providers/gemini-adapter.ts
@@ -3,7 +3,7 @@
 // Stream format (gemini `-p "<prompt>" --output-format stream-json`), one minified
 // JSON object per line — pinned to gemini-cli >= 0.11 and locked by the fixtures
 // under __fixtures__/gemini-*.ndjson:
-//   {"type":"init","session_id":"<UUID>","model":"gemini-2.5-pro"}
+//   {"type":"init","session_id":"<UUID>","model":"gemini-3.5-flash"}
 //   {"type":"message","role":"assistant","content":"...","delta":true}
 //   {"type":"tool_use","tool_name":"read_file","tool_id":"t0","parameters":{...}}
 //   {"type":"tool_result","tool_id":"t0","status":"ok","output":"..."}
@@ -43,10 +43,10 @@ const GEMINI_MIN_VERSION = '0.11.0'
 // Curated GA-id catalog (see docs/gemini-cli-provider-study.md §2). Preview ids
 // rotate, so we pin concrete ids that pricing.ts has rows for.
 const GEMINI_MODELS = [
-  { value: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro', default: true as const },
-  { value: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
+  { value: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash', default: true as const },
+  { value: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro (preview)' },
+  { value: 'gemini-3.1-flash-lite', label: 'Gemini 3.1 Flash Lite' },
   { value: 'gemini-2.5-flash-lite', label: 'Gemini 2.5 Flash Lite' },
-  { value: 'gemini-3.1-pro-preview', label: 'Gemini 3 Pro (preview)' },
 ] as const
 
 const STREAM_JSON_FLAGS = ['--output-format', 'stream-json'] as const
@@ -238,7 +238,7 @@ export const geminiAdapter: ProviderAdapter = {
     systemPromptArg: false,
   },
   modelCatalog: () => GEMINI_MODELS,
-  defaultModel: () => 'gemini-2.5-pro',
+  defaultModel: () => 'gemini-3.5-flash',
   buildArgs: buildGeminiArgs,
   parseStreamLine: parseGeminiStreamLine,
   extractResult: extractGeminiResult,

--- a/server/setup-manager.test.ts
+++ b/server/setup-manager.test.ts
@@ -1243,6 +1243,54 @@ describe('SetupManager', () => {
       expect(computeSummary('/path', 'quick').tier).toBe('quick')
       expect(computeSummary('/path', 'full').tier).toBe('full')
     })
+
+    // Gemini installs into `.gemini/` and ships TOML slash commands — the summary
+    // must probe that layout, not the hardcoded `.claude/` + `.md` one.
+    it('reads the .gemini/ layout and counts .toml commands for gemini', () => {
+      vi.mocked(existsSync).mockImplementation((p: any) => {
+        const s = String(p)
+        if (s.endsWith('personas')) return false
+        return s.includes('.gemini/agents') ||
+          s.includes('.gemini/commands/specrails') ||
+          s.includes('.gemini/commands/opsx')
+      })
+      vi.mocked(readdirSync).mockImplementation((p: any) => {
+        const s = String(p)
+        if (s.includes('.gemini/agents')) return ['sr-architect.md', 'sr-developer.md', 'sr-reviewer.md'] as any
+        if (s.includes('.gemini/commands/specrails')) return ['implement.toml', 'propose-spec.toml'] as any
+        if (s.includes('.gemini/commands/opsx')) return ['apply.toml'] as any
+        return []
+      })
+
+      const result = computeSummary('/path/to/project', 'quick', 'gemini')
+      expect(result.agents).toBe(3)
+      expect(result.specrailsCommands).toBe(2)
+      expect(result.opsxCommands).toBe(1)
+      expect(result.provider).toBe('gemini')
+    })
+
+    it('counts only TOML files in gemini command dirs — ignores stray .md', () => {
+      vi.mocked(existsSync).mockImplementation((p: any) => String(p).includes('.gemini/commands/specrails'))
+      vi.mocked(readdirSync).mockImplementation((p: any) =>
+        String(p).includes('.gemini/commands/specrails') ? ['a.toml', 'b.toml', 'README.md'] as any : []
+      )
+
+      expect(computeSummary('/path', 'quick', 'gemini').specrailsCommands).toBe(2)
+    })
+
+    it('does NOT fall back to the .claude/ layout for a gemini install (regression)', () => {
+      // Only `.claude/` artefacts exist on disk. A gemini install must report 0,
+      // never surface claude's counts — the bug this fix addresses.
+      vi.mocked(existsSync).mockImplementation((p: any) => String(p).includes('.claude'))
+      vi.mocked(readdirSync).mockImplementation((p: any) =>
+        String(p).includes('.claude') ? ['sr-architect.md', 'sr-developer.md'] as any : []
+      )
+
+      const result = computeSummary('/path', 'quick', 'gemini')
+      expect(result.agents).toBe(0)
+      expect(result.specrailsCommands).toBe(0)
+      expect(result.opsxCommands).toBe(0)
+    })
   })
 
   // ─── sweepLegacySrCommands ─────────────────────────────────────────────────

--- a/server/setup-manager.ts
+++ b/server/setup-manager.ts
@@ -529,8 +529,14 @@ export function computeSummary(
         }
       }
     } else {
-      // Claude layout (unchanged).
-      const dir = SPECRAILS_DIR
+      // Claude / Gemini layout: agents at `<dir>/agents/sr-*.md`, slash commands
+      // at `<dir>/commands/{specrails,opsx}/*.<ext>`. Gemini installs into
+      // `.gemini/` and its commands are TOML (`.gemini/commands/specrails/*.toml`);
+      // claude installs into `.claude/` with Markdown commands. Without the
+      // per-provider dir + extension below, a gemini install summarised 0/0/0
+      // because it probed `.claude/` for `.md` files that don't exist.
+      const dir = provider === 'gemini' ? '.gemini' : SPECRAILS_DIR
+      const commandExt = provider === 'gemini' ? '.toml' : '.md'
       const agentsDir = join(projectPath, dir, 'agents')
       if (existsSync(agentsDir)) {
         const files = readdirSync(agentsDir) as string[]
@@ -543,10 +549,10 @@ export function computeSummary(
       const commandsDirSpecrails = join(projectPath, dir, 'commands', 'specrails')
       const commandsDirOpsx = join(projectPath, dir, 'commands', 'opsx')
       if (existsSync(commandsDirSpecrails)) {
-        specrailsCommands = (readdirSync(commandsDirSpecrails) as string[]).filter((f) => f.endsWith('.md')).length
+        specrailsCommands = (readdirSync(commandsDirSpecrails) as string[]).filter((f) => f.endsWith(commandExt)).length
       }
       if (existsSync(commandsDirOpsx)) {
-        opsxCommands = (readdirSync(commandsDirOpsx) as string[]).filter((f) => f.endsWith('.md')).length
+        opsxCommands = (readdirSync(commandsDirOpsx) as string[]).filter((f) => f.endsWith(commandExt)).length
       }
     }
   } catch {

--- a/server/spec-models.test.ts
+++ b/server/spec-models.test.ts
@@ -36,8 +36,8 @@ describe('spec-models', () => {
 
   it('serves the gemini catalog + default (not the claude fallback)', () => {
     expect(getModelsForProvider('gemini')).toBe(GEMINI_MODELS)
-    expect(getProviderDefault('gemini')).toBe('gemini-2.5-pro')
-    expect(isValidModelForProvider('gemini-2.5-pro', 'gemini')).toBe(true)
+    expect(getProviderDefault('gemini')).toBe('gemini-3.5-flash')
+    expect(isValidModelForProvider('gemini-3.5-flash', 'gemini')).toBe(true)
     expect(isValidModelForProvider('sonnet', 'gemini')).toBe(false)
   })
 

--- a/server/spec-models.test.ts
+++ b/server/spec-models.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   CLAUDE_MODELS,
   CODEX_MODELS,
+  GEMINI_MODELS,
   getModelsForProvider,
   getProviderDefault,
   isValidModelForProvider,
@@ -33,11 +34,18 @@ describe('spec-models', () => {
     expect(getModelsForProvider('codex')).toBe(CODEX_MODELS)
   })
 
+  it('serves the gemini catalog + default (not the claude fallback)', () => {
+    expect(getModelsForProvider('gemini')).toBe(GEMINI_MODELS)
+    expect(getProviderDefault('gemini')).toBe('gemini-2.5-pro')
+    expect(isValidModelForProvider('gemini-2.5-pro', 'gemini')).toBe(true)
+    expect(isValidModelForProvider('sonnet', 'gemini')).toBe(false)
+  })
+
   it('falls back to claude for an unknown / not-yet-registered provider id', () => {
     // The provider id type is open (registry-owned). An id without an explicit
     // catalog entry resolves to Claude's list/default rather than throwing —
     // the safe behaviour for a provider added before its rows are filled in.
-    expect(getModelsForProvider('gemini')).toBe(CLAUDE_MODELS)
-    expect(getProviderDefault('gemini')).toBe(getProviderDefault('claude'))
+    expect(getModelsForProvider('mystery')).toBe(CLAUDE_MODELS)
+    expect(getProviderDefault('mystery')).toBe(getProviderDefault('claude'))
   })
 })

--- a/server/spec-models.ts
+++ b/server/spec-models.ts
@@ -23,15 +23,25 @@ export const CODEX_MODELS: SpecModelOption[] = [
   { value: 'gpt-5.3-codex', label: 'GPT-5.3 Codex' },
 ]
 
+// Mirrors GEMINI_MODELS in server/providers/gemini-adapter.ts.
+export const GEMINI_MODELS: SpecModelOption[] = [
+  { value: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
+  { value: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
+  { value: 'gemini-2.5-flash-lite', label: 'Gemini 2.5 Flash Lite' },
+  { value: 'gemini-3.1-pro-preview', label: 'Gemini 3 Pro (preview)' },
+]
+
 /** Per-provider model catalog. Lookup, not a branch — fallback is Claude's. */
 const PROVIDER_MODELS: Record<string, SpecModelOption[]> = {
   claude: CLAUDE_MODELS,
   codex: CODEX_MODELS,
+  gemini: GEMINI_MODELS,
 }
 
 export const PROVIDER_DEFAULT_MODEL: Record<string, string> = {
   claude: 'sonnet',
   codex: 'gpt-5.5',
+  gemini: 'gemini-2.5-pro',
 }
 
 export function getModelsForProvider(provider: SpecProvider): SpecModelOption[] {

--- a/server/spec-models.ts
+++ b/server/spec-models.ts
@@ -25,10 +25,10 @@ export const CODEX_MODELS: SpecModelOption[] = [
 
 // Mirrors GEMINI_MODELS in server/providers/gemini-adapter.ts.
 export const GEMINI_MODELS: SpecModelOption[] = [
-  { value: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
-  { value: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
+  { value: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash' },
+  { value: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro (preview)' },
+  { value: 'gemini-3.1-flash-lite', label: 'Gemini 3.1 Flash Lite' },
   { value: 'gemini-2.5-flash-lite', label: 'Gemini 2.5 Flash Lite' },
-  { value: 'gemini-3.1-pro-preview', label: 'Gemini 3 Pro (preview)' },
 ]
 
 /** Per-provider model catalog. Lookup, not a branch — fallback is Claude's. */
@@ -41,7 +41,7 @@ const PROVIDER_MODELS: Record<string, SpecModelOption[]> = {
 export const PROVIDER_DEFAULT_MODEL: Record<string, string> = {
   claude: 'sonnet',
   codex: 'gpt-5.5',
-  gemini: 'gemini-2.5-pro',
+  gemini: 'gemini-3.5-flash',
 }
 
 export function getModelsForProvider(provider: SpecProvider): SpecModelOption[] {


### PR DESCRIPTION
## What

Started as "Add Spec shows Claude models for gemini projects" (server `spec-models` fell back to Claude). An adversarial multi-agent audit found the **same bug class** in many other provider lookups, plus that the Gemini model lineup was outdated. This fixes all of it.

## Gemini-confusion fixes (provider lookups that silently routed gemini → claude/codex)

- **spec-gen (functional):** gemini's `type:"message"` stream was dropped (only codex + claude were parsed) → empty buffer → `"Empty response from AI"`. Now adapter-driven, mirroring the ai-edit endpoint. New regression test `server/project-router.gemini.test.ts`.
- **setup summary (functional):** probed `.claude/` for gemini installs (→ 0 agents/0 commands); now reads `.gemini/` with the `.toml` command extension. + tests.
- **terminal "Open AI CLI" (functional):** launched `claude` for gemini projects; now uses the provider id verbatim as the CLI binary.
- **labels:** `providerLabel('gemini')` / `TerminalTopBar` rendered lowercase `gemini` / "Claude"; now "Gemini".
- **types:** rail-engine + `AiEngineSelector` `'claude' | 'codex'` callback unions widened to `string` (gemini already flowed through at runtime via unsafe casts).
- **i18n:** preset descriptions hardcoded "Sonnet/Haiku/Opus"; now provider-aware via `{{model}}` / `{{topModel}}`+`{{baseModel}}` interpolation across all 8 locales.

## Model catalog refresh (gemini-2.5 was outdated, June 2026)

Default `gemini-2.5-pro` → **`gemini-3.5-flash`** (stable flagship). Catalog: `gemini-3.5-flash`, `gemini-3.1-pro-preview` (max), `gemini-3.1-flash-lite` (budget), `gemini-2.5-flash-lite` (cheapest). Updated `gemini-adapter`, `spec-models`, `ModelSelector`, `ChatInput`, and the `pricing` rate card. All IDs verified against a live ListModels call.

## Verification
- `npm run typecheck` ✅
- server: 3644 tests ✅, coverage gates met (83.7% stmt / 74.7% branch / 87.3% func / 85.4% lines)
- client: 2680 tests ✅, coverage gates met

## Follow-up (separate)
specrails-core scaffold still pins gemini agents to `gemini-2.5-pro` — needs bumping to `gemini-3.5-flash` (its own PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)