### PR TITLE
fix(setup): require specrails-core >= 4.8.0 (Gemini target + fresh npx resolve)

### DIFF
--- a/server/core-package.ts
+++ b/server/core-package.ts
@@ -5,7 +5,12 @@
  * minute it is published — adopting a new major is a deliberate one-line
  * bump here, shipped through the app's own release pipeline.
  *
+ * Floor bumped to 4.8.0 — the version that ships the Gemini provider target
+ * (`.gemini/` commands + agents). It also changes the `npx` package-spec string,
+ * which invalidates any stale `_npx` exec cache that npx would otherwise reuse
+ * for the old `^4.6.0` range (so users actually resolve the newer core).
+ *
  * `SPECRAILS_CORE_BIN` remains the escape hatch for local/linked builds
  * (see getCoreCommand in setup-manager.ts).
  */
-export const CORE_PACKAGE_SPEC = 'specrails-core@^4.6.0'
+export const CORE_PACKAGE_SPEC = 'specrails-core@^4.8.0'


### PR DESCRIPTION
A Gemini project's `npx specrails-core init` failed with **`unsupported provider 'gemini' (expected: claude or codex)`** — the *pre-4.8.0* error message.

## Diagnosis
The published `specrails-core@4.8.0` is correct (verified the npm tarball: it has the gemini validation, detection, and `.gemini/` scaffold). The desktop runs `npx --prefer-online specrails-core@^4.6.0 init`, but **npx reused a stale 4.7.x** from its `_npx` exec cache: for an unchanged range spec, npx reuses the cached exec environment, and `--prefer-online` only refreshes npm *metadata*, not the npx exec cache.

## Fix
Bump `CORE_PACKAGE_SPEC` `^4.6.0` → `^4.8.0`. This:
- makes explicit that the desktop now requires the gemini-capable core (4.8.0), and
- **changes the package-spec string**, so npx computes a new cache key and resolves the newer core instead of reusing the stale one.

## Immediate workaround (for an already-affected machine)
`rm -rf "$(npm config get cache)/_npx"` then retry the install.

## Verification
typecheck + `core-package`/`setup-manager` tests (98) green.