### PR TITLE
feat(gemini): enable Gemini by default + headless rails fixes

### DIFF
--- a/server/desktop-router.test.ts
+++ b/server/desktop-router.test.ts
@@ -557,30 +557,29 @@ describe('desktop-router', () => {
       expect(res.body.codex).toBe(false)
     })
 
-    it('omits gemini entirely by default (beta opt-in → fully hidden)', async () => {
+    it('surfaces gemini by default (enabled — key reflects real detection)', async () => {
       const prev = process.env.SPECRAILS_GEMINI_BETA
       delete process.env.SPECRAILS_GEMINI_BETA
       try {
         const { app } = createApp()
         const res = await request(app).get('/api/available-providers')
         expect(res.status).toBe(200)
-        expect(res.body).not.toHaveProperty('gemini')
+        expect(res.body).toHaveProperty('gemini')
+        expect(typeof res.body.gemini).toBe('boolean')
       } finally {
         if (prev === undefined) delete process.env.SPECRAILS_GEMINI_BETA
         else process.env.SPECRAILS_GEMINI_BETA = prev
       }
     })
 
-    it('surfaces gemini availability when SPECRAILS_GEMINI_BETA=1', async () => {
+    it('forces gemini unavailable when SPECRAILS_GEMINI_BETA=0 (emergency rollback)', async () => {
       const prev = process.env.SPECRAILS_GEMINI_BETA
-      process.env.SPECRAILS_GEMINI_BETA = '1'
+      process.env.SPECRAILS_GEMINI_BETA = '0'
       try {
         const { app } = createApp()
         const res = await request(app).get('/api/available-providers')
         expect(res.status).toBe(200)
-        // Real detection (true/false depending on whether `gemini` is on PATH),
-        // but no longer force-hidden — the key reflects actual availability.
-        expect(typeof res.body.gemini).toBe('boolean')
+        expect(res.body.gemini).toBe(false)
       } finally {
         if (prev === undefined) delete process.env.SPECRAILS_GEMINI_BETA
         else process.env.SPECRAILS_GEMINI_BETA = prev
@@ -591,28 +590,9 @@ describe('desktop-router', () => {
   // ─── POST /projects — provider validation ───────────────────────────────────
 
   describe('POST /api/projects — provider field', () => {
-    it('rejects gemini by default — beta opt-in (SPECRAILS_GEMINI_BETA unset)', async () => {
+    it('accepts gemini by default (enabled)', async () => {
       const prev = process.env.SPECRAILS_GEMINI_BETA
       delete process.env.SPECRAILS_GEMINI_BETA
-      const projectPath = fs.mkdtempSync(path.join(require('os').tmpdir(), 'gemini-blocked-'))
-      try {
-        const { app } = createApp()
-        const res = await request(app).post('/api/projects').send({
-          path: projectPath,
-          provider: 'gemini',
-        })
-        expect(res.status).toBe(400)
-        expect(res.body.error).toMatch(/beta|SPECRAILS_GEMINI_BETA/)
-      } finally {
-        fs.rmSync(projectPath, { recursive: true, force: true })
-        if (prev === undefined) delete process.env.SPECRAILS_GEMINI_BETA
-        else process.env.SPECRAILS_GEMINI_BETA = prev
-      }
-    })
-
-    it('accepts gemini when SPECRAILS_GEMINI_BETA=1', async () => {
-      const prev = process.env.SPECRAILS_GEMINI_BETA
-      process.env.SPECRAILS_GEMINI_BETA = '1'
       const projectPath = fs.mkdtempSync(path.join(require('os').tmpdir(), 'gemini-project-'))
       try {
         const { app } = createApp()
@@ -622,6 +602,25 @@ describe('desktop-router', () => {
         })
         expect(res.status).toBe(201)
         expect(res.body.project.provider).toBe('gemini')
+      } finally {
+        fs.rmSync(projectPath, { recursive: true, force: true })
+        if (prev === undefined) delete process.env.SPECRAILS_GEMINI_BETA
+        else process.env.SPECRAILS_GEMINI_BETA = prev
+      }
+    })
+
+    it('rejects gemini when SPECRAILS_GEMINI_BETA=0 (emergency rollback)', async () => {
+      const prev = process.env.SPECRAILS_GEMINI_BETA
+      process.env.SPECRAILS_GEMINI_BETA = '0'
+      const projectPath = fs.mkdtempSync(path.join(require('os').tmpdir(), 'gemini-blocked-'))
+      try {
+        const { app } = createApp()
+        const res = await request(app).post('/api/projects').send({
+          path: projectPath,
+          provider: 'gemini',
+        })
+        expect(res.status).toBe(400)
+        expect(res.body.error).toMatch(/SPECRAILS_GEMINI_BETA|disabled/)
       } finally {
         fs.rmSync(projectPath, { recursive: true, force: true })
         if (prev === undefined) delete process.env.SPECRAILS_GEMINI_BETA

--- a/server/desktop-router.ts
+++ b/server/desktop-router.ts
@@ -34,13 +34,15 @@ function isCodexBetaDisabled(): boolean {
   return v === '0'
 }
 
-// Gemini is opt-IN (default off): unlike codex, its stream-json schema has not
-// yet been validated against a live binary, so it stays hidden + unselectable
-// until SPECRAILS_GEMINI_BETA=1 (or 'true'). The adapter is always registered
-// (pricing/getAdapter work); only project selection is gated.
-function isGeminiBetaEnabled(): boolean {
-  const v = (process.env.SPECRAILS_GEMINI_BETA ?? '').toLowerCase()
-  return v === '1' || v === 'true'
+// Gemini is enabled by DEFAULT now that its stream-json schema and the full rails
+// pipeline (architect→developer→reviewer delegation, headless agent loading, the
+// MAX_TURNS resume + reviewer gate) are validated against the live binary
+// (0.46/0.47). Emergency rollback: SPECRAILS_GEMINI_BETA=0 forces it back to
+// "unavailable" without redeploying — parity with codex's SPECRAILS_CODEX_BETA.
+// The adapter is always registered (pricing/getAdapter work); only project
+// selection is gated.
+function isGeminiBetaDisabled(): boolean {
+  return process.env.SPECRAILS_GEMINI_BETA === '0'
 }
 
 // Theme allow-list. Mirror of THEME_IDS in `client/src/lib/themes.ts` —
@@ -174,9 +176,9 @@ export function createDesktopRouter(
     // is forced unavailable when SPECRAILS_CODEX_BETA=0 (emergency rollback).
     const gated: Record<string, boolean> = { ...providers }
     if (isCodexBetaDisabled()) gated.codex = false
-    // Gemini is opt-in: omit it entirely (not just `false`) when the beta flag is
-    // off, so it stays fully invisible in the UI until SPECRAILS_GEMINI_BETA=1.
-    if (!isGeminiBetaEnabled()) delete gated.gemini
+    // Gemini: enabled by default; forced unavailable only when
+    // SPECRAILS_GEMINI_BETA=0 (emergency rollback, parity with codex).
+    if (isGeminiBetaDisabled()) gated.gemini = false
     res.json({ ...gated, tiers })
   })
 
@@ -244,9 +246,9 @@ export function createDesktopRouter(
       })
       return
     }
-    if (providers.includes('gemini') && !isGeminiBetaEnabled()) {
+    if (providers.includes('gemini') && isGeminiBetaDisabled()) {
       res.status(400).json({
-        error: 'Gemini provider is in beta and disabled by default. Set SPECRAILS_GEMINI_BETA=1 to enable.',
+        error: 'Gemini provider is currently disabled (SPECRAILS_GEMINI_BETA=0). Unset or set to 1 to enable.',
       })
       return
     }

--- a/server/providers/gemini-adapter.ts
+++ b/server/providers/gemini-adapter.ts
@@ -26,6 +26,7 @@
 // Spec: openspec/specs/multi-provider-architecture/spec.md
 
 import { execSync } from 'child_process'
+import { acknowledgeGeminiProjectAgents } from './gemini-agent-ack'
 import type {
   AdapterEvent,
   DetectionResult,
@@ -244,6 +245,9 @@ export const geminiAdapter: ProviderAdapter = {
   extractResult: extractGeminiResult,
   baselineAgents: () => ['sr-architect', 'sr-developer', 'sr-reviewer'],
   detectInstalled: detectGeminiInstalled,
+  // Pre-acknowledge the project's custom subagents so they load in headless
+  // `gemini -p` rail spawns (else invoke_agent reports "Subagent not found").
+  prepareHeadlessSpawn: acknowledgeGeminiProjectAgents,
 }
 
 export { GEMINI_MIN_VERSION as _GEMINI_MIN_VERSION, compareSemver as _compareSemver }

--- a/server/providers/gemini-agent-ack.test.ts
+++ b/server/providers/gemini-agent-ack.test.ts
@@ -1,0 +1,99 @@
+import { createHash } from 'crypto'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { homedir, tmpdir } from 'os'
+import { join } from 'path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { acknowledgeGeminiProjectAgents } from './gemini-agent-ack'
+import { geminiAdapter } from './gemini-adapter'
+
+describe('acknowledgeGeminiProjectAgents', () => {
+  let tmp: string
+  let origHome: string | undefined
+  let origUserProfile: string | undefined
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'gemini-ack-test-'))
+    // os.homedir() reads HOME on POSIX, USERPROFILE on Windows — redirect both so
+    // the real ~/.gemini/acknowledgments/agents.json is never touched.
+    origHome = process.env.HOME
+    origUserProfile = process.env.USERPROFILE
+    const fakeHome = join(tmp, 'home')
+    process.env.HOME = fakeHome
+    process.env.USERPROFILE = fakeHome
+  })
+
+  afterEach(() => {
+    if (origHome === undefined) delete process.env.HOME
+    else process.env.HOME = origHome
+    if (origUserProfile === undefined) delete process.env.USERPROFILE
+    else process.env.USERPROFILE = origUserProfile
+    rmSync(tmp, { recursive: true, force: true })
+  })
+
+  const ackPath = () => join(homedir(), '.gemini', 'acknowledgments', 'agents.json')
+  const sha = (s: string) => createHash('sha256').update(s).digest('hex')
+  const readAck = () => JSON.parse(readFileSync(ackPath(), 'utf8')) as Record<string, Record<string, string>>
+
+  function makeProject(name: string, agents: Record<string, string>): string {
+    const root = join(tmp, name)
+    const dir = join(root, '.gemini', 'agents')
+    mkdirSync(dir, { recursive: true })
+    for (const [id, content] of Object.entries(agents)) writeFileSync(join(dir, `${id}.md`), content)
+    return root
+  }
+
+  it('writes sha256-of-file-content per agent keyed by project path', () => {
+    const root = makeProject('repo', { 'sr-architect': 'ARCH\n', 'sr-developer': 'DEV\n' })
+    acknowledgeGeminiProjectAgents(root)
+    const ack = readAck()
+    expect(ack[root]['sr-architect']).toBe(sha('ARCH\n'))
+    expect(ack[root]['sr-developer']).toBe(sha('DEV\n'))
+  })
+
+  it('is a no-op when the project has no .gemini/agents dir', () => {
+    acknowledgeGeminiProjectAgents(join(tmp, 'empty'))
+    expect(existsSync(ackPath())).toBe(false)
+  })
+
+  it('is a no-op when the agents dir has no .md files', () => {
+    const root = join(tmp, 'noagents')
+    mkdirSync(join(root, '.gemini', 'agents'), { recursive: true })
+    acknowledgeGeminiProjectAgents(root)
+    expect(existsSync(ackPath())).toBe(false)
+  })
+
+  it('ignores non-.md and underscore-prefixed files', () => {
+    const root = makeProject('repo', { 'sr-architect': 'A\n' })
+    writeFileSync(join(root, '.gemini', 'agents', 'notes.txt'), 'x')
+    writeFileSync(join(root, '.gemini', 'agents', '_hidden.md'), 'x')
+    acknowledgeGeminiProjectAgents(root)
+    expect(Object.keys(readAck()[root])).toEqual(['sr-architect'])
+  })
+
+  it('merges — preserves other projects and earlier agents across calls', () => {
+    const a = makeProject('A', { 'sr-architect': 'A1\n' })
+    const b = makeProject('B', { 'sr-developer': 'B1\n' })
+    acknowledgeGeminiProjectAgents(a)
+    acknowledgeGeminiProjectAgents(b)
+    writeFileSync(join(a, '.gemini', 'agents', 'sr-reviewer.md'), 'A2\n')
+    acknowledgeGeminiProjectAgents(a)
+    const ack = readAck()
+    expect(ack[b]['sr-developer']).toBe(sha('B1\n')) // other project survives
+    expect(ack[a]['sr-architect']).toBe(sha('A1\n')) // earlier agent survives
+    expect(ack[a]['sr-reviewer']).toBe(sha('A2\n'))
+  })
+
+  it('recovers from a corrupt existing ack file', () => {
+    const root = makeProject('repo', { 'sr-architect': 'A\n' })
+    mkdirSync(join(homedir(), '.gemini', 'acknowledgments'), { recursive: true })
+    writeFileSync(ackPath(), 'not json{{{')
+    acknowledgeGeminiProjectAgents(root)
+    expect(readAck()[root]['sr-architect']).toBe(sha('A\n'))
+  })
+
+  it('is wired as the gemini adapter prepareHeadlessSpawn hook', () => {
+    expect(geminiAdapter.prepareHeadlessSpawn).toBe(acknowledgeGeminiProjectAgents)
+  })
+})

--- a/server/providers/gemini-agent-ack.ts
+++ b/server/providers/gemini-agent-ack.ts
@@ -1,0 +1,69 @@
+// Gemini headless subagent pre-acknowledgment.
+//
+// gemini 0.46+ DISCOVERS `<project>/.gemini/agents/*.md` but only ENABLES a
+// project's custom subagents after an interactive "New Agents Discovered →
+// Acknowledge and Enable" prompt. That prompt never fires in headless
+// (`gemini -p`) spawns — which is how the desktop runs every rail — so
+// `invoke_agent sr-architect` returns "Subagent not found" and the implement
+// orchestrator silently falls back to a generic agent (the specialised
+// architect/developer/reviewer personas never run in isolation).
+//
+// specrails-core writes the acknowledgment file at install time; this is the
+// defence-in-depth copy the desktop runs right before a gemini rail spawn, so a
+// project installed with an older core (or whose agents changed since install)
+// is still trusted headless. The file gemini reads is
+// `~/.gemini/acknowledgments/agents.json`, shaped
+//   { [projectRoot]: { [agentName]: <sha256-hex of the agent .md file> } }
+// where the hash is sha256 of the FULL agent markdown file (verified empirically
+// against gemini 0.47). Entries are MERGED so other projects (and other agents)
+// survive. Best-effort — callers swallow any error; a failure only means the
+// agents need the one-time interactive acknowledge.
+
+import { createHash } from 'crypto'
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs'
+import { homedir } from 'os'
+import { join } from 'path'
+
+type AckStore = Record<string, Record<string, string>>
+
+function ackFilePath(): string {
+  return join(homedir(), '.gemini', 'acknowledgments', 'agents.json')
+}
+
+/**
+ * Pre-acknowledge every `<projectPath>/.gemini/agents/*.md` so gemini loads them
+ * in headless mode. No-op when the project has no `.gemini/agents` dir or no
+ * agent files. The `projectPath` is the key gemini uses (the spawn cwd / repo
+ * root), matching what `specrails-core` writes at install.
+ */
+export function acknowledgeGeminiProjectAgents(projectPath: string): void {
+  const agentsDir = join(projectPath, '.gemini', 'agents')
+  if (!existsSync(agentsDir)) return
+  const agentFiles = readdirSync(agentsDir).filter(
+    (f) => f.endsWith('.md') && !f.startsWith('_'),
+  )
+  if (agentFiles.length === 0) return
+
+  const ackPath = ackFilePath()
+  let store: AckStore = {}
+  if (existsSync(ackPath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(ackPath, 'utf8')) as unknown
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        store = parsed as AckStore
+      }
+    } catch {
+      // Corrupt/unreadable file — start fresh rather than crash the spawn.
+    }
+  }
+
+  const projectEntry: Record<string, string> = { ...(store[projectPath] ?? {}) }
+  for (const file of agentFiles) {
+    const content = readFileSync(join(agentsDir, file), 'utf8')
+    projectEntry[file.slice(0, -3)] = createHash('sha256').update(content).digest('hex')
+  }
+  store[projectPath] = projectEntry
+
+  mkdirSync(join(homedir(), '.gemini', 'acknowledgments'), { recursive: true })
+  writeFileSync(ackPath, `${JSON.stringify(store, null, 2)}\n`)
+}

--- a/server/providers/types.ts
+++ b/server/providers/types.ts
@@ -131,6 +131,16 @@ export interface ProviderAdapter {
   // Health probe — runs at startup + via /setup-prerequisites. MUST complete
   // within 3 seconds; longer resolves to { installed: false }.
   detectInstalled(): Promise<DetectionResult>
+
+  /**
+   * Optional provider-specific filesystem prep run right before a HEADLESS rail
+   * spawn (cwd = projectPath). Gemini uses it to pre-acknowledge the project's
+   * custom subagents (`~/.gemini/acknowledgments/agents.json`) so they load in
+   * `gemini -p` mode instead of falling back to a generic agent; claude/codex
+   * omit it. Best-effort — managers wrap the call so a failure never blocks the
+   * spawn. Synchronous: it only touches small local JSON.
+   */
+  prepareHeadlessSpawn?(projectPath: string): void
 }
 
 export class UnknownProviderError extends Error {

--- a/server/queue-manager.ts
+++ b/server/queue-manager.ts
@@ -1122,6 +1122,19 @@ export class QueueManager {
       }
     }
 
+    // Provider-specific filesystem prep before a headless rail spawn. Gemini
+    // uses this to pre-acknowledge the project's custom subagents so they load
+    // in `gemini -p` mode (else invoke_agent reports "Subagent not found" and the
+    // orchestrator silently falls back to a generic agent). No-op for claude/codex.
+    if (this._cwd) {
+      try {
+        adapter.prepareHeadlessSpawn?.(this._cwd)
+      } catch (err) {
+        /* c8 ignore next -- best-effort prep; a failure is non-fatal */
+        console.warn(`[queue-manager] headless-spawn prep failed: ${(err as Error).message}`)
+      }
+    }
+
     // ─── Interactive ultracode branch ──────────────────────────────────────
     // When the launch requested interactive mode AND the command is ultracode
     // AND the adapter supports persistent stdin (claude), hand off to a resident

--- a/server/util/stream-display.test.ts
+++ b/server/util/stream-display.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import { extractDisplayText } from './stream-display'
+
+describe('extractDisplayText', () => {
+  describe('Claude stream-json frames', () => {
+    it('joins assistant text content blocks', () => {
+      const frame = {
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'hello ' }, { type: 'text', text: 'world' }] },
+      }
+      expect(extractDisplayText(frame)).toBe('hello world')
+    })
+
+    it('returns null for an assistant frame with no text blocks', () => {
+      const frame = { type: 'assistant', message: { content: [{ type: 'tool_use' }] } }
+      expect(extractDisplayText(frame)).toBeNull()
+    })
+
+    it('renders a top-level tool_use using name/input', () => {
+      const frame = { type: 'tool_use', name: 'Read', input: { file_path: '/x.ts' } }
+      expect(extractDisplayText(frame)).toBe('[tool: Read] {"file_path":"/x.ts"}')
+    })
+
+    it('returns null for tool_result / system / user / result frames', () => {
+      for (const type of ['tool_result', 'system_prompt', 'user', 'system', 'result']) {
+        expect(extractDisplayText({ type })).toBeNull()
+      }
+    })
+  })
+
+  describe('Codex exec --json frames', () => {
+    it('surfaces agent_message text on item.completed', () => {
+      const frame = { type: 'item.completed', item: { type: 'agent_message', text: 'done' } }
+      expect(extractDisplayText(frame)).toBe('done')
+    })
+
+    it('renders command_execution only on item.completed with exit code', () => {
+      const completed = {
+        type: 'item.completed',
+        item: { type: 'command_execution', command: 'ls -la', exit_code: 0 },
+      }
+      expect(extractDisplayText(completed)).toBe('[exec] → exit 0 ls -la')
+
+      const started = {
+        type: 'item.started',
+        item: { type: 'command_execution', command: 'ls -la' },
+      }
+      expect(extractDisplayText(started)).toBeNull()
+    })
+
+    it('prefixes agent_reasoning', () => {
+      const frame = { type: 'item.completed', item: { type: 'agent_reasoning', text: 'thinking' } }
+      expect(extractDisplayText(frame)).toBe('[reasoning] thinking')
+    })
+
+    it('returns null for thread/turn lifecycle frames', () => {
+      for (const type of ['thread.started', 'turn.started', 'turn.completed']) {
+        expect(extractDisplayText({ type })).toBeNull()
+      }
+    })
+  })
+
+  describe('Gemini stream-json frames', () => {
+    it('renders tool_use via tool_name/parameters (regression: no more [tool: undefined])', () => {
+      const frame = {
+        type: 'tool_use',
+        tool_name: 'read_file',
+        tool_id: 't0',
+        parameters: { file_path: '.specrails/local-tickets.json' },
+      }
+      expect(extractDisplayText(frame)).toBe('[tool: read_file] {"file_path":".specrails/local-tickets.json"}')
+    })
+
+    it('falls back to <unnamed> when neither name nor tool_name present', () => {
+      expect(extractDisplayText({ type: 'tool_use', parameters: {} })).toBe('[tool: <unnamed>] {}')
+    })
+
+    it('surfaces assistant message delta content', () => {
+      const frame = { type: 'message', role: 'assistant', content: 'The content is hello world', delta: true }
+      expect(extractDisplayText(frame)).toBe('The content is hello world')
+    })
+
+    it('ignores the role:user echo frame', () => {
+      const frame = { type: 'message', role: 'user', content: 'read note.txt' }
+      expect(extractDisplayText(frame)).toBeNull()
+    })
+
+    it('returns null for an empty assistant message', () => {
+      expect(extractDisplayText({ type: 'message', role: 'assistant', content: '' })).toBeNull()
+    })
+
+    it('returns null for init and tool_result frames', () => {
+      expect(extractDisplayText({ type: 'init', session_id: 'abc', model: 'gemini-3.5-flash' })).toBeNull()
+      expect(extractDisplayText({ type: 'tool_result', tool_id: 't0', status: 'success', output: '' })).toBeNull()
+    })
+  })
+
+  it('returns null for an unknown frame type', () => {
+    expect(extractDisplayText({ type: 'totally-unknown' })).toBeNull()
+  })
+})

--- a/server/util/stream-display.ts
+++ b/server/util/stream-display.ts
@@ -7,7 +7,8 @@
 /**
  * Map a parsed provider stream-json frame to the single display line the Job
  * Detail log shows (or null when the frame carries no user-facing text).
- * Handles both Claude `--output-format stream-json` and Codex `exec --json`.
+ * Handles Claude `--output-format stream-json`, Codex `exec --json`, and Gemini
+ * `--output-format stream-json` frame shapes.
  */
 export function extractDisplayText(event: Record<string, unknown>): string | null {
   const type = event.type as string
@@ -20,9 +21,22 @@ export function extractDisplayText(event: Record<string, unknown>): string | nul
     return texts.join('') || null
   }
   if (type === 'tool_use') {
-    const name = (event as Record<string, unknown>).name as string
-    const input = JSON.stringify((event as Record<string, unknown>).input ?? {})
+    // Claude emits `name`/`input`; Gemini stream-json uses `tool_name`/`parameters`.
+    // Tolerating both keeps a single tool_use branch across providers — without
+    // this fallback every Gemini tool call renders as `[tool: undefined] {}`.
+    const e = event as Record<string, unknown>
+    const name = (e.name as string | undefined) ?? (e.tool_name as string | undefined) ?? '<unnamed>'
+    const input = JSON.stringify(e.input ?? e.parameters ?? {})
     return `[tool: ${name}] ${input.slice(0, 120)}`
+  }
+  if (type === 'message') {
+    // Gemini stream-json streams assistant text as `message` delta frames whose
+    // `content` is a plain string; the `role:"user"` echo carries no display
+    // value. Without this branch the Job Detail log drops all Gemini narration.
+    const e = event as Record<string, unknown>
+    if ((e.role as string | undefined) !== 'assistant') return null
+    const text = (e.content as string | undefined) ?? ''
+    return text.length > 0 ? text : null
   }
   if (type === 'tool_result' || type === 'system_prompt' || type === 'user' || type === 'system' || type === 'result') {
     return null


### PR DESCRIPTION
Flips Gemini from beta-opt-in to **enabled by default**, plus the desktop-side fixes that make headless Gemini rails actually work.

### Changes
- **Display** — `extractDisplayText` only knew Claude/Codex frame shapes, so every Gemini tool call rendered as `[tool: undefined] {}` and assistant text was dropped from the Job Detail log. Now handles Gemini's `tool_name`/`parameters` + `type:"message"` frames. (`4d6ca5b`)
- **Headless agent loading (defence-in-depth)** — new optional `prepareHeadlessSpawn(projectPath)` adapter hook; the Gemini adapter pre-acknowledges the project's `.gemini/agents/*.md` (`~/.gemini/acknowledgments/agents.json`) before every rail spawn, so subagents load under `gemini -p` instead of falling back to a generic agent. No-op for claude/codex. Covers projects installed with an older core or whose agents changed since install. (`917042c`)
- **Enable by default** — `SPECRAILS_GEMINI_BETA` flips from opt-IN to enabled-by-default (parity with codex); `=0` is the emergency rollback. (`6908ff6`)

### ⚠️ Merge order — AFTER specrails-core
This depends on **specrails-core PR fjpulidop/specrails-core#303** being merged AND published to npm first. The desktop spawns `npx specrails-core@^4.6.0` at install; until core's gemini fixes (skill translation, install-time ack, hardened orchestrator) are on npm, a Gemini project added through the app would scaffold broken. So:

1. Merge + release **core #303** → new core on npm.
2. Then merge this PR.

The `enable Gemini by default` commit specifically must not ship before core is published.

### Verification
- typecheck (server+CLI+client) green; gemini gate tests + ack tests green; server coverage 83.78/74.91/87.29/85.51 (≥ thresholds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)