### PR TITLE
fix(desktop-release): unblock Windows + macOS bundled-resource assembly

### DIFF
--- a/scripts/assemble-bundled-core.mjs
+++ b/scripts/assemble-bundled-core.mjs
@@ -102,7 +102,7 @@ function main() {
     )
     console.log(`[assemble-bundled-core] npm install ${spec} → ${tmp}`)
     execFileSync(
-      'npm',
+      process.platform === 'win32' ? 'npm.cmd' : 'npm',
       [
         'install',
         spec,

--- a/scripts/assemble-bundled-core.mjs
+++ b/scripts/assemble-bundled-core.mjs
@@ -53,6 +53,31 @@ import { fileURLToPath } from 'node:url'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.resolve(__dirname, '..')
 
+/**
+ * Recursively remove every `node_modules/.bin` directory under `root`.
+ *
+ * WHY: npm populates `.bin` with symlinks to package executables. `cpSync`
+ * rewrites those symlinks to ABSOLUTE paths pointing back into the (about-to-be
+ * deleted) temp install prefix, so the staged copy ends up with DANGLING links.
+ * Tauri then fails the build enumerating `bundle.resources` with
+ * `resource path .../node_modules/.bin/<x> doesn't exist`. The `.bin` shims are
+ * never used by our `node <cli>` invocation, so pruning them is safe and is the
+ * stated intent of the assembly (see the symlink note in the file header).
+ */
+function pruneBinDirs(root) {
+  if (!existsSync(root)) return
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const full = path.join(root, entry.name)
+    if (entry.isSymbolicLink()) continue
+    if (!entry.isDirectory()) continue
+    if (entry.name === '.bin') {
+      rmSync(full, { recursive: true, force: true })
+      continue
+    }
+    pruneBinDirs(full)
+  }
+}
+
 const PACKAGE = 'specrails-core'
 const DEFAULT_VERSION = 'latest'
 
@@ -140,11 +165,20 @@ function main() {
     // Stage the FULL dependency tree. The package's own node_modules (nested
     // deps) plus the hoisted deps at the install root both matter — copy the
     // hoisted root tree, then overlay any package-local node_modules.
-    cpSync(nodeModules, path.join(dest, 'node_modules'), { recursive: true })
+    cpSync(nodeModules, path.join(dest, 'node_modules'), {
+      recursive: true,
+      verbatimSymlinks: true,
+    })
     const pkgLocalModules = path.join(pkgDir, 'node_modules')
     if (existsSync(pkgLocalModules)) {
-      cpSync(pkgLocalModules, path.join(dest, 'node_modules'), { recursive: true })
+      cpSync(pkgLocalModules, path.join(dest, 'node_modules'), {
+        recursive: true,
+        verbatimSymlinks: true,
+      })
     }
+    // Drop the npm `.bin` shims — they are dangling after the copy and Tauri
+    // refuses to bundle a non-existent resource path. Never used at runtime.
+    pruneBinDirs(path.join(dest, 'node_modules'))
     // The staged node_modules must not contain the package itself referencing
     // its own stale copy — but cpSync of the hoisted tree already includes
     // `node_modules/specrails-core`; that is harmless (we run dist/ from dest,

--- a/scripts/assemble-bundled-openspec.mjs
+++ b/scripts/assemble-bundled-openspec.mjs
@@ -49,6 +49,28 @@ import { fileURLToPath } from 'node:url'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.resolve(__dirname, '..')
 
+/**
+ * Recursively remove every `node_modules/.bin` directory under `root`.
+ *
+ * WHY: `cpSync` rewrites npm's `.bin` symlinks to ABSOLUTE paths into the
+ * (about-to-be deleted) temp install prefix, leaving DANGLING links that make
+ * Tauri fail enumerating `bundle.resources` ("resource path ... doesn't exist").
+ * The `.bin` shims are never used by our `node <cli>` invocation.
+ */
+function pruneBinDirs(root) {
+  if (!existsSync(root)) return
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const full = path.join(root, entry.name)
+    if (entry.isSymbolicLink()) continue
+    if (!entry.isDirectory()) continue
+    if (entry.name === '.bin') {
+      rmSync(full, { recursive: true, force: true })
+      continue
+    }
+    pruneBinDirs(full)
+  }
+}
+
 const PACKAGE = '@fission-ai/openspec'
 const DEFAULT_VERSION = '1.4.1'
 
@@ -108,7 +130,13 @@ function main() {
     // Stage the whole node_modules tree (deps included) into dest (clean first).
     rmSync(dest, { recursive: true, force: true })
     mkdirSync(dest, { recursive: true })
-    cpSync(nodeModules, path.join(dest, 'node_modules'), { recursive: true })
+    cpSync(nodeModules, path.join(dest, 'node_modules'), {
+      recursive: true,
+      verbatimSymlinks: true,
+    })
+    // Drop the npm `.bin` shims — they are dangling after the copy and Tauri
+    // refuses to bundle a non-existent resource path. Never used at runtime.
+    pruneBinDirs(path.join(dest, 'node_modules'))
 
     // Assert the CLI entry exists where bundled-openspec.ts will look for it.
     const stagedCli = path.join(dest, 'node_modules', '@fission-ai', 'openspec', binRel)

--- a/scripts/assemble-bundled-openspec.mjs
+++ b/scripts/assemble-bundled-openspec.mjs
@@ -79,7 +79,7 @@ function main() {
     )
     console.log(`[assemble-bundled-openspec] npm install ${spec} → ${tmp}`)
     execFileSync(
-      'npm',
+      process.platform === 'win32' ? 'npm.cmd' : 'npm',
       [
         'install',
         spec,


### PR DESCRIPTION
Fixes all three failed build jobs in release [run 27815906246](https://github.com/fjpulidop/specrails-desktop/actions/runs/27815906246) (`build-windows`, `build-windows-arm64`, `build-macos`).

## 1. Windows (x64 + arm64) — `spawnSync npm ENOENT`

`execFileSync('npm', ...)` runs without a shell, so on Windows it can't find bare `npm` (npm ships as `npm.cmd`). Broke the **Assemble bundled specrails-core** step on both Windows jobs. Resolve `npm.cmd` on `win32` in `assemble-bundled-core.mjs` and `assemble-bundled-openspec.mjs`.

## 2. macOS — `resource path core/node_modules/.bin/js-yaml doesn't exist`

`cpSync` rewrites npm's relative `.bin` symlinks to **absolute** paths into the temp install prefix, which is deleted in the `finally` block — leaving **dangling** links. Tauri then refuses to enumerate them as `bundle.resources` and the build fails.

Copy `node_modules` with `verbatimSymlinks: true` and recursively prune every `.bin` directory after the copy (the bin shims are never used by the `node <cli>` invocation). Applied to both assemble scripts.

Verified locally on macOS: both scripts stage cleanly, smoke check passes, zero `.bin` dirs and zero dangling symlinks remain.

POSIX runtime behaviour otherwise unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)