### PR TITLE
fix(desktop-release): spawn npm via shell on Windows (EINVAL on .cmd)

### DIFF
--- a/scripts/assemble-bundled-core.mjs
+++ b/scripts/assemble-bundled-core.mjs
@@ -126,8 +126,11 @@ function main() {
       JSON.stringify({ name: 'bundled-core-stage', private: true, version: '0.0.0' }),
     )
     console.log(`[assemble-bundled-core] npm install ${spec} → ${tmp}`)
+    // On Windows npm is `npm.cmd`; Node 20.12+ (CVE-2024-27980) refuses to
+    // spawn a `.cmd` without a shell (EINVAL), so run through the shell there —
+    // the shell resolves `npm` → `npm.cmd` from PATH. POSIX spawns directly.
     execFileSync(
-      process.platform === 'win32' ? 'npm.cmd' : 'npm',
+      'npm',
       [
         'install',
         spec,
@@ -137,7 +140,12 @@ function main() {
         '--ignore-scripts',
         '--silent',
       ],
-      { cwd: tmp, encoding: 'utf8', stdio: ['ignore', 'inherit', 'inherit'] },
+      {
+        cwd: tmp,
+        encoding: 'utf8',
+        stdio: ['ignore', 'inherit', 'inherit'],
+        shell: process.platform === 'win32',
+      },
     )
 
     const nodeModules = path.join(tmp, 'node_modules')

--- a/scripts/assemble-bundled-openspec.mjs
+++ b/scripts/assemble-bundled-openspec.mjs
@@ -100,8 +100,11 @@ function main() {
       JSON.stringify({ name: 'bundled-openspec-stage', private: true, version: '0.0.0' }),
     )
     console.log(`[assemble-bundled-openspec] npm install ${spec} → ${tmp}`)
+    // On Windows npm is `npm.cmd`; Node 20.12+ (CVE-2024-27980) refuses to
+    // spawn a `.cmd` without a shell (EINVAL), so run through the shell there —
+    // the shell resolves `npm` → `npm.cmd` from PATH. POSIX spawns directly.
     execFileSync(
-      process.platform === 'win32' ? 'npm.cmd' : 'npm',
+      'npm',
       [
         'install',
         spec,
@@ -111,7 +114,12 @@ function main() {
         '--ignore-scripts',
         '--silent',
       ],
-      { cwd: tmp, encoding: 'utf8', stdio: ['ignore', 'inherit', 'inherit'] },
+      {
+        cwd: tmp,
+        encoding: 'utf8',
+        stdio: ['ignore', 'inherit', 'inherit'],
+        shell: process.platform === 'win32',
+      },
     )
 
     const nodeModules = path.join(tmp, 'node_modules')


### PR DESCRIPTION
Follow-up to #407. The re-dispatched release ([run 27817048446](https://github.com/fjpulidop/specrails-desktop/actions/runs/27817048446)) still failed on both Windows jobs — the `npm.cmd` fix traded `ENOENT` for:

```
Error: spawnSync npm.cmd EINVAL
```

Node 20.12+ (CVE-2024-27980 hardening) refuses to spawn a `.cmd`/`.bat` directly without a shell. Fix: invoke `npm` and set `shell: true` on `win32` so the shell resolves `npm` → `npm.cmd` from PATH. POSIX keeps `shell: false` (spawns directly) — unchanged. Applied to both assemble scripts. Verified locally on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)