### PR TITLE
feat(core-update): voluntary app-global specrails-core update channel

### DIFF
--- a/client/src/components/settings/CoreUpdateSection.tsx
+++ b/client/src/components/settings/CoreUpdateSection.tsx
@@ -1,0 +1,170 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { toast } from 'sonner'
+import { useTranslation } from 'react-i18next'
+import { Download, RefreshCw, CheckCircle2, Loader2 } from 'lucide-react'
+import { useSharedWebSocket } from '../../hooks/useSharedWebSocket'
+
+interface CoreUpdateStatus {
+  available: boolean
+  currentVersion: string | null
+  bundledVersion: string | null
+  latestVersion: string | null
+  updateAvailable: boolean
+  updating: boolean
+  lastCheckedAt: number | null
+}
+
+type ProgressPhase = 'downloading' | 'materializing' | 'done' | 'error' | null
+
+/**
+ * App-global specrails-core update channel. Detects a newer published core
+ * (npm latest > installed `framework/current`) and applies it WITHOUT restarting
+ * the app — the swap re-points every project workspace at the new framework.
+ * Mirrors the other GlobalSettings sections; progress streams over the shared
+ * WebSocket (`core_update.progress`, no projectId).
+ */
+export function CoreUpdateSection() {
+  const { t } = useTranslation('settings')
+  const { registerHandler, unregisterHandler } = useSharedWebSocket()
+  const [status, setStatus] = useState<CoreUpdateStatus | null>(null)
+  const [checking, setChecking] = useState(false)
+  const [phase, setPhase] = useState<ProgressPhase>(null)
+
+  const refresh = useCallback(async (): Promise<CoreUpdateStatus | null> => {
+    try {
+      const res = await fetch('/api/core-update/status')
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data = (await res.json()) as CoreUpdateStatus
+      setStatus(data)
+      return data
+    } catch {
+      setStatus((prev) => prev ?? null)
+      return null
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  // Stream update progress (app-level message — reaches every handler).
+  const refreshRef = useRef(refresh)
+  refreshRef.current = refresh
+  useEffect(() => {
+    const handler = (raw: unknown): void => {
+      const msg = raw as Record<string, unknown>
+      if (msg.type !== 'core_update.progress') return
+      const p = msg.phase as ProgressPhase
+      setPhase(p)
+      if (p === 'done') {
+        toast.success(t('coreUpdate.toastDone', { version: String(msg.version ?? '') }))
+        void refreshRef.current()
+        setTimeout(() => setPhase(null), 2500)
+      } else if (p === 'error') {
+        toast.error(t('coreUpdate.toastError', { message: String(msg.message ?? '') }))
+        void refreshRef.current()
+        setTimeout(() => setPhase(null), 4000)
+      }
+    }
+    registerHandler('core-update', handler)
+    return () => unregisterHandler('core-update')
+  }, [registerHandler, unregisterHandler, t])
+
+  const onCheck = useCallback(async (): Promise<void> => {
+    setChecking(true)
+    try {
+      const res = await fetch('/api/core-update/check', { method: 'POST' })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data = (await res.json()) as CoreUpdateStatus
+      setStatus(data)
+      if (!data.updateAvailable) toast.success(t('coreUpdate.toastUpToDate'))
+    } catch (err) {
+      toast.error(t('coreUpdate.toastCheckFailed', { message: (err as Error).message }))
+    } finally {
+      setChecking(false)
+    }
+  }, [t])
+
+  const onUpdate = useCallback(async (): Promise<void> => {
+    setPhase('downloading')
+    try {
+      const res = await fetch('/api/core-update/update', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' })
+      if (res.status !== 202) {
+        const body = (await res.json().catch(() => ({}))) as { message?: string }
+        throw new Error(body.message ?? `HTTP ${res.status}`)
+      }
+      // Success/failure arrives over WS (core_update.progress).
+    } catch (err) {
+      setPhase(null)
+      toast.error(t('coreUpdate.toastError', { message: (err as Error).message }))
+    }
+  }, [t])
+
+  if (!status) {
+    return <div className="h-20 bg-muted/30 rounded-lg animate-pulse" />
+  }
+
+  const busy = phase === 'downloading' || phase === 'materializing' || status.updating
+  const current = status.currentVersion ?? '—'
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+        {t('coreUpdate.heading')}
+      </h3>
+      <div className="rounded-md border border-border p-3 space-y-3">
+        {!status.available ? (
+          <p className="text-[11px] text-muted-foreground">{t('coreUpdate.unavailable')}</p>
+        ) : (
+          <>
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <p className="text-xs text-foreground">
+                  {t('coreUpdate.installed')}{' '}
+                  <span className="font-semibold tabular-nums">{current}</span>
+                </p>
+                <p className="text-[10px] text-muted-foreground/70 truncate">
+                  {status.updateAvailable && status.latestVersion
+                    ? t('coreUpdate.updateAvailable', { version: status.latestVersion })
+                    : status.lastCheckedAt
+                      ? t('coreUpdate.upToDate')
+                      : t('coreUpdate.neverChecked')}
+                </p>
+              </div>
+              {status.updateAvailable && status.latestVersion ? (
+                <button
+                  type="button"
+                  onClick={onUpdate}
+                  disabled={busy}
+                  className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-lg border border-accent-primary/45 bg-accent-primary/15 px-3 text-[11px] font-semibold text-accent-primary disabled:opacity-50"
+                >
+                  {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Download className="h-3.5 w-3.5" />}
+                  {busy
+                    ? t(phase === 'materializing' ? 'coreUpdate.materializing' : 'coreUpdate.downloading')
+                    : t('coreUpdate.update', { version: status.latestVersion })}
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={onCheck}
+                  disabled={checking || busy}
+                  className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-background px-3 text-[11px] font-medium text-muted-foreground hover:text-foreground disabled:opacity-50"
+                >
+                  {checking ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : phase === 'done' ? (
+                    <CheckCircle2 className="h-3.5 w-3.5 text-accent-success" />
+                  ) : (
+                    <RefreshCw className="h-3.5 w-3.5" />
+                  )}
+                  {checking ? t('coreUpdate.checking') : t('coreUpdate.check')}
+                </button>
+              )}
+            </div>
+            <p className="text-[10px] text-muted-foreground/70">{t('coreUpdate.affectsAll')}</p>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/client/src/components/settings/__tests__/CoreUpdateSection.test.tsx
+++ b/client/src/components/settings/__tests__/CoreUpdateSection.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const toastSuccess = vi.fn()
+const toastError = vi.fn()
+vi.mock('sonner', () => ({ toast: { success: (m: string) => toastSuccess(m), error: (m: string) => toastError(m) } }))
+
+// Capture the registered WS handler so tests can push core_update.progress events.
+let wsHandler: ((msg: unknown) => void) | null = null
+vi.mock('../../../hooks/useSharedWebSocket', () => ({
+  useSharedWebSocket: () => ({
+    registerHandler: (_id: string, fn: (msg: unknown) => void) => { wsHandler = fn },
+    unregisterHandler: () => { wsHandler = null },
+    connectionStatus: 'connected',
+  }),
+}))
+
+import { CoreUpdateSection } from '../CoreUpdateSection'
+
+type Resp = { ok: boolean; status?: number; body: unknown }
+function routeFetch(map: Record<string, Resp | Resp[]>) {
+  const counters: Record<string, number> = {}
+  global.fetch = vi.fn().mockImplementation((url: string) => {
+    const key = Object.keys(map).find((k) => String(url).includes(k))
+    if (!key) return Promise.reject(new Error(`unmapped ${url}`))
+    const entry = map[key]
+    const r = Array.isArray(entry) ? entry[counters[key]++] ?? entry[entry.length - 1] : entry
+    return Promise.resolve({ ok: r.ok, status: r.status ?? (r.ok ? 200 : 500), json: async () => r.body })
+  }) as never
+}
+
+const STATUS = (over: Record<string, unknown> = {}) => ({
+  available: true,
+  currentVersion: '4.8.0',
+  bundledVersion: '4.8.0',
+  latestVersion: null,
+  updateAvailable: false,
+  updating: false,
+  lastCheckedAt: null,
+  ...over,
+})
+
+beforeEach(() => {
+  toastSuccess.mockClear()
+  toastError.mockClear()
+  wsHandler = null
+})
+
+describe('CoreUpdateSection', () => {
+  it('renders unavailable note when no bundled core', async () => {
+    routeFetch({ '/core-update/status': { ok: true, body: STATUS({ available: false, currentVersion: null, bundledVersion: null }) } })
+    render(<CoreUpdateSection />)
+    await screen.findByText('Specrails Core')
+    expect(screen.getByText("Core updates aren't available in this build.")).toBeTruthy()
+    expect(screen.queryByText('Check for updates')).toBeNull()
+  })
+
+  it('shows installed version + Check button when up to date', async () => {
+    routeFetch({ '/core-update/status': { ok: true, body: STATUS() } })
+    render(<CoreUpdateSection />)
+    await screen.findByText('Specrails Core')
+    expect(screen.getByText('4.8.0')).toBeTruthy()
+    expect(screen.getByText('Check for updates')).toBeTruthy()
+  })
+
+  it('Check reports up-to-date with a success toast', async () => {
+    routeFetch({
+      '/core-update/status': { ok: true, body: STATUS() },
+      '/core-update/check': { ok: true, body: STATUS({ latestVersion: '4.8.0', lastCheckedAt: 1 }) },
+    })
+    render(<CoreUpdateSection />)
+    const btn = await screen.findByText('Check for updates')
+    fireEvent.click(btn)
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled())
+  })
+
+  it('surfaces an available update and applies it via WS done event', async () => {
+    routeFetch({
+      '/core-update/status': [
+        { ok: true, body: STATUS() },
+        // refetch after WS done reflects the new version
+        { ok: true, body: STATUS({ currentVersion: '4.9.0', updateAvailable: false }) },
+      ],
+      '/core-update/check': { ok: true, body: STATUS({ latestVersion: '4.9.0', updateAvailable: true, lastCheckedAt: 1 }) },
+      '/core-update/update': { ok: true, status: 202, body: { accepted: true } },
+    })
+    render(<CoreUpdateSection />)
+    fireEvent.click(await screen.findByText('Check for updates'))
+    const updateBtn = await screen.findByText('Update to 4.9.0')
+    fireEvent.click(updateBtn)
+    // Simulate the server streaming completion.
+    await waitFor(() => expect(wsHandler).toBeTypeOf('function'))
+    act(() => wsHandler?.({ type: 'core_update.progress', phase: 'done', version: '4.9.0' }))
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled())
+  })
+
+  it('shows an error toast when the check request fails', async () => {
+    routeFetch({
+      '/core-update/status': { ok: true, body: STATUS() },
+      '/core-update/check': { ok: false, status: 502, body: {} },
+    })
+    render(<CoreUpdateSection />)
+    fireEvent.click(await screen.findByText('Check for updates'))
+    await waitFor(() => expect(toastError).toHaveBeenCalled())
+  })
+
+  it('shows an error toast on a WS error event', async () => {
+    routeFetch({ '/core-update/status': { ok: true, body: STATUS() } })
+    render(<CoreUpdateSection />)
+    await screen.findByText('Specrails Core')
+    await waitFor(() => expect(wsHandler).toBeTypeOf('function'))
+    act(() => wsHandler?.({ type: 'core_update.progress', phase: 'error', message: 'boom' }))
+    await waitFor(() => expect(toastError).toHaveBeenCalled())
+  })
+})

--- a/client/src/locales/de/settings.json
+++ b/client/src/locales/de/settings.json
@@ -200,5 +200,23 @@
     "copyCode": "Code kopieren",
     "codeCopied": "Code kopiert",
     "cancel": "Abbrechen"
+  },
+  "coreUpdate": {
+    "heading": "Specrails Core",
+    "installed": "Installiert:",
+    "updateAvailable": "Update verfügbar: {{version}}",
+    "upToDate": "Aktuell",
+    "neverChecked": "Nicht geprüft",
+    "check": "Nach Updates suchen",
+    "checking": "Wird geprüft…",
+    "update": "Auf {{version}} aktualisieren",
+    "downloading": "Wird heruntergeladen…",
+    "materializing": "Wird installiert…",
+    "affectsAll": "Gilt für alle Projekte — kein Neustart nötig.",
+    "unavailable": "Core-Updates sind in diesem Build nicht verfügbar.",
+    "toastDone": "Specrails Core auf {{version}} aktualisiert",
+    "toastError": "Core-Update fehlgeschlagen: {{message}}",
+    "toastUpToDate": "Specrails Core ist aktuell",
+    "toastCheckFailed": "Update-Prüfung fehlgeschlagen: {{message}}"
   }
 }

--- a/client/src/locales/en/settings.json
+++ b/client/src/locales/en/settings.json
@@ -200,5 +200,23 @@
     "copyCode": "Copy code",
     "codeCopied": "Code copied",
     "cancel": "Cancel"
+  },
+  "coreUpdate": {
+    "heading": "Specrails Core",
+    "installed": "Installed:",
+    "updateAvailable": "Update available: {{version}}",
+    "upToDate": "Up to date",
+    "neverChecked": "Not checked yet",
+    "check": "Check for updates",
+    "checking": "Checking…",
+    "update": "Update to {{version}}",
+    "downloading": "Downloading…",
+    "materializing": "Installing…",
+    "affectsAll": "Applies to all projects — no restart needed.",
+    "unavailable": "Core updates aren't available in this build.",
+    "toastDone": "Specrails Core updated to {{version}}",
+    "toastError": "Core update failed: {{message}}",
+    "toastUpToDate": "Specrails Core is up to date",
+    "toastCheckFailed": "Update check failed: {{message}}"
   }
 }

--- a/client/src/locales/es/settings.json
+++ b/client/src/locales/es/settings.json
@@ -200,5 +200,23 @@
     "copyCode": "Copiar código",
     "codeCopied": "Código copiado",
     "cancel": "Cancelar"
+  },
+  "coreUpdate": {
+    "heading": "Specrails Core",
+    "installed": "Instalado:",
+    "updateAvailable": "Actualización disponible: {{version}}",
+    "upToDate": "Actualizado",
+    "neverChecked": "Sin comprobar",
+    "check": "Buscar actualizaciones",
+    "checking": "Comprobando…",
+    "update": "Actualizar a {{version}}",
+    "downloading": "Descargando…",
+    "materializing": "Instalando…",
+    "affectsAll": "Afecta a todos los proyectos — sin reiniciar.",
+    "unavailable": "Las actualizaciones del core no están disponibles en esta versión.",
+    "toastDone": "Specrails Core actualizado a {{version}}",
+    "toastError": "Error al actualizar el core: {{message}}",
+    "toastUpToDate": "Specrails Core está actualizado",
+    "toastCheckFailed": "Error al comprobar actualizaciones: {{message}}"
   }
 }

--- a/client/src/locales/fr/settings.json
+++ b/client/src/locales/fr/settings.json
@@ -200,5 +200,23 @@
     "copyCode": "Copier le code",
     "codeCopied": "Code copié",
     "cancel": "Annuler"
+  },
+  "coreUpdate": {
+    "heading": "Specrails Core",
+    "installed": "Installé :",
+    "updateAvailable": "Mise à jour disponible : {{version}}",
+    "upToDate": "À jour",
+    "neverChecked": "Non vérifié",
+    "check": "Rechercher des mises à jour",
+    "checking": "Vérification…",
+    "update": "Mettre à jour vers {{version}}",
+    "downloading": "Téléchargement…",
+    "materializing": "Installation…",
+    "affectsAll": "S'applique à tous les projets — aucun redémarrage requis.",
+    "unavailable": "Les mises à jour du core ne sont pas disponibles dans cette version.",
+    "toastDone": "Specrails Core mis à jour vers {{version}}",
+    "toastError": "Échec de la mise à jour du core : {{message}}",
+    "toastUpToDate": "Specrails Core est à jour",
+    "toastCheckFailed": "Échec de la vérification : {{message}}"
   }
 }

--- a/client/src/locales/it/settings.json
+++ b/client/src/locales/it/settings.json
@@ -200,5 +200,23 @@
     "copyCode": "Copia codice",
     "codeCopied": "Codice copiato",
     "cancel": "Annulla"
+  },
+  "coreUpdate": {
+    "heading": "Specrails Core",
+    "installed": "Installato:",
+    "updateAvailable": "Aggiornamento disponibile: {{version}}",
+    "upToDate": "Aggiornato",
+    "neverChecked": "Non verificato",
+    "check": "Cerca aggiornamenti",
+    "checking": "Verifica…",
+    "update": "Aggiorna a {{version}}",
+    "downloading": "Download…",
+    "materializing": "Installazione…",
+    "affectsAll": "Si applica a tutti i progetti — nessun riavvio necessario.",
+    "unavailable": "Gli aggiornamenti del core non sono disponibili in questa build.",
+    "toastDone": "Specrails Core aggiornato a {{version}}",
+    "toastError": "Aggiornamento del core non riuscito: {{message}}",
+    "toastUpToDate": "Specrails Core è aggiornato",
+    "toastCheckFailed": "Verifica aggiornamenti non riuscita: {{message}}"
   }
 }

--- a/client/src/locales/ja/settings.json
+++ b/client/src/locales/ja/settings.json
@@ -200,5 +200,23 @@
     "copyCode": "コードをコピー",
     "codeCopied": "コードをコピーしました",
     "cancel": "キャンセル"
+  },
+  "coreUpdate": {
+    "heading": "Specrails Core",
+    "installed": "インストール済み:",
+    "updateAvailable": "アップデートあり: {{version}}",
+    "upToDate": "最新です",
+    "neverChecked": "未確認",
+    "check": "アップデートを確認",
+    "checking": "確認中…",
+    "update": "{{version}} に更新",
+    "downloading": "ダウンロード中…",
+    "materializing": "インストール中…",
+    "affectsAll": "すべてのプロジェクトに適用 — 再起動不要。",
+    "unavailable": "このビルドではコアの更新は利用できません。",
+    "toastDone": "Specrails Core を {{version}} に更新しました",
+    "toastError": "コアの更新に失敗しました: {{message}}",
+    "toastUpToDate": "Specrails Core は最新です",
+    "toastCheckFailed": "更新の確認に失敗しました: {{message}}"
   }
 }

--- a/client/src/locales/pt/settings.json
+++ b/client/src/locales/pt/settings.json
@@ -200,5 +200,23 @@
     "copyCode": "Copiar código",
     "codeCopied": "Código copiado",
     "cancel": "Cancelar"
+  },
+  "coreUpdate": {
+    "heading": "Specrails Core",
+    "installed": "Instalado:",
+    "updateAvailable": "Atualização disponível: {{version}}",
+    "upToDate": "Atualizado",
+    "neverChecked": "Não verificado",
+    "check": "Procurar atualizações",
+    "checking": "A verificar…",
+    "update": "Atualizar para {{version}}",
+    "downloading": "A descarregar…",
+    "materializing": "A instalar…",
+    "affectsAll": "Aplica-se a todos os projetos — sem reiniciar.",
+    "unavailable": "As atualizações do core não estão disponíveis nesta versão.",
+    "toastDone": "Specrails Core atualizado para {{version}}",
+    "toastError": "Falha na atualização do core: {{message}}",
+    "toastUpToDate": "O Specrails Core está atualizado",
+    "toastCheckFailed": "Falha ao verificar atualizações: {{message}}"
   }
 }

--- a/client/src/locales/zh/settings.json
+++ b/client/src/locales/zh/settings.json
@@ -200,5 +200,23 @@
     "copyCode": "复制配对码",
     "codeCopied": "配对码已复制",
     "cancel": "取消"
+  },
+  "coreUpdate": {
+    "heading": "Specrails Core",
+    "installed": "已安装：",
+    "updateAvailable": "有可用更新：{{version}}",
+    "upToDate": "已是最新",
+    "neverChecked": "尚未检查",
+    "check": "检查更新",
+    "checking": "检查中…",
+    "update": "更新到 {{version}}",
+    "downloading": "下载中…",
+    "materializing": "安装中…",
+    "affectsAll": "适用于所有项目 — 无需重启。",
+    "unavailable": "此版本不支持核心更新。",
+    "toastDone": "Specrails Core 已更新到 {{version}}",
+    "toastError": "核心更新失败：{{message}}",
+    "toastUpToDate": "Specrails Core 已是最新",
+    "toastCheckFailed": "检查更新失败：{{message}}"
   }
 }

--- a/client/src/pages/GlobalSettingsPage.tsx
+++ b/client/src/pages/GlobalSettingsPage.tsx
@@ -5,6 +5,7 @@ import { TerminalSettingsSection } from '../components/settings/TerminalSettings
 import { AppearanceSection } from '../components/settings/AppearanceSection'
 import { LanguageSection } from '../components/settings/LanguageSection'
 import { CodeSectionSettings } from '../components/settings/CodeSectionSettings'
+import { CoreUpdateSection } from '../components/settings/CoreUpdateSection'
 import { MobileAccessSection } from '../components/settings/MobileAccessSection'
 import { Settings, Trash2, Zap, Plus, Bell, GraduationCap } from 'lucide-react'
 import { Button } from '../components/ui/button'
@@ -337,6 +338,8 @@ export default function SettingsDialog({ open, onClose, onOpenOnboarding }: Sett
             <LanguageSection />
 
             <CodeSectionSettings />
+
+            <CoreUpdateSection />
 
             <MobileAccessSection />
 

--- a/server/core-update-manager.test.ts
+++ b/server/core-update-manager.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, symlinkSync, existsSync } from 'fs'
+import os from 'os'
+import path from 'path'
+
+import { CoreUpdateManager } from './core-update-manager'
+import { frameworkRoot, readCurrentFrameworkVersion } from './framework-manager'
+
+/** Minimal fake of core's compiled CLI — enough for install-framework + swap-current. */
+const FAKE_CLI = `
+const fs = require('fs'); const path = require('path')
+function arg(n){const i=process.argv.indexOf('--'+n);return i>=0?process.argv[i+1]:undefined}
+const pd=(p)=>p==='codex'?'.codex':p==='gemini'?'.gemini':'.claude'
+function swap(fw,v){const c=path.join(fw,'current');try{fs.unlinkSync(c)}catch{}fs.symlinkSync(v,c)}
+const sub=process.argv[2]
+if(sub==='install-framework'){const fw=arg('framework-dir');const v=arg('version');const d=path.join(fw,v,pd(arg('provider')),'agents');fs.mkdirSync(d,{recursive:true});fs.writeFileSync(path.join(d,'sr-architect.md'),'x');if(!process.argv.includes('--no-swap'))swap(fw,v);process.exit(0)}
+if(sub==='swap-current'){const fw=arg('framework-dir');const v=arg('version');if(!fs.existsSync(path.join(fw,v)))process.exit(41);swap(fw,v);process.exit(0)}
+process.exit(7)
+`
+/** Fake CLI whose install-framework always fails. */
+const FAKE_CLI_FAIL = `process.exit(2)`
+
+function writeCore(dir: string, version: string, cliBody = FAKE_CLI): void {
+  mkdirSync(path.join(dir, 'dist', 'installer'), { recursive: true })
+  writeFileSync(path.join(dir, 'dist', 'installer', 'cli.js'), cliBody)
+  writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ version }))
+}
+
+describe('CoreUpdateManager', () => {
+  let home: string
+  let bundledCore: string
+  let prevEnv: string | undefined
+
+  beforeEach(() => {
+    home = mkdtempSync(path.join(os.tmpdir(), 'cu-home-'))
+    bundledCore = mkdtempSync(path.join(os.tmpdir(), 'cu-bundled-'))
+    prevEnv = process.env.SPECRAILS_BUNDLED_CORE_PATH
+  })
+  afterEach(() => {
+    if (prevEnv === undefined) delete process.env.SPECRAILS_BUNDLED_CORE_PATH
+    else process.env.SPECRAILS_BUNDLED_CORE_PATH = prevEnv
+    rmSync(home, { recursive: true, force: true })
+    rmSync(bundledCore, { recursive: true, force: true })
+  })
+
+  /** Make the bundled core present (so isAvailable() is true) at `version`. */
+  function bundle(version = '4.8.0'): void {
+    writeCore(bundledCore, version)
+    process.env.SPECRAILS_BUNDLED_CORE_PATH = bundledCore
+  }
+
+  /** npmInstall mock that stages a fake newer core into <cwd>/node_modules/specrails-core. */
+  function stagingInstaller(version: string, cliBody = FAKE_CLI) {
+    return (_spec: string, cwd: string): void => {
+      writeCore(path.join(cwd, 'node_modules', 'specrails-core'), version, cliBody)
+    }
+  }
+
+  describe('availability + status', () => {
+    it('reports unavailable when no bundled core', () => {
+      delete process.env.SPECRAILS_BUNDLED_CORE_PATH
+      const m = new CoreUpdateManager({ home })
+      expect(m.isAvailable()).toBe(false)
+      const s = m.getStatus()
+      expect(s.available).toBe(false)
+      expect(s.bundledVersion).toBeNull()
+    })
+
+    it('falls back currentVersion to bundled when no framework/current yet', () => {
+      bundle('4.8.0')
+      const m = new CoreUpdateManager({ home })
+      const s = m.getStatus()
+      expect(s.available).toBe(true)
+      expect(s.bundledVersion).toBe('4.8.0')
+      expect(s.currentVersion).toBe('4.8.0')
+      expect(s.updateAvailable).toBe(false)
+      expect(s.latestVersion).toBeNull()
+    })
+  })
+
+  describe('checkForUpdate', () => {
+    it('caches the latest version and computes updateAvailable', async () => {
+      bundle('4.8.0')
+      const m = new CoreUpdateManager({ home, fetchLatest: async () => '4.9.0' })
+      const s = await m.checkForUpdate()
+      expect(s.latestVersion).toBe('4.9.0')
+      expect(s.updateAvailable).toBe(true)
+      expect(s.lastCheckedAt).toBeTypeOf('number')
+    })
+
+    it('does not flag an update when latest equals current', async () => {
+      bundle('4.9.0')
+      const m = new CoreUpdateManager({ home, fetchLatest: async () => '4.9.0' })
+      const s = await m.checkForUpdate()
+      expect(s.updateAvailable).toBe(false)
+    })
+
+    it('throws on an unparseable npm version', async () => {
+      bundle('4.8.0')
+      const m = new CoreUpdateManager({ home, fetchLatest: async () => 'not-a-version' })
+      await expect(m.checkForUpdate()).rejects.toThrow(/unparseable/)
+    })
+
+    describe('default registry fetch (no injected fetchLatest)', () => {
+      const realFetch = global.fetch
+      afterEach(() => {
+        global.fetch = realFetch
+      })
+
+      it('reads the version from the npm registry response', async () => {
+        bundle('4.8.0')
+        global.fetch = (async () => ({ ok: true, json: async () => ({ version: '4.9.1' }) })) as never
+        const m = new CoreUpdateManager({ home })
+        const s = await m.checkForUpdate()
+        expect(s.latestVersion).toBe('4.9.1')
+        expect(s.updateAvailable).toBe(true)
+      })
+
+      it('throws when the registry responds non-2xx', async () => {
+        bundle('4.8.0')
+        global.fetch = (async () => ({ ok: false, status: 503, json: async () => ({}) })) as never
+        const m = new CoreUpdateManager({ home })
+        await expect(m.checkForUpdate()).rejects.toThrow(/503/)
+      })
+
+      it('throws when the registry response has no version', async () => {
+        bundle('4.8.0')
+        global.fetch = (async () => ({ ok: true, json: async () => ({}) })) as never
+        const m = new CoreUpdateManager({ home })
+        await expect(m.checkForUpdate()).rejects.toThrow(/no version/)
+      })
+    })
+  })
+
+  describe('update', () => {
+    it('materializes + swaps current to the newer staged core and broadcasts', async () => {
+      bundle('4.8.0')
+      const events: Array<Record<string, unknown>> = []
+      const m = new CoreUpdateManager({
+        home,
+        broadcast: (msg) => events.push(msg as Record<string, unknown>),
+        providers: () => ['claude', 'gemini'],
+        fetchLatest: async () => '4.9.0',
+        npmInstall: stagingInstaller('4.9.0'),
+      })
+      await m.checkForUpdate()
+      const res = await m.update()
+      expect(res).toEqual({ ok: true, version: '4.9.0' })
+      expect(readCurrentFrameworkVersion(home)).toBe('4.9.0')
+      const fw = frameworkRoot(home)
+      expect(existsSync(path.join(fw, '4.9.0', '.claude', 'agents', 'sr-architect.md'))).toBe(true)
+      expect(existsSync(path.join(fw, '4.9.0', '.gemini', 'agents'))).toBe(true)
+      const phases = events.filter((e) => e.type === 'core_update.progress').map((e) => e.phase)
+      expect(phases).toContain('downloading')
+      expect(phases).toContain('materializing')
+      expect(phases).toContain('done')
+      expect(events.some((e) => e.type === 'framework.updated' && e.version === '4.9.0')).toBe(true)
+    })
+
+    it('rejects when unavailable (no bundled core)', async () => {
+      delete process.env.SPECRAILS_BUNDLED_CORE_PATH
+      const m = new CoreUpdateManager({ home, npmInstall: stagingInstaller('4.9.0') })
+      const res = await m.update('4.9.0')
+      expect(res.ok).toBe(false)
+      expect(res.error).toMatch(/unavailable/i)
+    })
+
+    it('rejects when there is no valid target version', async () => {
+      bundle('4.8.0')
+      const m = new CoreUpdateManager({ home })
+      const res = await m.update()
+      expect(res.ok).toBe(false)
+      expect(res.error).toMatch(/valid target/i)
+    })
+
+    it('rejects a target that is not newer than current', async () => {
+      bundle('5.0.0')
+      // Seed framework/current at 5.0.0.
+      const fw = frameworkRoot(home)
+      mkdirSync(path.join(fw, '5.0.0'), { recursive: true })
+      symlinkSync('5.0.0', path.join(fw, 'current'))
+      const m = new CoreUpdateManager({ home, npmInstall: stagingInstaller('4.0.0') })
+      const res = await m.update('4.0.0')
+      expect(res.ok).toBe(false)
+      expect(res.error).toMatch(/not newer/i)
+    })
+
+    it('surfaces a materialize failure as a failed result + error event', async () => {
+      bundle('4.8.0')
+      const events: Array<Record<string, unknown>> = []
+      const m = new CoreUpdateManager({
+        home,
+        broadcast: (msg) => events.push(msg as Record<string, unknown>),
+        npmInstall: stagingInstaller('4.9.0', FAKE_CLI_FAIL),
+      })
+      const res = await m.update('4.9.0')
+      expect(res.ok).toBe(false)
+      expect(readCurrentFrameworkVersion(home)).toBeNull()
+      expect(events.some((e) => e.type === 'core_update.progress' && e.phase === 'error')).toBe(true)
+    })
+
+    it('fails when the staged core has no cli.js', async () => {
+      bundle('4.8.0')
+      const m = new CoreUpdateManager({
+        home,
+        // installer that produces an empty node_modules/specrails-core (no dist).
+        npmInstall: (_s, cwd) => mkdirSync(path.join(cwd, 'node_modules', 'specrails-core'), { recursive: true }),
+      })
+      const res = await m.update('4.9.0')
+      expect(res.ok).toBe(false)
+      expect(res.error).toMatch(/cli\.js/)
+    })
+  })
+})

--- a/server/core-update-manager.ts
+++ b/server/core-update-manager.ts
@@ -1,0 +1,270 @@
+import { execFileSync } from 'child_process'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import { FrameworkManager, readCurrentFrameworkVersion, type FrameworkBroadcast } from './framework-manager'
+import { isNewer, isValidVersion } from './semver-lite'
+
+/**
+ * CoreUpdateManager — the voluntary, app-global specrails-core update channel.
+ *
+ * The bundled framework (see FrameworkManager) is pinned to the core version
+ * shipped inside the app build. This manager lets a user UPDATE specrails-core
+ * independently of the desktop app: it queries npm for the latest published
+ * version, and on an explicit request npm-installs that newer core into a temp
+ * staging dir, materializes its framework into `~/.specrails/framework/<version>`
+ * and atomically swaps `framework/current` to it — every project workspace that
+ * symlinks `current/...` jumps to the new core with NO restart and NO per-project
+ * `npx`. The previous `framework/<version>` dir is left intact (non-destructive).
+ *
+ * Detection is deliberately simple (KISS): npm `latest` strictly greater than the
+ * installed `framework/current` version ⇒ an update is available. There is no
+ * compatibility-range gate; the floor is the app-bundled core (the update only
+ * ever moves the pointer UP — FrameworkManager.versionCheck has an anti-downgrade
+ * guard so the next startup never reverts a manual update).
+ *
+ * The whole feature is gated on a bundled core being present (desktop mode); in
+ * dev / non-desktop mode `isAvailable()` is false and projects use the legacy npx
+ * path, so a core "update" would have no effect and the UI shows "unavailable".
+ */
+
+export const CORE_PACKAGE = 'specrails-core'
+const REGISTRY_URL = `https://registry.npmjs.org/${CORE_PACKAGE}/latest`
+const CHECK_TIMEOUT_MS = 10_000
+const INSTALL_TIMEOUT_MS = 180_000
+
+export type CoreUpdatePhase = 'downloading' | 'materializing' | 'done' | 'error'
+
+export interface CoreUpdateStatus {
+  /** True when the bundled-framework system is active (desktop mode). */
+  available: boolean
+  /** The version `framework/current` resolves to (falls back to bundled). */
+  currentVersion: string | null
+  /** The core version shipped inside this app build. */
+  bundledVersion: string | null
+  /** Latest published npm version (null until a check has run). */
+  latestVersion: string | null
+  /** latestVersion strictly newer than currentVersion. */
+  updateAvailable: boolean
+  /** An update is currently in progress. */
+  updating: boolean
+  /** Epoch ms of the last successful npm check (null if never). */
+  lastCheckedAt: number | null
+}
+
+export interface CoreUpdateResult {
+  ok: boolean
+  version?: string
+  error?: string
+}
+
+export interface CoreUpdateManagerOptions {
+  home?: string
+  broadcast?: FrameworkBroadcast
+  /** Installed-provider union to materialize for (default `['claude']`). */
+  providers?: () => string[]
+  /** Override the npm-latest fetch (tests). */
+  fetchLatest?: () => Promise<string>
+  /** Override the npm install (tests). Installs `spec` into `cwd`. */
+  npmInstall?: (spec: string, cwd: string) => void
+  /** Override FrameworkManager construction for a staged core root (tests). */
+  makeFramework?: (coreRoot: string) => FrameworkManager
+}
+
+export class CoreUpdateManager {
+  private readonly home?: string
+  private readonly broadcast?: FrameworkBroadcast
+  private readonly providersFn: () => string[]
+  private readonly fetchLatestFn: () => Promise<string>
+  private readonly npmInstallFn: (spec: string, cwd: string) => void
+  private readonly makeFrameworkFn: (coreRoot: string) => FrameworkManager
+
+  private latestVersion: string | null = null
+  private lastCheckedAt: number | null = null
+  private updating = false
+
+  constructor(opts: CoreUpdateManagerOptions = {}) {
+    this.home = opts.home
+    this.broadcast = opts.broadcast
+    this.providersFn = opts.providers ?? (() => ['claude'])
+    this.fetchLatestFn = opts.fetchLatest ?? (() => fetchLatestFromRegistry())
+    this.npmInstallFn = opts.npmInstall ?? defaultNpmInstall
+    this.makeFrameworkFn =
+      opts.makeFramework ??
+      ((coreRoot) => new FrameworkManager({ home: this.home, broadcast: this.broadcast, coreRoot }))
+  }
+
+  /** A read-only FrameworkManager pointed at the bundled core. */
+  private bundledFramework(): FrameworkManager {
+    return new FrameworkManager({ home: this.home })
+  }
+
+  /** True when the bundled-framework system is active (a bundled core is present). */
+  isAvailable(): boolean {
+    return this.bundledFramework().isAvailable()
+  }
+
+  /** Current status — no network (uses the cached latest from the last check). */
+  getStatus(): CoreUpdateStatus {
+    const fm = this.bundledFramework()
+    const bundledVersion = fm.bundledVersion()
+    const currentVersion = readCurrentFrameworkVersion(this.home) ?? bundledVersion
+    const updateAvailable =
+      this.latestVersion != null &&
+      currentVersion != null &&
+      isNewer(this.latestVersion, currentVersion)
+    return {
+      available: fm.isAvailable(),
+      currentVersion,
+      bundledVersion,
+      latestVersion: this.latestVersion,
+      updateAvailable,
+      updating: this.updating,
+      lastCheckedAt: this.lastCheckedAt,
+    }
+  }
+
+  /** Hit npm for the latest published version, cache it, return refreshed status. */
+  async checkForUpdate(): Promise<CoreUpdateStatus> {
+    const latest = await this.fetchLatestFn()
+    if (!isValidVersion(latest)) {
+      throw new Error(`core-update: npm returned an unparseable version "${latest}"`)
+    }
+    this.latestVersion = latest.trim().replace(/^[v=]+/, '')
+    this.lastCheckedAt = Date.now()
+    return this.getStatus()
+  }
+
+  /**
+   * Materialize + swap to `targetVersion` (default: the cached latest). Streams
+   * `core_update.progress` WS events and broadcasts `framework.updated` on
+   * success. Returns the outcome; never throws (errors become a failed result +
+   * an `error` progress event).
+   */
+  async update(targetVersion?: string): Promise<CoreUpdateResult> {
+    if (this.updating) {
+      return { ok: false, error: 'An update is already in progress.' }
+    }
+    if (!this.isAvailable()) {
+      return { ok: false, error: 'Core updates are unavailable in this build.' }
+    }
+    const requested = (targetVersion ?? this.latestVersion ?? '').trim().replace(/^[v=]+/, '')
+    if (!requested || !isValidVersion(requested)) {
+      return { ok: false, error: 'No valid target version to update to. Check for updates first.' }
+    }
+    const current = readCurrentFrameworkVersion(this.home)
+    if (current && !isNewer(requested, current)) {
+      return { ok: false, error: `Already on ${current}; ${requested} is not newer.` }
+    }
+
+    this.updating = true
+    this.emit('downloading', { version: requested })
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'core-update-'))
+    try {
+      this.npmInstallFn(`${CORE_PACKAGE}@${requested}`, tmp)
+      const coreRoot = path.join(tmp, 'node_modules', CORE_PACKAGE)
+      const cli = path.join(coreRoot, 'dist', 'installer', 'cli.js')
+      if (!fs.existsSync(cli)) {
+        throw new Error('downloaded core is missing dist/installer/cli.js')
+      }
+      const fm = this.makeFrameworkFn(coreRoot)
+      // The version actually installed (npm may resolve a dist-tag/range).
+      const installed = fm.bundledVersion() ?? requested
+
+      this.emit('materializing', { version: installed })
+      const providers = uniqueProviders(this.providersFn())
+      const mat = fm.materialize(installed, providers)
+      if (!mat.ran) {
+        throw new Error('framework materialize did not run (no usable core)')
+      }
+      if (mat.errors.length > 0) {
+        throw new Error(
+          `framework materialize failed: ${mat.errors.map((e) => `${e.provider}: ${e.message}`).join('; ')}`,
+        )
+      }
+      const swapped = fm.swapCurrent(installed)
+      if (!swapped) {
+        throw new Error('framework swap-current failed')
+      }
+
+      this.latestVersion = installed
+      this.lastCheckedAt = Date.now()
+      this.emit('done', { version: installed })
+      // Reuse the existing app-level event so any listener that reacts to a
+      // framework version bump (e.g. core-version banners) refreshes too.
+      this.safeBroadcast({ type: 'framework.updated', version: installed })
+      return { ok: true, version: installed }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      this.emit('error', { message })
+      return { ok: false, error: message }
+    } finally {
+      this.updating = false
+      try {
+        fs.rmSync(tmp, { recursive: true, force: true })
+      } catch {
+        /* best-effort temp cleanup */
+      }
+    }
+  }
+
+  private emit(phase: CoreUpdatePhase, extra: { version?: string; message?: string }): void {
+    this.safeBroadcast({ type: 'core_update.progress', phase, ...extra })
+  }
+
+  private safeBroadcast(msg: { type: string; [k: string]: unknown }): void {
+    try {
+      this.broadcast?.(msg)
+    } catch {
+      /* broadcast is best-effort */
+    }
+  }
+}
+
+function uniqueProviders(values: string[]): string[] {
+  const out = Array.from(new Set(values.filter((v) => typeof v === 'string' && v.length > 0)))
+  return out.length > 0 ? out : ['claude']
+}
+
+/** GET the latest published version from the npm registry (no npm binary needed). */
+async function fetchLatestFromRegistry(): Promise<string> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), CHECK_TIMEOUT_MS)
+  try {
+    const res = await fetch(REGISTRY_URL, {
+      signal: controller.signal,
+      headers: { accept: 'application/json' },
+    })
+    if (!res.ok) {
+      throw new Error(`npm registry returned ${res.status}`)
+    }
+    const json = (await res.json()) as { version?: unknown }
+    if (typeof json.version !== 'string' || json.version.length === 0) {
+      throw new Error('npm registry response has no version field')
+    }
+    return json.version
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
+ * Install `spec` into `cwd` with a minimal isolated package.json — mirrors
+ * `scripts/assemble-bundled-core.mjs`. On Windows npm is `npm.cmd`; Node 20.12+
+ * (CVE-2024-27980) refuses to spawn a `.cmd` without a shell, so run through the
+ * shell there. POSIX spawns directly.
+ */
+function defaultNpmInstall(spec: string, cwd: string): void {
+  fs.writeFileSync(
+    path.join(cwd, 'package.json'),
+    JSON.stringify({ name: 'core-update-stage', private: true, version: '0.0.0' }),
+  )
+  execFileSync('npm', ['install', spec, '--no-audit', '--no-fund', '--no-save', '--ignore-scripts', '--silent'], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'inherit', 'inherit'],
+    timeout: INSTALL_TIMEOUT_MS,
+    shell: process.platform === 'win32',
+  })
+}

--- a/server/desktop-router.test.ts
+++ b/server/desktop-router.test.ts
@@ -65,6 +65,7 @@ function createMockRegistry(desktopDb: DbInstance) {
     }),
     touchProject: vi.fn(),
     listContexts: vi.fn(() => Array.from(contexts.values())),
+    installedProvidersUnion: vi.fn(() => ['claude']),
   } as unknown as ProjectRegistry
 
   return { registry, contexts }
@@ -1391,6 +1392,42 @@ describe('desktop-router', () => {
       await request(app).patch('/api/language').send({ language: 'ja' })
       const res = await request(app).get('/api/language')
       expect(res.body.language).toBe('ja')
+    })
+  })
+
+  // ─── core-update channel ────────────────────────────────────────────────────
+  // No bundled core in the test env ⇒ available:false; these cover the route
+  // wiring + the unavailable guard without touching npm/network.
+  describe('GET /api/core-update/status', () => {
+    it('returns available:false when no bundled core is present', async () => {
+      const prev = process.env.SPECRAILS_BUNDLED_CORE_PATH
+      delete process.env.SPECRAILS_BUNDLED_CORE_PATH
+      try {
+        const { app } = createApp()
+        const res = await request(app).get('/api/core-update/status')
+        expect(res.status).toBe(200)
+        expect(res.body.available).toBe(false)
+        expect(res.body.updateAvailable).toBe(false)
+      } finally {
+        if (prev === undefined) delete process.env.SPECRAILS_BUNDLED_CORE_PATH
+        else process.env.SPECRAILS_BUNDLED_CORE_PATH = prev
+      }
+    })
+  })
+
+  describe('POST /api/core-update/update', () => {
+    it('409 when core updates are unavailable in this build', async () => {
+      const prev = process.env.SPECRAILS_BUNDLED_CORE_PATH
+      delete process.env.SPECRAILS_BUNDLED_CORE_PATH
+      try {
+        const { app } = createApp()
+        const res = await request(app).post('/api/core-update/update').send({})
+        expect(res.status).toBe(409)
+        expect(res.body.error).toBe('unavailable')
+      } finally {
+        if (prev === undefined) delete process.env.SPECRAILS_BUNDLED_CORE_PATH
+        else process.env.SPECRAILS_BUNDLED_CORE_PATH = prev
+      }
     })
   })
 

--- a/server/desktop-router.ts
+++ b/server/desktop-router.ts
@@ -8,6 +8,7 @@ import type { ProjectRegistry } from './project-registry'
 import { getDesktopSetting, setDesktopSetting, listProjects, listAgents, getAgent, addAgent, updateAgent, listWebhooks, getWebhook, addWebhook, updateWebhook, removeWebhook, getProjectSetupSession } from './desktop-db'
 import type { WebhookEvent } from './desktop-db'
 import { WebhookManager } from './webhook-manager'
+import { CoreUpdateManager } from './core-update-manager'
 import { createSpecrailsTechClient } from './specrails-tech-client'
 import { checkCoreCompat, getCLIStatus, detectAvailableCLIs } from './core-compat'
 import { hasAdapter, listAdapters } from './providers'
@@ -830,6 +831,52 @@ export function createDesktopRouter(
     const parsed = budgetRaw !== undefined ? Number(budgetRaw) : NaN
     const monthlyBudgetUsd = Number.isFinite(parsed) && parsed >= 0 ? parsed : 5.0
     res.json({ language, monthlyBudgetUsd })
+  })
+
+  // ─── specrails-core update channel (app-global) ─────────────────────────────
+  // Detect + apply a specrails-core framework update independently of the desktop
+  // app update. See server/core-update-manager.ts. A single manager instance
+  // persists for the router lifetime (holds the cached latest + in-progress flag).
+  const coreUpdate = new CoreUpdateManager({
+    // `core_update.progress` / `framework.updated` are app-level (no projectId)
+    // and not members of the WsMessage union; cast at this single boundary.
+    broadcast: (msg) => broadcast(msg as unknown as WsMessage),
+    providers: () => registry.installedProvidersUnion(),
+  })
+
+  // GET /api/core-update/status — current/bundled/latest versions, no network.
+  router.get('/core-update/status', (_req, res) => {
+    res.json(coreUpdate.getStatus())
+  })
+
+  // POST /api/core-update/check — hit npm for the latest version, refresh status.
+  router.post('/core-update/check', (_req, res) => {
+    void coreUpdate
+      .checkForUpdate()
+      .then((status) => res.json(status))
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : 'check failed'
+        res.status(502).json({ error: 'check_failed', message })
+      })
+  })
+
+  // POST /api/core-update/update — materialize + swap to the target (default latest).
+  // 202 + async progress over the `core_update.progress` WS event.
+  router.post('/core-update/update', (req, res) => {
+    if (!coreUpdate.isAvailable()) {
+      res.status(409).json({ error: 'unavailable', message: 'Core updates are unavailable in this build.' })
+      return
+    }
+    const status = coreUpdate.getStatus()
+    if (status.updating) {
+      res.status(409).json({ error: 'in_progress', message: 'An update is already in progress.' })
+      return
+    }
+    const version = (req.body as { version?: unknown } | undefined)?.version
+    const target = typeof version === 'string' ? version : undefined
+    res.status(202).json({ accepted: true })
+    // Fire-and-forget; outcome is delivered over WS (`core_update.progress`).
+    void coreUpdate.update(target)
   })
 
   return router

--- a/server/framework-manager.test.ts
+++ b/server/framework-manager.test.ts
@@ -7,6 +7,7 @@ import {
   existsSync,
   lstatSync,
   readlinkSync,
+  symlinkSync,
 } from 'fs'
 import os from 'os'
 import path from 'path'
@@ -372,6 +373,47 @@ process.exit(7)
       expect(existsSync(path.join(fw, '5.0.0', '.claude', 'agents'))).toBe(true)
       expect(existsSync(path.join(fw, '5.1.0', '.claude', 'agents'))).toBe(true)
       expect(readCurrentFrameworkVersion(home)).toBe('5.1.0')
+    })
+
+    it('anti-downgrade: never reverts current to an OLDER bundled core (manual update guard)', () => {
+      // Simulate the core update channel having moved current AHEAD of bundled.
+      installFakeCore('5.0.0')
+      const fm = new FrameworkManager({ home })
+      fm.versionCheck(['claude'])
+      expect(readCurrentFrameworkVersion(home)).toBe('5.0.0')
+      // A user voluntarily materialized 5.2.0 via the update channel.
+      mkdirSync(path.join(frameworkRoot(home), '5.2.0', '.claude', 'agents'), { recursive: true })
+      const cur = path.join(frameworkRoot(home), 'current')
+      rmSync(cur, { force: true })
+      writeFileSync(path.join(frameworkRoot(home), '5.2.0', 'marker'), 'x')
+      symlinkSync('5.2.0', cur)
+      expect(readCurrentFrameworkVersion(home)).toBe('5.2.0')
+      // Next startup versionCheck sees bundled 5.0.0 < current 5.2.0 → MUST NOT downgrade.
+      const res = withFileLock(home, () => fm.versionCheck(['claude']))
+      expect(res.swapped).toBe(false)
+      expect(readCurrentFrameworkVersion(home)).toBe('5.2.0')
+    })
+  })
+
+  describe('coreRoot override (update channel)', () => {
+    it('materializes from an OVERRIDE core root instead of the bundled one', () => {
+      // No bundled core at all — only the override.
+      delete process.env.SPECRAILS_BUNDLED_CORE_PATH
+      const override = mkdtempSync(path.join(os.tmpdir(), 'fm-override-'))
+      try {
+        mkdirSync(path.join(override, 'dist', 'installer'), { recursive: true })
+        writeFileSync(path.join(override, 'dist', 'installer', 'cli.js'), FAKE_CLI)
+        writeFileSync(path.join(override, 'package.json'), JSON.stringify({ version: '6.0.0' }))
+        const fm = new FrameworkManager({ home, coreRoot: override })
+        expect(fm.isAvailable()).toBe(true)
+        expect(fm.bundledVersion()).toBe('6.0.0')
+        const res = fm.materialize('6.0.0', ['claude'])
+        expect(res.ran).toBe(true)
+        expect(fm.swapCurrent('6.0.0')).toBe(true)
+        expect(readCurrentFrameworkVersion(home)).toBe('6.0.0')
+      } finally {
+        rmSync(override, { recursive: true, force: true })
+      }
     })
   })
 })

--- a/server/framework-manager.ts
+++ b/server/framework-manager.ts
@@ -4,6 +4,7 @@ import path from 'path'
 
 import { getBundledCoreCli, getBundledCoreVersion } from './bundled-core'
 import { resolveHome, atomicWrite } from './artifact-registry'
+import { isNewer } from './semver-lite'
 
 /**
  * FrameworkManager — materializes the bundled specrails-core framework ONCE into
@@ -28,6 +29,15 @@ export interface FrameworkManagerOptions {
   home?: string
   /** App-level WS broadcast (no projectId) for `framework.updated`. */
   broadcast?: FrameworkBroadcast
+  /**
+   * Override the specrails-core package root used to materialize the framework.
+   * Default: the BUNDLED core (`SPECRAILS_BUNDLED_CORE_PATH`). The core update
+   * channel (`CoreUpdateManager`) passes a freshly npm-installed newer core root
+   * here so `materialize`/`swapCurrent` run that version's `install-framework`
+   * instead of the bundled one. When set, `<coreRoot>/dist/installer/cli.js`
+   * must exist and its `package.json` version is the materialized version.
+   */
+  coreRoot?: string
 }
 
 export interface MaterializeResult {
@@ -79,19 +89,48 @@ export function readCurrentFrameworkVersion(home?: string): string | null {
 export class FrameworkManager {
   private readonly home?: string
   private readonly broadcast?: FrameworkBroadcast
+  private readonly coreRoot?: string
 
   constructor(opts: FrameworkManagerOptions = {}) {
     this.home = opts.home
     this.broadcast = opts.broadcast
+    this.coreRoot = opts.coreRoot
   }
 
-  /** True when a usable bundled core is present (else all methods no-op). */
+  /**
+   * Resolve the core CLI to shell out to: the override core root (update channel)
+   * when set, else the bundled core. Returns null when neither is present.
+   */
+  private resolveCli(): string | null {
+    if (this.coreRoot) {
+      const cli = path.join(this.coreRoot, 'dist', 'installer', 'cli.js')
+      return fs.existsSync(cli) ? cli : null
+    }
+    return getBundledCoreCli()
+  }
+
+  /** True when a usable core (override or bundled) is present (else methods no-op). */
   isAvailable(): boolean {
-    return getBundledCoreCli() !== null
+    return this.resolveCli() !== null
   }
 
-  /** The bundled core version (the version the app should materialize), or null. */
+  /**
+   * The version the app should materialize: the override core's version (update
+   * channel) when a `coreRoot` is set, else the bundled core version. Null when
+   * neither is present / unreadable.
+   */
   bundledVersion(): string | null {
+    if (this.coreRoot) {
+      try {
+        const pkg = JSON.parse(
+          fs.readFileSync(path.join(this.coreRoot, 'package.json'), 'utf8'),
+        ) as { version?: string }
+        const v = pkg.version?.trim()
+        return v && v.length > 0 ? v : null
+      } catch {
+        return null
+      }
+    }
     return getBundledCoreVersion()
   }
 
@@ -106,7 +145,7 @@ export class FrameworkManager {
    * (ran:false) when no bundled core is present.
    */
   materialize(version?: string, providers: string[] = ['claude']): MaterializeResult {
-    const cli = getBundledCoreCli()
+    const cli = this.resolveCli()
     if (!cli) {
       return { ran: false, version: null, providers: [], errors: [] }
     }
@@ -158,7 +197,7 @@ export class FrameworkManager {
    * `swap-current` only moves the version pointer (provider-invariant).
    */
   swapCurrent(version: string, _provider = 'claude'): boolean {
-    const cli = getBundledCoreCli()
+    const cli = this.resolveCli()
     if (!cli) return false
     if (readCurrentFrameworkVersion(this.home) === version) return true
     const fwDir = frameworkRoot(this.home)
@@ -179,11 +218,20 @@ export class FrameworkManager {
    */
   versionCheck(providers: string[] = ['claude']): { swapped: boolean; version: string | null } {
     const bundled = this.bundledVersion()
-    if (!getBundledCoreCli() || !bundled) {
+    if (!this.resolveCli() || !bundled) {
       return { swapped: false, version: readCurrentFrameworkVersion(this.home) }
     }
     const current = readCurrentFrameworkVersion(this.home)
     if (current === bundled) {
+      return { swapped: false, version: current }
+    }
+    // Anti-downgrade guard: NEVER swap `current` down to the bundled version when
+    // `current` is already NEWER. The core update channel lets a user voluntarily
+    // materialize a core newer than the one shipped in this app build; without
+    // this guard the next startup versionCheck would revert that manual update
+    // back to the (older) bundled version. Only first-run (current null) or a
+    // genuinely newer bundled core (a fresh app update) proceeds.
+    if (current && !isNewer(bundled, current)) {
       return { swapped: false, version: current }
     }
     // Materialize EVERY requested provider first (each with `--no-swap`), then
@@ -245,7 +293,7 @@ export class FrameworkManager {
     version?: string
     codeRoot: string
   }): { ran: boolean; error?: string } {
-    const cli = getBundledCoreCli()
+    const cli = this.resolveCli()
     if (!cli) return { ran: false }
     const ver = input.version ?? this.bundledVersion()
     if (!ver) return { ran: false }
@@ -281,9 +329,10 @@ export class FrameworkManager {
     if (this.home) {
       env.SPECRAILS_REGISTRY_HOME = this.home
     }
-    // Point the bundled core CLI's scriptDir at the bundled package so its
-    // template/command sources resolve from the bundle, not a global install.
-    const coreRoot = process.env.SPECRAILS_BUNDLED_CORE_PATH
+    // Point the core CLI's scriptDir at the package whose framework we are
+    // materializing so its template/command sources resolve from there: the
+    // OVERRIDE core (update channel) when set, else the bundled package.
+    const coreRoot = this.coreRoot ?? process.env.SPECRAILS_BUNDLED_CORE_PATH
     if (coreRoot) env.SPECRAILS_CORE_SCRIPT_DIR = coreRoot
     return env
   }

--- a/server/semver-lite.test.ts
+++ b/server/semver-lite.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { compareVersions, isNewer, isValidVersion } from './semver-lite'
+
+describe('semver-lite', () => {
+  describe('compareVersions', () => {
+    it('orders by major, minor, patch', () => {
+      expect(compareVersions('1.0.0', '2.0.0')).toBe(-1)
+      expect(compareVersions('2.0.0', '1.0.0')).toBe(1)
+      expect(compareVersions('1.2.0', '1.3.0')).toBe(-1)
+      expect(compareVersions('1.2.3', '1.2.4')).toBe(-1)
+      expect(compareVersions('1.2.3', '1.2.3')).toBe(0)
+      expect(compareVersions('4.9.0', '4.8.2')).toBe(1)
+    })
+
+    it('treats a prerelease as lower than the released version', () => {
+      expect(compareVersions('1.0.0-rc.1', '1.0.0')).toBe(-1)
+      expect(compareVersions('1.0.0', '1.0.0-rc.1')).toBe(1)
+    })
+
+    it('compares prerelease identifiers per semver §11', () => {
+      expect(compareVersions('1.0.0-alpha', '1.0.0-alpha.1')).toBe(-1) // shorter set lower
+      expect(compareVersions('1.0.0-alpha.1', '1.0.0-alpha.2')).toBe(-1) // numeric
+      expect(compareVersions('1.0.0-alpha.1', '1.0.0-beta')).toBe(-1) // numeric < non-numeric
+      expect(compareVersions('1.0.0-beta', '1.0.0-alpha')).toBe(1) // lexical
+      expect(compareVersions('1.0.0-rc.1', '1.0.0-rc.1')).toBe(0)
+    })
+
+    it('tolerates leading v/= and whitespace, ignores build metadata', () => {
+      expect(compareVersions(' v1.2.3 ', '=1.2.3')).toBe(0)
+      expect(compareVersions('1.2.3+build.5', '1.2.3+build.9')).toBe(0)
+    })
+
+    it('treats unparseable input as 0.0.0', () => {
+      expect(compareVersions('garbage', '0.0.0')).toBe(0)
+      expect(compareVersions('1.0.0', 'nope')).toBe(1)
+      // partial versions fill missing parts with 0
+      expect(compareVersions('1', '1.0.0')).toBe(0)
+      expect(compareVersions('1.2', '1.2.0')).toBe(0)
+    })
+  })
+
+  describe('isNewer', () => {
+    it('is true only when strictly greater', () => {
+      expect(isNewer('4.9.0', '4.8.0')).toBe(true)
+      expect(isNewer('4.8.0', '4.8.0')).toBe(false)
+      expect(isNewer('4.7.0', '4.8.0')).toBe(false)
+      expect(isNewer('5.0.0', '4.9.9')).toBe(true)
+    })
+  })
+
+  describe('isValidVersion', () => {
+    it('accepts well-formed versions', () => {
+      expect(isValidVersion('1.2.3')).toBe(true)
+      expect(isValidVersion('v4.8.0')).toBe(true)
+      expect(isValidVersion('1.2.3-rc.1')).toBe(true)
+      expect(isValidVersion('1.2.3+build')).toBe(true)
+    })
+    it('rejects malformed versions', () => {
+      expect(isValidVersion('1.2')).toBe(false)
+      expect(isValidVersion('latest')).toBe(false)
+      expect(isValidVersion('')).toBe(false)
+      expect(isValidVersion('x.y.z')).toBe(false)
+    })
+  })
+})

--- a/server/semver-lite.ts
+++ b/server/semver-lite.ts
@@ -1,0 +1,86 @@
+/**
+ * Minimal semver comparison — the repo has no `semver` dependency and the core
+ * update channel only needs "is A strictly newer than B" plus a total order.
+ *
+ * Supports `MAJOR.MINOR.PATCH` with an optional `-prerelease` suffix. A version
+ * WITH a prerelease tag sorts BELOW the same version without one (`4.9.0-rc.1` <
+ * `4.9.0`), matching semver §11. Prerelease identifiers are compared
+ * left-to-right: numeric identifiers numerically, others lexically, numeric <
+ * non-numeric, and a shorter prerelease set sorts lower when all prior
+ * identifiers are equal. Build metadata (`+…`) is ignored. Leading `v`/`=` and
+ * surrounding whitespace are tolerated. Unparseable input sorts as `0.0.0`.
+ */
+
+interface Parsed {
+  major: number
+  minor: number
+  patch: number
+  prerelease: string[]
+}
+
+function parse(raw: string): Parsed {
+  const cleaned = String(raw ?? '')
+    .trim()
+    .replace(/^[v=]+/, '')
+    .split('+', 1)[0] // drop build metadata
+  const [core, pre] = cleaned.split('-', 2) as [string, string | undefined]
+  const parts = core.split('.')
+  const num = (s: string | undefined): number => {
+    const n = Number.parseInt(s ?? '', 10)
+    return Number.isFinite(n) && n >= 0 ? n : 0
+  }
+  return {
+    major: num(parts[0]),
+    minor: num(parts[1]),
+    patch: num(parts[2]),
+    prerelease: pre && pre.length > 0 ? pre.split('.') : [],
+  }
+}
+
+function comparePrerelease(a: string[], b: string[]): number {
+  // No prerelease outranks any prerelease (1.0.0 > 1.0.0-rc).
+  if (a.length === 0 && b.length === 0) return 0
+  if (a.length === 0) return 1
+  if (b.length === 0) return -1
+  const len = Math.max(a.length, b.length)
+  for (let i = 0; i < len; i++) {
+    const ai = a[i]
+    const bi = b[i]
+    if (ai === undefined) return -1 // shorter set sorts lower
+    if (bi === undefined) return 1
+    if (ai === bi) continue
+    const an = /^\d+$/.test(ai)
+    const bn = /^\d+$/.test(bi)
+    if (an && bn) {
+      const d = Number.parseInt(ai, 10) - Number.parseInt(bi, 10)
+      if (d !== 0) return d < 0 ? -1 : 1
+    } else if (an) {
+      return -1 // numeric identifiers have lower precedence than non-numeric
+    } else if (bn) {
+      return 1
+    } else {
+      return ai < bi ? -1 : 1
+    }
+  }
+  return 0
+}
+
+/** -1 if a < b, 0 if equal, 1 if a > b. */
+export function compareVersions(a: string, b: string): number {
+  const pa = parse(a)
+  const pb = parse(b)
+  if (pa.major !== pb.major) return pa.major < pb.major ? -1 : 1
+  if (pa.minor !== pb.minor) return pa.minor < pb.minor ? -1 : 1
+  if (pa.patch !== pb.patch) return pa.patch < pb.patch ? -1 : 1
+  return comparePrerelease(pa.prerelease, pb.prerelease)
+}
+
+/** True when `candidate` is strictly newer than `base`. */
+export function isNewer(candidate: string, base: string): boolean {
+  return compareVersions(candidate, base) > 0
+}
+
+/** True when `raw` looks like a parseable `MAJOR.MINOR.PATCH[-pre]` version. */
+export function isValidVersion(raw: string): boolean {
+  return /^[v=]?\d+\.\d+\.\d+(?:[-+].*)?$/.test(String(raw ?? '').trim())
+}


### PR DESCRIPTION
## What

Adds a **Specrails Core** section to the global settings dialog that detects a newer published `specrails-core` and applies it **without restarting the app**. The framework swap re-points every project workspace at the new core (O(1) on POSIX), so all projects update at once.

Detection is deliberately simple (per request): npm `latest` **strictly greater** than the installed `framework/current` version ⇒ an update is offered. No compatibility-range gate; the app-bundled core remains the floor/fallback and the update only ever moves the pointer **up**.

## Why

Today `specrails-core` is pinned to whatever ships inside the app build and only updates when the whole desktop app updates. This decouples it: a user can pick up a core fix/feature voluntarily from general settings — app-global, since `framework/current` is shared across all projects.

## How

**Server**
- `semver-lite.ts` — dependency-free `MAJOR.MINOR.PATCH[-pre]` comparison (`compareVersions`/`isNewer`/`isValidVersion`).
- `core-update-manager.ts` — `getStatus()` (no network), `checkForUpdate()` (npm registry GET), `update()` (npm-install the newer core into a temp stage → materialize its framework → atomic `swapCurrent` → `core_update.progress` + `framework.updated` WS). Net/npm/framework deps are injectable for tests.
- `framework-manager.ts` — optional `coreRoot` override so `materialize`/`swapCurrent` run a downloaded core instead of the bundled one; **anti-downgrade guard** in `versionCheck` so a startup never reverts a manual update back to the older bundled version.
- `desktop-router.ts` — `GET /api/core-update/status`, `POST /api/core-update/check`, `POST /api/core-update/update` (202 + async WS progress; 409 when unavailable).

**Client**
- `CoreUpdateSection.tsx` wired into `GlobalSettingsPage`, streaming progress over the shared WebSocket. i18n keys added to all 8 locales.

## Scope / limits
- Gated on a bundled core being present (desktop mode); dev/non-desktop shows "unavailable" and projects keep the legacy path.
- Non-destructive: the previous `framework/<version>` dir stays on disk (rollback-capable, not yet surfaced in UI).
- `npm install` of the newer core is the one runtime network call — it's a voluntary, explicit action only.

## Tests
semver, manager (status/check/update happy + materialize failure + not-newer + unavailable + default registry fetch), framework override + downgrade guard, routes, and the client section. `typecheck` + server & client coverage gates pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)