### PR TITLE
fix(setup): run bundled openspec init with real Node, not the pkg binary

### DIFF
--- a/server/path-resolver.test.ts
+++ b/server/path-resolver.test.ts
@@ -9,6 +9,7 @@ import {
   parseLoginShellOutput,
   getPathDiagnostic,
   resolveBundledRuntimePath,
+  resolveBundledNodeExe,
   __resetPathResolverForTest,
 } from './path-resolver'
 
@@ -421,3 +422,61 @@ function makeFakeSpawn(opts: { stdout: string; exitCode: number | null; hang?: b
     return child
   }
 }
+
+describe('resolveBundledNodeExe', () => {
+  const ORIGINAL_RUNTIMES = process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH
+
+  afterEach(() => {
+    if (ORIGINAL_RUNTIMES === undefined) delete process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH
+    else process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH = ORIGINAL_RUNTIMES
+    setPlatform(ORIGINAL_PLATFORM)
+  })
+
+  it('returns null when SPECRAILS_BUNDLED_RUNTIMES_PATH is unset', () => {
+    delete process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH
+    expect(resolveBundledNodeExe()).toBeNull()
+  })
+
+  it('returns null when set but the node binary is absent', () => {
+    const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'rt-empty-'))
+    process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH = empty
+    try {
+      expect(resolveBundledNodeExe()).toBeNull()
+    } finally {
+      fs.rmSync(empty, { recursive: true, force: true })
+    }
+  })
+
+  it('returns the POSIX node path when the bundled binary exists (non-win32)', () => {
+    setPlatform('darwin')
+    const { base } = makeRuntimesDir()
+    process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH = base
+    try {
+      expect(resolveBundledNodeExe()).toBe(path.join(base, 'node', 'bin', 'node'))
+    } finally {
+      fs.rmSync(base, { recursive: true, force: true })
+    }
+  })
+
+  it('returns the node.exe path on win32', () => {
+    setPlatform('win32')
+    const { base } = makeRuntimesDir()
+    process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH = base
+    try {
+      expect(resolveBundledNodeExe()).toBe(path.join(base, 'node', 'node.exe'))
+    } finally {
+      fs.rmSync(base, { recursive: true, force: true })
+    }
+  })
+
+  it('never returns process.execPath (the pkg binary) — the openspec-init regression guard', () => {
+    setPlatform('darwin')
+    const { base } = makeRuntimesDir()
+    process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH = base
+    try {
+      expect(resolveBundledNodeExe()).not.toBe(process.execPath)
+    } finally {
+      fs.rmSync(base, { recursive: true, force: true })
+    }
+  })
+})

--- a/server/path-resolver.ts
+++ b/server/path-resolver.ts
@@ -103,6 +103,26 @@ export function resolveBundledRuntimePath(): string {
 }
 
 /**
+ * Absolute path to the bundled REAL Node executable (`runtimes/node/bin/node` on
+ * POSIX, `runtimes/node/node.exe` on Windows), or `null` when no bundled runtimes
+ * are present (non-desktop mode, a runtimes-less build, or a partial extraction).
+ *
+ * This is the node that must run bundled node CLIs (e.g. the openspec ESM CLI).
+ * It is deliberately NOT `process.execPath`: in the packaged app `process.execPath`
+ * is the `specrails-server` pkg binary, which cannot run an external ESM CLI —
+ * passing it as `SPECRAILS_OPENSPEC_NODE` made `openspec init` exit with code -1.
+ * Existence-gated so a stale/partial bundle degrades to the PATH `node` instead.
+ */
+export function resolveBundledNodeExe(): string | null {
+  const runtimesPath = process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH
+  if (!runtimesPath || runtimesPath.length === 0) return null
+  const exe = process.platform === 'win32'
+    ? path.join(runtimesPath, 'node', 'node.exe')
+    : path.join(runtimesPath, 'node', 'bin', 'node')
+  return fileExists(exe) ? exe : null
+}
+
+/**
  * Synchronously prepend well-known package-manager bin directories to
  * `process.env.PATH` if they are missing. No-op on Windows.
  *

--- a/server/setup-manager-bundled-core.test.ts
+++ b/server/setup-manager-bundled-core.test.ts
@@ -79,6 +79,7 @@ describe('SetupManager — bundled-core install path', () => {
   let prevCore: string | undefined
   let prevHome: string | undefined
   let prevOpenspec: string | undefined
+  let prevRuntimes: string | undefined
   let openspecDir: string
 
   beforeEach(() => {
@@ -91,7 +92,10 @@ describe('SetupManager — bundled-core install path', () => {
     prevCore = process.env.SPECRAILS_BUNDLED_CORE_PATH
     prevHome = process.env.SPECRAILS_REGISTRY_HOME
     prevOpenspec = process.env.SPECRAILS_BUNDLED_OPENSPEC_PATH
+    prevRuntimes = process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH
     delete process.env.SPECRAILS_BUNDLED_OPENSPEC_PATH
+    // Default: no bundled runtimes → SPECRAILS_OPENSPEC_NODE falls back to PATH `node`.
+    delete process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH
     process.env.SPECRAILS_REGISTRY_HOME = home
   })
 
@@ -102,6 +106,8 @@ describe('SetupManager — bundled-core install path', () => {
     else process.env.SPECRAILS_REGISTRY_HOME = prevHome
     if (prevOpenspec === undefined) delete process.env.SPECRAILS_BUNDLED_OPENSPEC_PATH
     else process.env.SPECRAILS_BUNDLED_OPENSPEC_PATH = prevOpenspec
+    if (prevRuntimes === undefined) delete process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH
+    else process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH = prevRuntimes
     rmSync(home, { recursive: true, force: true })
     rmSync(coreDir, { recursive: true, force: true })
     rmSync(project, { recursive: true, force: true })
@@ -194,8 +200,42 @@ describe('SetupManager — bundled-core install path', () => {
     expect(existsSync(envFile)).toBe(true)
     const env = JSON.parse(readFileSync(envFile, 'utf8'))
     expect(env.bin).toBe(openspecCli)
-    // NODE is the same node the bundled core runs with (process.execPath).
-    expect(env.node).toBe(process.execPath)
+    // NODE must be a REAL node executable, NOT process.execPath (the packaged
+    // pkg binary, which cannot run openspec's ESM CLI → exit -1). With no bundled
+    // runtimes set, it falls back to `node` on PATH.
+    expect(env.node).toBe('node')
+    expect(env.node).not.toBe(process.execPath)
+  })
+
+  it('uses the bundled Node binary as SPECRAILS_OPENSPEC_NODE when bundled runtimes are present', async () => {
+    installFakeCore('5.0.0')
+    const openspecCli = installFakeOpenspec()
+
+    // Arm a fake bundled runtimes tree with a real node binary at the POSIX path
+    // (the test only runs assertions on POSIX layout; on win32 the candidate is
+    // node/node.exe — guard accordingly).
+    const runtimes = mkdtempSync(path.join(os.tmpdir(), 'sm-bc-rt-'))
+    const nodeExe = process.platform === 'win32'
+      ? path.join(runtimes, 'node', 'node.exe')
+      : path.join(runtimes, 'node', 'bin', 'node')
+    mkdirSync(path.dirname(nodeExe), { recursive: true })
+    writeFileSync(nodeExe, '#!/bin/sh\n', { mode: 0o755 })
+    process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH = runtimes
+
+    try {
+      sm.startInstall('proj-os-rt', project, 'proj-os-rt')
+      await waitFor(() => getByType('setup_install_done').length > 0 || getByType('setup_error').length > 0)
+
+      expect(getByType('setup_error')).toEqual([])
+      const { readFileSync, existsSync } = await import('fs')
+      const envFile = path.join(project, 'openspec-env.json')
+      expect(existsSync(envFile)).toBe(true)
+      const env = JSON.parse(readFileSync(envFile, 'utf8'))
+      expect(env.bin).toBe(openspecCli)
+      expect(env.node).toBe(nodeExe)
+    } finally {
+      rmSync(runtimes, { recursive: true, force: true })
+    }
   })
 
   it('omits the openspec env (npx fallback) when no bundled openspec is present', async () => {

--- a/server/setup-manager.ts
+++ b/server/setup-manager.ts
@@ -15,6 +15,7 @@ import { mirrorProjectEntry, resolveArtifacts } from './artifact-registry'
 import { installConfigPath, type InstallConfigProject } from './install-config-path'
 import { getBundledCoreCli, getBundledCoreRoot, getBundledCoreVersion } from './bundled-core'
 import { getBundledOpenspecCli } from './bundled-openspec'
+import { resolveBundledNodeExe } from './path-resolver'
 import { FrameworkManager } from './framework-manager'
 import type { ProviderAdapter, SpawnAction, ProviderId } from './providers/types'
 
@@ -108,7 +109,13 @@ function spawnBundledCoreInit(args: string[], cwd: string): ChildProcess | null 
   const openspecCli = getBundledOpenspecCli()
   if (openspecCli) {
     env.SPECRAILS_OPENSPEC_BIN = openspecCli
-    env.SPECRAILS_OPENSPEC_NODE = process.execPath
+    // Core runs openspec as `<node> <cli> init …`. SPECRAILS_OPENSPEC_NODE MUST be
+    // a REAL node executable — NOT process.execPath (the packaged `specrails-server`
+    // pkg binary), which cannot run openspec's ESM CLI and made `openspec init`
+    // exit with code -1 (→ core throws InstallerError code 50, setup fails). Prefer
+    // the bundled Node; fall back to `node` on PATH (resolveStartupPath prepends the
+    // bundled node bin in desktop mode, so PATH `node` is the bundled node too).
+    env.SPECRAILS_OPENSPEC_NODE = resolveBundledNodeExe() ?? 'node'
   }
 
   console.log(


### PR DESCRIPTION
## Problem

In the **packaged app**, Add Project failed at the OpenSpec step:

```
bundled specrails-core exited with code 50
✗ OpenSpec init failed: command
  "/Applications/Specrails.app/Contents/MacOS/specrails-server
   .../@fission-ai/openspec/bin/openspec.js init --tools claude <repo>"
  exited with code -1
```

Setup passed `SPECRAILS_OPENSPEC_NODE = process.execPath` to specrails-core. But in the bundle `process.execPath` is the **`specrails-server` pkg binary**, which can't run openspec's ESM CLI. Core invokes `<node> <openspec.js> init …`, the pkg binary crashes (exit `-1`), core throws `InstallerError(…, 50)`, and the whole setup fails.

Core's own contract (`openspec-invocation.test.ts`) documents `SPECRAILS_OPENSPEC_NODE` as a **real node executable** (`/bundle/node/bin/node`). The rail-side openspec shim already uses the bundled `node`; only the setup path passed the wrong binary.

> This is also the root cause of the secondary "`.specrails` still lands in the repo" report: core aborts (code 50) before completing the relocated workspace assembly, so retried/failed runs leave artifacts behind. With openspec init fixed, core completes and relocation works.

## Fix

- `path-resolver.ts` — new `resolveBundledNodeExe()` returns the bundled real Node (`runtimes/node/bin/node`, `node.exe` on Windows), existence-gated, `null` when absent.
- `setup-manager.ts` — `SPECRAILS_OPENSPEC_NODE = resolveBundledNodeExe() ?? 'node'`. Never `process.execPath`. The `node` fallback resolves to the bundled node too (`resolveStartupPath` prepends its bin in desktop mode).

## Tests
- Fixed the bundled-core test that **encoded the bug** (`expect(env.node).toBe(process.execPath)` → now a real node), added a bundled-runtimes case, and unit tests for `resolveBundledNodeExe`.
- `tsc` clean; server coverage gate green (path-resolver 92%, setup-manager 82.3%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yDpwMwyGtwYF9mh5tTKk4