### PR TITLE
test(integrations): de-flake "Auto-install button when uv missing"

### DIFF
--- a/client/src/pages/__tests__/IntegrationsPage.test.tsx
+++ b/client/src/pages/__tests__/IntegrationsPage.test.tsx
@@ -128,11 +128,17 @@ describe('IntegrationsPage', () => {
       requirements: [{ name: 'uv', installed: false, executable: false, meetsMinimum: false, minVersion: '0.1.0' }],
     })
     render(<IntegrationsPage />)
-    await waitFor(() => screen.getByText('serena'))
-    fireEvent.click(screen.getByRole('button', { name: /install$/i }))
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /auto-install/i })).toBeInTheDocument()
-    })
+    await screen.findByText('serena')
+    // Wait for the Install button to mount before clicking, then assert the
+    // Auto-install button via findByRole — clicking Install triggers a
+    // preview-install fetch whose modal renders the uv-missing requirement a
+    // tick later, so a synchronous getByRole raced the async render under CI
+    // load (flaky "Unable to find /auto-install/i"). findBy* retries; the bumped
+    // timeout absorbs the two sequential async fetches on a slow runner.
+    fireEvent.click(await screen.findByRole('button', { name: /install$/i }))
+    expect(
+      await screen.findByRole('button', { name: /auto-install/i }, { timeout: 5000 }),
+    ).toBeInTheDocument()
   })
 
   it('shows the Jira card (not an empty state) when no plugins are bundled', async () => {


### PR DESCRIPTION
## Problem

The release CI for #413 went red on a **flaky, pre-existing** test — `IntegrationsPage › shows Auto-install button when uv prerequisite is missing` (`Unable to find role=button /auto-install/i`). A run at the **same commit passed**, confirming a race, not a regression. It is unrelated to the recent feature PRs.

The test clicked **Install** then asserted **Auto-install** with a synchronous `getByRole` inside `waitFor`. Clicking Install fires a `preview-install` fetch whose modal renders the uv-missing requirement a tick later — under CI load the assertion raced that async render.

## Fix

`findBy*` (which retries) instead of `getByText` + immediate `getByRole`; wait for the Install button before clicking; bump the auto-install timeout to absorb the two sequential async fetches on a slow runner. No production code change.

Verified locally with 5 consecutive green runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yDpwMwyGtwYF9mh5tTKk4