### PR TITLE
feat(setup): force SPECRAILS_RELOCATE=1 on core init (relocation now opt-in)

### DIFF
--- a/server/setup-manager-bundled-core.test.ts
+++ b/server/setup-manager-bundled-core.test.ts
@@ -60,6 +60,7 @@ if (sub === 'init') {
       JSON.stringify({
         bin: process.env.SPECRAILS_OPENSPEC_BIN || null,
         node: process.env.SPECRAILS_OPENSPEC_NODE || null,
+        relocate: process.env.SPECRAILS_RELOCATE || null,
       }),
     )
   } catch {}
@@ -205,6 +206,9 @@ describe('SetupManager — bundled-core install path', () => {
     // runtimes set, it falls back to `node` on PATH.
     expect(env.node).toBe('node')
     expect(env.node).not.toBe(process.execPath)
+    // The desktop forces relocation: core installs in-repo by default, but the
+    // desktop must keep the user's repo pristine + manages the spawn cwd.
+    expect(env.relocate).toBe('1')
   })
 
   it('uses the bundled Node binary as SPECRAILS_OPENSPEC_NODE when bundled runtimes are present', async () => {

--- a/server/setup-manager.ts
+++ b/server/setup-manager.ts
@@ -75,7 +75,12 @@ function spawnCoreInit(args: string[], cwd: string): ChildProcess {
   // .cmd shim AND quotes each arg, so spaces (and newlines) survive intact.
   return spawnCli(bin, fullArgs, {
     cwd,
-    env: process.env,
+    // Force RELOCATION: specrails-core installs in-repo by DEFAULT now (so a
+    // standalone `npx specrails-core init` user's CLI finds the agents in their
+    // repo). The desktop manages the cwd (spawns rails with cwd=workspace), so
+    // it MUST relocate to keep the user's imported repo pristine — independent of
+    // whether the registry mirror already ran. See specrails-core init's gate.
+    env: { ...process.env, SPECRAILS_RELOCATE: '1' },
     stdio: ['ignore', 'pipe', 'pipe'],
   })
 }
@@ -96,7 +101,9 @@ function spawnBundledCoreInit(args: string[], cwd: string): ChildProcess | null 
   const coreRoot = getBundledCoreRoot()
   if (!cli || !coreRoot) return null
   const fullArgs = [cli, 'init', ...args]
-  const env: NodeJS.ProcessEnv = { ...process.env, SPECRAILS_CORE_SCRIPT_DIR: coreRoot }
+  // Force RELOCATION (core installs in-repo by default; the desktop keeps the
+  // user's repo pristine + manages the spawn cwd). See spawnCoreInit.
+  const env: NodeJS.ProcessEnv = { ...process.env, SPECRAILS_CORE_SCRIPT_DIR: coreRoot, SPECRAILS_RELOCATE: '1' }
 
   // Bundled openspec (offline) — the LAST network step of project-add. When the
   // app ships @fission-ai/openspec, point specrails-core's `installOpenSpecProject`


### PR DESCRIPTION
## Context

specrails-core now installs **in-repo by default** — a standalone `npx specrails-core init` puts real, committable agents/commands in the user's repo so their CLI (claude/codex/gemini, cwd=repo) finds them. Relocation to the `$HOME` workspace is opt-in via `--relocate` / `SPECRAILS_RELOCATE=1`.

## Change

The desktop manages the spawn cwd (rails run with `cwd = workspace`) and must keep the user's **imported repo pristine**, so it sets `SPECRAILS_RELOCATE=1` on both core-init spawns (`spawnCoreInit` + `spawnBundledCoreInit`).

This **guarantees relocation** independent of whether the registry mirror already ran — robust against a `mirrorProjectEntry` failure that would otherwise let core install into the user's repo (a leak).

A regression test asserts the bundled core init inherits `SPECRAILS_RELOCATE=1` (via the fake core recording its env).

## Verification
- `tsc` clean; setup-manager tests green (106); full server coverage gate **EXIT 0** (157 files).

> Pairs with the specrails-core PR "install in-repo by default; relocate via `--relocate` / `SPECRAILS_RELOCATE=1`". Backward-compatible: an older core ignores the unknown env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yDpwMwyGtwYF9mh5tTKk4