### PR TITLE
fix(windows): repair bundled-runtime probe + packaged core spawns

### DIFF
--- a/server/core-update-manager.ts
+++ b/server/core-update-manager.ts
@@ -5,6 +5,7 @@ import path from 'path'
 
 import { FrameworkManager, readCurrentFrameworkVersion, type FrameworkBroadcast } from './framework-manager'
 import { isNewer, isValidVersion } from './semver-lite'
+import { windowsSpawnEnv } from './util/win-spawn'
 
 /**
  * CoreUpdateManager — the voluntary, app-global specrails-core update channel.
@@ -266,5 +267,8 @@ function defaultNpmInstall(spec: string, cwd: string): void {
     stdio: ['ignore', 'inherit', 'inherit'],
     timeout: INSTALL_TIMEOUT_MS,
     shell: process.platform === 'win32',
+    // SystemRoot/ComSpec so npm.cmd's cmd.exe can start even if the packaged
+    // sidecar inherited a stripped Windows environment.
+    env: windowsSpawnEnv(),
   })
 }

--- a/server/framework-manager.test.ts
+++ b/server/framework-manager.test.ts
@@ -416,4 +416,42 @@ process.exit(7)
       }
     })
   })
+
+  describe('node interpreter (pkg-safety)', () => {
+    // In the packaged app process.execPath is the specrails-server pkg binary, not
+    // node — so the core CLI MUST be spawned with the bundled real node. Prove the
+    // bundled node (resolveBundledNodeExe) is the interpreter, not process.execPath,
+    // via a wrapper that records its invocation then exec's the real node.
+    it.skipIf(process.platform === 'win32')(
+      'spawns the core CLI with the bundled node when runtimes are present',
+      () => {
+        installFakeCore('5.0.0')
+        const runtimes = mkdtempSync(path.join(os.tmpdir(), 'fm-rt-'))
+        const prevRuntimes = process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH
+        try {
+          const nodeBin = path.join(runtimes, 'node', 'bin', 'node')
+          mkdirSync(path.dirname(nodeBin), { recursive: true })
+          const marker = path.join(runtimes, 'used-bundled-node')
+          // Wrapper: record that the bundled node ran, then exec the real node.
+          writeFileSync(
+            nodeBin,
+            `#!/bin/sh\necho used >> "${marker}"\nexec "${process.execPath}" "$@"\n`,
+            { mode: 0o755 },
+          )
+          process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH = runtimes
+
+          const fm = new FrameworkManager({ home })
+          const res = fm.materialize('5.0.0', ['claude'])
+          expect(res.ran).toBe(true)
+          expect(res.errors).toEqual([])
+          // The wrapper ran ⇒ argv[0] was the bundled node, NOT process.execPath.
+          expect(existsSync(marker)).toBe(true)
+        } finally {
+          if (prevRuntimes === undefined) delete process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH
+          else process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH = prevRuntimes
+          rmSync(runtimes, { recursive: true, force: true })
+        }
+      },
+    )
+  })
 })

--- a/server/framework-manager.ts
+++ b/server/framework-manager.ts
@@ -5,6 +5,20 @@ import path from 'path'
 import { getBundledCoreCli, getBundledCoreVersion } from './bundled-core'
 import { resolveHome, atomicWrite } from './artifact-registry'
 import { isNewer } from './semver-lite'
+import { resolveBundledNodeExe } from './path-resolver'
+
+/**
+ * The node interpreter to run the core CLI with. In the PACKAGED app
+ * `process.execPath` is the `specrails-server` pkg binary — NOT node — so
+ * `spawnSync(process.execPath, [cli, …])` would re-launch the server instead of
+ * running `cli.js`, silently breaking every framework materialize/swap/assemble.
+ * Use the bundled real node when present (it always is when a bundled core is —
+ * they ship together), and fall back to `process.execPath` only in dev/tests
+ * where `process.execPath` IS node.
+ */
+function nodeInterpreter(): string {
+  return resolveBundledNodeExe() ?? process.execPath
+}
 
 /**
  * FrameworkManager — materializes the bundled specrails-core framework ONCE into
@@ -161,7 +175,7 @@ export class FrameworkManager {
     const done: string[] = []
     for (const provider of dedupe(providers)) {
       const res = spawnSync(
-        process.execPath,
+        nodeInterpreter(),
         [
           cli,
           'install-framework',
@@ -202,7 +216,7 @@ export class FrameworkManager {
     if (readCurrentFrameworkVersion(this.home) === version) return true
     const fwDir = frameworkRoot(this.home)
     const res = spawnSync(
-      process.execPath,
+      nodeInterpreter(),
       [cli, 'swap-current', '--framework-dir', fwDir, '--version', version],
       { env: this.childEnv(), encoding: 'utf-8', timeout: 120_000 },
     )
@@ -299,7 +313,7 @@ export class FrameworkManager {
     if (!ver) return { ran: false }
     const fwDir = frameworkRoot(this.home)
     const res = spawnSync(
-      process.execPath,
+      nodeInterpreter(),
       [
         cli,
         'assemble',

--- a/server/openspec-shim.ts
+++ b/server/openspec-shim.ts
@@ -3,6 +3,7 @@ import os from 'os'
 import path from 'path'
 
 import { getBundledOpenspecCli } from './bundled-openspec'
+import { resolveBundledNodeExe } from './path-resolver'
 
 /**
  * openspec PATH shim — the robustness backstop for relocated Claude rails.
@@ -49,11 +50,15 @@ export function openspecShimDir(slug: string, jobId: string, home: string = os.h
 function realOpenspecInvocation(): { posix: string; windows: string } {
   const cli = getBundledOpenspecCli()
   if (cli) {
-    // node "<cli>" — invoke the bundled openspec as a node script (Tauri strips
-    // exec bits from bundled resources, so it can't be run as a binary).
+    // <node> "<cli>" — invoke the bundled openspec as a node script (Tauri strips
+    // exec bits from bundled resources, so it can't be run as a binary). Anchor to
+    // the absolute bundled node when present rather than a bare `node` (which is
+    // PATH-dependent and may be absent / a mismatched system node in a partial
+    // bundle); fall back to bare `node` only when no bundled runtimes ship.
+    const node = resolveBundledNodeExe()
     return {
-      posix: `node ${shq(cli)}`,
-      windows: `node ${winq(cli)}`,
+      posix: `${node ? shq(node) : 'node'} ${shq(cli)}`,
+      windows: `${node ? winq(node) : 'node'} ${winq(cli)}`,
     }
   }
   // Legacy fallback: npx resolves + caches openspec. `-y` skips the install

--- a/server/setup-manager-bundled-core.test.ts
+++ b/server/setup-manager-bundled-core.test.ts
@@ -223,7 +223,12 @@ describe('SetupManager — bundled-core install path', () => {
       ? path.join(runtimes, 'node', 'node.exe')
       : path.join(runtimes, 'node', 'bin', 'node')
     mkdirSync(path.dirname(nodeExe), { recursive: true })
-    writeFileSync(nodeExe, '#!/bin/sh\n', { mode: 0o755 })
+    // The core CLI is now spawned WITH this bundled node, so it must be a REAL,
+    // runnable node (else the fake init never executes). Symlink the test runner's
+    // node; its path differs from process.execPath, so the env.node !==
+    // process.execPath contract still holds while remaining executable.
+    const { symlinkSync } = await import('fs')
+    symlinkSync(process.execPath, nodeExe)
     process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH = runtimes
 
     try {

--- a/server/setup-manager.ts
+++ b/server/setup-manager.ts
@@ -7,7 +7,7 @@ import treeKill from 'tree-kill'
 import type { WsMessage } from './types'
 import { findCoreContract, detectCLISync, CLIProvider } from './core-compat'
 import { spawnAiCli } from './util/cli-prompt'
-import { spawnCli } from './util/win-spawn'
+import { spawnCli, windowsSpawnEnv } from './util/win-spawn'
 import { formatMissingSetupPrerequisites } from './setup-prerequisites'
 import { CORE_PACKAGE_SPEC } from './core-package'
 import { getAdapter, hasAdapter } from './providers'
@@ -39,7 +39,7 @@ function resolveCoreBinary(bin: string): string {
   if (bin.includes('/') || bin.includes('\\')) return resolvePath(bin)
 
   const result = spawnSync(WHICH_CMD, [bin], {
-    env: process.env,
+    env: windowsSpawnEnv(),
     shell: process.platform === 'win32',
     encoding: 'utf-8',
     timeout: 5_000,
@@ -80,7 +80,7 @@ function spawnCoreInit(args: string[], cwd: string): ChildProcess {
     // repo). The desktop manages the cwd (spawns rails with cwd=workspace), so
     // it MUST relocate to keep the user's imported repo pristine — independent of
     // whether the registry mirror already ran. See specrails-core init's gate.
-    env: { ...process.env, SPECRAILS_RELOCATE: '1' },
+    env: { ...windowsSpawnEnv(), SPECRAILS_RELOCATE: '1' },
     stdio: ['ignore', 'pipe', 'pipe'],
   })
 }
@@ -103,7 +103,7 @@ function spawnBundledCoreInit(args: string[], cwd: string): ChildProcess | null 
   const fullArgs = [cli, 'init', ...args]
   // Force RELOCATION (core installs in-repo by default; the desktop keeps the
   // user's repo pristine + manages the spawn cwd). See spawnCoreInit.
-  const env: NodeJS.ProcessEnv = { ...process.env, SPECRAILS_CORE_SCRIPT_DIR: coreRoot, SPECRAILS_RELOCATE: '1' }
+  const env: NodeJS.ProcessEnv = { ...windowsSpawnEnv(), SPECRAILS_CORE_SCRIPT_DIR: coreRoot, SPECRAILS_RELOCATE: '1' }
 
   // Bundled openspec (offline) — the LAST network step of project-add. When the
   // app ships @fission-ai/openspec, point specrails-core's `installOpenSpecProject`
@@ -125,11 +125,16 @@ function spawnBundledCoreInit(args: string[], cwd: string): ChildProcess | null 
     env.SPECRAILS_OPENSPEC_NODE = resolveBundledNodeExe() ?? 'node'
   }
 
+  // Run the core CLI with the REAL bundled node — NOT process.execPath, which in
+  // the packaged app is the `specrails-server` pkg binary and would re-launch the
+  // server instead of running cli.js (same trap as SPECRAILS_OPENSPEC_NODE above).
+  // Fall back to process.execPath only in dev/tests where it IS node.
+  const nodeBin = resolveBundledNodeExe() ?? process.execPath
   console.log(
-    `[SetupManager] spawning BUNDLED core: ${process.execPath} ${fullArgs.join(' ')} (cwd=${cwd})` +
+    `[SetupManager] spawning BUNDLED core: ${nodeBin} ${fullArgs.join(' ')} (cwd=${cwd})` +
       (openspecCli ? ' [bundled openspec: offline]' : ' [openspec: npx fallback]'),
   )
-  return spawnCli(process.execPath, fullArgs, {
+  return spawnCli(nodeBin, fullArgs, {
     cwd,
     env,
     stdio: ['ignore', 'pipe', 'pipe'],
@@ -148,7 +153,7 @@ function probeCoreRuntimeVersion(cwd: string): { ok: boolean; bin: string; versi
   const { bin, fullArgs } = buildCoreArgs(['version'])
   const result = spawnSync(bin, fullArgs, {
     cwd,
-    env: process.env,
+    env: windowsSpawnEnv(),
     shell: process.platform === 'win32',
     encoding: 'utf-8',
     timeout: CORE_PROBE_TIMEOUT_MS,

--- a/server/setup-prerequisites.test.ts
+++ b/server/setup-prerequisites.test.ts
@@ -7,7 +7,13 @@ vi.mock('child_process', () => ({
   spawnSync: vi.fn(),
 }))
 
+// On Windows the probe routes through cross-spawn (no shell:true). Forward its
+// `.sync` to the same spawnSync mock so the platform-forced win32 tests exercise
+// the real branch with the existing mock setups.
+vi.mock('cross-spawn', () => ({ default: { sync: vi.fn() } }))
+
 import { spawnSync } from 'child_process'
+import crossSpawn from 'cross-spawn'
 import {
   compareVersions,
   formatMissingSetupPrerequisites,
@@ -18,10 +24,16 @@ import {
 } from './setup-prerequisites'
 
 const mockSpawnSync = vi.mocked(spawnSync)
+const mockCrossSpawnSync = vi.mocked(crossSpawn.sync)
 
 describe('setup prerequisites', () => {
   beforeEach(() => {
     vi.resetAllMocks()
+    // cross-spawn (win32 path) delegates to the same spawnSync mock so a single
+    // mockImplementation drives both platform branches.
+    mockCrossSpawnSync.mockImplementation((cmd: any, args: any, opts: any) =>
+      mockSpawnSync(cmd, args, opts) as any,
+    )
     __resetSetupPrerequisitesCacheForTest()
   })
 
@@ -179,7 +191,7 @@ describe('setup prerequisites', () => {
     expect(node?.installHint).toMatch(/broken symlink/)
   })
 
-  it('quotes resolved paths containing whitespace on win32 (Program Files)', () => {
+  it('passes resolved paths with whitespace UNQUOTED on win32 (cross-spawn handles spaces)', () => {
     const originalPlatform = process.platform
     Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
     try {
@@ -188,17 +200,17 @@ describe('setup prerequisites', () => {
           if (args[0] === 'git') return { status: 0, stdout: 'C:\\Program Files\\Git\\cmd\\git.exe\r\n', stderr: '' } as any
           return { status: 0, stdout: `C:\\nodejs\\${args[0]}.cmd\r\n`, stderr: '' } as any
         }
-        if (cmd === '"C:\\Program Files\\Git\\cmd\\git.exe"') {
+        // cross-spawn is given the RAW path (no manual quoting); a quoted target
+        // would be a regression, so only the unquoted form resolves.
+        if (cmd === 'C:\\Program Files\\Git\\cmd\\git.exe') {
           return { status: 0, stdout: 'git version 2.42.1\n', stderr: '' } as any
         }
         if (cmd === 'C:\\nodejs\\node.cmd') return { status: 0, stdout: 'v20.11.0\n', stderr: '' } as any
         if (cmd === 'C:\\nodejs\\npm.cmd') return { status: 0, stdout: '10.0.0\n', stderr: '' } as any
         if (cmd === 'C:\\nodejs\\npx.cmd') return { status: 0, stdout: '10.0.0\n', stderr: '' } as any
-        // Provider CLIs on win32 — keep at least one usable so this test (which
-        // is about path-quoting for tools) is not gated by the provider rule.
         if (cmd === 'C:\\nodejs\\claude.cmd') return { status: 0, stdout: '1.0.0\n', stderr: '' } as any
         if (cmd === 'C:\\nodejs\\codex.cmd') return { status: 0, stdout: '0.128.0\n', stderr: '' } as any
-        return { status: 1, stdout: '', stderr: 'unquoted path' } as any
+        return { status: 1, stdout: '', stderr: 'quoted/unknown path' } as any
       })
 
       const status = getSetupPrerequisitesStatus()
@@ -315,6 +327,10 @@ describe('getSetupPrerequisitesStatus — desktop mode', () => {
 
   beforeEach(() => {
     vi.resetAllMocks()
+    // win32 probes route through cross-spawn → forward to the spawnSync mock.
+    mockCrossSpawnSync.mockImplementation((cmd: any, args: any, opts: any) =>
+      mockSpawnSync(cmd, args, opts) as any,
+    )
     __resetSetupPrerequisitesCacheForTest()
     tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sprq-'))
     process.env.SPECRAILS_IS_DESKTOP = '1'

--- a/server/setup-prerequisites.ts
+++ b/server/setup-prerequisites.ts
@@ -1,9 +1,30 @@
 import { spawnSync } from 'child_process'
+import type { SpawnSyncReturns } from 'child_process'
+import crossSpawn from 'cross-spawn'
 import fs from 'fs'
 import path from 'path'
 import { listAdapters } from './providers'
+import { windowsSpawnEnv } from './util/win-spawn'
 
 const WHICH_CMD = process.platform === 'win32' ? 'where' : 'which'
+
+/**
+ * Run `<cmd> <args>` synchronously. On Windows use cross-spawn (NOT `shell:true`):
+ * it spawns a real `.exe` directly (no `cmd.exe` interposition — pkg-safe and
+ * immune to the GUI-launch env stripping), and runs `.cmd`/`.bat` shims through
+ * `cmd.exe` with correct quoting (Node refuses to spawn `.cmd` without a shell
+ * since CVE-2024-27980). On POSIX it is a plain `spawnSync`. `windowsSpawnEnv()`
+ * guarantees `cmd.exe` can start (SystemRoot/ComSpec present even if the sidecar
+ * inherited a stripped env) — without it every bundled probe failed with a bogus
+ * "bundle corrupted — reinstall the app".
+ */
+function runVersionSpawn(cmd: string, args: string[]): SpawnSyncReturns<string> {
+  const opts = { env: windowsSpawnEnv(), encoding: 'utf-8' as const, timeout: 5_000 }
+  if (process.platform === 'win32') {
+    return crossSpawn.sync(cmd, args, opts)
+  }
+  return spawnSync(cmd, args, opts)
+}
 
 export type Platform = 'darwin' | 'win32' | 'linux'
 
@@ -61,11 +82,10 @@ interface CommandLookup {
 }
 
 function locateCommand(command: string): CommandLookup {
-  const result = spawnSync(WHICH_CMD, [command], {
-    env: process.env,
-    shell: process.platform === 'win32',
-    encoding: 'utf-8',
-  })
+  // cross-spawn (via runVersionSpawn) resolves the `where`/`which` executable
+  // and PATHEXT itself — no `shell:true` needed — and runs under an env that
+  // includes SystemRoot so `where` can actually start in the packaged sidecar.
+  const result = runVersionSpawn(WHICH_CMD, [command])
   if (result.error || (result.status ?? 1) !== 0) return { found: false }
   const resolvedPath = `${result.stdout ?? ''}`.trim().split(/\r?\n/)[0]?.trim() || undefined
   return { found: true, resolvedPath }
@@ -85,19 +105,14 @@ function probeVersion(command: string, resolvedPath?: string): VersionProbe {
   // `Cannot find module '/--version'` from pkg/prelude/bootstrap.js. Passing
   // an absolute path bypasses this interception.
   const target = resolvedPath || command
-  // On Windows we must use `shell: true` to execute `.cmd` shims (npm, npx) — Node
-  // refuses to spawn them directly since CVE-2024-27980. But cmd.exe splits the
-  // command line on whitespace, so an absolute path like
-  // `C:\Program Files\Git\cmd\git.exe` becomes `C:\Program` + arg `Files\Git\...`.
-  // Wrap the target in double quotes when it contains a space.
-  const isWin = process.platform === 'win32'
-  const quotedTarget = isWin && /\s/.test(target) ? `"${target}"` : target
-  const result = spawnSync(quotedTarget, ['--version'], {
-    env: process.env,
-    shell: isWin,
-    encoding: 'utf-8',
-    timeout: 5_000,
-  })
+  // Spawn via cross-spawn on Windows (NOT shell:true). A bundled `.exe`
+  // (node.exe, git.exe) is launched DIRECTLY — no cmd.exe interposition — so a
+  // path with spaces needs no manual quoting and pkg's bare-name redirect never
+  // applies. A `.cmd` shim (npm.cmd, npx.cmd) is run through cmd.exe by
+  // cross-spawn with correct escaping. The env carries SystemRoot so cmd.exe can
+  // start. This replaces the old `shell:true` path that made every bundled probe
+  // fail with a bogus "corrupted-bundle" when the sidecar env lacked SystemRoot.
+  const result = runVersionSpawn(target, ['--version'])
   if (result.error) {
     const err = result.error as NodeJS.ErrnoException
     return { executed: false, error: `${err.code ?? 'ERR'}: ${err.message}` }

--- a/server/util/win-spawn.test.ts
+++ b/server/util/win-spawn.test.ts
@@ -1,5 +1,40 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import { spawnCli, resolveWindowsBinary } from './win-spawn'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { spawnCli, resolveWindowsBinary, windowsSpawnEnv } from './win-spawn'
+
+describe('windowsSpawnEnv', () => {
+  const ORIGINAL = process.platform
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: ORIGINAL, configurable: true })
+  })
+
+  it('returns the base env unchanged on POSIX (identity)', () => {
+    if (process.platform === 'win32') return
+    const base = { FOO: 'bar' } as NodeJS.ProcessEnv
+    expect(windowsSpawnEnv(base)).toBe(base)
+  })
+
+  it('reconstructs SystemRoot/windir/ComSpec when missing on win32', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    const out = windowsSpawnEnv({ PATH: 'x' } as NodeJS.ProcessEnv)
+    expect(out.SystemRoot).toBe('C:\\Windows')
+    expect(out.windir).toBe('C:\\Windows')
+    expect(out.ComSpec).toBe('C:\\Windows\\System32\\cmd.exe')
+    expect(out.PATH).toBe('x')
+  })
+
+  it('preserves existing SystemRoot and derives ComSpec from it', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    const out = windowsSpawnEnv({ SystemRoot: 'D:\\Win\\' } as NodeJS.ProcessEnv)
+    expect(out.SystemRoot).toBe('D:\\Win\\')
+    expect(out.ComSpec).toBe('D:\\Win\\System32\\cmd.exe')
+  })
+
+  it('falls back to windir when SystemRoot is absent', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    const out = windowsSpawnEnv({ windir: 'E:\\Windows' } as NodeJS.ProcessEnv)
+    expect(out.SystemRoot).toBe('E:\\Windows')
+  })
+})
 
 describe('resolveWindowsBinary', () => {
   it('returns the input unchanged on POSIX (no-op)', () => {

--- a/server/util/win-spawn.ts
+++ b/server/util/win-spawn.ts
@@ -37,6 +37,26 @@ export function spawnCli(
   return spawn(binary, args, options)
 }
 
+/**
+ * Return an environment safe for spawning children on Windows. The desktop
+ * server runs as a pkg-packaged sidecar launched by the Tauri host, and that
+ * spawn can deliver a STRIPPED environment missing `SystemRoot` / `windir` /
+ * `ComSpec`. Without `SystemRoot`, `cmd.exe` (used to run `.cmd` shims like
+ * `npm.cmd`/`npx.cmd`, and by cross-spawn) fails to initialise — which silently
+ * broke every bundled-tool `--version` probe and any npx/npm spawn during setup.
+ * Reconstructs the canonical values when absent. No-op (returns `base`
+ * unchanged) on POSIX. Pass a base env to layer extra vars on top.
+ */
+export function windowsSpawnEnv(base: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  if (process.platform !== 'win32') return base
+  const env = { ...base }
+  const systemRoot = env.SystemRoot || env.windir || 'C:\\Windows'
+  env.SystemRoot = systemRoot
+  env.windir = env.windir || systemRoot
+  env.ComSpec = env.ComSpec || `${systemRoot.replace(/[\\/]$/, '')}\\System32\\cmd.exe`
+  return env
+}
+
 // Back-compat for callsites that only need the resolved binary
 // (e.g. logging). Kept as a no-op identity on POSIX; on Windows
 // `where`-based resolution lives inside cross-spawn now.


### PR DESCRIPTION
## Symptom
On Windows, Add Project reported **"bundle dañado — reinstala la app"** for Node.js, npm, npx AND Git (all four). Investigation found this was the visible tip of three distinct Windows-only root causes that made the packaged app's bundled-framework system non-functional.

## Root causes & fixes

### 1. Prereq probe — bogus "corrupted-bundle" for all four tools
`probeVersion()` / `locateCommand()` spawned with `shell:true` + `env:process.env`. The pkg/Tauri sidecar can inherit a **stripped environment missing `SystemRoot`**, so `cmd.exe` (run for `.cmd` shims and `where`) never initialises → every `--version` probe fails → bogus corrupted-bundle. `shell:true` also needlessly routed bundled `.exe` through `cmd.exe` (pkg bare-name interception + path-splitting on spaces).

**Fix:** Windows probes now go through **cross-spawn** (a real `.exe` is spawned directly; `.cmd` shims run via `cmd.exe` with correct quoting) under a reconstructed env (`windowsSpawnEnv`: `SystemRoot`/`windir`/`ComSpec`). New shared helper in `util/win-spawn.ts`.

### 2. CRITICAL — core CLI spawned via `process.execPath` (the pkg binary, not node)
`FrameworkManager.{materialize,swapCurrent,assembleWorkspace}` and `SetupManager.spawnBundledCoreInit` ran the core CLI with `process.execPath`. Under `@yao-pkg/pkg` that is the **`specrails-server` binary, not node**, so the spawn re-launched the server instead of running `cli.js`. The **entire bundled-framework offline system** (offline setup, materialize/swap, the core update channel) was broken in production.

**Fix:** resolve the bundled **real node** via `resolveBundledNodeExe()`, falling back to `process.execPath` only in dev/tests where execPath IS node.

### 3. openspec-shim emitted bare `node <cli>` (PATH-dependent)
Anchored to the absolute bundled node when present.

### Hardening
Remaining setup-core spawns (`resolveCoreBinary`, `probeCoreRuntimeVersion`, both init spawns, core-update `npm install`) now use `windowsSpawnEnv` so `cmd.exe` can start under a stripped sidecar env.

## Why it shipped
All tests run **unpackaged**, where `process.execPath` IS node and the env carries `SystemRoot` — so the production-only failures were invisible. Added a `framework-manager` test that proves the **bundled node** (not `process.execPath`) is the interpreter via a wrapper marker, and `win-spawn` tests for `windowsSpawnEnv`.

## Verification
`typecheck` + full server coverage gate pass locally (EXIT=0, 157 files). Per-platform pkg behaviour can't be exercised in vitest; a follow-up should add a Windows **in-bundle** smoke step to CI (macOS has one; Windows only validates staging) to drive the real `specrails-server.exe` `/api/setup-prerequisites`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)