### PR TITLE
fix(windows): inject SystemRoot env at the spawnCli chokepoint

### DIFF
--- a/server/util/win-spawn.ts
+++ b/server/util/win-spawn.ts
@@ -29,9 +29,13 @@ export function spawnCli(
   args: string[],
   options: SpawnOptions = {},
 ): ChildProcess {
-  /* c8 ignore next 3 -- Windows-only branch; coverage runs on Linux/macOS */
+  /* c8 ignore next 5 -- Windows-only branch; coverage runs on Linux/macOS */
   if (process.platform === 'win32') {
-    return crossSpawn(binary, args, options)
+    // Guarantee SystemRoot/ComSpec so cmd.exe (which cross-spawn uses to run
+    // `.cmd` shims like claude.cmd/npm.cmd) can start even when the packaged
+    // sidecar inherited a stripped environment. Chokepoint for EVERY Windows
+    // spawn — protects rails, chat, setup and probes uniformly.
+    return crossSpawn(binary, args, { ...options, env: windowsSpawnEnv(options.env) })
   }
 
   return spawn(binary, args, options)


### PR DESCRIPTION
Follow-up to #419. `spawnCli` is the chokepoint for every Windows `.cmd` spawn — including all AI-CLI invocations (rails, chat, setup) via `spawnAiCli`. cross-spawn runs `.cmd` shims (claude.cmd/npm.cmd/…) through `cmd.exe`, which needs `SystemRoot` to start. If the packaged Tauri sidecar inherited a **stripped environment**, those spawns would fail the same way the prerequisite probe did in #419.

Bake `windowsSpawnEnv()` into `spawnCli` so the **entire Windows spawn surface** is protected uniformly, not just the probe. No-op on POSIX and when `SystemRoot` is already present (the common case).

Server coverage + typecheck pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)