### PR TITLE
fix(windows): probe bundled npm/npx via node-direct, not the .cmd shim

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -492,6 +492,21 @@ jobs:
             if ($LASTEXITCODE -ne 0) { Write-Error "${tool} --version failed"; exit 1 }
           }
 
+          # Validate the EXACT npm/npx probe the shipped app uses: the bundled
+          # node.exe run DIRECTLY against npm-cli.js / npx-cli.js, bypassing the
+          # .cmd shim (the shim's inner `FOR /F CALL node npm-prefix.js` loads npm
+          # config and proved fragile under a stripped GUI-launch env). See
+          # server/setup-prerequisites.ts probeBundledNpmLike. This asserts the npm
+          # package ships intact and the runtime probe path actually works.
+          $npmCli = "src-tauri\runtimes\node\node_modules\npm\bin\npm-cli.js"
+          $npxCli = "src-tauri\runtimes\node\node_modules\npm\bin\npx-cli.js"
+          foreach ($cli in @($npmCli, $npxCli)) {
+            if (-not (Test-Path $cli)) { Write-Error "missing bundled npm CLI: ${cli}"; exit 1 }
+            Write-Host "Testing node ${cli} --version..."
+            & $node $cli --version
+            if ($LASTEXITCODE -ne 0) { Write-Error "node ${cli} --version failed"; exit 1 }
+          }
+
           # Functional git check: init + commit + log exercises git-core helpers/templates.
           $tmp = Join-Path $env:TEMP ("smokegit-" + [guid]::NewGuid())
           New-Item -ItemType Directory -Path $tmp | Out-Null

--- a/server/setup-prerequisites.test.ts
+++ b/server/setup-prerequisites.test.ts
@@ -558,6 +558,102 @@ describe('getSetupPrerequisitesStatus — desktop mode', () => {
     expect(tools.every((t) => t.bundled === undefined)).toBe(true)
     expect(tools.every((t) => t.error === undefined)).toBe(true)
   })
+
+  // Materialize the POSIX npm package CLI JS inside the default runtimes tree so
+  // npm/npx take the node-direct probe path (node <npm-cli.js> --version).
+  function addNpmCliJs(): { npmCli: string; npxCli: string } {
+    const binDir = path.join(runtimesBase, 'node', 'lib', 'node_modules', 'npm', 'bin')
+    fs.mkdirSync(binDir, { recursive: true })
+    const npmCli = path.join(binDir, 'npm-cli.js')
+    const npxCli = path.join(binDir, 'npx-cli.js')
+    fs.writeFileSync(npmCli, '// npm')
+    fs.writeFileSync(npxCli, '// npx')
+    return { npmCli, npxCli }
+  }
+
+  it('probes npm/npx via the bundled node + npm-cli.js (node-direct), NOT the shim', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+    addNpmCliJs()
+    mockSpawnSync.mockImplementation((cmd: any, args: any) => {
+      // node-direct: `node <…/npm-cli.js> --version` (npm package serves npx too)
+      if (typeof args?.[0] === 'string' && args[0].endsWith('npm-cli.js')) return { status: 0, stdout: '10.9.0\n' } as any
+      if (typeof args?.[0] === 'string' && args[0].endsWith('npx-cli.js')) return { status: 0, stdout: '10.9.0\n' } as any
+      // bare node/git bundled probes
+      if (typeof cmd === 'string' && cmd.endsWith('/node')) return { status: 0, stdout: 'v22.0.0\n' } as any
+      if (typeof cmd === 'string' && cmd.includes('git')) return { status: 0, stdout: 'git version 2.49.0\n' } as any
+      if (cmd === 'claude') return { status: 0, stdout: '1.0.0\n' } as any
+      if (cmd === 'codex') return { status: 0, stdout: '0.128.0\n' } as any
+      return { status: 0, stdout: '' } as any
+    })
+
+    const status = getSetupPrerequisitesStatus()
+    const npm = status.prerequisites.find((p) => p.key === 'npm')
+    const npx = status.prerequisites.find((p) => p.key === 'npx')
+    expect(npm?.bundled).toBe(true)
+    expect(npm?.executable).toBe(true)
+    expect(npm?.version).toBe('10.9.0')
+    expect(npm?.resolvedPath?.endsWith('npm-cli.js')).toBe(true)
+    expect(npx?.executable).toBe(true)
+    expect(npx?.resolvedPath?.endsWith('npx-cli.js')).toBe(true)
+  })
+
+  it('npm/npx are advisory (required:false) and never block when bundled core+openspec are present', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+    // Bundled core + bundled openspec → fully offline project-add (node cli.js /
+    // node openspec.js); npm/npx are never spawned, so a broken npm must not block.
+    const coreDir = path.join(tmpRoot, 'core')
+    fs.mkdirSync(path.join(coreDir, 'dist', 'installer'), { recursive: true })
+    fs.writeFileSync(path.join(coreDir, 'dist', 'installer', 'cli.js'), '// core')
+    const osDir = path.join(tmpRoot, 'openspec')
+    fs.mkdirSync(path.join(osDir, 'node_modules', '@fission-ai', 'openspec', 'bin'), { recursive: true })
+    fs.writeFileSync(path.join(osDir, 'node_modules', '@fission-ai', 'openspec', 'bin', 'openspec.js'), '// os')
+    process.env.SPECRAILS_BUNDLED_CORE_PATH = coreDir
+    process.env.SPECRAILS_BUNDLED_OPENSPEC_PATH = osDir
+    // Remove the bundled npm/npx shims so npm/npx fail to resolve entirely.
+    fs.rmSync(path.join(runtimesBase, 'node', 'bin', 'npm'), { force: true })
+    fs.rmSync(path.join(runtimesBase, 'node', 'bin', 'npx'), { force: true })
+    try {
+      mockSpawnSync.mockImplementation((cmd: any) => {
+        if (cmd === 'which' || cmd === 'where') return { status: 1 } as any
+        if (typeof cmd === 'string' && cmd.endsWith('/node')) return { status: 0, stdout: 'v22.0.0\n' } as any
+        if (typeof cmd === 'string' && cmd.includes('git')) return { status: 0, stdout: 'git version 2.49.0\n' } as any
+        return { status: 1, stdout: '', stderr: '' } as any
+      })
+      const status = getSetupPrerequisitesStatus()
+      const npm = status.prerequisites.find((p) => p.key === 'npm')
+      const npx = status.prerequisites.find((p) => p.key === 'npx')
+      expect(npm?.required).toBe(false)
+      expect(npx?.required).toBe(false)
+      expect(status.missingRequired.some((p) => p.key === 'npm' || p.key === 'npx')).toBe(false)
+      // node + git stay required.
+      expect(status.prerequisites.find((p) => p.key === 'node')?.required).toBe(true)
+      expect(status.prerequisites.find((p) => p.key === 'git')?.required).toBe(true)
+    } finally {
+      delete process.env.SPECRAILS_BUNDLED_CORE_PATH
+      delete process.env.SPECRAILS_BUNDLED_OPENSPEC_PATH
+    }
+  })
+
+  it('reports npm corrupted-bundle when the node-direct npm-cli.js probe fails', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+    addNpmCliJs()
+    mockSpawnSync.mockImplementation((cmd: any, args: any) => {
+      if (typeof args?.[0] === 'string' && args[0].endsWith('npm-cli.js')) return { status: 1, stdout: '', stderr: 'kaboom' } as any
+      if (typeof args?.[0] === 'string' && args[0].endsWith('npx-cli.js')) return { status: 0, stdout: '10.9.0\n' } as any
+      if (typeof cmd === 'string' && cmd.endsWith('/node')) return { status: 0, stdout: 'v22.0.0\n' } as any
+      if (typeof cmd === 'string' && cmd.includes('git')) return { status: 0, stdout: 'git version 2.49.0\n' } as any
+      if (cmd === 'claude') return { status: 0, stdout: '1.0.0\n' } as any
+      if (cmd === 'codex') return { status: 0, stdout: '0.128.0\n' } as any
+      return { status: 0, stdout: '' } as any
+    })
+
+    const status = getSetupPrerequisitesStatus()
+    const npm = status.prerequisites.find((p) => p.key === 'npm')
+    expect(npm?.executable).toBe(false)
+    expect(npm?.error).toBe('corrupted-bundle')
+    expect(npm?.resolvedPath?.endsWith('npm-cli.js')).toBe(true)
+    expect(npm?.executionError).toContain('kaboom')
+  })
 })
 
 describe('parseSemver', () => {

--- a/server/setup-prerequisites.ts
+++ b/server/setup-prerequisites.ts
@@ -5,6 +5,8 @@ import fs from 'fs'
 import path from 'path'
 import { listAdapters } from './providers'
 import { windowsSpawnEnv } from './util/win-spawn'
+import { getBundledCoreCli } from './bundled-core'
+import { getBundledOpenspecCli } from './bundled-openspec'
 
 const WHICH_CMD = process.platform === 'win32' ? 'where' : 'which'
 
@@ -97,6 +99,23 @@ interface VersionProbe {
   error?: string
 }
 
+/** Run `<bin> <args>` and interpret the result as a `--version` probe. */
+function runProbe(bin: string, args: string[]): VersionProbe {
+  const result = runVersionSpawn(bin, args)
+  if (result.error) {
+    const err = result.error as NodeJS.ErrnoException
+    return { executed: false, error: `${err.code ?? 'ERR'}: ${err.message}` }
+  }
+  if ((result.status ?? 1) !== 0) {
+    const stderr = `${result.stderr ?? ''}`.trim().slice(0, 400)
+    const signal = result.signal ? ` signal=${result.signal}` : ''
+    return { executed: false, error: `exit=${result.status ?? '?'}${signal}${stderr ? ` stderr=${stderr}` : ''}` }
+  }
+  const output = `${result.stdout ?? result.stderr ?? ''}`.trim()
+  const version = output.split(/\r?\n/)[0]?.trim() || undefined
+  return { executed: true, version }
+}
+
 function probeVersion(command: string, resolvedPath?: string): VersionProbe {
   // IMPORTANT: prefer the absolute path returned by `which`. When the server is
   // bundled with `pkg`, calling spawn with the bare command name `'node'` is
@@ -112,19 +131,7 @@ function probeVersion(command: string, resolvedPath?: string): VersionProbe {
   // cross-spawn with correct escaping. The env carries SystemRoot so cmd.exe can
   // start. This replaces the old `shell:true` path that made every bundled probe
   // fail with a bogus "corrupted-bundle" when the sidecar env lacked SystemRoot.
-  const result = runVersionSpawn(target, ['--version'])
-  if (result.error) {
-    const err = result.error as NodeJS.ErrnoException
-    return { executed: false, error: `${err.code ?? 'ERR'}: ${err.message}` }
-  }
-  if ((result.status ?? 1) !== 0) {
-    const stderr = `${result.stderr ?? ''}`.trim().slice(0, 400)
-    const signal = result.signal ? ` signal=${result.signal}` : ''
-    return { executed: false, error: `exit=${result.status ?? '?'}${signal}${stderr ? ` stderr=${stderr}` : ''}` }
-  }
-  const output = `${result.stdout ?? result.stderr ?? ''}`.trim()
-  const version = output.split(/\r?\n/)[0]?.trim() || undefined
-  return { executed: true, version }
+  return runProbe(target, ['--version'])
 }
 
 /** Extracts the first `major.minor.patch` triple from a version string.
@@ -197,6 +204,44 @@ function fileExists(p: string): boolean {
   }
 }
 
+/** The bundled REAL node executable inside the runtimes tree, or null. */
+function bundledNodeExe(runtimesBase: string): string | null {
+  return getBundledToolCandidates(runtimesBase, 'node').find(fileExists) ?? null
+}
+
+/**
+ * Absolute path to the bundled npm/npx CLI JS (`npm-cli.js` / `npx-cli.js`), or
+ * null. The npm package ships INSIDE the node distribution: at
+ * `node/node_modules/npm/bin/` on Windows and `node/lib/node_modules/npm/bin/`
+ * on POSIX. Both `npm` and `npx` are served by the npm package (npx-cli.js lives
+ * there too).
+ */
+function bundledNpmCliJs(runtimesBase: string, tool: 'npm' | 'npx'): string | null {
+  const file = tool === 'npx' ? 'npx-cli.js' : 'npm-cli.js'
+  const candidates =
+    process.platform === 'win32'
+      ? [path.join(runtimesBase, 'node', 'node_modules', 'npm', 'bin', file)]
+      : [path.join(runtimesBase, 'node', 'lib', 'node_modules', 'npm', 'bin', file)]
+  return candidates.find(fileExists) ?? null
+}
+
+/**
+ * Probe a bundled npm/npx by running the bundled node DIRECTLY against the npm
+ * package's CLI JS, instead of executing the `.cmd`/wrapper shim. The shims route
+ * through `cmd.exe` (Windows) / a wrapper script and proved fragile in the
+ * packaged app (a stripped sidecar env / cmd.exe quirks made `npm.cmd --version`
+ * fail with a bogus "corrupted-bundle" even though node.exe itself runs fine).
+ * Running `node npm-cli.js --version` is deterministic, shell-free and pkg-safe.
+ * Returns null when the bundled node or the CLI JS isn't present (caller falls
+ * back to probing the shim, then to the system tool).
+ */
+function probeBundledNpmLike(runtimesBase: string, tool: 'npm' | 'npx'): { probe: VersionProbe; resolvedPath: string } | null {
+  const nodeExe = bundledNodeExe(runtimesBase)
+  const cliJs = bundledNpmCliJs(runtimesBase, tool)
+  if (!nodeExe || !cliJs) return null
+  return { probe: runProbe(nodeExe, [cliJs, '--version']), resolvedPath: cliJs }
+}
+
 export interface PrerequisiteOptions {
   /** Optional: include `uv` (used by plugins like Serena). When false the
    *  setup wizard's `missingRequired` is not affected by uv's absence. */
@@ -230,6 +275,14 @@ function computeSetupPrerequisitesStatus(options: PrerequisiteOptions = {}): Set
   const isDesktop = process.env.SPECRAILS_IS_DESKTOP === '1'
   const runtimesBase = process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH ?? ''
 
+  // When the app ships a bundled core AND bundled openspec, project-add is fully
+  // OFFLINE: it runs `node cli.js` / `node openspec.js` directly and NEVER spawns
+  // npm or npx. So npm/npx are advisory (not required) in that mode — a broken or
+  // unprobeable npm/npx must NOT dead-end Add Project for tools the install flow
+  // never invokes. Outside the bundled-offline path (dev / no bundle) npx IS used
+  // (npx specrails-core), so npm/npx stay required there.
+  const bundledOfflineSetup = isDesktop && getBundledCoreCli() !== null && getBundledOpenspecCli() !== null
+
   const platform: Platform = process.platform === 'darwin'
     ? 'darwin'
     : process.platform === 'win32'
@@ -254,7 +307,7 @@ function computeSetupPrerequisitesStatus(options: PrerequisiteOptions = {}): Set
       kind: 'tool',
       label: 'npm',
       command: 'npm',
-      required: true,
+      required: !bundledOfflineSetup,
       minVersion: MIN_VERSIONS.npm,
       installUrl: 'https://nodejs.org/en/download',
       installHint: 'npm ships with Node.js LTS.',
@@ -264,7 +317,7 @@ function computeSetupPrerequisitesStatus(options: PrerequisiteOptions = {}): Set
       kind: 'tool',
       label: 'npx',
       command: 'npx',
-      required: true,
+      required: !bundledOfflineSetup,
       installUrl: 'https://nodejs.org/en/download',
       installHint: 'npx ships with npm and is required to run specrails-core.',
     },
@@ -321,17 +374,30 @@ function computeSetupPrerequisitesStatus(options: PrerequisiteOptions = {}): Set
     // Desktop mode: probe bundled absolute paths for node/npm/npx/git.
     // Provider CLIs (claude, codex) are always probed via system PATH regardless of mode.
     if (isDesktop && definition.kind === 'tool' && isBundledTool(definition.key)) {
-      const candidates = getBundledToolCandidates(runtimesBase, definition.key as BundledToolKey)
-      const bundledPath = candidates.find(fileExists)
-      // Only treat as bundled when the binary FILE actually exists. A missing
-      // file means this build never shipped runtimes for this platform/arch
-      // (e.g. a runtimes-less Windows ARM64 build, or a partial CI extraction)
+      const tool = definition.key as BundledToolKey
+      // npm/npx: probe by running the bundled node DIRECTLY against the npm
+      // package's CLI JS — robust where the `.cmd`/wrapper shim proved fragile in
+      // the packaged app (cmd.exe / stripped-env quirks made `npm.cmd --version`
+      // fail with a bogus "corrupted-bundle" even though node.exe runs fine).
+      let effective: { probe: VersionProbe; resolvedPath: string } | null =
+        tool === 'npm' || tool === 'npx' ? probeBundledNpmLike(runtimesBase, tool) : null
+
+      // Otherwise (node/git, or npm/npx whose CLI JS wasn't found) probe the
+      // bundled binary/shim directly. Only treat as bundled when the FILE exists;
+      // a missing file means this build shipped no runtimes for this platform/arch
       // — fall through to the system probe so a system-installed tool still
-      // satisfies the requirement, instead of dead-ending Add Project with a
-      // futile "reinstall the app" message. 'corrupted-bundle' is reserved for
-      // the case where the file EXISTS but fails its --version probe.
-      if (bundledPath) {
-        const probe = probeVersion(definition.key, bundledPath)
+      // satisfies the requirement instead of dead-ending Add Project with a futile
+      // "reinstall the app". 'corrupted-bundle' is reserved for file-EXISTS-but-
+      // fails-its-probe.
+      if (!effective) {
+        const bundledPath = getBundledToolCandidates(runtimesBase, tool).find(fileExists)
+        if (bundledPath) {
+          effective = { probe: probeVersion(tool, bundledPath), resolvedPath: bundledPath }
+        }
+      }
+
+      if (effective) {
+        const { probe, resolvedPath } = effective
         if (!probe.executed) {
           return {
             ...definition,
@@ -339,7 +405,7 @@ function computeSetupPrerequisitesStatus(options: PrerequisiteOptions = {}): Set
             executable: false,
             bundled: true as const,
             error: 'corrupted-bundle' as const,
-            resolvedPath: bundledPath,
+            resolvedPath,
             executionError: probe.error,
             meetsMinimum: false,
             installHint: 'Bundle corrupted — reinstall the Specrails app.',
@@ -351,12 +417,12 @@ function computeSetupPrerequisitesStatus(options: PrerequisiteOptions = {}): Set
           executable: true,
           bundled: true as const,
           version: probe.version,
-          resolvedPath: bundledPath,
+          resolvedPath,
           meetsMinimum: meetsMinimumVersion(probe.version, definition.minVersion),
           installHint: '',
         }
       }
-      // bundledPath not found → fall through to the system probe below.
+      // No bundled binary/CLI found → fall through to the system probe below.
     }
 
     // Non-desktop (or provider CLI in any mode, or desktop with bundle absent): system probe.

--- a/server/util/win-spawn.test.ts
+++ b/server/util/win-spawn.test.ts
@@ -22,6 +22,35 @@ describe('windowsSpawnEnv', () => {
     expect(out.PATH).toBe('x')
   })
 
+  it('backfills npm config env (USERPROFILE/APPDATA/HOMEDRIVE/TEMP) from defaults on win32', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    const out = windowsSpawnEnv({ PATH: 'x' } as NodeJS.ProcessEnv)
+    expect(out.USERPROFILE).toBe('C:\\Users\\Default')
+    expect(out.HOMEDRIVE).toBe('C:')
+    expect(out.HOMEPATH).toBe('\\Users\\Default')
+    expect(out.APPDATA).toBe('C:\\Users\\Default\\AppData\\Roaming')
+    expect(out.LOCALAPPDATA).toBe('C:\\Users\\Default\\AppData\\Local')
+    expect(out.TEMP).toBe('C:\\Users\\Default\\AppData\\Local\\Temp')
+    expect(out.TMP).toBe('C:\\Users\\Default\\AppData\\Local\\Temp')
+  })
+
+  it('derives APPDATA from an existing USERPROFILE and preserves existing values', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    const out = windowsSpawnEnv({ USERPROFILE: 'C:\\Users\\javi', TEMP: 'D:\\t' } as NodeJS.ProcessEnv)
+    expect(out.USERPROFILE).toBe('C:\\Users\\javi')
+    expect(out.HOMEDRIVE).toBe('C:')
+    expect(out.HOMEPATH).toBe('\\Users\\javi')
+    expect(out.APPDATA).toBe('C:\\Users\\javi\\AppData\\Roaming')
+    expect(out.TEMP).toBe('D:\\t') // preserved
+  })
+
+  it('builds USERPROFILE from HOMEDRIVE+HOMEPATH when USERPROFILE is absent', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    const out = windowsSpawnEnv({ HOMEDRIVE: 'E:', HOMEPATH: '\\Users\\x' } as NodeJS.ProcessEnv)
+    expect(out.USERPROFILE).toBe('E:\\Users\\x')
+    expect(out.APPDATA).toBe('E:\\Users\\x\\AppData\\Roaming')
+  })
+
   it('preserves existing SystemRoot and derives ComSpec from it', () => {
     Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
     const out = windowsSpawnEnv({ SystemRoot: 'D:\\Win\\' } as NodeJS.ProcessEnv)

--- a/server/util/win-spawn.ts
+++ b/server/util/win-spawn.ts
@@ -54,10 +54,31 @@ export function spawnCli(
 export function windowsSpawnEnv(base: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
   if (process.platform !== 'win32') return base
   const env = { ...base }
-  const systemRoot = env.SystemRoot || env.windir || 'C:\\Windows'
-  env.SystemRoot = systemRoot
+  const systemRoot = (env.SystemRoot || env.windir || 'C:\\Windows').replace(/[\\/]$/, '')
+  env.SystemRoot = env.SystemRoot || systemRoot
   env.windir = env.windir || systemRoot
-  env.ComSpec = env.ComSpec || `${systemRoot.replace(/[\\/]$/, '')}\\System32\\cmd.exe`
+  env.ComSpec = env.ComSpec || `${systemRoot}\\System32\\cmd.exe`
+
+  // npm/npx load @npmcli/config on startup (even `npm --version` and the inner
+  // npm-prefix.js resolver), which reads the user profile via USERPROFILE /
+  // APPDATA / HOMEDRIVE+HOMEPATH / TEMP. A GUI-launched, env-stripped sidecar can
+  // lack these → `node npm-cli.js --version` fails the same way the .cmd shim did.
+  // Backfill canonical Windows defaults when absent (node.exe itself needs none
+  // of these, which is why node/git probed fine while npm/npx did not).
+  const userProfile =
+    env.USERPROFILE ||
+    (env.HOMEDRIVE && env.HOMEPATH ? `${env.HOMEDRIVE}${env.HOMEPATH}` : 'C:\\Users\\Default')
+  env.USERPROFILE = userProfile
+  const drive = /^([A-Za-z]:)(.*)$/.exec(userProfile)
+  if (drive) {
+    env.HOMEDRIVE = env.HOMEDRIVE || drive[1]
+    env.HOMEPATH = env.HOMEPATH || (drive[2] || '\\')
+  }
+  env.APPDATA = env.APPDATA || `${userProfile}\\AppData\\Roaming`
+  env.LOCALAPPDATA = env.LOCALAPPDATA || `${userProfile}\\AppData\\Local`
+  const temp = env.TEMP || env.TMP || `${env.LOCALAPPDATA}\\Temp`
+  env.TEMP = env.TEMP || temp
+  env.TMP = env.TMP || temp
   return env
 }
 


### PR DESCRIPTION
## Symptom (after #419/#421)
On the shipped Windows app, the cross-spawn + SystemRoot fixes repaired **Node.js** and **Git** (they now show versions), but **npm** and **npx** still report *"bundle dañado — reinstala la app"*.

## Root cause (confirmed via multi-agent RCA)
Not a missing-files bug (CI assembly is a lossless extraction; staging smoke passes) and not primarily a missing-env bug. The modern Node 22 `npm.cmd` shim is **not** `node npm-cli.js %*` — it first runs an inner `FOR /F ... CALL "%NODE_EXE%" "%NPM_PREFIX_JS%"` subprocess (`npm-prefix.js`) that loads `@npmcli/config` and reads `USERPROFILE`/`APPDATA`. That whole chain is fragile under a stripped GUI-launch sidecar env. `node.exe --version` reads no config — which is exactly why the `.exe` tools worked while the `.cmd` shims didn't.

## Fixes
1. **Node-direct probe** — probe npm/npx by running the bundled `node.exe` **directly** against the npm package's `npm-cli.js` / `npx-cli.js` (which ship inside the node dist), bypassing the `.cmd` shim and `cmd.exe` entirely. Deterministic, shell-free, pkg-safe (absolute node path → no pkg bare-name redirect). Falls back to the shim only if the CLI JS is absent, then to the system tool.
2. **`windowsSpawnEnv` backfill** — also reconstruct `USERPROFILE`/`APPDATA`/`LOCALAPPDATA`/`HOMEDRIVE`+`HOMEPATH`/`TEMP`/`TMP`, since `npm-cli.js` still loads npm config at startup (the residual single point of failure once the shim is gone).
3. **npm/npx advisory when bundled** — when a bundled core **and** bundled openspec are present, project-add is fully offline (`node cli.js` / `node openspec.js`) and **never spawns npm/npx**, so they are downgraded from `required` to advisory and no longer dead-end Add Project. `node` + `git` stay required.
4. **CI** — the Windows smoke (x64 + arm64) now also runs `node npm-cli.js/npx-cli.js --version` (the exact runtime probe path), asserting the npm package ships intact and the probe works.

## Tests
node-direct success + corrupted-bundle, the env backfill (USERPROFILE/APPDATA/HOMEDRIVE/TEMP derivation), and the advisory-when-bundled gate. typecheck + server coverage pass.

> Note: Codex CLI in the user's report is an unrelated broken **global** install (`Missing optional dependency @openai/codex-win32-x64` → `npm i -g @openai/codex@latest`), not a bundle issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)