### PR TITLE
fix(setup): capture full core stack + spawn diagnostics on install failure

### DIFF
--- a/server/setup-manager.ts
+++ b/server/setup-manager.ts
@@ -11,7 +11,7 @@ import { spawnCli, windowsSpawnEnv } from './util/win-spawn'
 import { formatMissingSetupPrerequisites } from './setup-prerequisites'
 import { CORE_PACKAGE_SPEC } from './core-package'
 import { getAdapter, hasAdapter } from './providers'
-import { mirrorProjectEntry, resolveArtifacts } from './artifact-registry'
+import { mirrorProjectEntry, resolveArtifacts, resolveHome } from './artifact-registry'
 import { installConfigPath, installConfigPathForProvider, type InstallConfigProject } from './install-config-path'
 import { getBundledCoreCli, getBundledCoreRoot, getBundledCoreVersion } from './bundled-core'
 import { getBundledOpenspecCli } from './bundled-openspec'
@@ -705,20 +705,43 @@ async function validateCoreContract(): Promise<void> {
 
 const INSTALL_LOG_BUFFER_MAX = 2000
 
-function formatBufferedInstallError(baseMessage: string, logBuffer: string[]): string {
+/**
+ * Persist the FULL install log to `~/.specrails/logs/` and return the path (or
+ * null on failure). The in-error tail is only a window; the full log carries the
+ * complete child stack — needed because a Node uncaught error prints the ORIGIN
+ * frames ABOVE the entry frames, so an 8-line tail shows only the bottom of the
+ * stack + the error object, never where it was thrown.
+ */
+function persistInstallLog(projectId: string, logBuffer: string[]): string | null {
+  try {
+    const dir = join(resolveHome(), '.specrails', 'logs')
+    mkdirSync(dir, { recursive: true })
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-')
+    const file = join(dir, `setup-${projectId}-${stamp}.log`)
+    writeFileSync(file, logBuffer.join('\n') + '\n', { mode: 0o600 })
+    return file
+  } catch {
+    return null
+  }
+}
+
+function formatBufferedInstallError(baseMessage: string, logBuffer: string[], logPath?: string | null): string {
+  // Show a generous tail: a Node uncaught-exception dump is ~15-30 lines (header,
+  // stack frames, the `{errno,code,syscall,path}` object, version footer). 8 lines
+  // truncated to just the entry frames + error object, hiding the throw origin.
   const recentLines = logBuffer
     .map((line) => line.trim())
     .filter(Boolean)
-    .slice(-8)
+    .slice(-40)
 
-  if (recentLines.length === 0) return baseMessage
-
-  return [
-    baseMessage,
-    '',
-    'Recent output:',
-    ...recentLines.map((line) => `- ${line}`),
-  ].join('\n')
+  const parts = [baseMessage]
+  if (recentLines.length > 0) {
+    parts.push('', 'Recent output:', ...recentLines.map((line) => `- ${line}`))
+  }
+  if (logPath) {
+    parts.push('', `Full log: ${logPath}`)
+  }
+  return parts.join('\n')
 }
 
 export class SetupManager {
@@ -888,13 +911,29 @@ export class SetupManager {
       ? ['--yes', '--from-config', spawnConfigPath ?? configPath]
       : ['--yes', '--root-dir', projectPath]
 
+    // Seed the install log with a diagnostic header capturing the EXACT spawn
+    // (node interpreter, cli entry, cwd) + relevant env. This lands in the
+    // failure report so a Windows/packaged path issue (e.g. an EISDIR on the
+    // entry realpath) is diagnosable without server-console access.
+    const diagHeader: string[] = []
+    if (useBundledCore) {
+      diagHeader.push(
+        `[diag] node=${resolveBundledNodeExe() ?? process.execPath}`,
+        `[diag] cli=${getBundledCoreCli() ?? '<none>'}`,
+        `[diag] cwd=${projectPath}`,
+        `[diag] args=${initArgs.join(' ')}`,
+        `[diag] SPECRAILS_BUNDLED_RUNTIMES_PATH=${process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH ?? '<unset>'}`,
+        `[diag] SPECRAILS_BUNDLED_CORE_PATH=${process.env.SPECRAILS_BUNDLED_CORE_PATH ?? '<unset>'}`,
+      )
+    }
+
     // Bundled core (offline, node <cli> init) when available, else legacy npx.
     const child = useBundledCore
       ? spawnBundledCoreInit(initArgs, projectPath)!
       : spawnCoreInit(initArgs, projectPath)
 
     this._installProcesses.set(projectId, child)
-    this._installLogBuffer.set(projectId, [])
+    this._installLogBuffer.set(projectId, diagHeader)
 
     // spawnCoreInit uses shell:false on POSIX, so a spawn failure emits 'error'
     // (and NOT 'close') — without this handler the temp config file leaks and
@@ -966,12 +1005,14 @@ export class SetupManager {
         validateCoreContract().catch(() => { /* non-fatal */ })
       } else {
         const logBuffer = this._installLogBuffer.get(projectId) ?? []
+        const logPath = persistInstallLog(projectId, logBuffer)
         this._broadcast({
           type: 'setup_error',
           projectId,
           error: formatBufferedInstallError(
             `${useBundledCore ? 'bundled specrails-core' : 'npx specrails-core'} exited with code ${code ?? 'unknown'}`,
             logBuffer,
+            logPath,
           ),
         })
       }


### PR DESCRIPTION
## Context
After the Windows bundled-runtime fixes (#419/#421/#422), tool detection works and the bundled `specrails-core` **now actually executes** (previously it was spawned with `process.execPath` = the pkg server binary and never ran). With it running, a user hit on Windows:

```
… EISDIR lstat 'C:' … Node.js v22.22.3
```

The setup error only showed the **last 8 lines** of the child output. For a Node uncaught exception that's just the entry frames + the `{errno,code,syscall,path}` object — the **origin frames print above** and were hidden, so the throw site is unknown.

## What this does (diagnostics only)
- Widen the in-error tail **8 → 40 lines** so a full Node stack fits.
- Persist the **complete** install log to `~/.specrails/logs/setup-<id>-<ts>.log` (chmod 600) and reference its path in the error.
- Seed the install log with a `[diag]` header: the exact spawn (resolved node interpreter, cli entry, cwd, args) + `SPECRAILS_BUNDLED_RUNTIMES_PATH` / `SPECRAILS_BUNDLED_CORE_PATH`.

No behaviour change to the install itself.

## Why not a direct fix
I reproduced core **4.10.0** init end-to-end on POSIX with the **identical** desktop env (relocate, bundled script dir, registry home) — it completes fully (materialize + workspace assemble). Core's `util/fs` lstat/realpath/symlink helpers are all `try/catch`-wrapped, so the uncaught `EISDIR lstat 'C:'` is **Windows/packaged-path specific** and its origin frame is not visible in the 8-line tail. This change captures that frame so the next attempt pins the exact cause for a precise fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)