### PR TITLE
fix(windows): harden audited Windows-specific defects

### DIFF
--- a/cli/specrails-desktop.ts
+++ b/cli/specrails-desktop.ts
@@ -22,6 +22,7 @@ import { createInterface } from 'readline'
 import WebSocket from 'ws'
 import path from 'path'
 import os from 'os'
+import { spawnCli } from './win-spawn'
 import fs from 'fs'
 
 // ---------------------------------------------------------------------------
@@ -413,7 +414,16 @@ async function resolveProjectFromCwd(baseUrl: string, projectOverride?: string):
   try {
     // --project flag: resolve by path (absolute/relative) or by name
     if (projectOverride) {
-      const isPathLike = projectOverride.startsWith('/') || projectOverride.startsWith('.')
+      // Path vs name: POSIX absolute (`/…`), relative (`./…`), OR a Windows
+      // absolute (`C:\…` / `C:/…`) or any path containing a separator. Without
+      // the drive-letter/backslash cases `--project C:\repo` was mis-read as a
+      // project NAME on Windows and never matched.
+      const isPathLike =
+        path.isAbsolute(projectOverride) ||
+        projectOverride.startsWith('.') ||
+        /^[A-Za-z]:[\\/]/.test(projectOverride) ||
+        projectOverride.includes('/') ||
+        projectOverride.includes('\\')
       if (isPathLike) {
         const res = await httpGet(`${baseUrl}/api/resolve?path=${encodeURIComponent(projectOverride)}`)
         if (res.status === 200) {
@@ -651,7 +661,10 @@ async function runDirect(command: string): Promise<number> {
 
   let child: ReturnType<typeof spawn>
   try {
-    child = spawn('claude', args, {
+    // Windows: `claude` is `claude.cmd`; spawnCli routes through cross-spawn so
+    // the shim resolves and multi-line args survive (raw `spawn(shell:false)`
+    // threw ENOENT/EINVAL on Windows even with claude installed).
+    child = spawnCli('claude', args, {
       env: process.env,
       shell: false,
     })
@@ -987,7 +1000,10 @@ async function desktopStart(port: number): Promise<number> {
     logFd ?? 'ignore',
   ]
 
-  const child = spawnProc(args[0], args.slice(1), {
+  // spawnCli so a dev `tsx`(.cmd) launcher resolves on Windows and the env is
+  // SystemRoot-backfilled; for the packaged `node` path cross-spawn spawns the
+  // .exe directly (no cmd.exe wrapper), keeping `detached` clean.
+  const child = spawnCli(args[0], args.slice(1), {
     detached: true,
     stdio,
     env: { ...process.env },

--- a/cli/win-spawn.test.ts
+++ b/cli/win-spawn.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { windowsSpawnEnv, spawnCli } from './win-spawn'
+
+const ORIGINAL_PLATFORM = process.platform
+function setPlatform(value: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value, configurable: true })
+}
+
+describe('cli windowsSpawnEnv', () => {
+  afterEach(() => setPlatform(ORIGINAL_PLATFORM))
+
+  it('returns base unchanged on POSIX', () => {
+    setPlatform('linux')
+    const base = { FOO: 'bar' } as NodeJS.ProcessEnv
+    expect(windowsSpawnEnv(base)).toBe(base)
+  })
+
+  it('backfills SystemRoot/windir/ComSpec on win32 when absent', () => {
+    setPlatform('win32')
+    const out = windowsSpawnEnv({ PATH: 'x' } as NodeJS.ProcessEnv)
+    expect(out.SystemRoot).toBe('C:\\Windows')
+    expect(out.windir).toBe('C:\\Windows')
+    expect(out.ComSpec).toBe('C:\\Windows\\System32\\cmd.exe')
+    expect(out.PATH).toBe('x')
+  })
+
+  it('preserves existing SystemRoot and derives ComSpec from it', () => {
+    setPlatform('win32')
+    const out = windowsSpawnEnv({ SystemRoot: 'D:\\Win' } as NodeJS.ProcessEnv)
+    expect(out.SystemRoot).toBe('D:\\Win')
+    expect(out.ComSpec).toBe('D:\\Win\\System32\\cmd.exe')
+  })
+})
+
+describe('cli spawnCli (POSIX path)', () => {
+  afterEach(() => setPlatform(ORIGINAL_PLATFORM))
+
+  it('spawns a real binary and resolves output on POSIX', async () => {
+    if (process.platform === 'win32') return
+    const child = spawnCli('echo', ['hello'], { stdio: ['ignore', 'pipe', 'pipe'] })
+    let out = ''
+    child.stdout!.on('data', (b: Buffer) => { out += b.toString() })
+    const code: number = await new Promise((resolve) => child.on('close', (c) => resolve(c ?? -1)))
+    expect(code).toBe(0)
+    expect(out.trim()).toBe('hello')
+  })
+})

--- a/cli/win-spawn.ts
+++ b/cli/win-spawn.ts
@@ -1,0 +1,36 @@
+// Windows-safe spawn for the CLI bridge. Mirrors server/util/win-spawn.ts but is
+// self-contained because the CLI compiles with its own tsconfig (rootDir: cli).
+//
+// Two Windows problems this solves:
+//  1. `claude`/`tsx` etc. ship as `.cmd` shims. `spawn('claude', …, { shell:false })`
+//     fails with ENOENT (no extension expansion) and, since Node 20.12 /
+//     CVE-2024-27980, `spawn('claude.cmd', …, { shell:false })` fails with EINVAL.
+//     cross-spawn launches cmd.exe with quoted args so `.cmd` resolves and
+//     multi-line `--system-prompt`/`-p` values survive intact.
+//  2. A GUI-launched packaged app can inherit a stripped env missing SystemRoot/
+//     ComSpec, which cmd.exe needs to start — windowsSpawnEnv backfills them.
+
+import { spawn } from 'child_process'
+import type { ChildProcess, SpawnOptions } from 'child_process'
+import crossSpawn from 'cross-spawn'
+
+/** Reconstruct the Windows shell-critical env when a stripped sidecar lacks it. */
+export function windowsSpawnEnv(base: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  if (process.platform !== 'win32') return base
+  const env = { ...base }
+  const systemRoot = (env.SystemRoot || env.windir || 'C:\\Windows').replace(/[\\/]$/, '')
+  env.SystemRoot = env.SystemRoot || systemRoot
+  env.windir = env.windir || systemRoot
+  env.ComSpec = env.ComSpec || `${systemRoot}\\System32\\cmd.exe`
+  return env
+}
+
+/** Spawn `binary` Windows-safely: cross-spawn on win32 (resolves `.cmd`, quotes
+ *  args), plain spawn on POSIX. Backfills the Windows base env unless the caller
+ *  already supplied one. */
+export function spawnCli(binary: string, args: string[], options: SpawnOptions = {}): ChildProcess {
+  if (process.platform === 'win32') {
+    return crossSpawn(binary, args, { ...options, env: windowsSpawnEnv(options.env) })
+  }
+  return spawn(binary, args, options)
+}

--- a/server/artifact-registry.ts
+++ b/server/artifact-registry.ts
@@ -256,7 +256,26 @@ export function atomicWrite(filePath: string, data: string): void {
   } finally {
     closeSync(fd)
   }
-  renameSync(tmp, filePath)
+  // Windows: renaming over an EXISTING destination held open by a reader (the
+  // bundled core reads registry.json WITHOUT the lock by contract), an AV
+  // scanner, or a concurrent reader fails transiently with EPERM/EACCES/EBUSY.
+  // POSIX rename-over is atomic and never hits this. Bounded retry on Windows
+  // only; rethrow the last error so the caller's try/catch still surfaces it.
+  let lastErr: unknown
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      renameSync(tmp, filePath)
+      return
+    } catch (err) {
+      lastErr = err
+      const code = (err as NodeJS.ErrnoException).code
+      const retryable = process.platform === 'win32' && (code === 'EPERM' || code === 'EACCES' || code === 'EBUSY')
+      if (!retryable) throw err
+      syncSleep(20 * (attempt + 1))
+    }
+  }
+  try { unlinkSync(tmp) } catch { /* best-effort temp cleanup */ }
+  throw lastErr
 }
 
 /** Synchronous sleep without busy-spinning the CPU. */

--- a/server/binary-probe.ts
+++ b/server/binary-probe.ts
@@ -1,4 +1,5 @@
 import { execSync } from 'child_process'
+import { windowsSpawnEnv } from './util/win-spawn'
 
 // Windows has no `which`; probe via `where` instead. Both exit non-zero
 // when the command is missing, which the try/catch relies on.
@@ -18,7 +19,10 @@ export function binaryOnPath(binary: string): boolean {
   if (hit && now - hit.at < PROBE_TTL_MS) return hit.onPath
   let onPath: boolean
   try {
-    execSync(`${WHICH_CMD} ${binary}`, { stdio: 'ignore' })
+    // `where` runs via cmd.exe; pass a SystemRoot-backfilled env so the probe
+    // (a HARD gate before job/chat spawns) can't be falsely cached as missing
+    // when a packaged sidecar inherited a stripped env.
+    execSync(`${WHICH_CMD} ${binary}`, { stdio: 'ignore', env: windowsSpawnEnv() })
     onPath = true
   } catch {
     onPath = false

--- a/server/config.ts
+++ b/server/config.ts
@@ -3,6 +3,10 @@ import path from 'path'
 import { execSync, execFileSync } from 'child_process'
 import type { PhaseDefinition } from './types'
 
+// Windows has no `which`; it's `where`. The lone holdout that hardcoded `which`
+// here made gh/jira tracker detection always report unavailable on Windows.
+const WHICH_CMD = process.platform === 'win32' ? 'where' : 'which'
+
 export interface CommandInfo {
   id: string
   name: string
@@ -59,7 +63,7 @@ function runCommandArgs(file: string, args: string[], cwd?: string): string | nu
 }
 
 function detectGithub(): IssueTrackerInfo {
-  const ghPath = runCommand('which gh')
+  const ghPath = runCommand(`${WHICH_CMD} gh`)
   if (!ghPath) return { available: false, authenticated: false }
 
   const authOutput = runCommand('gh auth status')
@@ -69,7 +73,7 @@ function detectGithub(): IssueTrackerInfo {
 }
 
 function detectJira(): IssueTrackerInfo {
-  const jiraPath = runCommand('which jira')
+  const jiraPath = runCommand(`${WHICH_CMD} jira`)
   if (!jiraPath) return { available: false, authenticated: false }
 
   // jira CLI availability means it is configured (auth is implicit via jira config)

--- a/server/desktop-router.ts
+++ b/server/desktop-router.ts
@@ -71,14 +71,30 @@ const THEME_ID_ALLOWLIST = new Set<string>(['dracula', 'aurora-light', 'obsidian
 // kept duplicated to avoid pulling client code into the server bundle.
 const LANGUAGE_ID_ALLOWLIST = new Set<string>(['en', 'es', 'fr', 'de', 'pt', 'it', 'zh', 'ja'])
 
-// LOW-04: Deny registration of system-critical directory paths.
+// LOW-04: Deny registration of system-critical directory paths. The POSIX list
+// is matched against forward-slash-normalized, lowercased paths; on Windows it
+// was a complete no-op (no path matches `/etc`), so add a Windows deny-list and
+// fold case (Windows FS is case-insensitive).
 const DENIED_PATH_PREFIXES = [
   '/etc', '/usr', '/bin', '/sbin', '/lib', '/lib64',
   '/sys', '/proc', '/dev', '/boot', '/run',
 ]
+// Windows: deny the Windows dir, Program Files variants, and any bare drive root.
+const DENIED_WINDOWS_PREFIXES = [
+  'c:/windows', 'c:/program files', 'c:/program files (x86)', 'c:/programdata',
+]
 
 function isPathSafe(resolvedPath: string): boolean {
-  const normalized = resolvedPath.endsWith('/') ? resolvedPath : resolvedPath + '/'
+  const slashed = resolvedPath.replace(/\\/g, '/')
+  const normalized = slashed.endsWith('/') ? slashed : slashed + '/'
+  if (process.platform === 'win32') {
+    const lower = normalized.toLowerCase()
+    // Bare drive root (C:/) is never a valid project location.
+    if (/^[a-z]:\/$/.test(lower)) return false
+    return !DENIED_WINDOWS_PREFIXES.some(
+      (prefix) => lower.startsWith(prefix + '/') || lower === prefix + '/'
+    )
+  }
   return !DENIED_PATH_PREFIXES.some(
     (prefix) => normalized.startsWith(prefix + '/') || normalized === prefix + '/'
   )

--- a/server/file-summary-manager.ts
+++ b/server/file-summary-manager.ts
@@ -658,7 +658,11 @@ export class FileSummaryManager {
       awaitWriteFinish: { stabilityThreshold: 200, pollInterval: 100 },
     })
     watcher.on('change', (changed: string) => {
-      const rel = path.relative(projectPath, changed)
+      // The summary store keys off POSIX forward-slash relpaths everywhere
+      // (the REST normalizeRel, pathHash, knownSummaries seeding). On Windows
+      // path.relative yields backslashes, so normalize before lookup/markStale —
+      // otherwise `known.has(rel)` always misses and edits never mark stale.
+      const rel = path.relative(projectPath, changed).split(path.sep).join('/')
       if (!rel || rel.startsWith('..')) return
       // Skip the readSummary disk hit when this file provably has no summary.
       const known = this.knownSummaries.get(projectId)

--- a/server/framework-migration.ts
+++ b/server/framework-migration.ts
@@ -256,7 +256,7 @@ function runMigration(
     const bak = live + BAK_SUFFIX
     try {
       // Clear a stale backup from a prior aborted run.
-      if (fs.existsSync(bak)) fs.rmSync(bak, { recursive: true, force: true })
+      if (fs.existsSync(bak)) fs.rmSync(bak, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
       fs.renameSync(live, bak)
       backedUp.push({ live, bak })
     } catch (err) {
@@ -294,7 +294,7 @@ function runMigration(
     // REVERT: remove any freshly-created (broken) symlinks/dirs, restore backups.
     for (const { live } of backedUp) {
       try {
-        if (fs.existsSync(live) || isSymlink(live)) fs.rmSync(live, { recursive: true, force: true })
+        if (fs.existsSync(live) || isSymlink(live)) fs.rmSync(live, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
       } catch {
         /* best-effort */
       }
@@ -319,7 +319,7 @@ function runMigration(
     if (customs.length > 0) {
       const preserved = live + '.custom.preserved'
       try {
-        if (fs.existsSync(preserved)) fs.rmSync(preserved, { recursive: true, force: true })
+        if (fs.existsSync(preserved)) fs.rmSync(preserved, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
         fs.renameSync(bak, preserved)
         preservedCustom.push(...customs.map((c) => path.basename(c)))
       } catch {
@@ -327,7 +327,7 @@ function runMigration(
       }
     } else {
       try {
-        fs.rmSync(bak, { recursive: true, force: true })
+        fs.rmSync(bak, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
       } catch {
         /* leaving a stale .bak is harmless; never fail the migration on cleanup */
       }
@@ -345,7 +345,7 @@ function restoreBackups(backedUp: Array<{ live: string; bak: string }>): void {
   for (const { live, bak } of backedUp) {
     try {
       if (!fs.existsSync(bak)) continue
-      if (fs.existsSync(live) || isSymlink(live)) fs.rmSync(live, { recursive: true, force: true })
+      if (fs.existsSync(live) || isSymlink(live)) fs.rmSync(live, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
       fs.renameSync(bak, live)
     } catch {
       /* best-effort revert — a surviving .bak is recoverable by hand */

--- a/server/index.ts
+++ b/server/index.ts
@@ -27,7 +27,7 @@ import { createTelemetryRouter } from './telemetry-receiver'
 import { runCompactionForAll } from './telemetry-compactor'
 import { FrameworkManager } from './framework-manager'
 import { withFileLock } from './artifact-registry'
-import { resolveStartupPath, augmentPathFromLoginShell, getPathDiagnostic } from './path-resolver'
+import { resolveStartupPath, augmentPathFromLoginShell, getPathDiagnostic, ensureWindowsBaseEnv } from './path-resolver'
 // Side-effect import: registers every bundled ProviderAdapter (claude, codex,
 // future providers) so `getAdapter`/`hasAdapter`/`listAdapters` are populated
 // before any manager constructs a project context. See
@@ -35,6 +35,10 @@ import { resolveStartupPath, augmentPathFromLoginShell, getPathDiagnostic } from
 import './providers'
 
 const inheritedPathBeforeResolve = (process.env.PATH ?? '').split(process.platform === 'win32' ? ';' : ':').filter(Boolean).length
+// Backfill SystemRoot/ComSpec/etc into process.env BEFORE anything spawns, so a
+// stripped GUI-launch sidecar env never breaks cmd.exe-mediated spawns (PTY,
+// where-probes, .cmd shims). No-op on POSIX. Must precede resolveStartupPath().
+ensureWindowsBaseEnv()
 resolveStartupPath()
 
 const TERMINAL_PANEL_ENABLED = process.env.SPECRAILS_TERMINAL_PANEL !== 'false'

--- a/server/path-resolver.test.ts
+++ b/server/path-resolver.test.ts
@@ -10,6 +10,7 @@ import {
   getPathDiagnostic,
   resolveBundledRuntimePath,
   resolveBundledNodeExe,
+  ensureWindowsBaseEnv,
   __resetPathResolverForTest,
 } from './path-resolver'
 
@@ -477,6 +478,38 @@ describe('resolveBundledNodeExe', () => {
       expect(resolveBundledNodeExe()).not.toBe(process.execPath)
     } finally {
       fs.rmSync(base, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('ensureWindowsBaseEnv', () => {
+  afterEach(() => {
+    setPlatform(ORIGINAL_PLATFORM)
+  })
+
+  it('is a no-op on POSIX', () => {
+    setPlatform('linux')
+    const before = { ...process.env }
+    ensureWindowsBaseEnv()
+    // SystemRoot must NOT be injected on POSIX.
+    expect(process.env.SystemRoot).toBe(before.SystemRoot)
+  })
+
+  it('backfills SystemRoot/ComSpec into process.env on win32 when absent', () => {
+    setPlatform('win32')
+    const prevSR = process.env.SystemRoot
+    const prevCS = process.env.ComSpec
+    delete process.env.SystemRoot
+    delete process.env.ComSpec
+    try {
+      ensureWindowsBaseEnv()
+      expect(process.env.SystemRoot).toBe('C:\\Windows')
+      expect(process.env.ComSpec).toBe('C:\\Windows\\System32\\cmd.exe')
+    } finally {
+      if (prevSR === undefined) delete process.env.SystemRoot
+      else process.env.SystemRoot = prevSR
+      if (prevCS === undefined) delete process.env.ComSpec
+      else process.env.ComSpec = prevCS
     }
   })
 })

--- a/server/path-resolver.ts
+++ b/server/path-resolver.ts
@@ -3,6 +3,23 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import type { ChildProcess } from 'child_process'
+import { windowsSpawnEnv } from './util/win-spawn'
+
+/**
+ * Backfill the Windows shell-critical environment into `process.env` ONCE at
+ * startup. The desktop server runs as a pkg sidecar launched by the Tauri host,
+ * which can deliver a STRIPPED env missing `SystemRoot`/`windir`/`ComSpec`
+ * (and the npm-config family). Without `SystemRoot`, every `cmd.exe`-mediated
+ * spawn — PTY/PowerShell, `execSync('where …')`, `.cmd` shims — fails to start.
+ * Doing this on `process.env` directly means EVERY downstream consumer that
+ * copies `process.env` (terminal-manager, binary-probe, plugin spawns, …) is
+ * protected at the source, in addition to the per-callsite `windowsSpawnEnv()`.
+ * No-op on POSIX and for any var already present (the common case). Idempotent.
+ */
+export function ensureWindowsBaseEnv(): void {
+  if (process.platform !== 'win32') return
+  Object.assign(process.env, windowsSpawnEnv(process.env))
+}
 
 export type PathSource = 'inherited' | 'fast-path' | 'login-shell' | 'bundled'
 export type LoginShellStatus = 'ok' | 'skipped' | 'timeout' | 'error'

--- a/server/plugins/codex-mcp.ts
+++ b/server/plugins/codex-mcp.ts
@@ -9,9 +9,27 @@
 //      isolates plugin state"
 
 import { spawnSync } from 'child_process'
+import crossSpawn from 'cross-spawn'
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
+
+import { windowsSpawnEnv } from '../util/win-spawn'
+
+/**
+ * Spawn `codex` synchronously, Windows-safe. On Windows the codex CLI is a
+ * `.cmd` shim; Node 20.12+ (CVE-2024-27980) refuses to spawn `.cmd` without a
+ * shell, and the packaged sidecar may lack `SystemRoot`/`ComSpec` — so route
+ * through cross-spawn (resolves the shim, runs cmd.exe with correct quoting)
+ * under `windowsSpawnEnv()`. POSIX is a plain `spawnSync`.
+ */
+function codexSpawn(argv: string[], extraEnv: NodeJS.ProcessEnv) {
+  const env = windowsSpawnEnv({ ...process.env, ...extraEnv })
+  const opts = { env, encoding: 'utf-8' as const, timeout: 10_000 }
+  return process.platform === 'win32'
+    ? crossSpawn.sync('codex', argv, opts)
+    : spawnSync('codex', argv, opts)
+}
 
 /** Per-project CODEX_HOME root, sibling of the existing
  *  `~/.specrails/projects/<slug>/{telemetry,jobs,explore-cwd,...}` tree. */
@@ -45,15 +63,7 @@ export interface CodexMcpResult {
 export function codexMcpAdd(slug: string, name: string, entry: CodexMcpEntry): CodexMcpResult {
   const home = ensureCodexHome(slug)
   const argv = ['mcp', 'add', name, '--', entry.command, ...entry.args]
-  const result = spawnSync('codex', argv, {
-    env: {
-      ...process.env,
-      ...(entry.env ?? {}),
-      CODEX_HOME: home,
-    },
-    encoding: 'utf-8',
-    timeout: 10_000,
-  })
+  const result = codexSpawn(argv, { ...(entry.env ?? {}), CODEX_HOME: home })
   if (result.error) {
     return { ok: false, stdout: '', stderr: `${result.error.message}` }
   }
@@ -67,11 +77,7 @@ export function codexMcpAdd(slug: string, name: string, entry: CodexMcpEntry): C
 /** Run `codex mcp remove <name>` against the per-project CODEX_HOME. */
 export function codexMcpRemove(slug: string, name: string): CodexMcpResult {
   const home = ensureCodexHome(slug)
-  const result = spawnSync('codex', ['mcp', 'remove', name], {
-    env: { ...process.env, CODEX_HOME: home },
-    encoding: 'utf-8',
-    timeout: 10_000,
-  })
+  const result = codexSpawn(['mcp', 'remove', name], { CODEX_HOME: home })
   if (result.error) {
     return { ok: false, stdout: '', stderr: `${result.error.message}` }
   }
@@ -88,11 +94,7 @@ export function codexMcpRemove(slug: string, name: string): CodexMcpResult {
  *  for this subcommand. */
 export function codexMcpList(slug: string): { ok: boolean; servers: string[]; raw: string } {
   const home = ensureCodexHome(slug)
-  const result = spawnSync('codex', ['mcp', 'list'], {
-    env: { ...process.env, CODEX_HOME: home },
-    encoding: 'utf-8',
-    timeout: 10_000,
-  })
+  const result = codexSpawn(['mcp', 'list'], { CODEX_HOME: home })
   if (result.error || (result.status ?? 1) !== 0) {
     return { ok: false, servers: [], raw: `${result.stderr ?? result.stdout ?? ''}` }
   }

--- a/server/plugins/prereq-installer.ts
+++ b/server/plugins/prereq-installer.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'child_process'
 import type { WsMessage } from '../types'
+import { windowsSpawnEnv } from '../util/win-spawn'
 
 export type PrereqBroadcast = (msg: WsMessage) => void
 
@@ -82,7 +83,8 @@ export async function installPrerequisite(
     const child = spawn(cmd.shell, [], {
       shell: isWin ? 'powershell.exe' : true,
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: process.env,
+      // PowerShell needs SystemRoot/windir to start; backfill for a stripped env.
+      env: windowsSpawnEnv(),
     })
 
     let settled = false

--- a/server/plugins/serena/verify.ts
+++ b/server/plugins/serena/verify.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'child_process'
 import type { PluginVerifyResult } from '../../types'
+import { windowsSpawnEnv } from '../../util/win-spawn'
 
 const TIMEOUT_MS = 1800
 
@@ -29,6 +30,9 @@ export async function verifySerena(): Promise<PluginVerifyResult> {
       child = spawn('uv', ['--version'], {
         stdio: ['ignore', 'pipe', 'pipe'],
         shell: isWin,
+        // SystemRoot/ComSpec so cmd.exe (shell:true) can start under a stripped
+        // packaged-sidecar env; else uv is wrongly reported not-on-path.
+        env: windowsSpawnEnv(),
       })
     } catch {
       resolve({ ok: false, reason: 'uv-not-on-path', checkedAt })

--- a/server/terminal-manager.test.ts
+++ b/server/terminal-manager.test.ts
@@ -135,9 +135,17 @@ describe('shell resolution', () => {
 })
 
 describe('resolveShellFor (injectable, cross-platform)', () => {
-  it('prefers $SHELL when set, on any platform', () => {
-    expect(resolveShellFor('win32', { SHELL: '/bin/fish' }, () => true)).toBe('/bin/fish')
+  it('prefers $SHELL when set on POSIX (trimmed)', () => {
     expect(resolveShellFor('darwin', { SHELL: '  /bin/zsh  ' }, () => false)).toBe('/bin/zsh')
+    expect(resolveShellFor('linux', { SHELL: '/usr/bin/fish' }, () => false)).toBe('/usr/bin/fish')
+  })
+
+  it('IGNORES a POSIX-style $SHELL on Windows (Git Bash/MSYS) and uses the native chain', () => {
+    // $SHELL=/usr/bin/bash from Git Bash must NOT be spawned by ConPTY; fall
+    // through to pwsh/powershell/cmd instead.
+    const winPosh = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
+    const got = resolveShellFor('win32', { SHELL: '/usr/bin/bash', SystemRoot: 'C:\\Windows' }, (p) => p === winPosh)
+    expect(got).toBe(winPosh)
   })
 
   it('defaults to /bin/zsh on macOS and Linux', () => {

--- a/server/terminal-manager.ts
+++ b/server/terminal-manager.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import { spawn as ptySpawn, type IPty } from 'node-pty'
 import { newId as uuidv4 } from './ids'
+import { windowsSpawnEnv } from './util/win-spawn'
 import type { WebSocket } from 'ws'
 import type { DbInstance } from './db'
 import { OscParser, type OscMarkEvent } from './terminal-osc-parser'
@@ -75,8 +76,11 @@ export function resolveShellFor(
   env: NodeJS.ProcessEnv,
   exists: (p: string) => boolean,
 ): string {
+  // Honor $SHELL only on POSIX. On Windows $SHELL is not native but is commonly
+  // exported by Git Bash/MSYS2 as a Unix path (e.g. /usr/bin/bash) that ConPTY
+  // cannot spawn — so on win32 ignore it and fall through to pwsh→powershell→cmd.
   const envShell = env.SHELL
-  if (envShell && envShell.trim().length > 0) return envShell.trim()
+  if (platform !== 'win32' && envShell && envShell.trim().length > 0) return envShell.trim()
   if (platform === 'win32') {
     for (const dir of (env.PATH ?? '').split(';')) {
       if (!dir) continue
@@ -267,8 +271,13 @@ export class TerminalManager {
     const baseArgs = shellArgs(shell)
     const cols = clampDim(opts.cols ?? TERMINAL_DEFAULT_COLS, 2, 1000)
     const rows = clampDim(opts.rows ?? TERMINAL_DEFAULT_ROWS, 2, 1000)
+    // Build the PTY env from a SystemRoot-backfilled base so PowerShell/cmd can
+    // start even when the packaged sidecar inherited a stripped env (no
+    // SystemRoot/ComSpec → ConPTY spawn fails and the panel never opens). No-op
+    // on POSIX. (process.env is also backfilled globally at startup; this is the
+    // explicit guard at the PTY boundary.)
     const env: Record<string, string> = {}
-    for (const [k, v] of Object.entries(process.env)) {
+    for (const [k, v] of Object.entries(windowsSpawnEnv(process.env))) {
       if (typeof v === 'string') env[k] = v
     }
     env.TERM = 'xterm-256color'


### PR DESCRIPTION
Fixes the defects from the exhaustive Windows audit (18 adversarially-verified findings → 12 distinct bugs). The theme: callsites that bypassed the project's own established guards — cross-spawn (`.cmd` shims + CVE-2024-27980), `windowsSpawnEnv` (stripped GUI-launch sidecar env), `WHICH_CMD` (`which`→`where`), and POSIX path assumptions.

## Root-cause fix (kills the env cluster)
- **`path-resolver.ensureWindowsBaseEnv()`** — backfills `SystemRoot`/`ComSpec`/`windir` (+ npm-config vars) into `process.env` **once at startup**, so every consumer that copies `process.env` is protected at the source. No-op on POSIX.

## High
- **`terminal-manager`** — PTY env built from `windowsSpawnEnv()` so PowerShell/cmd (ConPTY) start under a stripped env (**panel no longer fails to open**); `resolveShellFor` ignores a POSIX `$SHELL` (Git Bash/MSYS) on win32.
- **`plugins/codex-mcp`** — `codexMcpAdd/Remove/List` via cross-spawn + `windowsSpawnEnv` (codex = `codex.cmd` → raw `spawnSync` threw EINVAL); **Serena install on codex projects unbroken**.
- **`config`** — `detectGithub/detectJira` use `WHICH_CMD` (was hardcoded `which` → always false on Windows → gh/jira tracker import dead).
- **`file-summary-manager`** — watcher POSIX-normalizes the relpath before the store lookup (backslash vs POSIX keys → **edits never marked summaries stale**).

## Medium
- **`binary-probe`** — `where` probe (hard gate before job/chat spawns) runs under `windowsSpawnEnv` so a stripped env can't falsely cache a tool as missing.
- **`cli`** — claude spawn + server-start spawn route through new `cli/win-spawn.ts`; `--project C:\path` detected as a path, not a name.
- **`artifact-registry`** — `atomicWrite` rename retries on Windows EPERM/EACCES/EBUSY.

## Low / hardening
- **`framework-migration`** — `rmSync` gets `maxRetries`/`retryDelay`.
- **`plugins/serena/verify` + `prereq-installer`** — pass `windowsSpawnEnv()`.
- **`desktop-router.isPathSafe`** — platform-aware deny-list (was a POSIX-only no-op on Windows).

## Consciously deferred (documented)
Client drag-drop quoting (`shell-quote.ts`) picks PowerShell on Windows — correct for the default shell. The rare cmd.exe-target mis-quote needs a 4-layer server→WS→context→viewport change for a low-severity, visible-and-editable mis-paste — not worth the churn now.

## Verification
`typecheck` + server coverage (158 files) + client coverage (230 files) all pass. New tests: `ensureWindowsBaseEnv`, cli `win-spawn`, `resolveShellFor` win32 `$SHELL` guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)