### PR TITLE
fix(windows): strip \\?\ verbatim prefix from bundled paths (EISDIR lstat 'C:')

### DIFF
--- a/server/bundled-core.ts
+++ b/server/bundled-core.ts
@@ -1,6 +1,8 @@
 import fs from 'fs'
 import path from 'path'
 
+import { stripWindowsVerbatimPrefix } from './util/win-spawn'
+
 /**
  * Bundled specrails-core resolution.
  *
@@ -17,7 +19,9 @@ import path from 'path'
 
 /** The bundled core package root (`<resource_dir>/core`) or null when absent. */
 export function getBundledCoreRoot(): string | null {
-  const p = process.env.SPECRAILS_BUNDLED_CORE_PATH
+  // Strip any `\\?\` verbatim prefix (Tauri resource_dir) — Node's module loader
+  // realpathSync chokes on it when running cli.js (EISDIR lstat 'C:').
+  const p = stripWindowsVerbatimPrefix(process.env.SPECRAILS_BUNDLED_CORE_PATH ?? '')
   if (!p || p.length === 0) return null
   // Existence-gate (defence-in-depth — lib.rs already gates, but a stale env
   // from a partial uninstall must never make us shell out to a missing file).

--- a/server/bundled-openspec.ts
+++ b/server/bundled-openspec.ts
@@ -1,6 +1,8 @@
 import fs from 'fs'
 import path from 'path'
 
+import { stripWindowsVerbatimPrefix } from './util/win-spawn'
+
 /**
  * Bundled `@fission-ai/openspec` resolution.
  *
@@ -31,7 +33,9 @@ const OPENSPEC_CLI_REL = path.join(
 
 /** The bundled openspec root (`<resource_dir>/openspec`) or null when absent. */
 function getBundledOpenspecRoot(): string | null {
-  const p = process.env.SPECRAILS_BUNDLED_OPENSPEC_PATH
+  // Strip any `\\?\` verbatim prefix (Tauri resource_dir) so `node openspec.js`
+  // resolves its entry without the realpathSync EISDIR-on-'C:' crash.
+  const p = stripWindowsVerbatimPrefix(process.env.SPECRAILS_BUNDLED_OPENSPEC_PATH ?? '')
   if (!p || p.length === 0) return null
   // Existence-gate (defence-in-depth — lib.rs already gates, but a stale env
   // from a partial uninstall must never make us point at a missing file).

--- a/server/path-resolver.test.ts
+++ b/server/path-resolver.test.ts
@@ -483,8 +483,18 @@ describe('resolveBundledNodeExe', () => {
 })
 
 describe('ensureWindowsBaseEnv', () => {
+  // ensureWindowsBaseEnv() mutates process.env in-place (SystemRoot/TEMP/APPDATA
+  // …); snapshot + fully restore so Windows-y values never leak to other tests
+  // in the same worker (a TEMP pointing at a non-existent Windows dir broke the
+  // browser-session test).
+  let envSnapshot: NodeJS.ProcessEnv
+  beforeEach(() => {
+    envSnapshot = { ...process.env }
+  })
   afterEach(() => {
     setPlatform(ORIGINAL_PLATFORM)
+    for (const k of Object.keys(process.env)) if (!(k in envSnapshot)) delete process.env[k]
+    Object.assign(process.env, envSnapshot)
   })
 
   it('is a no-op on POSIX', () => {
@@ -510,6 +520,25 @@ describe('ensureWindowsBaseEnv', () => {
       else process.env.SystemRoot = prevSR
       if (prevCS === undefined) delete process.env.ComSpec
       else process.env.ComSpec = prevCS
+    }
+  })
+
+  it('strips the \\\\?\\ verbatim prefix from bundled-path env vars on win32', () => {
+    setPlatform('win32')
+    const keys = ['SPECRAILS_BUNDLED_RUNTIMES_PATH', 'SPECRAILS_BUNDLED_CORE_PATH', 'SPECRAILS_BUNDLED_OPENSPEC_PATH'] as const
+    const prev = keys.map((k) => process.env[k])
+    process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH = '\\\\?\\C:\\Users\\javi\\AppData\\Local\\Specrails\\runtimes'
+    process.env.SPECRAILS_BUNDLED_CORE_PATH = '\\\\?\\C:\\Users\\javi\\AppData\\Local\\Specrails\\core'
+    delete process.env.SPECRAILS_BUNDLED_OPENSPEC_PATH
+    try {
+      ensureWindowsBaseEnv()
+      expect(process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH).toBe('C:\\Users\\javi\\AppData\\Local\\Specrails\\runtimes')
+      expect(process.env.SPECRAILS_BUNDLED_CORE_PATH).toBe('C:\\Users\\javi\\AppData\\Local\\Specrails\\core')
+    } finally {
+      keys.forEach((k, i) => {
+        if (prev[i] === undefined) delete process.env[k]
+        else process.env[k] = prev[i] as string
+      })
     }
   })
 })

--- a/server/path-resolver.ts
+++ b/server/path-resolver.ts
@@ -3,7 +3,14 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import type { ChildProcess } from 'child_process'
-import { windowsSpawnEnv } from './util/win-spawn'
+import { windowsSpawnEnv, stripWindowsVerbatimPrefix } from './util/win-spawn'
+
+/** Bundled-path env vars set by the Tauri host — normalized at startup. */
+const BUNDLED_PATH_ENV_VARS = [
+  'SPECRAILS_BUNDLED_RUNTIMES_PATH',
+  'SPECRAILS_BUNDLED_CORE_PATH',
+  'SPECRAILS_BUNDLED_OPENSPEC_PATH',
+] as const
 
 /**
  * Backfill the Windows shell-critical environment into `process.env` ONCE at
@@ -14,11 +21,23 @@ import { windowsSpawnEnv } from './util/win-spawn'
  * Doing this on `process.env` directly means EVERY downstream consumer that
  * copies `process.env` (terminal-manager, binary-probe, plugin spawns, …) is
  * protected at the source, in addition to the per-callsite `windowsSpawnEnv()`.
- * No-op on POSIX and for any var already present (the common case). Idempotent.
+ *
+ * ALSO strips the Windows verbatim prefix (`\\?\`) from the bundled-path env
+ * vars. Tauri's `resource_dir()` returns `\\?\C:\…` paths; Node's module loader
+ * `realpathSync` mishandles that prefix when resolving the main entry script,
+ * crashing the bundled-core child with `EISDIR: lstat 'C:'`. Normalizing here
+ * (before resolveStartupPath + before any spawn) means every reader
+ * (getBundledCoreCli, resolveBundledNodeExe, chromium/docs/setup-prerequisites,
+ * the PATH prepend) gets a plain `C:\…` path. No-op on POSIX / already-present /
+ * unprefixed. Idempotent.
  */
 export function ensureWindowsBaseEnv(): void {
   if (process.platform !== 'win32') return
   Object.assign(process.env, windowsSpawnEnv(process.env))
+  for (const key of BUNDLED_PATH_ENV_VARS) {
+    const v = process.env[key]
+    if (v) process.env[key] = stripWindowsVerbatimPrefix(v)
+  }
 }
 
 export type PathSource = 'inherited' | 'fast-path' | 'login-shell' | 'bundled'
@@ -110,13 +129,14 @@ function fastPathDirectories(): string[] {
  * Throws if the env var is missing.
  */
 export function resolveBundledRuntimePath(): string {
-  const p = process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH
-  if (!p) {
+  const raw = process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH
+  if (!raw) {
     throw new Error(
       '[path-resolver] resolveBundledRuntimePath() called but SPECRAILS_BUNDLED_RUNTIMES_PATH is not set'
     )
   }
-  return p
+  // Strip the `\\?\` verbatim prefix (Tauri resource_dir) — see ensureWindowsBaseEnv.
+  return stripWindowsVerbatimPrefix(raw)
 }
 
 /**
@@ -131,7 +151,9 @@ export function resolveBundledRuntimePath(): string {
  * Existence-gated so a stale/partial bundle degrades to the PATH `node` instead.
  */
 export function resolveBundledNodeExe(): string | null {
-  const runtimesPath = process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH
+  // Strip the `\\?\` verbatim prefix so the resulting node.exe path doesn't
+  // crash Node's module loader when it runs cli.js (EISDIR lstat 'C:').
+  const runtimesPath = stripWindowsVerbatimPrefix(process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH ?? '')
   if (!runtimesPath || runtimesPath.length === 0) return null
   const exe = process.platform === 'win32'
     ? path.join(runtimesPath, 'node', 'node.exe')

--- a/server/util/win-spawn.test.ts
+++ b/server/util/win-spawn.test.ts
@@ -1,5 +1,22 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { spawnCli, resolveWindowsBinary, windowsSpawnEnv } from './win-spawn'
+import { spawnCli, resolveWindowsBinary, windowsSpawnEnv, stripWindowsVerbatimPrefix } from './win-spawn'
+
+describe('stripWindowsVerbatimPrefix', () => {
+  it('strips the \\\\?\\ drive-letter prefix', () => {
+    expect(stripWindowsVerbatimPrefix('\\\\?\\C:\\Users\\javi\\core\\cli.js')).toBe('C:\\Users\\javi\\core\\cli.js')
+  })
+  it('rewrites \\\\?\\UNC\\server\\share to \\\\server\\share', () => {
+    expect(stripWindowsVerbatimPrefix('\\\\?\\UNC\\server\\share\\x')).toBe('\\\\server\\share\\x')
+  })
+  it('leaves an unprefixed path unchanged', () => {
+    expect(stripWindowsVerbatimPrefix('C:\\Users\\javi')).toBe('C:\\Users\\javi')
+    expect(stripWindowsVerbatimPrefix('/usr/local/bin/node')).toBe('/usr/local/bin/node')
+  })
+  it('tolerates empty/non-string', () => {
+    expect(stripWindowsVerbatimPrefix('')).toBe('')
+    expect(stripWindowsVerbatimPrefix(undefined as unknown as string)).toBe(undefined)
+  })
+})
 
 describe('windowsSpawnEnv', () => {
   const ORIGINAL = process.platform

--- a/server/util/win-spawn.ts
+++ b/server/util/win-spawn.ts
@@ -82,6 +82,23 @@ export function windowsSpawnEnv(base: NodeJS.ProcessEnv = process.env): NodeJS.P
   return env
 }
 
+/**
+ * Strip the Windows extended-length / "verbatim" path prefix (`\\?\`) from a
+ * path. Tauri's `resource_dir()` returns canonicalized paths like
+ * `\\?\C:\Users\…\core`, and Node's MODULE LOADER `realpathSync` (used to
+ * resolve the main entry script) does NOT handle the `\\?\` prefix — it parses
+ * the root as a bare `C:` and throws `EISDIR: lstat 'C:'`. So a bundled `node`
+ * interpreter or `cli.js` entry carrying this prefix crashes the child at
+ * startup. Normalizing the bundled path env vars to plain `C:\…` form fixes it.
+ * `\\?\UNC\server\share` → `\\server\share`. No-op on POSIX / unprefixed paths.
+ */
+export function stripWindowsVerbatimPrefix(p: string): string {
+  if (typeof p !== 'string' || p.length === 0) return p
+  if (p.startsWith('\\\\?\\UNC\\')) return '\\\\' + p.slice(8)
+  if (p.startsWith('\\\\?\\')) return p.slice(4)
+  return p
+}
+
 // Back-compat for callsites that only need the resolved binary
 // (e.g. logging). Kept as a no-op identity on POSIX; on Windows
 // `where`-based resolution lives inside cross-spawn now.


### PR DESCRIPTION
## Root cause (pinned from the #424 full stack)
The Windows bundled-core setup failure (`bundled specrails-core exited with code 1`) was `EISDIR: lstat 'C:'`. The full stack the diagnostics captured:

```
at Object.realpathSync (node:fs:2749:25)
at toRealPath (node:internal/modules/helpers)
at Function._findPath (node:internal/modules/cjs/loader)
at resolveMainPath (node:internal/modules/run_main)
at executeUserEntryPoint [as runMain]
```

The `[diag]` header showed why:
```
cli =\\?\C:\Users\javi\AppData\Local\Specrails\core\dist\installer\cli.js
node=\\?\C:\Users\…\runtimes\node\node.exe
SPECRAILS_BUNDLED_CORE_PATH=\\?\C:\Users\…\core
```

Tauri's `resource_dir()` returns **`\\?\`-prefixed** (extended-length / verbatim) paths. When the child runs `node <cli.js>`, Node's **module loader** resolves the entry via `fs.realpathSync`, which does **not** handle the `\\?\` prefix — it parses the root as a bare `C:` and throws `EISDIR: lstat 'C:'`. That's why it never reproduced on clean CI or POSIX (plain paths), and only surfaced now that the earlier fixes made the bundled core actually execute.

## Fix
Normalize the `\\?\` prefix away:
- **`stripWindowsVerbatimPrefix()`** (util/win-spawn) — `\\?\C:\…` → `C:\…`, `\\?\UNC\server\share` → `\\server\share`; no-op on POSIX/unprefixed.
- **`ensureWindowsBaseEnv()`** strips it from `SPECRAILS_BUNDLED_{RUNTIMES,CORE,OPENSPEC}_PATH` in `process.env` at startup (before `resolveStartupPath` + any spawn), so **every** reader gets a plain `C:\…` path.
- Defense-in-depth at the readers (`getBundledCoreRoot`, `getBundledOpenspecRoot`, `resolveBundledNodeExe`, `resolveBundledRuntimePath`).

## Verification
typecheck + server coverage (158 files) pass. New tests cover the helper (drive/UNC/unprefixed/empty) and the startup env normalization; the env-mutating test now fully snapshots/restores `process.env` so it can't leak win32 values to sibling tests.

> Note: the Rust host could also emit non-verbatim paths (a `dunce`-style strip in `src-tauri/src/lib.rs`); the JS fix here resolves the crash on the current host without a Rust change and defends against any future `\\?\` source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)