### PR TITLE
fix(windows): gemini detection (probe timeout) + npm-global bin on PATH

### DIFF
--- a/server/path-resolver.test.ts
+++ b/server/path-resolver.test.ts
@@ -68,12 +68,50 @@ describe('resolveStartupPath (fast path)', () => {
     expect(process.env.PATH).toBe(before)
   })
 
-  it('is no-op on win32', () => {
+  it('is no-op on win32 when no global-bin dirs exist to prepend', () => {
     setPlatform('win32')
+    const prevAppData = process.env.APPDATA
+    const prevPF = process.env.ProgramFiles
+    delete process.env.APPDATA
+    delete process.env.ProgramFiles
     const before = 'C:\\Windows\\System32;C:\\Program Files\\Git\\cmd'
     process.env.PATH = before
-    resolveStartupPath()
-    expect(process.env.PATH).toBe(before)
+    try {
+      resolveStartupPath()
+      expect(process.env.PATH).toBe(before)
+    } finally {
+      if (prevAppData === undefined) delete process.env.APPDATA
+      else process.env.APPDATA = prevAppData
+      if (prevPF === undefined) delete process.env.ProgramFiles
+      else process.env.ProgramFiles = prevPF
+    }
+  })
+
+  it('prepends an existing %APPDATA%\\npm global-bin dir on win32 (provider shims)', () => {
+    setPlatform('win32')
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'appdata-'))
+    const npmDir = path.join(tmp, 'npm')
+    fs.mkdirSync(npmDir, { recursive: true })
+    const prevAppData = process.env.APPDATA
+    const prevPF = process.env.ProgramFiles
+    process.env.APPDATA = tmp
+    delete process.env.ProgramFiles
+    process.env.PATH = 'C:\\Windows\\System32'
+    try {
+      resolveStartupPath()
+      const segs = (process.env.PATH ?? '').split(';')
+      expect(segs[0]).toBe(npmDir) // prepended first
+      expect(segs).toContain('C:\\Windows\\System32') // inherited preserved
+      // idempotent: a second pass doesn't duplicate it
+      resolveStartupPath()
+      expect((process.env.PATH ?? '').split(';').filter((s) => s === npmDir).length).toBe(1)
+    } finally {
+      if (prevAppData === undefined) delete process.env.APPDATA
+      else process.env.APPDATA = prevAppData
+      if (prevPF === undefined) delete process.env.ProgramFiles
+      else process.env.ProgramFiles = prevPF
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
   })
 
   it('records path sources in diagnostic', () => {

--- a/server/path-resolver.ts
+++ b/server/path-resolver.ts
@@ -124,6 +124,23 @@ function fastPathDirectories(): string[] {
 }
 
 /**
+ * Well-known Windows directories that hold globally-installed CLI shims
+ * (`claude.cmd` / `codex.cmd` / `gemini.cmd`) which a GUI-launched (Explorer/
+ * Tauri) process may not have on its inherited PATH. The per-user npm prefix
+ * places `.cmd` shims DIRECTLY in the prefix root (`%APPDATA%\npm`), not a `bin`
+ * subdir. `npm prefix -g` is the authoritative location for a custom prefix.
+ */
+function windowsGlobalBinDirs(): string[] {
+  if (process.platform !== 'win32') return []
+  const dirs: string[] = []
+  // Default per-user npm prefix: shims (`claude.cmd` …) live in the prefix ROOT.
+  if (process.env.APPDATA) dirs.push(path.join(process.env.APPDATA, 'npm'))
+  // Machine-wide Node install (also where a machine-scope npm prefix points).
+  if (process.env.ProgramFiles) dirs.push(path.join(process.env.ProgramFiles, 'nodejs'))
+  return dirs
+}
+
+/**
  * Returns the absolute path to the bundled runtimes directory.
  * Only valid when SPECRAILS_IS_DESKTOP=1 and SPECRAILS_BUNDLED_RUNTIMES_PATH is set.
  * Throws if the env var is missing.
@@ -208,9 +225,25 @@ export function resolveStartupPath(): void {
   const inheritedSet = new Set(inherited)
 
   if (process.platform === 'win32') {
+    // Prepend well-known global-CLI dirs (npm prefix, Program Files\nodejs) that
+    // a GUI-launched process may lack, so provider shims (claude/codex/gemini
+    // .cmd) — and any RECURSIVE bare-name invocation by a spawned CLI — resolve.
+    // Existence-gated + deduped; no-op when already present (the common case).
+    const winPrepend: string[] = []
+    for (const dir of windowsGlobalBinDirs()) {
+      if (dir && fileExists(dir) && !inheritedSet.has(dir)) {
+        winPrepend.push(dir)
+        inheritedSet.add(dir)
+      }
+    }
+    const winMerged = [...winPrepend, ...inherited]
+    if (winPrepend.length > 0) process.env.PATH = joinPath(winMerged)
     diagnostic = {
-      pathSegments: inherited,
-      pathSources: inherited.map(() => 'inherited' as PathSource),
+      pathSegments: winMerged,
+      pathSources: [
+        ...winPrepend.map(() => 'fast-path' as PathSource),
+        ...inherited.map(() => 'inherited' as PathSource),
+      ],
       loginShellStatus: 'skipped',
     }
     return

--- a/server/providers/gemini-adapter.ts
+++ b/server/providers/gemini-adapter.ts
@@ -26,6 +26,7 @@
 // Spec: openspec/specs/multi-provider-architecture/spec.md
 
 import { execSync } from 'child_process'
+import { windowsSpawnEnv } from '../util/win-spawn'
 import { acknowledgeGeminiProjectAgents } from './gemini-agent-ack'
 import type {
   AdapterEvent,
@@ -193,16 +194,20 @@ function compareSemver(a: string, b: string): number {
 
 async function detectGeminiInstalled(): Promise<DetectionResult> {
   try {
-    execSync(`${WHICH_CMD} gemini`, { stdio: 'ignore' })
+    execSync(`${WHICH_CMD} gemini`, { stdio: 'ignore', env: windowsSpawnEnv() })
   } catch {
     return { installed: false, executable: false }
   }
 
   try {
+    // gemini is a Node CLI; its cold `--version` (cmd.exe → node → load bundle,
+    // Defender scanning) can exceed a few seconds on Windows. Give it a generous
+    // budget + SystemRoot env so it isn't wrongly reported not-executable.
     const raw = execSync('gemini --version', {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'ignore'],
-      timeout: 3000,
+      timeout: process.platform === 'win32' ? 20_000 : 8_000,
+      env: windowsSpawnEnv(),
     }).trim()
     const match = raw.match(/\d+\.\d+\.\d+/)
     const version = match ? match[0] : raw

--- a/server/setup-prerequisites.ts
+++ b/server/setup-prerequisites.ts
@@ -20,13 +20,20 @@ const WHICH_CMD = process.platform === 'win32' ? 'where' : 'which'
  * inherited a stripped env) — without it every bundled probe failed with a bogus
  * "bundle corrupted — reinstall the app".
  */
-function runVersionSpawn(cmd: string, args: string[]): SpawnSyncReturns<string> {
-  const opts = { env: windowsSpawnEnv(), encoding: 'utf-8' as const, timeout: 5_000 }
+function runVersionSpawn(cmd: string, args: string[], timeoutMs = 5_000): SpawnSyncReturns<string> {
+  const opts = { env: windowsSpawnEnv(), encoding: 'utf-8' as const, timeout: timeoutMs }
   if (process.platform === 'win32') {
     return crossSpawn.sync(cmd, args, opts)
   }
   return spawnSync(cmd, args, opts)
 }
+
+// A bundled/system CLI's `--version` cold start can be slow on Windows: a npm
+// `.cmd` shim goes cmd.exe → node.exe → load the CLI bundle, while Defender
+// scans it. The Node-based gemini CLI in particular exceeded the old 5s cap and
+// was wrongly reported not-executable. Give version probes a generous Windows
+// budget; the `where`/`which` LOCATE probe stays fast (5s) since it's a builtin.
+const VERSION_PROBE_TIMEOUT_MS = process.platform === 'win32' ? 20_000 : 8_000
 
 export type Platform = 'darwin' | 'win32' | 'linux'
 
@@ -101,7 +108,7 @@ interface VersionProbe {
 
 /** Run `<bin> <args>` and interpret the result as a `--version` probe. */
 function runProbe(bin: string, args: string[]): VersionProbe {
-  const result = runVersionSpawn(bin, args)
+  const result = runVersionSpawn(bin, args, VERSION_PROBE_TIMEOUT_MS)
   if (result.error) {
     const err = result.error as NodeJS.ErrnoException
     return { executed: false, error: `${err.code ?? 'ERR'}: ${err.message}` }


### PR DESCRIPTION
Pinned via a 5-agent RCA workflow over the spawn/detection/PATH chain.

## 1. Gemini not detected (OUR BUG)
The prereq panel probes `<cli> --version` with a hardcoded **5s** timeout. **gemini is the only Node-based provider CLI** — its cold `gemini.cmd` start (cmd.exe → node.exe → load the `@google/gemini-cli` bundle while Defender scans) exceeds 5s on a packaged GUI-launched Windows sidecar → `ETIMEDOUT` → `executed:false` → `meetsMinimum:false` → rendered "not detected". claude (native) and codex (Rust) return sub-second and pass.

Decisive: **codex (same `%APPDATA%\npm` dir) IS detected**, so `where gemini` succeeds — this is **not** a PATH miss, it's the timeout.

**Fix:** generous Windows version-probe budget (20s; 8s POSIX) in `setup-prerequisites` (`runVersionSpawn`/`runProbe`) and in the gemini adapter's own detect (was 3s, no env) + pass `windowsSpawnEnv()`. The `where` LOCATE probe stays at 5s.

## 2. npm-global bin on PATH (defensive)
Prepend the Windows global-CLI dirs (`%APPDATA%\npm`, `%ProgramFiles%\nodejs`) to `process.env.PATH` at startup (existence-gated, deduped). A GUI-launched process can inherit a PATH without the per-user npm prefix; this makes provider shims — and any **recursive** bare-name invocation by a spawned CLI (e.g. an implement rail's claude sub-steps) — resolvable. No-op when already present / on POSIX.

## NOT our bug (user environment)
The **codex** explore + implement failure `Missing optional dependency @openai/codex-win32-x64` is a **broken global codex install** — our spawn reaches codex (it's codex's own startup crash). User fix: `npm i -g @openai/codex@latest`.

## Verification
typecheck + server coverage (158 files) pass. New tests: win32 `%APPDATA%\npm` prepend + idempotence + no-op-when-absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)