### PR TITLE
fix(audit): batch 1 — data-integrity + job/setup lifecycle (9 bugs)

### DIFF
--- a/server/agent-generator.ts
+++ b/server/agent-generator.ts
@@ -1,5 +1,6 @@
 import { createInterface } from 'readline'
 import { createHash } from 'crypto'
+import treeKill from 'tree-kill'
 import { spawnClaude } from './util/cli-prompt'
 
 /**
@@ -11,6 +12,26 @@ import { spawnClaude } from './util/cli-prompt'
  * Hard cap on the child: 90 seconds wall-clock. Callers should also set a
  * timeout on their fetch/HTTP layer for safety.
  */
+
+/**
+ * Kill a child's whole subtree with SIGTERM, escalating to SIGKILL after a grace
+ * window if it ignores the signal — so a hung/signal-swallowing CLI (and its
+ * grandchildren) is never orphaned. Consistent with QueueManager._kill.
+ */
+function escalateKill(child: { pid?: number; once: (e: string, cb: () => void) => void; kill: (s: NodeJS.Signals) => boolean }): void {
+  if (child.pid) {
+    treeKill(child.pid, 'SIGTERM')
+    const pid = child.pid
+    const esc = setTimeout(() => {
+      try { treeKill(pid, 'SIGKILL', () => { /* best-effort */ }) } catch { /* gone */ }
+    }, 2000)
+    esc.unref?.()
+    child.once('close', () => clearTimeout(esc))
+  } else {
+    try { child.kill('SIGTERM') } catch { /* already gone */ }
+  }
+}
+
 export async function generateCustomAgent(
   cwd: string,
   opts: { name: string; description: string },
@@ -64,7 +85,7 @@ export async function generateCustomAgent(
 
     let collected = ''
     const killer = setTimeout(() => {
-      try { child.kill('SIGTERM') } catch { /* ignore */ }
+      escalateKill(child)
       reject(new Error('agent generation timed out after 90s'))
     }, 90_000)
 
@@ -176,7 +197,7 @@ export async function testCustomAgent(
     let tokensOut = 0
     let truncated = false
     const killer = setTimeout(() => {
-      try { child.kill('SIGTERM') } catch { /* ignore */ }
+      escalateKill(child)
       reject(new Error('test agent run timed out after 120s'))
     }, 120_000)
 
@@ -206,7 +227,7 @@ export async function testCustomAgent(
       // Enforce token ceiling
       if (tokensIn + tokensOut >= tokenCeiling && !truncated) {
         truncated = true
-        try { child.kill('SIGTERM') } catch { /* ignore */ }
+        escalateKill(child)
       }
     })
 

--- a/server/desktop-db.ts
+++ b/server/desktop-db.ts
@@ -326,8 +326,17 @@ function applyDesktopMigrations(db: DbInstance): void {
   for (let i = 0; i < migrations.length; i++) {
     const version = i + 1
     if (!appliedVersions.has(version)) {
-      migrations[i]()
-      db.prepare('INSERT OR IGNORE INTO schema_migrations (version) VALUES (?)').run(version)
+      // Run each migration body and its version INSERT atomically (mirrors
+      // db.ts applyMigrations). SQLite DDL is transactional, so a crash/failure
+      // mid-migration rolls back the whole body instead of leaving a half-applied
+      // schema with the version unrecorded — which previously re-ran a bare
+      // `ALTER TABLE ADD COLUMN` on next startup and bricked app launch forever
+      // with 'duplicate column name'.
+      const tx = db.transaction(() => {
+        migrations[i]()
+        db.prepare('INSERT OR IGNORE INTO schema_migrations (version) VALUES (?)').run(version)
+      })
+      tx()
     }
   }
 }

--- a/server/hooks.test.ts
+++ b/server/hooks.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import express from 'express'
-import { createHooksRouter, getPhaseStates, getPhaseDefinitions, setActivePhases, resetPhases } from './hooks'
+import { createHooksRouter, getPhaseStates, getPhaseDefinitions, setActivePhases, resetPhases, dropPhaseScope } from './hooks'
+const PID = 'test-project'
 import type { WsMessage, PhaseName, PhaseDefinition } from './types'
 
 // The hooks module uses module-level state, so we need a fresh import for isolation.
@@ -9,9 +10,14 @@ import type { WsMessage, PhaseName, PhaseDefinition } from './types'
 function createApp(broadcast: (msg: WsMessage) => void) {
   const app = express()
   app.use(express.json())
-  app.use('/hooks', createHooksRouter(broadcast))
+  app.use('/hooks', createHooksRouter(PID, broadcast))
   return app
 }
+
+// Per-project phase state now persists in a Map keyed by projectId; drop the
+// test project's scope before every test so each starts from the defaults
+// (replaces the old reliance on module-singleton reset).
+beforeEach(() => { dropPhaseScope(PID) })
 
 describe('getPhaseStates', () => {
   let broadcast: ReturnType<typeof vi.fn>
@@ -19,12 +25,12 @@ describe('getPhaseStates', () => {
   beforeEach(() => {
     broadcast = vi.fn()
     // Reset all phases to idle before each test
-    resetPhases(broadcast)
+    resetPhases(PID, broadcast)
     broadcast.mockClear()
   })
 
   it('returns all phases as idle initially', () => {
-    const states = getPhaseStates()
+    const states = getPhaseStates(PID)
     expect(states).toEqual({
       architect: 'idle',
       developer: 'idle',
@@ -34,16 +40,16 @@ describe('getPhaseStates', () => {
   })
 
   it('returns a copy, not a reference', () => {
-    const states = getPhaseStates()
+    const states = getPhaseStates(PID)
     states.architect = 'running'
-    expect(getPhaseStates().architect).toBe('idle')
+    expect(getPhaseStates(PID).architect).toBe('idle')
   })
 })
 
 describe('resetPhases', () => {
   it('broadcasts a phase message for each phase', () => {
     const broadcast = vi.fn()
-    resetPhases(broadcast)
+    resetPhases(PID, broadcast)
 
     expect(broadcast).toHaveBeenCalledTimes(4)
     const phases: PhaseName[] = ['architect', 'developer', 'reviewer', 'ship']
@@ -68,10 +74,10 @@ describe('resetPhases', () => {
       .post('/hooks/events')
       .send({ event: 'agent_start', agent: 'architect' })
 
-    expect(getPhaseStates().architect).toBe('running')
+    expect(getPhaseStates(PID).architect).toBe('running')
 
-    resetPhases(broadcast)
-    expect(getPhaseStates().architect).toBe('idle')
+    resetPhases(PID, broadcast)
+    expect(getPhaseStates(PID).architect).toBe('idle')
   })
 })
 
@@ -82,7 +88,7 @@ describe('POST /hooks/events', () => {
 
   beforeEach(async () => {
     broadcast = vi.fn()
-    resetPhases(broadcast)
+    resetPhases(PID, broadcast)
     broadcast.mockClear()
     app = createApp(broadcast)
     const mod = await import('supertest')
@@ -96,7 +102,7 @@ describe('POST /hooks/events', () => {
 
     expect(res.status).toBe(200)
     expect(res.body).toEqual({ ok: true })
-    expect(getPhaseStates().architect).toBe('running')
+    expect(getPhaseStates(PID).architect).toBe('running')
     expect(broadcast).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'phase',
@@ -117,7 +123,7 @@ describe('POST /hooks/events', () => {
       .send({ event: 'agent_stop', agent: 'developer' })
 
     expect(res.status).toBe(200)
-    expect(getPhaseStates().developer).toBe('done')
+    expect(getPhaseStates(PID).developer).toBe('done')
   })
 
   it('transitions phase to error on agent_error', async () => {
@@ -126,7 +132,7 @@ describe('POST /hooks/events', () => {
       .send({ event: 'agent_error', agent: 'reviewer' })
 
     expect(res.status).toBe(200)
-    expect(getPhaseStates().reviewer).toBe('error')
+    expect(getPhaseStates(PID).reviewer).toBe('error')
   })
 
   it('ignores unknown agent names gracefully', async () => {
@@ -164,48 +170,48 @@ describe('POST /hooks/events', () => {
       await request(app)
         .post('/hooks/events')
         .send({ event: 'agent_start', agent: phase })
-      expect(getPhaseStates()[phase]).toBe('running')
+      expect(getPhaseStates(PID)[phase]).toBe('running')
     }
   })
 
   it('can transition through full lifecycle: idle -> running -> done', async () => {
-    expect(getPhaseStates().ship).toBe('idle')
+    expect(getPhaseStates(PID).ship).toBe('idle')
 
     await request(app)
       .post('/hooks/events')
       .send({ event: 'agent_start', agent: 'ship' })
-    expect(getPhaseStates().ship).toBe('running')
+    expect(getPhaseStates(PID).ship).toBe('running')
 
     await request(app)
       .post('/hooks/events')
       .send({ event: 'agent_stop', agent: 'ship' })
-    expect(getPhaseStates().ship).toBe('done')
+    expect(getPhaseStates(PID).ship).toBe('done')
   })
 
   it('can transition from running to error', async () => {
     await request(app)
       .post('/hooks/events')
       .send({ event: 'agent_start', agent: 'architect' })
-    expect(getPhaseStates().architect).toBe('running')
+    expect(getPhaseStates(PID).architect).toBe('running')
 
     await request(app)
       .post('/hooks/events')
       .send({ event: 'agent_error', agent: 'architect' })
-    expect(getPhaseStates().architect).toBe('error')
+    expect(getPhaseStates(PID).architect).toBe('error')
   })
 })
 
 describe('getPhaseDefinitions', () => {
   it('returns the default phase definitions', () => {
-    const defs = getPhaseDefinitions()
+    const defs = getPhaseDefinitions(PID)
     expect(defs).toHaveLength(4)
     expect(defs.map((d: PhaseDefinition) => d.key)).toEqual(['architect', 'developer', 'reviewer', 'ship'])
   })
 
   it('returns a copy, not a reference', () => {
-    const defs = getPhaseDefinitions()
+    const defs = getPhaseDefinitions(PID)
     defs.push({ key: 'extra', label: 'Extra', description: 'Extra phase' })
-    expect(getPhaseDefinitions()).toHaveLength(4)
+    expect(getPhaseDefinitions(PID)).toHaveLength(4)
   })
 })
 
@@ -218,7 +224,7 @@ describe('setActivePhases', () => {
   ]
 
   beforeEach(() => {
-    setActivePhases(DEFAULT_PHASES, vi.fn())
+    setActivePhases(PID, DEFAULT_PHASES, vi.fn())
   })
 
   it('replaces active phases with new definitions', () => {
@@ -226,9 +232,9 @@ describe('setActivePhases', () => {
       { key: 'plan', label: 'Plan', description: 'Planning phase' },
       { key: 'build', label: 'Build', description: 'Build phase' },
     ]
-    setActivePhases(custom, vi.fn())
+    setActivePhases(PID, custom, vi.fn())
 
-    const defs = getPhaseDefinitions()
+    const defs = getPhaseDefinitions(PID)
     expect(defs).toHaveLength(2)
     expect(defs[0].key).toBe('plan')
   })
@@ -237,9 +243,9 @@ describe('setActivePhases', () => {
     const custom: PhaseDefinition[] = [
       { key: 'plan', label: 'Plan', description: 'Planning phase' },
     ]
-    setActivePhases(custom, vi.fn())
+    setActivePhases(PID, custom, vi.fn())
 
-    expect(getPhaseStates().plan).toBe('idle')
+    expect(getPhaseStates(PID).plan).toBe('idle')
   })
 
   it('broadcasts idle state for each new phase', () => {
@@ -248,7 +254,7 @@ describe('setActivePhases', () => {
       { key: 'plan', label: 'Plan', description: 'Planning phase' },
       { key: 'build', label: 'Build', description: 'Build phase' },
     ]
-    setActivePhases(custom, broadcast)
+    setActivePhases(PID, custom, broadcast)
 
     expect(broadcast).toHaveBeenCalledTimes(2)
     expect(broadcast).toHaveBeenCalledWith(expect.objectContaining({ type: 'phase', phase: 'plan', state: 'idle' }))
@@ -259,9 +265,9 @@ describe('setActivePhases', () => {
     const custom: PhaseDefinition[] = [
       { key: 'custom1', label: 'Custom1', description: 'Custom phase 1' },
     ]
-    setActivePhases(custom, vi.fn())
+    setActivePhases(PID, custom, vi.fn())
 
-    const states = getPhaseStates()
+    const states = getPhaseStates(PID)
     expect(states.architect).toBeUndefined()
     expect(states.custom1).toBe('idle')
   })
@@ -276,7 +282,7 @@ describe('POST /hooks/events with db and activeJobRef', () => {
       { key: 'reviewer', label: 'Reviewer', description: 'Reviewer phase' },
       { key: 'ship', label: 'Ship', description: 'Ship phase' },
     ]
-    setActivePhases(defaults, vi.fn())
+    setActivePhases(PID, defaults, vi.fn())
   })
 
   it('calls db.prepare when db and activeJobRef.current are provided', async () => {
@@ -286,7 +292,7 @@ describe('POST /hooks/events with db and activeJobRef', () => {
 
     const app = express()
     app.use(express.json())
-    app.use('/hooks', createHooksRouter(broadcast, mockDb, activeJobRef))
+    app.use('/hooks', createHooksRouter(PID, broadcast, mockDb, activeJobRef))
 
     const { default: request } = await import('supertest')
     await request(app)
@@ -303,7 +309,7 @@ describe('POST /hooks/events with db and activeJobRef', () => {
 
     const app = express()
     app.use(express.json())
-    app.use('/hooks', createHooksRouter(broadcast, mockDb, activeJobRef))
+    app.use('/hooks', createHooksRouter(PID, broadcast, mockDb, activeJobRef))
 
     const { default: request } = await import('supertest')
     await request(app)

--- a/server/hooks.ts
+++ b/server/hooks.ts
@@ -10,17 +10,40 @@ const DEFAULT_PHASE_DEFINITIONS: PhaseDefinition[] = [
   { key: 'ship', label: 'Ship', description: 'Creates the PR, writes the description, and finalizes the changes for merge' },
 ]
 
-let activePhaseKeys: string[] = DEFAULT_PHASE_DEFINITIONS.map((d) => d.key)
-let activePhaseDefinitions: PhaseDefinition[] = [...DEFAULT_PHASE_DEFINITIONS]
-const phases: Record<string, PhaseState> = {
-  architect: 'idle',
-  developer: 'idle',
-  reviewer: 'idle',
-  ship: 'idle',
+// Phase tracking is PER-PROJECT — a module-level singleton bled one project's
+// active phase set + live states into every other project's `/state` snapshot
+// and `/hooks/events` validity check. Each project gets its own scope, keyed by
+// projectId. (The WS phase broadcasts already carry the right projectId via the
+// project's boundBroadcast; only this server-side snapshot/validity state was
+// global.)
+interface PhaseScope {
+  activePhaseKeys: string[]
+  activePhaseDefinitions: PhaseDefinition[]
+  phases: Record<string, PhaseState>
 }
 
-function isValidPhase(value: string): boolean {
-  return activePhaseKeys.includes(value)
+const scopes = new Map<string, PhaseScope>()
+
+function getScope(projectId: string): PhaseScope {
+  let s = scopes.get(projectId)
+  if (!s) {
+    s = {
+      activePhaseKeys: DEFAULT_PHASE_DEFINITIONS.map((d) => d.key),
+      activePhaseDefinitions: [...DEFAULT_PHASE_DEFINITIONS],
+      phases: Object.fromEntries(DEFAULT_PHASE_DEFINITIONS.map((d) => [d.key, 'idle' as PhaseState])),
+    }
+    scopes.set(projectId, s)
+  }
+  return s
+}
+
+/** Drop a project's phase scope (called on project removal to avoid a leak). */
+export function dropPhaseScope(projectId: string): void {
+  scopes.delete(projectId)
+}
+
+function isValidPhase(projectId: string, value: string): boolean {
+  return getScope(projectId).activePhaseKeys.includes(value)
 }
 
 function eventToState(event: string): PhaseState | null {
@@ -30,30 +53,30 @@ function eventToState(event: string): PhaseState | null {
   return null
 }
 
-export function getPhaseStates(): Record<string, PhaseState> {
-  return { ...phases }
+export function getPhaseStates(projectId: string): Record<string, PhaseState> {
+  return { ...getScope(projectId).phases }
 }
 
-export function getPhaseDefinitions(): PhaseDefinition[] {
-  return [...activePhaseDefinitions]
+export function getPhaseDefinitions(projectId: string): PhaseDefinition[] {
+  return [...getScope(projectId).activePhaseDefinitions]
 }
 
 export function setActivePhases(
+  projectId: string,
   definitions: PhaseDefinition[],
   broadcast: (msg: WsMessage) => void
 ): void {
+  const scope = getScope(projectId)
   // Clear old phase entries
-  for (const key of activePhaseKeys) {
-    delete phases[key]
+  for (const key of scope.activePhaseKeys) {
+    delete scope.phases[key]
   }
   // Install new phase set
-  activePhaseDefinitions = definitions
-  activePhaseKeys = definitions.map((d) => d.key)
-  for (const key of activePhaseKeys) {
-    phases[key] = 'idle'
-  }
-  // Broadcast idle state for each new phase
-  for (const key of activePhaseKeys) {
+  scope.activePhaseDefinitions = definitions
+  scope.activePhaseKeys = definitions.map((d) => d.key)
+  for (const key of scope.activePhaseKeys) {
+    scope.phases[key] = 'idle'
+    // Broadcast idle state for each new phase
     broadcast({
       type: 'phase',
       phase: key,
@@ -63,9 +86,10 @@ export function setActivePhases(
   }
 }
 
-export function resetPhases(broadcast: (msg: WsMessage) => void): void {
-  for (const key of activePhaseKeys) {
-    phases[key] = 'idle'
+export function resetPhases(projectId: string, broadcast: (msg: WsMessage) => void): void {
+  const scope = getScope(projectId)
+  for (const key of scope.activePhaseKeys) {
+    scope.phases[key] = 'idle'
     broadcast({
       type: 'phase',
       phase: key,
@@ -76,6 +100,7 @@ export function resetPhases(broadcast: (msg: WsMessage) => void): void {
 }
 
 export function createHooksRouter(
+  projectId: string,
   broadcast: (msg: WsMessage) => void,
   db?: DbInstance,
   activeJobRef?: { current: string | null }
@@ -85,7 +110,7 @@ export function createHooksRouter(
   router.post('/events', (req: Request, res: Response) => {
     const { event, agent } = req.body ?? {}
 
-    if (!agent || !isValidPhase(agent)) {
+    if (!agent || !isValidPhase(projectId, agent)) {
       console.warn(`[hooks] unknown agent: ${agent}`)
       res.json({ ok: true })
       return
@@ -98,7 +123,7 @@ export function createHooksRouter(
       return
     }
 
-    phases[agent] = newState
+    getScope(projectId).phases[agent] = newState
     broadcast({
       type: 'phase',
       phase: agent,

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -93,7 +93,7 @@ function createTestApp() {
   const app = express()
   app.use(express.json())
 
-  app.use('/hooks', createHooksRouter(broadcast, db, {
+  app.use('/hooks', createHooksRouter('test-project', broadcast, db, {
     current: null,
   }))
 
@@ -119,7 +119,7 @@ function createTestApp() {
   app.get('/api/state', (_req, res) => {
     res.json({
       projectName: 'test-project',
-      phases: getPhaseStates(),
+      phases: getPhaseStates('test-project'),
       busy: (queueManager.getActiveJobId() as string | null) !== null,
     })
   })
@@ -255,7 +255,7 @@ describe('API endpoints', () => {
   beforeEach(async () => {
     // Reset phases to clean state
     const dummyBroadcast = vi.fn()
-    resetPhases(dummyBroadcast)
+    resetPhases('test-project', dummyBroadcast)
 
     const created = createTestApp()
     app = created.app

--- a/server/jira/jira-credential-store.ts
+++ b/server/jira/jira-credential-store.ts
@@ -36,8 +36,16 @@ export function getOrCreateKey(keyfilePath: string = defaultKeyfilePath()): Buff
     const raw = fs.readFileSync(keyfilePath, 'utf-8').trim()
     const key = Buffer.from(raw, 'base64')
     if (key.length === 32) return key
-  } catch {
-    // Missing or corrupt — (re)create below.
+    // File exists but the decoded key is the wrong length (truncated/corrupt) —
+    // fall through to regenerate. A WRONG-LENGTH existing key is unrecoverable
+    // anyway, so rotating is the only option.
+  } catch (err) {
+    // ONLY (re)create when the file genuinely doesn't exist. A transient FS
+    // error (EACCES/EBUSY/EMFILE/momentary unreadability) must NOT rotate the
+    // key — doing so makes every previously-stored Jira token across all
+    // projects permanently undecryptable. Rethrow so the caller sees the real
+    // error instead of silently destroying credentials.
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
   }
   const key = crypto.randomBytes(32)
   const dir = path.dirname(keyfilePath)

--- a/server/project-registry.ts
+++ b/server/project-registry.ts
@@ -18,6 +18,8 @@ import { TicketWatcher } from './ticket-watcher'
 import { getTerminalManager } from './terminal-manager'
 import { BrowserCaptureManager } from './browser-capture-manager'
 import { removeExploreCwd } from './explore-cwd-manager'
+import { dropPhaseScope } from './hooks'
+import { killTransientChildren } from './transient-children'
 import { mirrorProjectEntry, removeRegistryEntry, reconcileFromProjects, resolveArtifacts, resolveHome } from './artifact-registry'
 import { resolveProjectExecution } from './workspace-resolution'
 import { removeWorkspace } from './workspace-manager'
@@ -189,6 +191,8 @@ export class ProjectRegistry {
       try { ctx.queueManager.shutdown() } catch { /* ignore */ }
       try { ctx.chatManager.shutdown() } catch { /* ignore */ }
       try { ctx.setupManager.abort(id) } catch { /* ignore */ }
+      // Kill untracked fire-and-forget children (Quick spec-gen) for this project.
+      try { killTransientChildren(id) } catch { /* ignore */ }
       // M12: these three also spawn children that outlive removeProject. Proposal
       // and AgentRefine write to the per-project DB in their close handlers — if
       // not disposed before db.close() they throw on the closed connection and
@@ -211,6 +215,8 @@ export class ProjectRegistry {
       try { ctx.fileSummaryManager.dispose() } catch { /* ignore */ }
       // Drop the app-managed Explore Spec cwd (CLAUDE.md + symlink to project)
       try { removeExploreCwd(ctx.project.slug) } catch { /* ignore — non-fatal */ }
+      // Drop this project's per-project phase-tracking scope (avoid a leak).
+      try { dropPhaseScope(id) } catch { /* ignore */ }
       // Close the DB connection BEFORE removing the project's data dir below.
       try { ctx.db.close() } catch { /* ignore */ }
       // B54: remove the ENTIRE app-managed data dir for this project, not just
@@ -286,6 +292,11 @@ export class ProjectRegistry {
     for (const ctx of this._contexts.values()) {
       try { ctx.queueManager.shutdown() } catch { /* ignore */ }
       try { ctx.chatManager.shutdown() } catch { /* ignore */ }
+      // Install/enrich wizard children + the 3s install poll interval are NOT
+      // torn down by the spawner shutdowns above — mirror removeProject()'s
+      // setupManager.abort() so a quit mid-wizard doesn't orphan them.
+      try { ctx.setupManager.abort(ctx.project.id) } catch { /* ignore */ }
+      try { killTransientChildren(ctx.project.id) } catch { /* ignore */ }
       try { ctx.proposalManager.shutdown() } catch { /* ignore */ }
       try { ctx.agentRefineManager.shutdown() } catch { /* ignore */ }
       try { ctx.specLauncherManager.shutdown() } catch { /* ignore */ }

--- a/server/project-router-jobs.ts
+++ b/server/project-router-jobs.ts
@@ -174,7 +174,7 @@ export function registerJobsRoutes(deps: ProjectRoutesDeps): void {
     res.json({
       projectName: project.name,
       projectId: project.id,
-      phases: getPhaseStates(),
+      phases: getPhaseStates(project.id),
       busy: queueManager.getActiveJobId() !== null,
       currentJobId: queueManager.getActiveJobId(),
       featureFlags: {

--- a/server/project-router-tickets.ts
+++ b/server/project-router-tickets.ts
@@ -62,6 +62,7 @@ import {
 import { generateAutoTitle } from './explore-draft-title'
 import type { TicketCreatedMessage, TicketUpdatedMessage, TicketDeletedMessage, TicketAiEditStreamMessage, TicketAiEditDoneMessage, TicketAiEditErrorMessage, SpecGenStreamMessage, SpecGenDoneMessage, SpecGenErrorMessage, LocalTicket } from './types'
 import { spawnAiCli } from './util/cli-prompt'
+import { trackTransientChild } from './transient-children'
 import { createInterface } from 'readline'
 import treeKill from 'tree-kill'
 import { resolveProjectExecution } from './workspace-resolution'
@@ -362,6 +363,9 @@ export function registerTicketsRoutes(deps: ProjectRoutesDeps): void {
       stdio: ['ignore', 'pipe', 'pipe'],
       cwd: specGenExec.cwd,
     })
+    // Register so removeProject()/shutdown() can tree-kill this otherwise-untracked
+    // fire-and-forget child (auto-unregisters on close/error).
+    trackTransientChild(projectId, child)
 
     // Watchdog: unlike ai-edit, generate-spec keeps no cancellable handle, so a
     // hung CLI (network stall, model never emitting a terminating event) would

--- a/server/project-router.ts
+++ b/server/project-router.ts
@@ -72,6 +72,7 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
   router.use('/:projectId/hooks', (req: Request, res: Response, next: NextFunction) => {
     const projectCtx = ctx(req)
     const hooksRouter = memoizedSubRouter(hooksRouterByCtx, projectCtx, () => createHooksRouter(
+      projectCtx.project.id,
       projectCtx.broadcast,
       projectCtx.db,
       {

--- a/server/queue-manager.ts
+++ b/server/queue-manager.ts
@@ -718,10 +718,49 @@ export class QueueManager {
       console.error(`[QueueManager] _startJob(${nextJobId}) threw before spawn: ${(err as Error)?.message}`)
       // Only release if we never established a child (else _onJobExit owns cleanup).
       if (this._activeJobId === nextJobId && this._activeProcess === null) {
+        // Stamp the job terminal — _onJobExit never runs without a child, so the
+        // job would otherwise wedge 'running' forever and never fire
+        // onJobFinished (rail/webhook never settle) and leak its per-job maps.
+        this._failWedgedJob(nextJobId, (err as Error)?.message ?? 'startup failure')
         this._activeJobId = null
         this._drainQueue()
       }
     })
+  }
+
+  /**
+   * Stamp a job terminal-failed when `_startJob` threw BEFORE a child was ever
+   * established (so no `_onJobExit` will run). Mirrors _onJobExit's terminal
+   * bookkeeping: in-memory + DB status, per-job map cleanup, onJobFinished, and
+   * a queue-state broadcast. Best-effort and never throws.
+   */
+  private _failWedgedJob(jobId: string, reason: string): void {
+    const job = this._jobs.get(jobId)
+    if (job && job.status === 'running') {
+      job.status = 'failed'
+      job.finishedAt = new Date().toISOString()
+    }
+    // Clear per-job selection/snapshot maps (none were consumed by a spawn).
+    this._jobExecution.delete(jobId)
+    this._snapshotRefs.delete(jobId)
+    this._jobModelSelection.delete(jobId)
+    this._jobProfileSelection.delete(jobId)
+    this._jobInteractiveSelection.delete(jobId)
+    if (this._db) {
+      try {
+        finishJob(this._db, jobId, { exit_code: -1, status: 'failed' })
+      } catch {
+        /* DB may be closed mid-shutdown — never throw from the drain catch */
+      }
+    }
+    try {
+      this._onJobFinished?.(jobId, 'failed', undefined)
+    } catch {
+      /* onJobFinished is best-effort */
+    }
+    this._persistQueueState()
+    this._broadcastQueueState()
+    console.error(`[QueueManager] job ${jobId} failed before spawn: ${reason}`)
   }
 
   /**
@@ -966,11 +1005,12 @@ export class QueueManager {
     this._recomputePositions()
     this._persistJob(job)
 
+    const phaseScopeId = this._projectId ?? this._cwd ?? 'default'
     const commandPhases = this._phasesForCommand(job.command)
     if (commandPhases.length > 0) {
-      setActivePhases(commandPhases, this._broadcast)
+      setActivePhases(phaseScopeId, commandPhases, this._broadcast)
     } else {
-      resetPhases(this._broadcast)
+      resetPhases(phaseScopeId, this._broadcast)
     }
 
     const commandToRun = job.command.trim()
@@ -1307,6 +1347,15 @@ export class QueueManager {
 
     this._activeProcess = child
     this._activeJobId = jobId
+
+    // Honour a cancel that arrived during the async pre-spawn window (it recorded
+    // intent in _cancelingJobs via _kill but found no child yet). SIGTERM the
+    // just-spawned child now; the close handler wired below fires _onJobExit,
+    // which reads _cancelingJobs and stamps 'canceled'. No early-return — the
+    // exit handler MUST still be wired so the job settles.
+    if (this._cancelingJobs.has(jobId)) {
+      this._kill(jobId)
+    }
 
     // Without this listener, an ENOENT (e.g. claude not on PATH) propagates
     // as an unhandled 'error' event and crashes the entire app. Node still
@@ -1809,6 +1858,13 @@ export class QueueManager {
   }
 
   private _kill(jobId: string): void {
+    // Record the cancel intent UP FRONT — even when no child exists yet. A
+    // cancel arriving during the async pre-spawn window (plugin verify / profile
+    // snapshot) would otherwise early-return below before recording intent, the
+    // child would later spawn unobserved, and _onJobExit would stamp 'completed'.
+    // With the intent recorded, the post-spawn check in _startJob SIGTERMs the
+    // child once it exists, and _onJobExit reads it to stamp 'canceled'.
+    this._cancelingJobs.add(jobId)
     if (!this._activeProcess || !this._activeProcess.pid) return
 
     this._clearZombieTimer()
@@ -1819,7 +1875,6 @@ export class QueueManager {
       clearTimeout(this._killTimer)
       this._killTimer = null
     }
-    this._cancelingJobs.add(jobId)
     treeKill(this._activeProcess.pid, 'SIGTERM')
 
     const pid = this._activeProcess.pid

--- a/server/spawn-lifecycle.ts
+++ b/server/spawn-lifecycle.ts
@@ -13,6 +13,7 @@
 
 import type { ChildProcess } from 'node:child_process'
 import { createInterface } from 'node:readline'
+import treeKill from 'tree-kill'
 import { spawnAiCli } from './util/cli-prompt'
 import type { ProviderAdapter, AdapterEvent, SpawnAction, SpawnOptions } from './providers/types'
 
@@ -129,7 +130,21 @@ export function runAiCliInvocation(hooks: RunInvocationHooks): Promise<Invocatio
     if (hooks.timeoutMs != null) {
       timer = setTimeout(() => {
         hooks.onTimeout?.()
-        try { child.kill('SIGTERM') } catch { /* already gone */ }
+        // treeKill the whole subtree (a bare child.kill leaves grandchildren),
+        // then escalate to SIGKILL after a grace window if the child ignores
+        // SIGTERM — otherwise a hung, signal-swallowing CLI is orphaned for the
+        // host's lifetime. (Mirrors QueueManager._kill.)
+        if (child.pid) {
+          treeKill(child.pid, 'SIGTERM')
+          const pid = child.pid
+          const killTimer = setTimeout(() => {
+            try { treeKill(pid, 'SIGKILL', () => { /* best-effort */ }) } catch { /* gone */ }
+          }, 2000)
+          killTimer.unref?.()
+          child.once('close', () => clearTimeout(killTimer))
+        } else {
+          try { child.kill('SIGTERM') } catch { /* already gone */ }
+        }
         settle({ code: null, timedOut: true, spawnFailed: false, child })
       }, hooks.timeoutMs)
     }

--- a/server/transient-children.test.ts
+++ b/server/transient-children.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest'
+import { EventEmitter } from 'events'
+import { trackTransientChild, killTransientChildren } from './transient-children'
+
+vi.mock('tree-kill', () => ({ default: vi.fn() }))
+import treeKill from 'tree-kill'
+
+function fakeChild(pid: number | undefined): any {
+  const ee = new EventEmitter() as any
+  ee.pid = pid
+  return ee
+}
+
+describe('transient-children', () => {
+  it('tree-kills tracked children on killTransientChildren', () => {
+    const c1 = fakeChild(111)
+    const c2 = fakeChild(222)
+    trackTransientChild('p1', c1)
+    trackTransientChild('p1', c2)
+    killTransientChildren('p1')
+    expect(treeKill).toHaveBeenCalledWith(111, 'SIGTERM')
+    expect(treeKill).toHaveBeenCalledWith(222, 'SIGTERM')
+    // forgotten after kill — a second call kills nothing new
+    ;(treeKill as any).mockClear()
+    killTransientChildren('p1')
+    expect(treeKill).not.toHaveBeenCalled()
+  })
+
+  it('auto-unregisters a child on close so it is not killed later', () => {
+    const c = fakeChild(333)
+    trackTransientChild('p2', c)
+    c.emit('close')
+    ;(treeKill as any).mockClear()
+    killTransientChildren('p2')
+    expect(treeKill).not.toHaveBeenCalled()
+  })
+
+  it('killing an unknown project is a no-op', () => {
+    ;(treeKill as any).mockClear()
+    killTransientChildren('nope')
+    expect(treeKill).not.toHaveBeenCalled()
+  })
+
+  it('skips a child with no pid', () => {
+    const c = fakeChild(undefined)
+    trackTransientChild('p3', c)
+    ;(treeKill as any).mockClear()
+    killTransientChildren('p3')
+    expect(treeKill).not.toHaveBeenCalled()
+  })
+})

--- a/server/transient-children.ts
+++ b/server/transient-children.ts
@@ -1,0 +1,45 @@
+import treeKill from 'tree-kill'
+import type { ChildProcess } from 'child_process'
+
+/**
+ * Registry of fire-and-forget child processes that are NOT owned by a long-lived
+ * manager (QueueManager / ChatManager / SetupManager track their own). The Quick
+ * spec-generation spawn in particular keeps only a closure handle + a watchdog,
+ * so `ProjectRegistry.removeProject()` / `shutdown()` could not terminate it —
+ * it survived project removal (burning AI-CLI spend) until the watchdog fired.
+ *
+ * Children registered here are tree-killed when their project is removed or the
+ * app shuts down. Self-cleaning: each child is auto-unregistered on `close`.
+ */
+const byProject = new Map<string, Set<ChildProcess>>()
+
+/** Track a child under a projectId; auto-removes itself on close. */
+export function trackTransientChild(projectId: string, child: ChildProcess): void {
+  let set = byProject.get(projectId)
+  if (!set) {
+    set = new Set()
+    byProject.set(projectId, set)
+  }
+  set.add(child)
+  const drop = (): void => {
+    const s = byProject.get(projectId)
+    if (s) {
+      s.delete(child)
+      if (s.size === 0) byProject.delete(projectId)
+    }
+  }
+  child.once('close', drop)
+  child.once('error', drop)
+}
+
+/** SIGTERM the whole subtree of every tracked child for a project, then forget. */
+export function killTransientChildren(projectId: string): void {
+  const set = byProject.get(projectId)
+  if (!set) return
+  for (const child of set) {
+    if (child.pid) {
+      try { treeKill(child.pid, 'SIGTERM') } catch { /* best-effort */ }
+    }
+  }
+  byProject.delete(projectId)
+}


### PR DESCRIPTION
First batch of the exhaustive multi-agent bug audit (Tier 0/1 + teardown). 9 adversarially-confirmed bugs:

| # | Sev | Bug |
|---|-----|-----|
| H2 | High | desktop-db migrations non-transactional → app-startup lockout |
| H1 | High | cancel lost in the async pre-spawn window |
| M1 | Med | _startJob throw wedges job 'running' forever |
| H4 | High | global phase state bled across projects |
| M9 | Med | jira keyfile rotated on transient FS error → all tokens lost |
| M10 | Med | setup children leaked on graceful shutdown |
| M11 | Med | generate-spec fire-and-forget child untracked |
| L17/L18 | Low | spawn-lifecycle/agent-generator no SIGKILL escalation |

typecheck + server coverage (159 files) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)