### PR TITLE
fix(audit): batch 2 — Jira sync, plugins, terminal, profiles (10 bugs)

### DIFF
--- a/server/jira/jira-client.test.ts
+++ b/server/jira/jira-client.test.ts
@@ -374,13 +374,15 @@ describe('request() Retry-After parsing on 429', () => {
     }
   })
 
-  it('clamps a past HTTP-date Retry-After to >= 0 (falsy 0 is dropped)', async () => {
+  it('keeps a past HTTP-date Retry-After as 0 (immediate retry, not dropped)', async () => {
     const past = new Date(Date.now() - 50_000).toUTCString()
     const { fetchImpl } = makeFetch({ status: 429, ok: false, headers: { 'Retry-After': past } })
     const res = await new JiraClient(cloudCfg()).myself()
     if (!res.ok) {
-      // parseRetryAfter returns 0 for a past date → 0 is falsy → retryAfterMs omitted
-      expect(res.retryAfterMs).toBeUndefined()
+      // parseRetryAfter returns 0 for a past date → Jira says retry now. The fix
+      // guards on `!== undefined`, so 0 is preserved instead of falling through
+      // to exponential backoff.
+      expect(res.retryAfterMs).toBe(0)
     }
   })
 
@@ -915,12 +917,27 @@ describe('addComment', () => {
 // ───────────────────────────────────────────────────────────────────────────
 
 describe('getComments', () => {
-  it('GETs /issue/{id}/comment', async () => {
+  it('GETs /issue/{id}/comment with pagination params (single page)', async () => {
     const comments = [{ id: '1', body: 'a' }]
-    const { fetchImpl, requests } = makeFetch({ body: { comments } })
+    const { fetchImpl, requests } = makeFetch({ body: { comments, total: 1, startAt: 0 } })
     const res = await new JiraClient(cloudCfg()).getComments('PROJ-1')
     expect(requests[0].method).toBe('GET')
-    expect(requests[0].url).toBe('https://acme.atlassian.net/rest/api/3/issue/PROJ-1/comment?expand=properties')
+    expect(requests[0].url).toBe('https://acme.atlassian.net/rest/api/3/issue/PROJ-1/comment?expand=properties&startAt=0&maxResults=100')
     if (res.ok) expect(res.data.comments).toEqual(comments)
+  })
+
+  it('pages through all comments until total is reached', async () => {
+    // First page returns 100 (of 150), second returns the rest.
+    const page1 = Array.from({ length: 100 }, (_, i) => ({ id: String(i), body: 'x' }))
+    const page2 = Array.from({ length: 50 }, (_, i) => ({ id: String(100 + i), body: 'y' }))
+    const { requests } = makeFetch((req) =>
+      req.url.includes('startAt=0')
+        ? { body: { comments: page1, total: 150, startAt: 0 } }
+        : { body: { comments: page2, total: 150, startAt: 100 } },
+    )
+    const res = await new JiraClient(cloudCfg()).getComments('PROJ-1')
+    expect(requests.length).toBe(2)
+    expect(requests[1].url).toContain('startAt=100')
+    if (res.ok) expect(res.data.comments).toHaveLength(150)
   })
 })

--- a/server/jira/jira-client.ts
+++ b/server/jira/jira-client.ts
@@ -110,7 +110,7 @@ export class JiraClient {
       const code = classify(res.status)
       const retryAfter = res.headers.get('Retry-After')
       const retryAfterMs = retryAfter ? parseRetryAfter(retryAfter) : undefined
-      return { ok: false, status: res.status, code, error: truncate(errText), ...(retryAfterMs ? { retryAfterMs } : {}) }
+      return { ok: false, status: res.status, code, error: truncate(errText), ...(retryAfterMs !== undefined ? { retryAfterMs } : {}) }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
       return { ok: false, status: 0, code: 'network', error: msg }
@@ -178,7 +178,7 @@ export class JiraClient {
    * removed Oct 2025). Always pass an explicit `fields` array; page via
    * `nextPageToken`. On DC v2 this falls back to the classic /search.
    */
-  searchJql(args: {
+  async searchJql(args: {
     jql: string
     fields: string[]
     nextPageToken?: string
@@ -186,13 +186,24 @@ export class JiraClient {
     reconcileIssues?: string[]
   }): Promise<JiraResult<{ issues: JiraIssue[]; nextPageToken?: string; isLast?: boolean }>> {
     if (this.cfg.apiVersion === '2') {
-      // DC/Server: classic search with startAt/maxResults.
-      return this.request('POST', '/search', {
+      // DC/Server: classic search with startAt/maxResults. The classic response
+      // carries {issues,total,startAt,maxResults} — NOT nextPageToken — so
+      // SYNTHESIZE a nextPageToken (= next startAt) while more pages remain.
+      // Without this the poll loop only ever read the first 100 issues.
+      const startAt = args.nextPageToken ? parseInt(args.nextPageToken, 10) || 0 : 0
+      const maxResults = args.maxResults ?? 100
+      const res = await this.request<{ issues?: JiraIssue[]; total?: number }>('POST', '/search', {
         jql: args.jql,
         fields: args.fields,
-        maxResults: args.maxResults ?? 100,
-        startAt: args.nextPageToken ? parseInt(args.nextPageToken, 10) || 0 : 0,
+        maxResults,
+        startAt,
       })
+      if (!res.ok) return res
+      const issues = res.data.issues ?? []
+      const total = res.data.total ?? issues.length
+      const nextStart = startAt + issues.length
+      const nextPageToken = issues.length > 0 && nextStart < total ? String(nextStart) : undefined
+      return { ok: true, status: res.status, data: { issues, nextPageToken, isLast: nextPageToken === undefined } }
     }
     return this.request('POST', '/search/jql', {
       jql: args.jql,
@@ -273,10 +284,30 @@ export class JiraClient {
    * GET /issue/{id}/comment?expand=properties — used to dedup comments via the
    * self-marker (invisible comment property, with a legacy body fallback).
    */
-  getComments(
+  async getComments(
     issueIdOrKey: string
   ): Promise<JiraResult<{ comments: Array<{ id: string; body: unknown; properties?: Array<{ key: string; value?: unknown }> }> }>> {
-    return this.request('GET', `/issue/${encodeURIComponent(issueIdOrKey)}/comment?expand=properties`)
+    // PAGE through ALL comments: the dedup self-marker may sit on an older page,
+    // and a single (default ~50) page would miss it on a heavily-commented issue,
+    // re-posting a duplicate completion/discard comment. Cap pages defensively.
+    type Comment = { id: string; body: unknown; properties?: Array<{ key: string; value?: unknown }> }
+    const all: Comment[] = []
+    let startAt = 0
+    const maxResults = 100
+    for (let page = 0; page < 50; page++) {
+      const enc = encodeURIComponent(issueIdOrKey)
+      const res = await this.request<{ comments?: Comment[]; total?: number; startAt?: number }>(
+        'GET',
+        `/issue/${enc}/comment?expand=properties&startAt=${startAt}&maxResults=${maxResults}`,
+      )
+      if (!res.ok) return res
+      const batch = res.data.comments ?? []
+      all.push(...batch)
+      const total = res.data.total ?? all.length
+      startAt += batch.length
+      if (batch.length === 0 || startAt >= total) break
+    }
+    return { ok: true, status: 200, data: { comments: all } }
   }
 
   // ─── Read-only details panel (issue fields + Development) ────────────────────

--- a/server/jira/jira-materializer.ts
+++ b/server/jira/jira-materializer.ts
@@ -219,8 +219,14 @@ export function upsertIssuesIntoStore(
   let anyChange = false
   for (const issue of issues) {
     const u = issue.fields.updated ? Date.parse(issue.fields.updated) : 0
-    if (!Number.isNaN(u) && u > maxUpdatedMs) maxUpdatedMs = u
     const link = getLinkByIssueId(db, issue.id)
+    // Do NOT advance the high-water past a FROZEN issue (one with a pending
+    // outbox op whose content we suppress): if the op later dead-letters without
+    // the Jira `updated` timestamp changing, a high-water moved past it would
+    // never re-fetch the suppressed remote change → permanently stale cache.
+    // Only count issues whose content we actually reconcile here.
+    const isFrozen = link ? frozenLocalIds.has(link.localId) : false
+    if (!Number.isNaN(u) && u > maxUpdatedMs && !isFrozen) maxUpdatedMs = u
     if (!link) { anyChange = true; continue }
     if (issue.key && issue.key !== link.jiraKey) { anyChange = true; continue }
     const existing = preStore.tickets[String(link.localId)]

--- a/server/jira/jira-sync-manager.ts
+++ b/server/jira/jira-sync-manager.ts
@@ -536,8 +536,17 @@ export class JiraSyncManager {
     const frozen = this.frozenLocalIds()
     let jql = `project = "${conn.jiraProjectKey}" ORDER BY updated ASC`
     if (!full && conn.highWaterMs && conn.highWaterMs > 0) {
-      const since = formatJqlDate(conn.highWaterMs - POLL_OVERLAP_MS)
-      jql = `project = "${conn.jiraProjectKey}" AND updated >= "${since}" ORDER BY updated ASC`
+      // RELATIVE JQL date (`-Nm`) instead of an absolute wall-clock string: an
+      // absolute `formatJqlDate(...)` is emitted in UTC but Jira interprets a
+      // bare JQL datetime in the ACCOUNT timezone, so on a behind-UTC instance
+      // the floor rose above the high-water and silently skipped hours of
+      // updates. Relative dates evaluate against Jira's own clock with no TZ
+      // wall-clock interpretation, eliminating the gap. The high-water is derived
+      // from Jira's own `updated` values, so minutes-ago from the server clock
+      // (within the 2-min overlap for skew) maps to the right Jira floor.
+      const sinceFloorMs = conn.highWaterMs - POLL_OVERLAP_MS
+      const minutesAgo = Math.max(1, Math.ceil((Date.now() - sinceFloorMs) / 60_000))
+      jql = `project = "${conn.jiraProjectKey}" AND updated >= "-${minutesAgo}m" ORDER BY updated ASC`
     }
 
     let nextPageToken: string | undefined

--- a/server/plugin-manager.ts
+++ b/server/plugin-manager.ts
@@ -322,6 +322,7 @@ export class PluginManager {
     name: string,
     broadcast: PluginBroadcast,
     providerId?: string,
+    slug?: string,
   ): Promise<void> {
     const plugin = this.registry.byName.get(name)
     if (!plugin) throw new PluginNotFoundError(name)
@@ -406,6 +407,7 @@ export class PluginManager {
     const ctx = {
       projectPath,
       projectId,
+      slug,
       providerId,
       recordInstalledFile: (rel: string) => { installedFiles.push(rel) },
       log: onLog,
@@ -462,6 +464,18 @@ export class PluginManager {
           // the next install attempt.
         }
       }
+      // For cli-add providers (codex), a successful `codex mcp add` lives in
+      // CODEX_HOME, NOT the snapshotted filesystem — the file rollback above
+      // can't undo it. Run the plugin's uninstall so a verify-failed codex
+      // install leaves no orphaned MCP registration (best-effort).
+      if (providerId && hasAdapter(providerId) && getAdapter(providerId).mcpRegistration === 'cli-add') {
+        try {
+          await plugin.uninstall({
+            projectPath, projectId, slug, providerId,
+            recordInstalledFile: () => {}, log: onLog,
+          })
+        } catch { /* best-effort rollback of the codex registration */ }
+      }
       throw err instanceof PluginInstallError ? err : new PluginInstallError(
         `install of '${name}' failed: ${(err as Error)?.message ?? String(err)}`,
         err,
@@ -486,6 +500,7 @@ export class PluginManager {
     name: string,
     broadcast: PluginBroadcast,
     providerId?: string,
+    slug?: string,
   ): Promise<void> {
     const state = this.getProjectState(projectPath)
     const entry = state.plugins[name]
@@ -509,6 +524,7 @@ export class PluginManager {
       await plugin.uninstall({
         projectPath,
         projectId,
+        slug,
         providerId,
         recordInstalledFile: () => {},
         log: onLog,

--- a/server/plugins-router.ts
+++ b/server/plugins-router.ts
@@ -95,7 +95,7 @@ export function createPluginsRouter(): Router {
   router.post('/:name/install', async (req, res) => {
     try {
       const { project, broadcast } = ctx(req)
-      await getPluginManager().install(pluginRoot(project), project.id, req.params.name, broadcast, project.provider)
+      await getPluginManager().install(pluginRoot(project), project.id, req.params.name, broadcast, project.provider, project.slug)
       res.status(200).json({ ok: true })
     } catch (err) {
       handleError(res, err)
@@ -106,7 +106,7 @@ export function createPluginsRouter(): Router {
   router.delete('/:name', async (req, res) => {
     try {
       const { project, broadcast } = ctx(req)
-      await getPluginManager().uninstall(pluginRoot(project), project.id, req.params.name, broadcast, project.provider)
+      await getPluginManager().uninstall(pluginRoot(project), project.id, req.params.name, broadcast, project.provider, project.slug)
       res.status(200).json({ ok: true })
     } catch (err) {
       handleError(res, err)

--- a/server/plugins/serena/install.ts
+++ b/server/plugins/serena/install.ts
@@ -19,12 +19,13 @@ function isCodex(ctx: PluginLifecycleContext): boolean {
   return getAdapter(ctx.providerId).mcpRegistration === 'cli-add'
 }
 
-/** Project slug used by codex-mcp helpers — derived from the project path's
- *  basename. The app maintains the canonical slug elsewhere (ProjectRegistry);
- *  for the install context we don't have the registry, but the basename is a
- *  stable per-project identifier sufficient for CODEX_HOME isolation. */
-function slugFromProjectPath(projectPath: string): string {
-  return path.basename(projectPath)
+/** Resolve the canonical per-project slug for codex-mcp CODEX_HOME isolation.
+ *  PREFER the registry slug threaded through the lifecycle context (the SAME
+ *  slug used by ~/.specrails/projects/<slug>/ everywhere else). Fall back to the
+ *  path basename only when absent — basenames collide between same-named repos
+ *  and would point CODEX_HOME at a shared/wrong dir. */
+function resolveCodexSlug(ctx: PluginLifecycleContext): string {
+  return ctx.slug && ctx.slug.trim().length > 0 ? ctx.slug : path.basename(ctx.projectPath)
 }
 
 export async function installSerena(ctx: PluginLifecycleContext): Promise<void> {
@@ -36,7 +37,7 @@ export async function installSerena(ctx: PluginLifecycleContext): Promise<void> 
     if (!entry) {
       throw new Error('serena manifest is missing providerSupport.codex.mcpEntry')
     }
-    const slug = slugFromProjectPath(ctx.projectPath)
+    const slug = resolveCodexSlug(ctx)
     ctx.log(`Registering serena MCP via 'codex mcp add' (CODEX_HOME=~/.specrails/projects/${slug}/codex-home/)`)
     const result = codexMcpAdd(slug, 'serena', entry)
     if (!result.ok) {
@@ -60,7 +61,7 @@ export async function installSerena(ctx: PluginLifecycleContext): Promise<void> 
 
 export async function uninstallSerena(ctx: PluginLifecycleContext): Promise<void> {
   if (isCodex(ctx)) {
-    const slug = slugFromProjectPath(ctx.projectPath)
+    const slug = resolveCodexSlug(ctx)
     // Probe first so removing an already-removed server doesn't surface as an
     // error (e.g. the user uninstalled via terminal then via the app).
     const listing = codexMcpList(slug)

--- a/server/profile-manager.ts
+++ b/server/profile-manager.ts
@@ -249,6 +249,34 @@ export function getProfile(projectPath: string, name: string, expectedProvider: 
   return validateProfile(raw, expectedProvider)
 }
 
+/**
+ * Non-validating read for the editor: returns the parsed profile body plus any
+ * schema/structural validation errors (instead of throwing). A profile that
+ * became invalid against the current agent catalog must still be openable so the
+ * user can repair it — `getProfile` would throw and lock it out. JSON-parse
+ * errors still throw (unrepairable in the editor). `validateProfile` remains the
+ * gate on create/update/launch.
+ */
+export function getProfileRaw(
+  projectPath: string,
+  name: string,
+  expectedProvider: string = 'claude',
+): { profile: unknown; valid: boolean; errors: string[] } {
+  assertValidName(name)
+  const full = profilePath(projectPath, name)
+  if (!fs.existsSync(full)) {
+    throw new ProfileNotFoundError(name)
+  }
+  const raw = JSON.parse(fs.readFileSync(full, 'utf8'))
+  try {
+    validateProfile(raw, expectedProvider)
+    return { profile: raw, valid: true, errors: [] }
+  } catch (err) {
+    const errors = err instanceof ProfileValidationError ? err.errors : [(err as Error).message]
+    return { profile: raw, valid: false, errors }
+  }
+}
+
 export function createProfile(projectPath: string, profile: Profile, expectedProvider: string = 'claude'): void {
   assertValidName(profile.name)
   validateProfile(profile, expectedProvider)
@@ -300,6 +328,11 @@ export function renameProfile(
   toName: string,
   expectedProvider: string = 'claude',
 ): Profile {
+  // Renaming the default away would leave no default → resolveProfile returns
+  // null and rails silently drop to legacy/no-profile mode. Mirror deleteProfile.
+  if (fromName === 'default' || fromName === 'project-default') {
+    throw new ProfileValidationError(['cannot rename the default profile'])
+  }
   const source = getProfile(projectPath, fromName, expectedProvider)
   assertValidName(toName)
   if (fs.existsSync(profilePath(projectPath, toName))) {

--- a/server/profiles-router.ts
+++ b/server/profiles-router.ts
@@ -11,6 +11,7 @@ import {
   deleteProfile,
   duplicateProfile,
   getProfile,
+  getProfileRaw,
   listProfiles,
   renameProfile,
   resolveProfile,
@@ -776,7 +777,11 @@ export function createProfilesRouter(): Router {
   router.get('/:name', (req, res) => {
     try {
       const { project } = ctx(req)
-      res.json({ profile: getProfile(specRoot(project), req.params.name, project.provider ?? 'claude') })
+      // Non-validating read so a profile that drifted invalid against the current
+      // catalog can still be opened + repaired in the editor (getProfile threw and
+      // locked it out). The body + validation errors are both returned.
+      const { profile, valid, errors } = getProfileRaw(specRoot(project), req.params.name, project.provider ?? 'claude')
+      res.json({ profile, valid, validationErrors: errors })
     } catch (err) {
       handleError(res, err)
     }

--- a/server/terminal-manager.test.ts
+++ b/server/terminal-manager.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { EventEmitter } from 'events'
+import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import {
@@ -106,19 +107,23 @@ describe('RingBuffer', () => {
 })
 
 describe('shell resolution', () => {
-  it('uses $SHELL when set', () => {
+  it('uses $SHELL when set AND it exists', () => {
+    if (process.platform === 'win32') return
     const prev = process.env.SHELL
-    process.env.SHELL = '/bin/custom-shell'
-    expect(resolveShell()).toBe('/bin/custom-shell')
+    process.env.SHELL = '/bin/sh' // POSIX-guaranteed to exist
+    expect(resolveShell()).toBe('/bin/sh')
     if (prev === undefined) delete process.env.SHELL
     else process.env.SHELL = prev
   })
 
-  it('falls back on macOS/Linux', () => {
+  it('falls back to an existing shell on macOS/Linux (existence-gated)', () => {
     const prev = process.env.SHELL
     delete process.env.SHELL
     if (process.platform !== 'win32') {
-      expect(resolveShell()).toBe('/bin/zsh')
+      // Returns the first existing candidate; /bin/sh is the POSIX-mandated floor.
+      const resolved = resolveShell()
+      expect(['/bin/zsh', '/bin/bash', '/usr/bin/bash', '/bin/sh']).toContain(resolved)
+      expect(fs.existsSync(resolved)).toBe(true)
     }
     if (prev) process.env.SHELL = prev
   })
@@ -135,9 +140,14 @@ describe('shell resolution', () => {
 })
 
 describe('resolveShellFor (injectable, cross-platform)', () => {
-  it('prefers $SHELL when set on POSIX (trimmed)', () => {
-    expect(resolveShellFor('darwin', { SHELL: '  /bin/zsh  ' }, () => false)).toBe('/bin/zsh')
-    expect(resolveShellFor('linux', { SHELL: '/usr/bin/fish' }, () => false)).toBe('/usr/bin/fish')
+  it('prefers $SHELL when set AND it exists on POSIX (trimmed)', () => {
+    expect(resolveShellFor('darwin', { SHELL: '  /bin/zsh  ' }, (p) => p === '/bin/zsh')).toBe('/bin/zsh')
+    expect(resolveShellFor('linux', { SHELL: '/usr/bin/fish' }, (p) => p === '/usr/bin/fish')).toBe('/usr/bin/fish')
+  })
+
+  it('ignores a $SHELL that does not exist and falls through the existence-gated chain', () => {
+    // $SHELL set but missing → fall to the first existing candidate.
+    expect(resolveShellFor('linux', { SHELL: '/opt/gone/fish' }, (p) => p === '/bin/bash')).toBe('/bin/bash')
   })
 
   it('IGNORES a POSIX-style $SHELL on Windows (Git Bash/MSYS) and uses the native chain', () => {
@@ -148,9 +158,15 @@ describe('resolveShellFor (injectable, cross-platform)', () => {
     expect(got).toBe(winPosh)
   })
 
-  it('defaults to /bin/zsh on macOS and Linux', () => {
-    expect(resolveShellFor('darwin', {}, () => false)).toBe('/bin/zsh')
-    expect(resolveShellFor('linux', {}, () => false)).toBe('/bin/zsh')
+  it('prefers /bin/zsh when it exists on POSIX', () => {
+    expect(resolveShellFor('darwin', {}, (p) => p === '/bin/zsh')).toBe('/bin/zsh')
+  })
+
+  it('existence-gates the POSIX fallback chain and ends at /bin/sh', () => {
+    // No candidate exists → POSIX-mandated /bin/sh (was an unspawnable /bin/zsh).
+    expect(resolveShellFor('linux', {}, () => false)).toBe('/bin/sh')
+    // /bin/zsh absent but /bin/bash present → bash.
+    expect(resolveShellFor('linux', {}, (p) => p === '/bin/bash')).toBe('/bin/bash')
   })
 
   it('on Windows prefers pwsh.exe found on PATH', () => {

--- a/server/terminal-manager.test.ts
+++ b/server/terminal-manager.test.ts
@@ -423,9 +423,11 @@ describe('TerminalManager lifecycle', () => {
     const a = tm2.create('proj-A', { cwd: os.tmpdir() })
     const b = tm2.create('proj-A', { cwd: os.tmpdir() })
     const c = tm2.create('proj-A', { cwd: os.tmpdir() })
-    expect(a.name).toBe('zsh')
-    expect(b.name).toBe('zsh (2)')
-    expect(c.name).toBe('zsh (3)')
+    // The auto-name base is the RESOLVED shell's basename (existence-gated, so
+    // it may be bash/sh on a host without zsh — assert the suffix RELATIONSHIP,
+    // not a hardcoded 'zsh' which couples to the OS shell set).
+    expect(b.name).toBe(`${a.name} (2)`)
+    expect(c.name).toBe(`${a.name} (3)`)
     void tm2.shutdown()
     if (prev === undefined) delete process.env.SHELL
     else process.env.SHELL = prev

--- a/server/terminal-manager.ts
+++ b/server/terminal-manager.ts
@@ -79,8 +79,8 @@ export function resolveShellFor(
   // Honor $SHELL only on POSIX. On Windows $SHELL is not native but is commonly
   // exported by Git Bash/MSYS2 as a Unix path (e.g. /usr/bin/bash) that ConPTY
   // cannot spawn — so on win32 ignore it and fall through to pwsh→powershell→cmd.
-  const envShell = env.SHELL
-  if (platform !== 'win32' && envShell && envShell.trim().length > 0) return envShell.trim()
+  const envShell = env.SHELL?.trim()
+  if (platform !== 'win32' && envShell && exists(envShell)) return envShell
   if (platform === 'win32') {
     for (const dir of (env.PATH ?? '').split(';')) {
       if (!dir) continue
@@ -92,7 +92,12 @@ export function resolveShellFor(
     if (exists(winPosh)) return winPosh
     return env.COMSPEC || 'cmd.exe'
   }
-  return '/bin/zsh'
+  // POSIX: existence-gate the fallback chain. A host without /bin/zsh (most
+  // Linux) would otherwise get an unspawnable shell. /bin/sh is POSIX-mandated.
+  for (const candidate of ['/bin/zsh', '/bin/bash', '/usr/bin/bash', '/bin/sh']) {
+    if (exists(candidate)) return candidate
+  }
+  return '/bin/sh'
 }
 
 export function shellArgs(shell: string): string[] {

--- a/server/types.ts
+++ b/server/types.ts
@@ -829,6 +829,11 @@ export interface PluginProviderSupportEntry {
 export interface PluginLifecycleContext {
   projectPath: string
   projectId: string
+  /** Canonical ProjectRegistry slug — the SAME slug every other per-project
+   *  `~/.specrails/projects/<slug>/` path uses (codex-home etc.). Plugins MUST
+   *  prefer this over deriving a slug from the path basename, which collides
+   *  between same-basename projects and points CODEX_HOME at the wrong dir. */
+  slug?: string
   /** Provider id of the project the install is targeting. Plugins use this
    *  to decide between the project-json MCP merge path (claude) and the
    *  `<binary> mcp add` cli-add path (codex). Optional for backwards compat;


### PR DESCRIPTION
Second audit batch: 10 adversarially-confirmed bugs across Jira, plugins, terminal, profiles.

| # | Sev | Bug |
|---|-----|-----|
| H6 | High | Jira DC poll capped at first 100 issues (no pagination) |
| H7 | High | Jira high-water TZ gap (UTC string vs account-TZ) → use relative JQL |
| H5 | High | plugin slug from path.basename collides (codex CODEX_HOME) |
| H8 | High | POSIX terminal shell fallback not existence-gated |
| M8 | Med | invalid profile can't be opened/repaired |
| L3 | Low | codex mcp add not rolled back on verify fail |
| L6 | Low | default profile can be renamed away |
| L14 | Low | Retry-After:0 dropped to backoff |
| L15 | Low | comment dedup only scans first page |
| L16 | Low | high-water advanced past frozen issues |

typecheck + server coverage (159 files) pass. (Setup-relocation bugs M6/L4/L5 deferred to batch 3.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)