### PR TITLE
fix(audit): batch 3 — chat/explore, tickets/contract, setup (9 bugs)

### DIFF
--- a/server/artifact-registry.ts
+++ b/server/artifact-registry.ts
@@ -416,17 +416,22 @@ function buildMirroredEntry(
   existing: ProjectEntry | undefined,
   canon: string,
   desiredSlug: string,
-  input: { providers: string[]; primaryProvider: string; coreVersion?: string; desktopProjectId?: string },
+  input: { providers: string[]; primaryProvider: string; providersExplicit: boolean; coreVersion?: string; desktopProjectId?: string },
   now: string,
   touchInstall: boolean,
   home?: string,
 ): ProjectEntry {
   let entry: ProjectEntry
   if (existing) {
+    // Preserve the existing provider set on a metadata-only re-mirror (e.g. the
+    // install step re-mirrors with no providers arg → normalizeProviders defaults
+    // to ['claude']). Narrowing a multi-provider entry to claude-only would give
+    // a concurrent core-standalone reader the wrong contract until next boot.
+    // Only adopt the input providers when the caller EXPLICITLY supplied them.
     entry = {
       ...existing,
-      providers: input.providers,
-      primaryProvider: input.primaryProvider,
+      providers: input.providersExplicit ? input.providers : existing.providers,
+      primaryProvider: input.providersExplicit ? input.primaryProvider : existing.primaryProvider,
       coreVersion: input.coreVersion ?? existing.coreVersion,
       source: 'desktop',
       createdAt: existing.createdAt ?? now,
@@ -479,7 +484,15 @@ export function mirrorProjectEntry(input: MirrorProjectInput, home?: string): Pr
       existing,
       canon,
       input.slug,
-      { providers, primaryProvider, coreVersion: input.coreVersion, desktopProjectId: input.desktopProjectId },
+      {
+        providers,
+        primaryProvider,
+        // Only treat providers as authoritative when the caller actually supplied
+        // them; a metadata-only re-mirror (no providers arg) must not narrow.
+        providersExplicit: Array.isArray(input.providers) && input.providers.length > 0,
+        coreVersion: input.coreVersion,
+        desktopProjectId: input.desktopProjectId,
+      },
       now,
       true,
       home,
@@ -645,7 +658,14 @@ export function reconcileFromProjects(projects: ReconcileProjectInput[], home?: 
         existing,
         canon,
         p.slug,
-        { providers, primaryProvider, coreVersion: p.coreVersion, desktopProjectId: p.desktopProjectId },
+        {
+          providers,
+          primaryProvider,
+          // Startup reconcile from desktop.sqlite IS authoritative for providers.
+          providersExplicit: Array.isArray(p.providers) && p.providers.length > 0,
+          coreVersion: p.coreVersion,
+          desktopProjectId: p.desktopProjectId,
+        },
         now,
         false,
         home,

--- a/server/chat-manager.ts
+++ b/server/chat-manager.ts
@@ -867,6 +867,12 @@ export class ChatManager {
               })
               currentChild = newChild
               args = respawnArgs
+              // Reset the per-turn accumulators so the resumed turn REPLACES the
+              // pre-crash partial output instead of appending to it (which would
+              // duplicate the assistant text and double-count tokens/cost).
+              this._buffers.set(conversationId, '')
+              this._streamFilters.set(conversationId, { inBlock: false, pendingTail: '' })
+              adapterEvents.length = 0
               this._activeProcesses.set(conversationId, newChild)
               newChild.stderr?.on('data', (chunk: Buffer) => {
                 const text = chunk.toString()
@@ -1177,6 +1183,14 @@ export class ChatManager {
         this._abortingConversations.delete(conversationId)
         markStreamingEnded(true)
         recordInv(wasAborting ? 'aborted' : 'success')
+
+        // On abort, the abort() path already emitted chat_error and the turn is
+        // user-cancelled — do NOT persist the partial assistant message, update
+        // the session, or broadcast chat_done (mirrors the legacy close handler).
+        if (wasAborting) {
+          resolve()
+          return
+        }
 
         const parsed = parseSpecDraftBlocks(fullText)
         const persistedText = parsed.blocks.length > 0 ? parsed.stripped : fullText

--- a/server/explore-stdin-session.ts
+++ b/server/explore-stdin-session.ts
@@ -128,11 +128,22 @@ export class ExploreStdinSessions {
     if (s) s.handlers = null
   }
 
-  /** Write one framed user turn to the persistent child's stdin. */
+  /**
+   * Write one framed user turn to the persistent child's stdin. Returns false
+   * ONLY when the data cannot be enqueued at all (no session / no stdin /
+   * destroyed). `stream.write()` returning false means BACKPRESSURE (the bytes
+   * are buffered and flush on 'drain') — NOT failure — so we must not treat it
+   * as a dead child and fail the turn. Any non-throwing write is a success.
+   */
   writeTurn(id: string, text: string): boolean {
     const s = this._sessions.get(id)
     if (!s || !s.child.stdin || s.child.stdin.destroyed) return false
-    return s.child.stdin.write(frameStreamJsonUserMessage(text))
+    try {
+      s.child.stdin.write(frameStreamJsonUserMessage(text)) // ignore backpressure boolean
+      return true
+    } catch {
+      return false
+    }
   }
 
   /** Kill and forget one conversation's persistent child (idempotent). */

--- a/server/project-router-chat.ts
+++ b/server/project-router-chat.ts
@@ -215,8 +215,23 @@ export function registerChatRoutes(deps: ProjectRoutesDeps): void {
     if (!conversation) { res.status(404).json({ error: 'Conversation not found' }); return }
     const { title, model } = req.body ?? {}
     const patch: { title?: string; model?: string } = {}
-    if (title !== undefined) patch.title = title
-    if (model !== undefined) patch.model = model
+    if (title !== undefined) {
+      if (typeof title !== 'string') { res.status(400).json({ error: 'title must be a string' }); return }
+      patch.title = title
+    }
+    if (model !== undefined) {
+      // Validate against the conversation's own provider so a bad value can't be
+      // persisted and break the next turn's spawn. (Mirrors the POST handler.)
+      const convProvider = (conversation.provider as SpecProvider | null) ?? ('claude' as SpecProvider)
+      if (typeof model !== 'string' || !isValidModelForProvider(model, convProvider)) {
+        res.status(400).json({
+          error: `Invalid model "${String(model)}" for provider "${convProvider}"`,
+          allowed: getModelsForProvider(convProvider).map((m) => m.value),
+        })
+        return
+      }
+      patch.model = model
+    }
     updateConversation(db, req.params.id as string, patch)
     const updated = getConversation(db, req.params.id as string) as ChatConversationRow
     res.json({ ok: true, conversation: updated })

--- a/server/project-router-tickets.ts
+++ b/server/project-router-tickets.ts
@@ -774,11 +774,20 @@ export function registerTicketsRoutes(deps: ProjectRoutesDeps): void {
           flippedInPlace = true
           return
         }
-        // Idempotent on conversationId: if a draft ticket already references this
-        // conversation, update in place rather than create a second one.
-        const existing = Object.values(s.tickets).find(
-          (t) => t.origin_conversation_id === conversationId && t.status === 'draft',
+        // Idempotent on conversationId. A ticket from this conversation may
+        // already exist as a DRAFT (update in place) OR as a COMMITTED ticket
+        // (it was already turned into a real spec) — in the latter case do NOT
+        // insert a duplicate draft sharing the same origin_conversation_id
+        // (which would also break the delete→conversation cascade). Return the
+        // committed ticket unchanged instead.
+        const anyExisting = Object.values(s.tickets).find(
+          (t) => t.origin_conversation_id === conversationId,
         )
+        if (anyExisting && anyExisting.status !== 'draft') {
+          saved = anyExisting
+          return
+        }
+        const existing = anyExisting && anyExisting.status === 'draft' ? anyExisting : undefined
         const title = providedTitle || existing?.title || generateAutoTitle(messages.map((m) => ({ role: m.role, content: m.content ?? '' })))
         if (existing) {
           existing.title = title
@@ -909,8 +918,16 @@ export function registerTicketsRoutes(deps: ProjectRoutesDeps): void {
         let flipTarget: Ticket | undefined
         if (draftTicketId !== null) {
           flipTarget = s.tickets[String(draftTicketId)]
-          if (!flipTarget || flipTarget.status !== 'draft') {
+          if (!flipTarget) {
             explicitDraftMissing = true
+            return
+          }
+          if (flipTarget.status !== 'draft') {
+            // Already committed (lost-response retry / second tab / watchdog
+            // re-fire): return the committed ticket idempotently instead of a
+            // spurious 404. The draft was flipped on the first call.
+            created = flipTarget
+            wasFlip = true
             return
           }
         } else if (conversationId) {
@@ -1038,7 +1055,13 @@ export function registerTicketsRoutes(deps: ProjectRoutesDeps): void {
       // are checked inside runContractRefine. Claude-only today — codex
       // contract refine isn't wired (the spawn hardcodes the `claude`
       // binary). Skip silently on codex projects.
-      if (conversationId && created && project.provider === 'claude') {
+      // Gate on the CONVERSATION's own engine, not the project's PRIMARY
+      // provider: a multi-provider project with a non-claude primary can still
+      // run an Explore on the claude engine + opt into Contract Refine.
+      const convoProvider = conversationId
+        ? (getConversation(ctx(req).db, conversationId)?.provider ?? 'claude')
+        : null
+      if (conversationId && created && convoProvider === 'claude') {
         const createdTicketId = created.id
         const convoId = conversationId
         console.log(`[project-router] from-draft hook: scheduling refine ticket=${createdTicketId} conv=${convoId}`)
@@ -1058,9 +1081,9 @@ export function registerTicketsRoutes(deps: ProjectRoutesDeps): void {
             console.error('[project-router] runContractRefine error:', err)
           })
         })
-      } else if (conversationId && created && project.provider === 'codex') {
+      } else if (conversationId && created && convoProvider && convoProvider !== 'claude') {
         console.log(
-          `[project-router] from-draft contract refine skipped for codex project (ticket #${created.id})`,
+          `[project-router] from-draft contract refine skipped for ${convoProvider} conversation (ticket #${created.id})`,
         )
       }
     } catch (err) {

--- a/server/project-router.test.ts
+++ b/server/project-router.test.ts
@@ -2703,7 +2703,7 @@ describe('project-router', () => {
   // ─── PATCH conversation model ──────────────────────────────────────────────
 
   describe('PATCH /:projectId/chat/conversations/:id model update', () => {
-    it('updates model on a conversation', async () => {
+    it('updates model on a conversation with a valid model', async () => {
       const ctx = makeContext(db)
       const { app } = createApp(new Map([['proj-1', ctx]]))
       const createRes = await request(app)
@@ -2712,9 +2712,35 @@ describe('project-router', () => {
       const convId = createRes.body.conversation.id
       const res = await request(app)
         .patch(`/api/projects/proj-1/chat/conversations/${convId}`)
-        .send({ model: 'claude-3-haiku' })
+        .send({ model: 'haiku' })
       expect(res.status).toBe(200)
       expect(res.body.ok).toBe(true)
+    })
+
+    it('rejects an invalid model with 400 (no longer persists garbage)', async () => {
+      const ctx = makeContext(db)
+      const { app } = createApp(new Map([['proj-1', ctx]]))
+      const createRes = await request(app)
+        .post('/api/projects/proj-1/chat/conversations')
+        .send({ model: 'sonnet' })
+      const convId = createRes.body.conversation.id
+      const res = await request(app)
+        .patch(`/api/projects/proj-1/chat/conversations/${convId}`)
+        .send({ model: 'not-a-real-model' })
+      expect(res.status).toBe(400)
+    })
+
+    it('rejects a non-string title with 400', async () => {
+      const ctx = makeContext(db)
+      const { app } = createApp(new Map([['proj-1', ctx]]))
+      const createRes = await request(app)
+        .post('/api/projects/proj-1/chat/conversations')
+        .send({ model: 'sonnet' })
+      const convId = createRes.body.conversation.id
+      const res = await request(app)
+        .patch(`/api/projects/proj-1/chat/conversations/${convId}`)
+        .send({ title: { not: 'a string' } })
+      expect(res.status).toBe(400)
     })
   })
 

--- a/server/setup-manager.ts
+++ b/server/setup-manager.ts
@@ -755,6 +755,10 @@ export class SetupManager {
   private _checkpoints: Map<string, Map<string, CheckpointStatus>>
   // Track checkpoint start times
   private _checkpointStart: Map<string, Map<string, number>>
+  // Project ids whose install/enrich was explicitly aborted — the close handler
+  // checks this to suppress a spurious setup_error / double onSetupDone when the
+  // SIGTERM'd child closes with a null exit code.
+  private _abortedProjects: Set<string> = new Set()
   // Ring buffer for install log lines — allows clients to recover log on reconnect
   private _installLogBuffer: Map<string, string[]>
   // Track each project's chosen AI provider for binary selection
@@ -786,6 +790,7 @@ export class SetupManager {
   // ─── Full Install: TUI installer (npx specrails-core) ────────────────────────
 
   startInstall(projectId: string, projectPath: string, projectSlug?: string, provider?: string): void {
+    this._abortedProjects.delete(projectId) // fresh run — clear any prior abort flag
     if (this._installProcesses.has(projectId)) {
       console.warn(`[SetupManager] install already running for ${projectId}`)
       return
@@ -982,6 +987,9 @@ export class SetupManager {
         try { rmSync(spawnConfigPath, { force: true }) } catch { /* non-fatal */ }
       }
       this._installProcesses.delete(projectId)
+      // Explicit abort already tore down + fired onSetupDone — don't surface a
+      // spurious setup_error for the SIGTERM'd child's null exit.
+      if (this._abortedProjects.has(projectId)) return
       if (code === 0) {
         const validation = validateInstalledCore(projectPath)
         if (!validation.ok) {
@@ -1022,6 +1030,7 @@ export class SetupManager {
   // ─── Enrich: claude -p "/specrails:enrich --from-config" ────────────────────
 
   startEnrich(projectId: string, projectPath: string, provider?: ProviderId, projectName?: string): void {
+    this._abortedProjects.delete(projectId) // fresh run — clear any prior abort flag
     if (this._setupProcesses.has(projectId)) {
       console.warn(`[SetupManager] enrich already running for ${projectId}`)
       return
@@ -1279,6 +1288,9 @@ export class SetupManager {
     child.on('close', (code) => {
       this._setupProcesses.delete(projectId)
       this._stopFilesystemPoll(projectId)
+      // Explicit abort already tore down + fired onSetupDone — suppress the
+      // failure branch (spurious error + a second onSetupDone) here.
+      if (this._abortedProjects.has(projectId)) return
 
       // Final filesystem sync
       this._syncFilesystemCheckpoints(projectId, projectPath)
@@ -1432,6 +1444,10 @@ export class SetupManager {
   // ─── Abort ────────────────────────────────────────────────────────────────────
 
   abort(projectId: string): void {
+    // Mark aborted so the still-registered close handlers suppress their failure
+    // branch (spurious setup_error + a second onSetupDone) when the SIGTERM'd
+    // child closes with a null code. Cleared on the next startInstall/startEnrich.
+    this._abortedProjects.add(projectId)
     this._stopFilesystemPoll(projectId)
     this._projectProviders.delete(projectId)
     this._projectTiers.delete(projectId)


### PR DESCRIPTION
Third audit batch: 9 confirmed bugs (chat/explore, tickets/contract, registry/setup).

| # | Sev | Bug |
|---|-----|-----|
| H3 | High | persistent-stdin misreads backpressure as dead child |
| M2 | Med | crash respawn duplicates response + double-counts cost |
| M3 | Med | finishTurn persists/chat_done after abort |
| M7 | Med | PATCH chat persists unvalidated model/title |
| L8 | Low | contract-refine gated on primary not conversation engine |
| L9 | Low | from-draft 404 on retry instead of idempotent return |
| L10 | Low | save-as-draft dup for already-committed conversation |
| L4 | Low | re-mirror narrows multi-provider registry to claude |
| L5 | Low | abort broadcasts spurious setup_error + double onSetupDone |

typecheck + server coverage (159 files) pass. M6 (setup repo-vs-workspace) → batch 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)