### PR TITLE
fix(audit): batch 5 — client per-project isolation + overlays (5 bugs)

### DIFF
--- a/client/src/components/SplitViewShell.tsx
+++ b/client/src/components/SplitViewShell.tsx
@@ -91,6 +91,23 @@ export function SplitViewShell({
     [handleDividerMove, handleDividerUp],
   )
 
+  // Unmount safety net: if the shell unmounts MID-DRAG (project switch dispatches
+  // closeAll, sub-900px resize dispatches exitSplit — neither fires pointerup),
+  // the window listeners added on pointerdown would leak and keep dispatching
+  // onSetRatio. Remove them unconditionally on unmount.
+  useEffect(() => {
+    return () => {
+      window.removeEventListener('pointermove', handleDividerMove)
+      window.removeEventListener('pointerup', handleDividerUp)
+      window.removeEventListener('pointercancel', handleDividerUp)
+      const drag = dragRef.current
+      if (drag) {
+        try { drag.element.releasePointerCapture(drag.pointerId) } catch { /* already released */ }
+        dragRef.current = null
+      }
+    }
+  }, [handleDividerMove, handleDividerUp])
+
   const handleDividerKey = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {
       const step = 0.04

--- a/client/src/hooks/useActivity.ts
+++ b/client/src/hooks/useActivity.ts
@@ -84,6 +84,9 @@ export function useActivity({ activeProjectId, limit = 50 }: UseActivityOpts): U
     if (loading || !hasMore) return
     setLoading(true)
     const base = getApiBase()
+    // Pin the project this pagination belongs to; if the user switches before
+    // the response lands, drop it so we don't splice project A's items into B.
+    const requestProjectId = activeProjectIdRef.current
     try {
       setItems((prev) => {
         const oldest = prev[prev.length - 1]
@@ -93,6 +96,7 @@ export function useActivity({ activeProjectId, limit = 50 }: UseActivityOpts): U
         fetch(`${base}/activity?limit=${limit}&before=${before}`)
           .then((res) => res.json())
           .then((data: ActivityItem[]) => {
+            if (activeProjectIdRef.current !== requestProjectId) { setLoading(false); return }
             setItems((cur) => dedupeItems([...cur, ...data]))
             setHasMore(data.length === limit)
             setLoading(false)

--- a/client/src/hooks/useCompareUrlSync.ts
+++ b/client/src/hooks/useCompareUrlSync.ts
@@ -26,6 +26,16 @@ export function useCompareUrlSync() {
   useEffect(() => {
     if (didRestoreRef.current) return
     if (tickets.length === 0) return // wait for tickets to load
+
+    // Viewport too narrow → keep the params for a later (wide) restore and do
+    // NOT mark restored: marking it would let the write-effect below run, see
+    // inSplit=false + hadCompare=true, and permanently STRIP the params (so a
+    // rotate-back-to-wide could never restore the comparison).
+    const compareRawEarly = new URLSearchParams(location.search).get('compare')
+    if (compareRawEarly && typeof window !== 'undefined' && window.innerWidth < 900) {
+      return
+    }
+
     didRestoreRef.current = true
 
     const params = new URLSearchParams(location.search)
@@ -35,11 +45,6 @@ export function useCompareUrlSync() {
 
     const compareId = Number.parseInt(compareRaw, 10)
     const originSide = sideRaw === 'right' ? 'right' : 'left'
-
-    if (typeof window !== 'undefined' && window.innerWidth < 900) {
-      // Viewport too narrow → ignore; keep param for later
-      return
-    }
 
     const exists = tickets.some((t) => t.id === compareId)
     if (!exists) {

--- a/client/src/hooks/usePipeline.ts
+++ b/client/src/hooks/usePipeline.ts
@@ -158,11 +158,16 @@ export function usePipeline(activeProjectId?: string | null) {
   // Fetch initial state for this project via REST (WS init only fires on connect)
   useEffect(() => {
     if (!activeProjectId) return
+    // Guard against a project switch resolving an in-flight fetch into the wrong
+    // project: A's /state could land after the user switched to B and overwrite
+    // B's live state. Bail on resolve if this effect was cleaned up.
+    let cancelled = false
     async function fetchState() {
       try {
         const res = await fetch(`${getApiBase()}/state`)
-        if (!res.ok) return
+        if (cancelled || !res.ok) return
         const msg = await res.json()
+        if (cancelled) return
         if (msg.projectName) setProjectName(msg.projectName)
         if (msg.phaseDefinitions) {
           setPhaseDefinitions(msg.phaseDefinitions)
@@ -179,6 +184,7 @@ export function usePipeline(activeProjectId?: string | null) {
       }
     }
     fetchState()
+    return () => { cancelled = true }
   }, [activeProjectId])
 
   return { phases, phaseDefinitions, projectName, logLines, connectionStatus, recentJobs, queueState }

--- a/client/src/hooks/useSpecGenTracker.tsx
+++ b/client/src/hooks/useSpecGenTracker.tsx
@@ -226,8 +226,14 @@ export function SpecGenTrackerProvider({ children }: { children: ReactNode }) {
     if (msg.type !== 'ticket_created' && msg.type !== 'ticket_updated') return
     const ticket = msg.ticket as LocalTicket | undefined
     if (!ticket) return
+    const eventProjectId = msg.projectId as string | undefined
 
     for (const [convId, spec] of exploreRef.current.entries()) {
+      // Only consider specs belonging to the project that emitted the ticket
+      // event — a ticket in project B almost never matches A's knownTicketIds,
+      // which previously triggered spurious cross-project polls (and a premature
+      // "couldn't find" drop of A's still-pending spec).
+      if (eventProjectId && spec.projectId !== eventProjectId) continue
       if (!spec.knownTicketIds.has(ticket.id)) {
         pollForNewTicket(spec, convId)
       }


### PR DESCRIPTION
Audit batch 5 (client).

| # | Sev | Bug |
|---|-----|-----|
| M16 | Med | usePipeline /state resolves into wrong project on switch |
| M17 | Med | useActivity loadMore splices wrong project's page |
| L20 | Low | SpecGenTracker cross-project poll triggering |
| M18 | Med | narrow-viewport refresh wipes ?compare params |
| L1 | Low | SplitViewShell leaks window pointer listeners mid-drag unmount |

typecheck + client coverage (230 files) pass. **Remaining: M6 (setup repo-vs-workspace), M14 (WebRTC multi-room offers) → final batch.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)