### PR TITLE
fix(audit): batch 6 — setup workspace artifacts + WebRTC multi-room (2 bugs)

### DIFF
--- a/server/mobile/mobile-gateway.ts
+++ b/server/mobile/mobile-gateway.ts
@@ -220,8 +220,8 @@ export class MobileGateway {
       signalBase,
       doFetch: (url, init) => fetch(url, init),
       rooms: () => listDevices(this._db).filter((d) => !d.revoked).map((d) => d.id),
-      makeOffer: () => this.webrtcOffer(),
-      acceptAnswer: (sdp) => this.webrtcAnswer(sdp),
+      makeOffer: (room) => this.webrtcOffer(room),
+      acceptAnswer: (room, sdp) => this.webrtcAnswer(sdp, room),
     })
     this._signal.start()
   }
@@ -257,17 +257,20 @@ export class MobileGateway {
   /** Open a serverless WebRTC pairing offer (for the first QR). Returns the offer
    *  SDP + a single-use secret + the desktop identity; the webview encodes these
    *  into the QR the companion scans. */
-  async webrtcOffer(): Promise<{ sdp: string; secret: string; hubName: string; hubInstanceId: string } | null> {
+  async webrtcOffer(room?: string): Promise<{ sdp: string; secret: string; hubName: string; hubInstanceId: string } | null> {
     if (!this._webrtc) return null
     const secret = randomBytes(16).toString('base64url')
-    const { sdp } = await this._webrtc.createOffer(secret)
+    // Per-room slot for reconnect (room = device id); undefined ⇒ the QR slot.
+    const { sdp } = room !== undefined ? await this._webrtc.createOffer(secret, room) : await this._webrtc.createOffer(secret)
     return { sdp, secret, hubName: this.desktopName(), hubInstanceId: this.instanceId() }
   }
 
-  /** Apply the companion's scanned answer SDP to the open offer. */
-  async webrtcAnswer(sdp: string): Promise<boolean> {
+  /** Apply the companion's scanned answer SDP to the open offer (per-room slot
+   *  for reconnect; the QR slot when no room given). */
+  async webrtcAnswer(sdp: string, room?: string): Promise<boolean> {
     if (!this._webrtc) return false
-    return (await this._webrtc.acceptAnswer(sdp)).ok
+    const res = room !== undefined ? await this._webrtc.acceptAnswer(sdp, room) : await this._webrtc.acceptAnswer(sdp)
+    return res.ok
   }
 }
 

--- a/server/mobile/mobile-signal-reconnect.test.ts
+++ b/server/mobile/mobile-signal-reconnect.test.ts
@@ -47,7 +47,32 @@ describe('MobileSignalReconnect', () => {
 
     store.set('dev-1:answer', JSON.stringify({ sdp: 'ANSWER_SDP' })) // phone answers
     await r.poll()
-    expect(acceptAnswer).toHaveBeenCalledWith('ANSWER_SDP')
+    expect(acceptAnswer).toHaveBeenCalledWith('dev-1', 'ANSWER_SDP')
+  })
+
+  it('routes per-room offers/answers when two devices reconnect in one cycle (M14)', async () => {
+    const { store, doFetch } = fakeMailbox()
+    const makeOffer = vi.fn(async (room: string) => ({
+      sdp: `OFFER_${room}`, secret: `sec_${room}`, hubName: 'Mac', hubInstanceId: 'inst-1',
+    }))
+    const acceptAnswer = vi.fn(async () => true)
+    const r = new MobileSignalReconnect({
+      signalBase: 'http://h/s.php', doFetch, rooms: () => ['dev-A', 'dev-B'], makeOffer, acceptAnswer,
+    })
+    store.set('dev-A:req', '1')
+    store.set('dev-B:req', '1')
+    await r.poll()
+    // Each room gets its OWN offer (no clobber).
+    expect(makeOffer).toHaveBeenCalledWith('dev-A')
+    expect(makeOffer).toHaveBeenCalledWith('dev-B')
+    expect(JSON.parse(store.get('dev-A:offer') ?? '{}')).toMatchObject({ sdp: 'OFFER_dev-A' })
+    expect(JSON.parse(store.get('dev-B:offer') ?? '{}')).toMatchObject({ sdp: 'OFFER_dev-B' })
+    // Answers route back to the correct room.
+    store.set('dev-A:answer', JSON.stringify({ sdp: 'ANS_A' }))
+    store.set('dev-B:answer', JSON.stringify({ sdp: 'ANS_B' }))
+    await r.poll()
+    expect(acceptAnswer).toHaveBeenCalledWith('dev-A', 'ANS_A')
+    expect(acceptAnswer).toHaveBeenCalledWith('dev-B', 'ANS_B')
   })
 
   it('does nothing when the mailbox is empty', async () => {

--- a/server/mobile/mobile-signal-reconnect.ts
+++ b/server/mobile/mobile-signal-reconnect.ts
@@ -20,10 +20,11 @@ export interface SignalReconnectDeps {
   doFetch: (url: string, init?: { method?: string; body?: string }) => Promise<SignalFetchResult>
   /** Active (non-revoked) device ids — each is a mailbox "room". */
   rooms: () => string[]
-  /** Create a fresh offer + its single-use secret (and the desktop identity). */
-  makeOffer: () => Promise<{ sdp: string; secret: string; hubName: string; hubInstanceId: string } | null>
-  /** Apply the companion's answer SDP to the open offer. */
-  acceptAnswer: (sdp: string) => Promise<boolean>
+  /** Create a fresh offer + its single-use secret (and the desktop identity) for
+   *  a specific room, so concurrent rooms don't clobber each other's offers. */
+  makeOffer: (room: string) => Promise<{ sdp: string; secret: string; hubName: string; hubInstanceId: string } | null>
+  /** Apply the companion's answer SDP to that room's open offer. */
+  acceptAnswer: (room: string, sdp: string) => Promise<boolean>
 }
 
 export class MobileSignalReconnect {
@@ -55,7 +56,7 @@ export class MobileSignalReconnect {
           // A phone asking to reconnect? → answer with a fresh offer.
           const req = await this._get(room, 'req')
           if (req !== null) {
-            const offer = await this._deps.makeOffer()
+            const offer = await this._deps.makeOffer(room)
             if (offer) {
               await this._post(
                 room,
@@ -69,7 +70,7 @@ export class MobileSignalReconnect {
           if (ans) {
             try {
               const parsed = JSON.parse(ans) as { sdp?: unknown }
-              if (typeof parsed.sdp === 'string') await this._deps.acceptAnswer(parsed.sdp)
+              if (typeof parsed.sdp === 'string') await this._deps.acceptAnswer(room, parsed.sdp)
             } catch {
               /* malformed answer — ignore */
             }

--- a/server/mobile/mobile-webrtc-peer.ts
+++ b/server/mobile/mobile-webrtc-peer.ts
@@ -20,23 +20,33 @@ interface PendingOffer {
   secret: string
 }
 
+/** Default slot for the QR-pairing flow (a single un-keyed offer at a time). */
+const QR_KEY = '__qr__'
+
 export class MobileWebrtcGateway {
-  private _pending: PendingOffer | null = null
+  // Pending (un-answered) offers keyed by room/device id. A single slot would be
+  // CLOBBERED when multiple devices reconnect in one poll cycle: device B's
+  // createOffer closed device A's still-open offer, and acceptAnswer applied A's
+  // answer to whatever happened to be pending. Per-room keying isolates them.
+  private _pending = new Map<string, PendingOffer>()
   private _active = new Set<RTCPeerConnection>()
 
   constructor(private _deps: MobileWebrtcGatewayDeps) {}
 
-  /** Drop the open (un-answered) offer. */
-  clearOffer(): void {
-    const p = this._pending
-    this._pending = null
-    if (p) this._close(p.pc)
+  /** Drop the open (un-answered) offer for one room (default = QR slot). */
+  clearOffer(key: string = QR_KEY): void {
+    const p = this._pending.get(key)
+    if (p) {
+      this._pending.delete(key)
+      this._close(p.pc)
+    }
   }
 
   /** Create a fresh pairing offer (peer + DataChannel + gathered offer SDP).
-   *  Replaces any previously-open offer. Returns the SDP to embed in the QR. */
-  async createOffer(secret: string): Promise<{ sdp: string }> {
-    this.clearOffer()
+   *  Replaces any previously-open offer FOR THE SAME ROOM. Returns the SDP to
+   *  embed in the QR / post to the room's mailbox. */
+  async createOffer(secret: string, key: string = QR_KEY): Promise<{ sdp: string }> {
+    this.clearOffer(key)
     const pc = new RTCPeerConnection({ iceServers: [] })
     const dc = pc.createDataChannel('mobile')
 
@@ -56,7 +66,8 @@ export class MobileWebrtcGateway {
       console.log('[webrtc] pc connectionState:', s)
       if (s === 'failed' || s === 'closed' || s === 'disconnected') {
         this._active.delete(pc)
-        if (this._pending?.pc === pc) this._pending = null
+        // Drop this pc from whichever room slot still holds it.
+        if (this._pending.get(key)?.pc === pc) this._pending.delete(key)
       }
     })
 
@@ -69,20 +80,20 @@ export class MobileWebrtcGateway {
       throw new Error('no local description after ICE gathering')
     }
     console.log(`[webrtc] offer ready: ${(sdp.match(/a=candidate/g) ?? []).length} ICE candidates`)
-    this._pending = { pc, secret }
+    this._pending.set(key, { pc, secret })
     return { sdp }
   }
 
-  /** Apply the companion's scanned answer SDP to the open offer and keep the
-   *  connection alive for the session. */
-  async acceptAnswer(sdp: string): Promise<{ ok: boolean }> {
-    const p = this._pending
+  /** Apply the companion's scanned answer SDP to the open offer FOR THE SAME ROOM
+   *  and keep the connection alive for the session. */
+  async acceptAnswer(sdp: string, key: string = QR_KEY): Promise<{ ok: boolean }> {
+    const p = this._pending.get(key)
     if (!p) return { ok: false }
     try {
       console.log(`[webrtc] applying answer: ${(sdp.match(/a=candidate/g) ?? []).length} ICE candidates`)
       await p.pc.setRemoteDescription({ type: 'answer', sdp })
       this._active.add(p.pc)
-      this._pending = null
+      this._pending.delete(key)
       return { ok: true }
     } catch {
       return { ok: false }
@@ -91,7 +102,7 @@ export class MobileWebrtcGateway {
 
   /** Tear down every peer (gateway stopping / disabled). */
   stop(): void {
-    this.clearOffer()
+    for (const key of [...this._pending.keys()]) this.clearOffer(key)
     for (const pc of this._active) this._close(pc)
     this._active.clear()
   }

--- a/server/setup-manager.ts
+++ b/server/setup-manager.ts
@@ -17,6 +17,7 @@ import { getBundledCoreCli, getBundledCoreRoot, getBundledCoreVersion } from './
 import { getBundledOpenspecCli } from './bundled-openspec'
 import { resolveBundledNodeExe } from './path-resolver'
 import { FrameworkManager } from './framework-manager'
+import { resolveProjectExecution } from './workspace-resolution'
 import type { ProviderAdapter, SpawnAction, ProviderId } from './providers/types'
 
 /**
@@ -759,6 +760,10 @@ export class SetupManager {
   // checks this to suppress a spurious setup_error / double onSetupDone when the
   // SIGTERM'd child closes with a null exit code.
   private _abortedProjects: Set<string> = new Set()
+  // projectId → registry slug (captured at startInstall) so post-install
+  // validation/summary/checkpoint reads resolve the RELOCATED workspace artifact
+  // root rather than the (pristine) repo path.
+  private _projectSlugs: Map<string, string> = new Map()
   // Ring buffer for install log lines — allows clients to recover log on reconnect
   private _installLogBuffer: Map<string, string[]>
   // Track each project's chosen AI provider for binary selection
@@ -791,6 +796,7 @@ export class SetupManager {
 
   startInstall(projectId: string, projectPath: string, projectSlug?: string, provider?: string): void {
     this._abortedProjects.delete(projectId) // fresh run — clear any prior abort flag
+    if (projectSlug) this._projectSlugs.set(projectId, projectSlug)
     if (this._installProcesses.has(projectId)) {
       console.warn(`[SetupManager] install already running for ${projectId}`)
       return
@@ -991,7 +997,10 @@ export class SetupManager {
       // spurious setup_error for the SIGTERM'd child's null exit.
       if (this._abortedProjects.has(projectId)) return
       if (code === 0) {
-        const validation = validateInstalledCore(projectPath)
+        // Relocated installs write artifacts to the workspace, not the repo —
+        // validate/sweep/summarize against the resolved artifact root.
+        const artifactRoot = this._artifactRoot(projectId, projectPath)
+        const validation = validateInstalledCore(artifactRoot)
         if (!validation.ok) {
           this._broadcast({
             type: 'setup_error',
@@ -1002,8 +1011,8 @@ export class SetupManager {
         }
         this._advanceCheckpoint(projectId, 'base_install')
         this._completeCheckpoint(projectId, 'base_install')
-        const legacySrRemoved = sweepLegacySrCommands(projectPath)
-        const summary: SetupSummary = { ...computeSummary(projectPath, tier, this._projectProviders.get(projectId) ?? 'claude'), legacySrRemoved }
+        const legacySrRemoved = sweepLegacySrCommands(artifactRoot)
+        const summary: SetupSummary = { ...computeSummary(artifactRoot, tier, this._projectProviders.get(projectId) ?? 'claude'), legacySrRemoved }
         this._broadcast({
           type: 'setup_install_done',
           projectId,
@@ -1299,19 +1308,23 @@ export class SetupManager {
         // Sync filesystem checkpoints
         this._syncFilesystemCheckpoints(projectId, projectPath)
 
+        // Relocated installs write artifacts to the workspace, not the repo —
+        // resolve the has-agents/has-commands gate + summary against it.
+        const artifactRoot = this._artifactRoot(projectId, projectPath)
+
         // Check if setup is truly complete — real artifacts must exist
-        const hasAgents = existsSync(join(projectPath, SPECRAILS_DIR, 'agents')) &&
-          hasFiles(join(projectPath, SPECRAILS_DIR, 'agents'), /^sr-.*\.md$/)
+        const hasAgents = existsSync(join(artifactRoot, SPECRAILS_DIR, 'agents')) &&
+          hasFiles(join(artifactRoot, SPECRAILS_DIR, 'agents'), /^sr-.*\.md$/)
         const hasCommands = (
-          (existsSync(join(projectPath, SPECRAILS_DIR, 'commands', 'sr')) && hasFiles(join(projectPath, SPECRAILS_DIR, 'commands', 'sr'), /\.md$/)) ||
-          (existsSync(join(projectPath, SPECRAILS_DIR, 'commands', 'specrails')) && hasFiles(join(projectPath, SPECRAILS_DIR, 'commands', 'specrails'), /\.md$/))
+          (existsSync(join(artifactRoot, SPECRAILS_DIR, 'commands', 'sr')) && hasFiles(join(artifactRoot, SPECRAILS_DIR, 'commands', 'sr'), /\.md$/)) ||
+          (existsSync(join(artifactRoot, SPECRAILS_DIR, 'commands', 'specrails')) && hasFiles(join(artifactRoot, SPECRAILS_DIR, 'commands', 'specrails'), /\.md$/))
         )
         const isComplete = hasAgents && hasCommands
 
         if (isComplete) {
-          const legacySrRemoved = sweepLegacySrCommands(projectPath)
+          const legacySrRemoved = sweepLegacySrCommands(artifactRoot)
           const tier = this._projectTiers.get(projectId) ?? 'full'
-          const summary: SetupSummary = { ...computeSummary(projectPath, tier, this._projectProviders.get(projectId) ?? 'claude'), legacySrRemoved }
+          const summary: SetupSummary = { ...computeSummary(artifactRoot, tier, this._projectProviders.get(projectId) ?? 'claude'), legacySrRemoved }
           this._onSetupDone?.(projectId)
           this._broadcast({
             type: 'setup_complete',
@@ -1399,11 +1412,26 @@ export class SetupManager {
     this._broadcast({ type: 'setup_checkpoint', projectId, checkpoint: key, status: 'done', duration_ms })
   }
 
+  /** Resolve the artifact root for post-install reads. For a RELOCATED project
+   *  (registry entry + populated workspace) the `.specrails`/provider dirs live
+   *  in the workspace, NOT the pristine repo path — `resolveProjectExecution`
+   *  returns that cwd. Falls back to the repo path (legacy) when no slug is
+   *  known or the project isn't relocated. */
+  private _artifactRoot(projectId: string, projectPath: string): string {
+    const slug = this._projectSlugs.get(projectId)
+    if (!slug) return projectPath
+    try {
+      return resolveProjectExecution({ slug, path: projectPath }).cwd
+    } catch {
+      return projectPath
+    }
+  }
+
   private _syncFilesystemCheckpoints(projectId: string, projectPath: string): void {
     const statuses = this._checkpoints.get(projectId)
     if (!statuses) return
 
-    const fsChecks = checkFilesystem(projectPath)
+    const fsChecks = checkFilesystem(this._artifactRoot(projectId, projectPath))
 
     for (const [key, exists] of Object.entries(fsChecks)) {
       if (!exists) continue
@@ -1451,6 +1479,7 @@ export class SetupManager {
     this._stopFilesystemPoll(projectId)
     this._projectProviders.delete(projectId)
     this._projectTiers.delete(projectId)
+    this._projectSlugs.delete(projectId)
     this._onSetupDone?.(projectId)
 
     const installChild = this._installProcesses.get(projectId)


### PR DESCRIPTION
Final audit batch (the 2 deferred for careful multi-site threading).

| # | Sev | Bug |
|---|-----|-----|
| M6 | Med | setup validation/summary read repo path, not relocated workspace |
| M14 | Med | single WebRTC offer slot clobbered by concurrent device reconnects |

Tests: per-room reconnect routing + 2-room isolation regression. typecheck + server coverage (159 files) pass.

**This completes the 46-bug audit fix series (PRs #436, #438, #439, #440, #441, #442, this).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)