### PR TITLE
fix(codex): surface turn.failed/error + handle command_execution (codex 0.139 schema drift)

### DIFF
--- a/server/chat-manager.test.ts
+++ b/server/chat-manager.test.ts
@@ -914,6 +914,54 @@ describe('ChatManager', () => {
     })
   })
 
+  // ─── Codex failure surfacing (codex 0.139 turn.failed/error) ───────────────
+
+  describe('codex failure surfacing', () => {
+    function codexLine(obj: Record<string, unknown>): string {
+      return JSON.stringify(obj)
+    }
+
+    it('surfaces codex turn.failed reason via chat_error and does NOT futilely respawn', async () => {
+      const convId = 'conv-codex-fail'
+      createConversation(db, { id: convId, model: 'gpt-5.5', kind: 'explore', provider: 'codex' })
+      const child = createMockChildProcess()
+      vi.mocked(mockSpawn).mockReturnValue(child as any)
+
+      const sendPromise = cm.sendMessage(convId, 'dame la siguiente mejor spec')
+      pushLine(child, codexLine({ type: 'thread.started', thread_id: 'T1' }))
+      pushLine(child, codexLine({ type: 'error', message: "You've hit your usage limit." }))
+      pushLine(child, codexLine({ type: 'turn.failed', error: { message: "You've hit your usage limit." } }))
+      await finishProcess(child, 1)
+      await sendPromise
+
+      const errs = getBroadcastedByType(broadcast, 'chat_error')
+      expect(errs).toHaveLength(1)
+      // Real reason surfaced, not a generic "Process exited with code 1".
+      expect(errs[0].error).toBe("You've hit your usage limit.")
+      // A provider-reported failure recurs on respawn — the turn must NOT retry.
+      expect(vi.mocked(mockSpawn)).toHaveBeenCalledTimes(1)
+    })
+
+    it('still crash-respawns an explore turn that dies WITHOUT an error frame', async () => {
+      // Guard: the no-respawn behaviour is gated on an explicit error frame, not
+      // on every non-zero exit. A bare crash (e.g. ENOENT mid-stream) still
+      // retries once per the existing lifecycle contract.
+      const convId = 'conv-codex-bare-crash'
+      createConversation(db, { id: convId, model: 'gpt-5.5', kind: 'explore', provider: 'codex' })
+      const first = createMockChildProcess()
+      const second = createMockChildProcess()
+      vi.mocked(mockSpawn).mockReturnValueOnce(first as any).mockReturnValueOnce(second as any)
+
+      const sendPromise = cm.sendMessage(convId, 'next spec')
+      pushLine(first, codexLine({ type: 'thread.started', thread_id: 'T2' }))
+      await finishProcess(first, 1)
+      await finishProcess(second, 1)
+      await sendPromise
+
+      expect(vi.mocked(mockSpawn)).toHaveBeenCalledTimes(2)
+    })
+  })
+
   // ─── Persistent-stdin Explore fast-path (big bet #3, flag-gated) ───────────
 
   describe('persistent-stdin Explore', () => {

--- a/server/chat-manager.ts
+++ b/server/chat-manager.ts
@@ -745,6 +745,10 @@ export class ChatManager {
     /** True iff a kind:'result' event has arrived; mirrors the legacy
      *  `lastResultEvent !== null` check that the crash-respawn guard uses. */
     let sawResult = false
+    /** Explicit failure reason emitted by the provider (codex `turn.failed` /
+     *  `error`). When set, the turn failed for a concrete reason (usage limit,
+     *  auth, model) that a respawn cannot fix — surface it instead of retrying. */
+    let capturedErrorMessage: string | null = null
     const turnStartedAt = new Date().toISOString()
 
     const stdoutReader = createInterface({ input: child.stdout!, crlfDelay: Infinity })
@@ -810,6 +814,11 @@ export class ChatManager {
             if (sid) capturedSessionId = sid
           }
           break
+        case 'error':
+          // Capture the provider's explicit failure reason. Last-wins (codex
+          // emits `error` then `turn.failed`, both carrying the same message).
+          capturedErrorMessage = ev.message
+          break
         case 'tool-use':
         case 'other':
           // No-op for ChatManager — adapter parses tool_use into the unified
@@ -836,7 +845,10 @@ export class ChatManager {
           conversation.kind === 'explore' &&
           !wasAborting &&
           code !== 0 &&
-          !sawResult
+          !sawResult &&
+          // A provider-reported failure (usage limit, auth, unsupported model)
+          // will recur identically on respawn — surface it instead of retrying.
+          !capturedErrorMessage
         ) {
           const life = this._exploreLifecycle.get(conversationId)
           if (life && life.crashCount === 0) {
@@ -1022,12 +1034,17 @@ export class ChatManager {
           }
         } else {
           const stderrTail = stderrBuf.trim().slice(-500)
+          // Prefer the provider's own failure reason (codex turn.failed/error)
+          // over the generic exit-code/stderr message.
+          const error = capturedErrorMessage
+            ? capturedErrorMessage
+            : stderrTail
+              ? `${binary} exited with code ${code ?? 'unknown'}: ${stderrTail}`
+              : `Process exited with code ${code ?? 'unknown'}`
           this._broadcast({
             type: 'chat_error',
             conversationId,
-            error: stderrTail
-              ? `${binary} exited with code ${code ?? 'unknown'}: ${stderrTail}`
-              : `Process exited with code ${code ?? 'unknown'}`,
+            error,
             timestamp: new Date().toISOString(),
           })
         }

--- a/server/providers/codex-adapter.test.ts
+++ b/server/providers/codex-adapter.test.ts
@@ -250,6 +250,47 @@ describe('codexAdapter.parseStreamLine — fixture-based', () => {
     }
   })
 
+  it('parses item.completed command_execution (codex 0.139) as tool-use', () => {
+    const ev = codexAdapter.parseStreamLine(
+      '{"type":"item.completed","item":{"id":"item_2","type":"command_execution","command":"ls -la","exit_code":0}}',
+    )
+    expect(ev?.kind).toBe('tool-use')
+    if (ev?.kind === 'tool-use') {
+      expect(ev.name).toBe('ls -la')
+      expect(ev.inputPreview).toContain('ls -la')
+    }
+  })
+
+  it('parses item.completed mcp_tool_call (codex 0.139) as tool-use', () => {
+    const ev = codexAdapter.parseStreamLine(
+      '{"type":"item.completed","item":{"id":"item_3","type":"mcp_tool_call","name":"serena.find","arguments":"{}"}}',
+    )
+    expect(ev?.kind).toBe('tool-use')
+    if (ev?.kind === 'tool-use') expect(ev.name).toBe('serena.find')
+  })
+
+  it('surfaces turn.failed (codex 0.139) as kind=error with the nested message', () => {
+    const ev = codexAdapter.parseStreamLine(
+      '{"type":"turn.failed","error":{"message":"You\'ve hit your usage limit."}}',
+    )
+    expect(ev?.kind).toBe('error')
+    if (ev?.kind === 'error') expect(ev.message).toBe("You've hit your usage limit.")
+  })
+
+  it('surfaces a standalone error frame as kind=error', () => {
+    const ev = codexAdapter.parseStreamLine(
+      '{"type":"error","message":"model gpt-5.5 is not available on your plan"}',
+    )
+    expect(ev?.kind).toBe('error')
+    if (ev?.kind === 'error') expect(ev.message).toContain('not available')
+  })
+
+  it('falls back to a generic message when turn.failed carries no error.message', () => {
+    const ev = codexAdapter.parseStreamLine('{"type":"turn.failed"}')
+    expect(ev?.kind).toBe('error')
+    if (ev?.kind === 'error') expect(ev.message).toBe('codex turn failed')
+  })
+
   it('parses turn.completed as result', () => {
     const ev = codexAdapter.parseStreamLine(
       '{"type":"turn.completed","usage":{"input_tokens":100,"output_tokens":50}}',

--- a/server/providers/codex-adapter.ts
+++ b/server/providers/codex-adapter.ts
@@ -4,10 +4,20 @@
 //   {"type":"thread.started","thread_id":"<UUID>"}
 //   {"type":"turn.started"}
 //   {"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"..."}}
-//   {"type":"item.completed","item":{"id":"item_1","type":"function_call",
-//     "name":"shell","arguments":"..."}}
+//   {"type":"item.completed","item":{"id":"item_1","type":"command_execution",
+//     "command":"…","exit_code":0}}
 //   {"type":"turn.completed","usage":{"input_tokens":N,"cached_input_tokens":N,
 //     "output_tokens":N,"reasoning_output_tokens":N}}
+//
+// Failure path (codex 0.139.0+): a failing turn (usage limit, API 4xx, network,
+// sandbox error) emits `{"type":"error","message":"…"}` then
+// `{"type":"turn.failed","error":{"message":"…"}}` and the process exits 1 —
+// there is NO `turn.completed`. Both must be surfaced as `kind:'error'` or the
+// real reason is swallowed and the user sees an empty/failed turn with no cause.
+//
+// Tool/shell items were renamed across codex versions: 0.128 emitted
+// `function_call` / `local_shell_call`; 0.139 emits `command_execution` /
+// `mcp_tool_call`. The parser matches all four for forward/backward compat.
 //
 // Codex does not emit `total_cost_usd`; cost is estimated downstream via
 // server/pricing.ts. Codex does not honour Claude's OTEL env vars; signals are
@@ -147,16 +157,39 @@ function parseCodexStreamLine(line: string): AdapterEvent | null {
     return { kind: 'result', payload: parsed }
   }
 
+  // A failed turn (codex 0.139+) emits `error` then `turn.failed` and exits 1,
+  // with no `turn.completed`. Surface the reason instead of dropping it.
+  if (type === 'turn.failed') {
+    const err = parsed.error as { message?: string } | undefined
+    return { kind: 'error', message: err?.message ?? 'codex turn failed' }
+  }
+  if (type === 'error') {
+    const msg = parsed.message as string | undefined
+    return { kind: 'error', message: msg ?? 'codex error' }
+  }
+
   if (type === 'item.completed') {
-    const item = parsed.item as { type?: string; text?: string; name?: string; arguments?: string } | undefined
+    const item = parsed.item as { type?: string; text?: string; name?: string; arguments?: string; command?: string } | undefined
     if (item?.type === 'agent_message') {
       const text = item.text ?? ''
       if (text) return { kind: 'text-delta', text }
       return { kind: 'other', type, raw: parsed }
     }
-    if (item?.type === 'function_call' || item?.type === 'local_shell_call') {
-      const name = item.name ?? (item.type === 'local_shell_call' ? 'shell' : '<unnamed>')
-      const inputPreview = item.arguments ? item.arguments.slice(0, 200) : ''
+    // Tool/shell invocations. Names drifted across codex versions:
+    //   0.128 → function_call / local_shell_call (name + arguments)
+    //   0.139 → command_execution / mcp_tool_call (command)
+    if (
+      item?.type === 'command_execution' ||
+      item?.type === 'mcp_tool_call' ||
+      item?.type === 'function_call' ||
+      item?.type === 'local_shell_call'
+    ) {
+      const name =
+        item.name ??
+        item.command ??
+        (item.type === 'local_shell_call' || item.type === 'command_execution' ? 'shell' : '<unnamed>')
+      const rawInput = item.command ?? item.arguments ?? ''
+      const inputPreview = rawInput ? rawInput.slice(0, 200) : ''
       return { kind: 'tool-use', name, inputPreview }
     }
     return { kind: 'other', type, raw: parsed }

--- a/server/providers/types.ts
+++ b/server/providers/types.ts
@@ -48,6 +48,10 @@ export type AdapterEvent =
   | { kind: 'tool-use'; name: string; inputPreview: string }
   | { kind: 'session-started'; sessionId: string }
   | { kind: 'result'; payload: Record<string, unknown> }
+  // Provider reported an explicit failure for the turn (e.g. codex
+  // `turn.failed` / top-level `error`). Carries the human-readable reason so
+  // callers can surface it instead of swallowing it into `{ kind: 'other' }`.
+  | { kind: 'error'; message: string }
   | { kind: 'other'; type: string; raw: Record<string, unknown> }
 
 export interface NormalisedResult {

--- a/server/util/stream-display.test.ts
+++ b/server/util/stream-display.test.ts
@@ -58,6 +58,22 @@ describe('extractDisplayText', () => {
         expect(extractDisplayText({ type })).toBeNull()
       }
     })
+
+    it('surfaces turn.failed with the nested error message (codex 0.139)', () => {
+      const frame = { type: 'turn.failed', error: { message: "You've hit your usage limit." } }
+      expect(extractDisplayText(frame)).toBe("[turn failed] You've hit your usage limit.")
+    })
+
+    it('surfaces a standalone error frame', () => {
+      expect(extractDisplayText({ type: 'error', message: 'model not available' })).toBe(
+        '[error] model not available',
+      )
+    })
+
+    it('renders bare turn.failed / error frames without a trailing space', () => {
+      expect(extractDisplayText({ type: 'turn.failed' })).toBe('[turn failed]')
+      expect(extractDisplayText({ type: 'error' })).toBe('[error]')
+    })
   })
 
   describe('Gemini stream-json frames', () => {

--- a/server/util/stream-display.ts
+++ b/server/util/stream-display.ts
@@ -72,5 +72,17 @@ export function extractDisplayText(event: Record<string, unknown>): string | nul
   if (type === 'thread.started' || type === 'turn.started' || type === 'turn.completed') {
     return null
   }
+  // Codex failure frames (0.139+): surface the reason in the rail log instead of
+  // exiting with "failed, no reason". `turn.failed` nests the message under
+  // `error.message`; the standalone `error` frame carries it at `message`.
+  if (type === 'turn.failed') {
+    const err = event.error as { message?: string } | undefined
+    const msg = err?.message ?? ''
+    return `[turn failed]${msg ? ` ${msg}` : ''}`
+  }
+  if (type === 'error') {
+    const msg = (event.message as string | undefined) ?? ''
+    return `[error]${msg ? ` ${msg}` : ''}`
+  }
   return null
 }


### PR DESCRIPTION
## Problem

Codex stopped working on **macOS and Windows**. Root cause: the codex CLI advanced to **0.139.x**, which changed its `exec --json` stream in two ways the adapter never migrated to. (The audit batches #436–#443 touched zero codex code — this is CLI version drift, not a regression.)

### 1. Failure frames swallowed (the visible "no funciona")
A failing turn (usage limit, API 4xx, auth, unsupported model, sandbox error) in 0.139 emits:
```
{"type":"error","message":"You've hit your usage limit."}
{"type":"turn.failed","error":{"message":"You've hit your usage limit."}}
```
then exits 1 — **no `turn.completed`**. The adapter mapped both to `{kind:'other'}`, so:
- **Explore**: `sawResult` stayed false → a futile crash-respawn fired (fails identically) → only a generic error surfaced, the real reason discarded.
- **Rails**: job failed with the reason never shown (`extractDisplayText` returned `null`).

### 2. Tool item rename
0.128 emitted `function_call` / `local_shell_call`; 0.139 emits `command_execution` / `mcp_tool_call`. The adapter's tool-use branch matched only the old names → tool/telemetry events dropped.

## Fix
- New `AdapterEvent` kind `error`. `parseCodexStreamLine` maps `turn.failed` (nested `error.message`) and top-level `error` to it.
- `ChatManager`: captures the reason, surfaces it via `chat_error`, and **skips the respawn** when a provider error was reported (it would recur).
- `extractDisplayText`: renders `[turn failed] …` / `[error] …` so the rail log shows the cause.
- Tool-use branch now matches `command_execution` / `mcp_tool_call` (+ legacy names), deriving the name from `item.command`.

## Tests
- `codex-adapter.test.ts` — `turn.failed`, standalone `error`, bare-frame fallback, `command_execution`, `mcp_tool_call`.
- `stream-display.test.ts` — `[turn failed]` / `[error]` rendering.
- `chat-manager.test.ts` — codex turn.failed surfaces the real reason + no futile respawn; bare crash still respawns once.

Server coverage: 84.37% stmts / 75.46% branch / 87.59% funcs / 86.23% lines — all gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LauNZYteQ2qXCcVECoPMwp