### PR TITLE
fix(gemini): detect binary on packaged Windows + stop macOS keychain re-prompts

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -27,7 +27,7 @@ import { createTelemetryRouter } from './telemetry-receiver'
 import { runCompactionForAll } from './telemetry-compactor'
 import { FrameworkManager } from './framework-manager'
 import { withFileLock } from './artifact-registry'
-import { resolveStartupPath, augmentPathFromLoginShell, getPathDiagnostic, ensureWindowsBaseEnv } from './path-resolver'
+import { resolveStartupPath, augmentPathFromLoginShell, augmentAuthEnvFromLoginShell, getPathDiagnostic, ensureWindowsBaseEnv } from './path-resolver'
 // Side-effect import: registers every bundled ProviderAdapter (claude, codex,
 // future providers) so `getAdapter`/`hasAdapter`/`listAdapters` are populated
 // before any manager constructs a project context. See
@@ -603,6 +603,11 @@ server.listen(port, '127.0.0.1', () => {
     const source = process.stdin.isTTY ? 'terminal' : 'gui'
     console.log(`[path-resolver] inherited=${inheritedPathBeforeResolve} augmented=${Math.max(0, augmented)} loginShell=${diag.loginShellStatus} source=${source}`)
   })
+  // Recover provider auth env (e.g. GEMINI_API_KEY) from the user's login shell
+  // so a GUI-launched server doesn't force gemini onto its macOS-Keychain OAuth
+  // path. Independent of the PATH probe above (which is skipped when the bundle
+  // is active). Fire-and-forget; never logs secret values.
+  void augmentAuthEnvFromLoginShell()
 })
 
 // ─── Clean shutdown ───────────────────────────────────────────────────────────

--- a/server/path-resolver.test.ts
+++ b/server/path-resolver.test.ts
@@ -6,11 +6,14 @@ import path from 'path'
 import {
   resolveStartupPath,
   augmentPathFromLoginShell,
+  augmentAuthEnvFromLoginShell,
   parseLoginShellOutput,
+  parseLoginShellEnv,
   getPathDiagnostic,
   resolveBundledRuntimePath,
   resolveBundledNodeExe,
   ensureWindowsBaseEnv,
+  AUTH_ENV_VARS,
   __resetPathResolverForTest,
 } from './path-resolver'
 
@@ -266,6 +269,52 @@ describe('resolveStartupPath — desktop mode', () => {
     expect(parts[1]).toContain('git')
   })
 
+  it('Windows + active bundle: also prepends %APPDATA%\\npm (provider shims) AFTER bundled node/git', () => {
+    // Regression: the desktop bundled branch returned early, skipping the win32
+    // fallback's npm-prefix prepend — so gemini.cmd/claude.cmd in %APPDATA%\npm
+    // were never on PATH in the packaged Windows app, breaking provider detection.
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    const appdata = fs.mkdtempSync(path.join(os.tmpdir(), 'appdata-'))
+    const npmDir = path.join(appdata, 'npm')
+    fs.mkdirSync(npmDir, { recursive: true })
+    const prevAppData = process.env.APPDATA
+    const prevPF = process.env.ProgramFiles
+    process.env.APPDATA = appdata
+    delete process.env.ProgramFiles
+    process.env.PATH = '/Windows/System32'
+    try {
+      resolveStartupPath()
+      const parts = (process.env.PATH ?? '').split(';')
+      // bundled node/git first, then the npm shim dir, then inherited.
+      expect(parts[0]).toContain('node')
+      expect(parts[1]).toContain('git')
+      expect(parts).toContain(npmDir)
+      expect(parts.indexOf(npmDir)).toBeGreaterThan(1)
+      expect(parts.indexOf(npmDir)).toBeLessThan(parts.indexOf('/Windows/System32'))
+      const diag = getPathDiagnostic()
+      expect(diag.pathSources[diag.pathSegments.indexOf(npmDir)]).toBe('fast-path')
+      // idempotent: a second pass doesn't duplicate the npm dir
+      resolveStartupPath()
+      expect((process.env.PATH ?? '').split(';').filter((s) => s === npmDir).length).toBe(1)
+    } finally {
+      if (prevAppData === undefined) delete process.env.APPDATA
+      else process.env.APPDATA = prevAppData
+      if (prevPF === undefined) delete process.env.ProgramFiles
+      else process.env.ProgramFiles = prevPF
+      fs.rmSync(appdata, { recursive: true, force: true })
+    }
+  })
+
+  it('macOS + active bundle: adds NO npm dirs (windowsGlobalBinDirs is win32-only) — POSIX byte-identical', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+    process.env.PATH = '/usr/bin:/bin'
+    resolveStartupPath()
+    const diag = getPathDiagnostic()
+    // Only the two bundled dirs are prepended; everything else stays inherited.
+    expect(diag.pathSources.filter((s) => s === 'bundled')).toHaveLength(2)
+    expect(diag.pathSources).not.toContain('fast-path')
+  })
+
   it('marks prepended dirs as bundled in diagnostic', () => {
     Object.defineProperty(process, 'platform', { value: 'darwin' })
     process.env.PATH = '/usr/bin'
@@ -461,6 +510,93 @@ function makeFakeSpawn(opts: { stdout: string; exitCode: number | null; hang?: b
     return child
   }
 }
+
+describe('parseLoginShellEnv', () => {
+  it('extracts KEY=VALUE pairs between the env sentinels', () => {
+    const stdout =
+      'rc noise\n__SRH_ENV_BEGIN__GEMINI_API_KEY=abc123\nGOOGLE_API_KEY=\nGOOGLE_CLOUD_PROJECT=my-proj\n__SRH_ENV_END__\ntrailing'
+    const env = parseLoginShellEnv(stdout)
+    expect(env.GEMINI_API_KEY).toBe('abc123')
+    expect(env.GOOGLE_CLOUD_PROJECT).toBe('my-proj')
+    // Empty values are dropped (an unset var prints `KEY=`)
+    expect(env.GOOGLE_API_KEY).toBeUndefined()
+  })
+
+  it('returns {} when sentinels are missing', () => {
+    expect(parseLoginShellEnv('no sentinels')).toEqual({})
+    expect(parseLoginShellEnv('__SRH_ENV_BEGIN__GEMINI_API_KEY=x')).toEqual({})
+  })
+
+  it('preserves `=` characters inside a value', () => {
+    const stdout = '__SRH_ENV_BEGIN__GEMINI_API_KEY=a=b=c\n__SRH_ENV_END__'
+    expect(parseLoginShellEnv(stdout).GEMINI_API_KEY).toBe('a=b=c')
+  })
+})
+
+describe('augmentAuthEnvFromLoginShell', () => {
+  const PREV: Record<string, string | undefined> = {}
+  beforeEach(() => {
+    __resetPathResolverForTest()
+    delete process.env.VITEST
+    process.env.NODE_ENV = 'production'
+    for (const k of AUTH_ENV_VARS) { PREV[k] = process.env[k]; delete process.env[k] }
+  })
+  afterEach(() => {
+    process.env.VITEST = 'true'
+    process.env.NODE_ENV = 'test'
+    setPlatform(ORIGINAL_PLATFORM)
+    for (const k of AUTH_ENV_VARS) {
+      if (PREV[k] === undefined) delete process.env[k]
+      else process.env[k] = PREV[k]
+    }
+  })
+
+  it('backfills GEMINI_API_KEY (and others) from the login shell when unset', async () => {
+    setPlatform('darwin')
+    const fakeSpawn = makeFakeSpawn({
+      stdout: '__SRH_ENV_BEGIN__GEMINI_API_KEY=sk-live-xyz\nGOOGLE_CLOUD_PROJECT=proj-1\n__SRH_ENV_END__',
+      exitCode: 0,
+    })
+    await augmentAuthEnvFromLoginShell({ spawnFn: fakeSpawn as any })
+    expect(process.env.GEMINI_API_KEY).toBe('sk-live-xyz')
+    expect(process.env.GOOGLE_CLOUD_PROJECT).toBe('proj-1')
+  })
+
+  it('does NOT override an already-set value', async () => {
+    setPlatform('darwin')
+    process.env.GEMINI_API_KEY = 'explicit-key'
+    const fakeSpawn = makeFakeSpawn({
+      stdout: '__SRH_ENV_BEGIN__GEMINI_API_KEY=from-shell\n__SRH_ENV_END__',
+      exitCode: 0,
+    })
+    await augmentAuthEnvFromLoginShell({ spawnFn: fakeSpawn as any })
+    expect(process.env.GEMINI_API_KEY).toBe('explicit-key')
+  })
+
+  it('is a no-op on win32 (does not spawn)', async () => {
+    setPlatform('win32')
+    const spawnFn = vi.fn()
+    await augmentAuthEnvFromLoginShell({ spawnFn: spawnFn as any })
+    expect(spawnFn).not.toHaveBeenCalled()
+  })
+
+  it('skips under VITEST=true', async () => {
+    process.env.VITEST = 'true'
+    setPlatform('darwin')
+    const spawnFn = vi.fn()
+    await augmentAuthEnvFromLoginShell({ spawnFn: spawnFn as any })
+    expect(spawnFn).not.toHaveBeenCalled()
+  })
+
+  it('resolves without throwing on timeout (hung shell)', async () => {
+    setPlatform('darwin')
+    const hangingSpawn = makeFakeSpawn({ stdout: '', exitCode: null, hang: true })
+    await expect(
+      augmentAuthEnvFromLoginShell({ spawnFn: hangingSpawn as any, timeoutMs: 30 }),
+    ).resolves.toBeUndefined()
+    expect(process.env.GEMINI_API_KEY).toBeUndefined()
+  })
+})
 
 describe('resolveBundledNodeExe', () => {
   const ORIGINAL_RUNTIMES = process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH

--- a/server/path-resolver.ts
+++ b/server/path-resolver.ts
@@ -201,14 +201,26 @@ export function resolveStartupPath(): void {
       if (nodeBinDir && gitBinDir) {
         const inherited = splitPath(process.env.PATH)
         const inheritedSet = new Set(inherited)
-        const toAdd = [nodeBinDir, gitBinDir].filter((d) => !inheritedSet.has(d))
-        const merged = [...toAdd, ...inherited]
+        const bundledDirs = [nodeBinDir, gitBinDir].filter((d) => !inheritedSet.has(d))
+        bundledDirs.forEach((d) => inheritedSet.add(d))
+        // Provider CLIs (claude/codex/gemini) are NEVER bundled — they always
+        // come from the system. On Windows their `.cmd` shims live in
+        // `%APPDATA%\npm`, which a GUI-launched (Explorer/Tauri) process may not
+        // have on PATH. This branch returns early, skipping the win32 fallback
+        // block below that would otherwise add them — so prepend them here too,
+        // AFTER the bundled node/git (which must still win for node/git).
+        // No-op on macOS/Linux (windowsGlobalBinDirs() returns []), keeping
+        // POSIX desktop PATH byte-identical.
+        const winGlobal = windowsGlobalBinDirs().filter((d) => d && fileExists(d) && !inheritedSet.has(d))
+        winGlobal.forEach((d) => inheritedSet.add(d))
+        const merged = [...bundledDirs, ...winGlobal, ...inherited]
         process.env.PATH = joinPath(merged)
         bundledRuntimesActive = true
         diagnostic = {
           pathSegments: merged,
           pathSources: [
-            ...toAdd.map(() => 'bundled' as PathSource),
+            ...bundledDirs.map(() => 'bundled' as PathSource),
+            ...winGlobal.map(() => 'fast-path' as PathSource),
             ...inherited.map(() => 'inherited' as PathSource),
           ],
           loginShellStatus: 'skipped',
@@ -375,6 +387,104 @@ export async function augmentPathFromLoginShell(opts: AugmentOptions = {}): Prom
     warnedLoginShell = true
     console.warn(`[path-resolver] login-shell merge ${status}; using fast-path PATH only`)
   }
+}
+
+const ENV_BEGIN = '__SRH_ENV_BEGIN__'
+const ENV_END = '__SRH_ENV_END__'
+
+/**
+ * Provider auth env vars to recover from the user's login shell. A GUI-launched
+ * (Finder/Dock) desktop server inherits launchd's minimal env, NOT the user's
+ * `.zshrc`/`.bashrc` exports — so a `GEMINI_API_KEY` (or Vertex config) the user
+ * set in their dotfiles never reaches the gemini spawn. Without it, gemini-cli
+ * falls back to its OAuth path, which on macOS re-reads the cached token through
+ * the Keychain on EVERY spawn → the repeated "allow access to your keychain"
+ * prompts. Recovering the key here makes gemini use API-key auth and skip the
+ * Keychain entirely. Values are NEVER logged.
+ */
+export const AUTH_ENV_VARS = [
+  'GEMINI_API_KEY',
+  'GOOGLE_API_KEY',
+  'GOOGLE_GENAI_USE_VERTEXAI',
+  'GOOGLE_CLOUD_PROJECT',
+  'GOOGLE_CLOUD_LOCATION',
+  'GOOGLE_APPLICATION_CREDENTIALS',
+] as const
+
+/** Parse the `KEY=value` block emitted between the env sentinels. */
+export function parseLoginShellEnv(stdout: string): Record<string, string> {
+  const begin = stdout.indexOf(ENV_BEGIN)
+  if (begin === -1) return {}
+  const start = begin + ENV_BEGIN.length
+  const end = stdout.indexOf(ENV_END, start)
+  if (end === -1) return {}
+  const block = stdout.slice(start, end)
+  const out: Record<string, string> = {}
+  for (const line of block.split('\n')) {
+    const eq = line.indexOf('=')
+    if (eq <= 0) continue
+    const key = line.slice(0, eq)
+    const value = line.slice(eq + 1)
+    if (value.length > 0) out[key] = value
+  }
+  return out
+}
+
+/**
+ * Spawn the user's login shell once and backfill any provider auth env vars it
+ * exposes into `process.env` (only when not already set — never override an
+ * explicit value). POSIX-only and runs REGARDLESS of bundle state (unlike the
+ * PATH augmentation, which is skipped when the bundle is active): macOS desktop
+ * builds bundle node/git, so the PATH login-shell probe is skipped, yet we still
+ * need to recover the gemini key. Async, fire-and-forget — must not block
+ * startup. No-op on Windows (GUI inherits user env) and in tests.
+ */
+export async function augmentAuthEnvFromLoginShell(opts: AugmentOptions = {}): Promise<void> {
+  if (process.platform === 'win32') return
+  if (process.env.NODE_ENV === 'test' || process.env.VITEST === 'true') return
+
+  const spawnFn = opts.spawnFn ?? spawn
+  const timeoutMs = opts.timeoutMs ?? LOGIN_SHELL_TIMEOUT_MS
+  const shell = process.env.SHELL || '/bin/sh'
+  // `printf` reuses POSIX positional `$VAR` expansion (works in sh/bash/zsh).
+  const fmt = ENV_BEGIN + AUTH_ENV_VARS.map((v) => `${v}=%s\n`).join('') + ENV_END
+  const refs = AUTH_ENV_VARS.map((v) => `"$${v}"`).join(' ')
+  const command = `printf '${fmt}' ${refs}`
+
+  await new Promise<void>((resolve) => {
+    let child: ChildProcess
+    try {
+      child = spawnFn(shell, ['-l', '-i', '-c', command], { stdio: ['ignore', 'pipe', 'pipe'] })
+    } catch {
+      resolve()
+      return
+    }
+
+    let stdout = ''
+    let settled = false
+    const timer = setTimeout(() => {
+      try { child.kill('SIGKILL') } catch { /* ignore */ }
+    }, timeoutMs)
+    const finish = () => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      resolve()
+    }
+
+    child.stdout?.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf-8') })
+    child.stderr?.on('data', () => { /* discard */ })
+    child.on('error', finish)
+    child.on('close', () => {
+      const recovered = parseLoginShellEnv(stdout)
+      for (const key of AUTH_ENV_VARS) {
+        const val = recovered[key]
+        // Backfill only when unset/empty — never clobber an explicit value.
+        if (val && !process.env[key]) process.env[key] = val
+      }
+      finish()
+    })
+  })
 }
 
 function mergeLoginShellPath(rawPath: string): void {

--- a/server/util/cli-prompt.test.ts
+++ b/server/util/cli-prompt.test.ts
@@ -1,4 +1,13 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+
+// Wrap spawnCli with a spy that still delegates to the real implementation, so
+// the real-binary dispatch tests keep working while the env-passthrough tests
+// can inspect the options handed to spawnCli.
+vi.mock('./win-spawn', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./win-spawn')>()
+  return { ...actual, spawnCli: vi.fn(actual.spawnCli) }
+})
+
 import {
   transformClaudeArgsForWindows,
   transformCodexArgsForWindows,
@@ -8,6 +17,7 @@ import {
   spawnGemini,
   spawnAiCli,
 } from './cli-prompt'
+import { spawnCli } from './win-spawn'
 
 describe('transformClaudeArgsForWindows', () => {
   it('returns args unchanged when no prompt flags are present', () => {
@@ -241,6 +251,43 @@ describe('spawn dispatch (POSIX fallthrough)', () => {
     // trust var is set — without it gemini silently disables --yolo headless.
     const child = spawnGemini(['--version'], { env: { FOO: 'bar' }, stdio: ['ignore', 'pipe', 'pipe'] })
     smokeSpawnSync(child)
+  })
+
+  it('spawnGemini forwards GEMINI_API_KEY from process.env into the spawn env', () => {
+    if (skipOnWin) return
+    // Without the key in the env, gemini-cli falls back to OAuth → macOS Keychain
+    // re-prompts. Forwarding it from process.env keeps gemini on API-key auth.
+    const prev = process.env.GEMINI_API_KEY
+    process.env.GEMINI_API_KEY = 'sk-test-123'
+    try {
+      const child = spawnGemini(['--version'], { env: { FOO: 'bar' }, stdio: ['ignore', 'pipe', 'pipe'] })
+      smokeSpawnSync(child)
+      const opts = vi.mocked(spawnCli).mock.calls.at(-1)![2] as { env: NodeJS.ProcessEnv }
+      expect(opts.env.GEMINI_API_KEY).toBe('sk-test-123')
+      expect(opts.env.FOO).toBe('bar') // caller env preserved
+      expect(opts.env.GEMINI_CLI_TRUST_WORKSPACE).toBe('true')
+    } finally {
+      if (prev === undefined) delete process.env.GEMINI_API_KEY
+      else process.env.GEMINI_API_KEY = prev
+    }
+  })
+
+  it('spawnGemini does NOT override a key already present in options.env', () => {
+    if (skipOnWin) return
+    const prev = process.env.GEMINI_API_KEY
+    process.env.GEMINI_API_KEY = 'from-process'
+    try {
+      const child = spawnGemini(['--version'], {
+        env: { GEMINI_API_KEY: 'from-caller' },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+      smokeSpawnSync(child)
+      const opts = vi.mocked(spawnCli).mock.calls.at(-1)![2] as { env: NodeJS.ProcessEnv }
+      expect(opts.env.GEMINI_API_KEY).toBe('from-caller')
+    } finally {
+      if (prev === undefined) delete process.env.GEMINI_API_KEY
+      else process.env.GEMINI_API_KEY = prev
+    }
   })
 
   it('spawnAiCli runs a real binary end-to-end on POSIX', async () => {

--- a/server/util/cli-prompt.ts
+++ b/server/util/cli-prompt.ts
@@ -179,8 +179,25 @@ export function spawnCodex(args: string[], options: SpawnOptions = {}): ChildPro
  * No multi-line argv quirk (the prompt rides on a single `-p` value), so the
  * Windows path is identical to POSIX.
  */
+// Gemini auth env vars. Forwarded from `process.env` into the spawn env when
+// present so a caller that narrows the env (or a relocated spawn) still carries
+// the API key — without it gemini-cli falls back to OAuth, which on macOS
+// re-prompts for Keychain access on every spawn. `process.env` is itself
+// backfilled from the login shell at startup (see augmentAuthEnvFromLoginShell).
+const GEMINI_AUTH_ENV_VARS = [
+  'GEMINI_API_KEY',
+  'GOOGLE_API_KEY',
+  'GOOGLE_GENAI_USE_VERTEXAI',
+  'GOOGLE_CLOUD_PROJECT',
+  'GOOGLE_CLOUD_LOCATION',
+  'GOOGLE_APPLICATION_CREDENTIALS',
+] as const
+
 export function spawnGemini(args: string[], options: SpawnOptions = {}): ChildProcess {
-  const env = { ...(options.env ?? process.env), GEMINI_CLI_TRUST_WORKSPACE: 'true' }
+  const env: NodeJS.ProcessEnv = { ...(options.env ?? process.env), GEMINI_CLI_TRUST_WORKSPACE: 'true' }
+  for (const key of GEMINI_AUTH_ENV_VARS) {
+    if (process.env[key] && env[key] === undefined) env[key] = process.env[key]
+  }
   return spawnCli('gemini', args, { ...options, env })
 }
 


### PR DESCRIPTION
Two independent Gemini provider failures.

## 1. Windows: binary not detected
In the packaged app, `resolveStartupPath()` takes the desktop-mode bundled-runtimes branch and **returns early**, before the win32 fallback block that prepends `%APPDATA%\npm` — where `npm i -g @google/gemini-cli` installs `gemini.cmd`. So the provider shim was never on PATH and the `where gemini` probe (`core-compat`, `setup-prerequisites`) failed. (The prior fix #434 added `windowsGlobalBinDirs()` only to the fallback branch, which the packaged app never reaches.)

**Fix:** the bundled branch now also prepends `windowsGlobalBinDirs()` — **after** the bundled node/git (which must still win for node/git), existence-gated + deduped. No-op on macOS/Linux (`windowsGlobalBinDirs()` returns `[]`), so POSIX desktop PATH is byte-identical.

## 2. macOS: Keychain re-prompts on every gemini spawn
A GUI-launched (Finder/Dock) server inherits launchd's minimal env, **not** the user's `.zshrc`. So a `GEMINI_API_KEY` exported in dotfiles never reached gemini, and gemini-cli fell back to OAuth — which on macOS re-reads the cached token through the **Keychain on every spawn** → the repeated "allow keychain access" prompts.

**Fix:**
- New `augmentAuthEnvFromLoginShell()` recovers `GEMINI_API_KEY` / `GOOGLE_*` from the user's login shell at startup. POSIX-only; runs **even when the bundle is active** (unlike the PATH probe, which is skipped then — macOS desktop bundles node/git); backfills `process.env` only when unset (never overrides); **never logs values**.
- `spawnGemini()` forwards those vars from `process.env` into the spawn env (defense-in-depth + survives env-narrowing callers).

With the key present, gemini uses API-key auth and skips the Keychain entirely. (Users who authenticate purely via gemini's own OAuth/Keychain — no shell key — are unaffected by #2; the durable fix there is signing/UI key entry, a follow-up.)

## Tests
- `path-resolver.test.ts` — Windows bundle+npm prepend ordering & idempotence; macOS adds no npm dirs (POSIX byte-identical); `parseLoginShellEnv`; auth backfill incl. no-override / win32-noop / timeout-safe.
- `cli-prompt.test.ts` — gemini env passthrough + no-override of a caller-set key.

Server coverage: 84.42 / 75.51 / 87.62 / 86.27 — all gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LauNZYteQ2qXCcVECoPMwp