### PR TITLE
fix(explore): give gemini the project context + show the real provider in the bubble

### DIFF
--- a/client/src/components/explore-spec/ExploreSpecShell.tsx
+++ b/client/src/components/explore-spec/ExploreSpecShell.tsx
@@ -7,6 +7,7 @@ import remarkGfm from 'remark-gfm'
 import { Button } from '../ui/button'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '../ui/dialog'
 import { useChatContext, type ChatConversation } from '../../hooks/useChat'
+import { providerLabel } from '../../lib/provider-capabilities'
 import { useSpecDraftStream } from '../../hooks/useSpecDraftStream'
 import { useDesktop } from '../../hooks/useDesktop'
 import { useJiraConnection } from '../../hooks/useJiraConnection'
@@ -749,11 +750,11 @@ export function ExploreSpecShell({
               </div>
             )}
             {conversation?.messages.map((m, i) => (
-              <TurnBubble key={i} role={m.role} content={m.content} timestamp={m.created_at} />
+              <TurnBubble key={i} role={m.role} content={m.content} timestamp={m.created_at} provider={conversation?.provider} />
             ))}
             {(pendingTurn || conversation?.isStreaming) && (
               conversation?.streamingText
-                ? <TurnBubble role="assistant" content={renderedStream} streaming />
+                ? <TurnBubble role="assistant" content={renderedStream} streaming provider={conversation?.provider} />
                 : (
                   <div className="px-5 pb-1">
                     <ExploreStatusPills
@@ -969,7 +970,7 @@ function formatChatTime(iso?: string): string | null {
   return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
 }
 
-function TurnBubble({ role, content, streaming, timestamp }: { role: 'user' | 'assistant' | 'system'; content: string; streaming?: boolean; timestamp?: string }) {
+function TurnBubble({ role, content, streaming, timestamp, provider }: { role: 'user' | 'assistant' | 'system'; content: string; streaming?: boolean; timestamp?: string; provider?: string | null }) {
   const { t } = useTranslation('explore')
   if (role === 'system') return null
   const isUser = role === 'user'
@@ -981,7 +982,7 @@ function TurnBubble({ role, content, streaming, timestamp }: { role: 'user' | 'a
       <div className={`max-w-[85%] rounded-lg px-3 py-2 text-sm ${isUser ? 'bg-primary/10 text-foreground' : 'bg-card/60 border border-border/40'}`}>
         <div className="flex items-baseline justify-between gap-3 mb-1">
           <div className="text-[10px] uppercase tracking-wider text-muted-foreground/60 font-semibold">
-            {isUser ? t('shell.you') : 'Claude'}
+            {isUser ? t('shell.you') : providerLabel(provider)}
           </div>
           {timeLabel && (
             <div className="text-[10px] text-muted-foreground/50 font-mono tabular-nums">

--- a/client/src/components/explore-spec/__tests__/ExploreSpecShell.test.tsx
+++ b/client/src/components/explore-spec/__tests__/ExploreSpecShell.test.tsx
@@ -7,7 +7,7 @@ import { SharedWebSocketContext } from '../../../hooks/useSharedWebSocket'
 const mockStartWithMessage = vi.fn().mockResolvedValue('conv-1')
 const mockSendMessage = vi.fn().mockResolvedValue(undefined)
 const conversationsRef: { value: Array<{
-  id: string; title: string | null; model: string;
+  id: string; title: string | null; model: string; provider?: string | null;
   messages: Array<{ role: 'user' | 'assistant' | 'system'; content: string }>;
   isStreaming: boolean; streamingText: string; commandProposals: string[]
 }> } = { value: [] }
@@ -161,6 +161,43 @@ describe('ExploreSpecShell', () => {
     await screen.findByText('response')
     fireEvent.keyDown(window, { key: 'Escape' })
     expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('labels the assistant bubble with the conversation provider (Gemini, not Claude)', async () => {
+    const ws = makeFakeWs()
+    conversationsRef.value = [{
+      id: 'conv-1', title: null, model: 'gemini-2.5-pro', provider: 'gemini',
+      messages: [{ role: 'user', content: 'hi' }, { role: 'assistant', content: 'gemini reply' }],
+      isStreaming: false, streamingText: '', commandProposals: [],
+    }]
+    render(<ExploreSpecShell initialIdea="hi" pendingSpecId="pending-1" initialAttachmentIds={[]} onClose={onClose} />, { wrapper: wrap(ws) })
+    await screen.findByText('gemini reply')
+    expect(screen.getByText('Gemini')).toBeInTheDocument()
+    expect(screen.queryByText('Claude')).not.toBeInTheDocument()
+  })
+
+  it('labels codex conversations Codex', async () => {
+    const ws = makeFakeWs()
+    conversationsRef.value = [{
+      id: 'conv-1', title: null, model: 'gpt-5.5', provider: 'codex',
+      messages: [{ role: 'assistant', content: 'codex reply' }],
+      isStreaming: false, streamingText: '', commandProposals: [],
+    }]
+    render(<ExploreSpecShell initialIdea="hi" pendingSpecId="pending-1" initialAttachmentIds={[]} onClose={onClose} />, { wrapper: wrap(ws) })
+    await screen.findByText('codex reply')
+    expect(screen.getByText('Codex')).toBeInTheDocument()
+  })
+
+  it('falls back to Claude when provider is null (single-provider legacy)', async () => {
+    const ws = makeFakeWs()
+    conversationsRef.value = [{
+      id: 'conv-1', title: null, model: 'sonnet', provider: null,
+      messages: [{ role: 'assistant', content: 'claude reply' }],
+      isStreaming: false, streamingText: '', commandProposals: [],
+    }]
+    render(<ExploreSpecShell initialIdea="hi" pendingSpecId="pending-1" initialAttachmentIds={[]} onClose={onClose} />, { wrapper: wrap(ws) })
+    await screen.findByText('claude reply')
+    expect(screen.getByText('Claude')).toBeInTheDocument()
   })
 
   it('clicking a chip sends it as the next user message', async () => {

--- a/client/src/hooks/useChat.ts
+++ b/client/src/hooks/useChat.ts
@@ -12,6 +12,9 @@ export interface ChatConversation {
   id: string
   title: string | null
   model: string
+  /** AI provider driving this conversation (claude/codex/gemini). NULL/undefined
+   *  on single-provider projects → rendered as the default (Claude). */
+  provider?: string | null
   messages: ChatMessage[]
   isStreaming: boolean
   streamingText: string
@@ -105,6 +108,7 @@ export function useChat(): UseChatReturn {
                 id: c.id,
                 title: c.title,
                 model: c.model,
+                provider: c.provider,
                 messages: msgData.messages,
                 isStreaming: false,
                 streamingText: '',
@@ -115,6 +119,7 @@ export function useChat(): UseChatReturn {
                 id: c.id,
                 title: c.title,
                 model: c.model,
+                provider: c.provider,
                 messages: [],
                 isStreaming: false,
                 streamingText: '',
@@ -232,6 +237,7 @@ export function useChat(): UseChatReturn {
         id: data.conversation.id,
         title: data.conversation.title,
         model: data.conversation.model,
+        provider: data.conversation.provider,
         messages: [],
         isStreaming: false,
         streamingText: '',
@@ -365,6 +371,10 @@ export function useChat(): UseChatReturn {
         id: data.conversation.id,
         title: data.conversation.title,
         model: data.conversation.model,
+        // Server persists provider only on multi-provider projects (else NULL).
+        // Fall back to the requested engine so a freshly-started gemini/codex
+        // session labels its bubbles correctly without waiting for a reload.
+        provider: data.conversation.provider ?? provider ?? null,
         messages: [],
         isStreaming: false,
         streamingText: '',
@@ -399,6 +409,7 @@ export function useChat(): UseChatReturn {
         id: data.conversation.id,
         title: data.conversation.title,
         model: data.conversation.model,
+        provider: data.conversation.provider,
         messages: data.messages,
         isStreaming: false,
         streamingText: '',

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -179,6 +179,9 @@ export interface ChatConversationSummary {
   id: string
   title: string | null
   model: string
+  /** AI provider for this conversation. NULL on single-provider projects
+   *  (legacy = claude); set to the selected engine on multi-provider projects. */
+  provider?: string | null
   created_at: string
   updated_at: string
 }

--- a/server/chat-manager.test.ts
+++ b/server/chat-manager.test.ts
@@ -1177,6 +1177,86 @@ describe('ChatManager', () => {
       await sendPromise
     })
 
+    // ─── Explore scoped-context delivery per provider (systemPromptArg) ───────
+    const SPECRAILS_SCOPE = { specrails: true, openspec: false, full: false, mcp: false, contractRefine: false, userMcp: false }
+    const PREPEND_MARKER = 'Project context selected in Add Spec'
+
+    function seedTetrisTickets(): void {
+      const fsMod = require('fs') as typeof import('fs')
+      const pathMod = require('path') as typeof import('path')
+      fsMod.mkdirSync(pathMod.join(projectPath, '.specrails'), { recursive: true })
+      fsMod.writeFileSync(
+        pathMod.join(projectPath, '.specrails', 'local-tickets.json'),
+        JSON.stringify({ tickets: [{ id: 1, title: 'Tetris MVP in React', status: 'todo', priority: 'high', description: 'Build the falling-tetromino game loop' }] }),
+      )
+    }
+
+    it('gemini explore turn PREPENDS the project tickets into the user prompt (systemPromptArg=false)', async () => {
+      // Regression: gemini dropped opts.systemPrompt and got no scoped context,
+      // so it ignored the project (Tetris) and wandered the .gemini tooling dir.
+      seedTetrisTickets()
+      const cmG = new ChatManager(broadcast, db, projectPath, 'P', 'gemini', 'proj-g', 'slug-g')
+      const convId = 'conv-gemini-ctx'
+      createConversation(db, { id: convId, model: 'gemini-2.5-pro', kind: 'explore', provider: 'gemini', contextScope: SPECRAILS_SCOPE })
+      const child = createMockChildProcess()
+      vi.mocked(mockSpawn).mockReturnValue(child as any)
+      const sendPromise = cmG.sendMessage(convId, 'dame la siguiente mejor spec', { lightweight: true })
+      await Promise.resolve(); await Promise.resolve()
+
+      const args = vi.mocked(mockSpawn).mock.calls[0][1] as string[]
+      const prompt = args.find((a) => a.includes(PREPEND_MARKER))
+      expect(prompt).toBeDefined()
+      expect(prompt).toContain('## Specrails Tickets')
+      expect(prompt).toContain('Tetris MVP in React')
+      expect(prompt).toContain('## User turn')
+      expect(prompt).toContain('dame la siguiente mejor spec')
+
+      pushLine(child, JSON.stringify({ type: 'message', role: 'assistant', content: 'ok' }))
+      await finishProcess(child, 0)
+      await sendPromise
+    })
+
+    it('codex explore turn keeps the prepend (parity, systemPromptArg=false)', async () => {
+      seedTetrisTickets()
+      const cmC = new ChatManager(broadcast, db, projectPath, 'P', 'codex', 'proj-c', 'slug-c')
+      const convId = 'conv-codex-ctx'
+      createConversation(db, { id: convId, model: 'gpt-5.5', kind: 'explore', provider: 'codex', contextScope: SPECRAILS_SCOPE })
+      const child = createMockChildProcess()
+      vi.mocked(mockSpawn).mockReturnValue(child as any)
+      const sendPromise = cmC.sendMessage(convId, 'next spec', { lightweight: true })
+      await Promise.resolve(); await Promise.resolve()
+
+      const args = vi.mocked(mockSpawn).mock.calls[0][1] as string[]
+      expect(args.some((a) => a.includes(PREPEND_MARKER) && a.includes('Tetris MVP in React'))).toBe(true)
+
+      pushLine(child, JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'ok' } }))
+      await finishProcess(child, 0)
+      await sendPromise
+    })
+
+    it('claude explore turn does NOT prepend (carries scope via --system-prompt, systemPromptArg=true)', async () => {
+      seedTetrisTickets()
+      const cmCl = new ChatManager(broadcast, db, projectPath, 'P', 'claude', 'proj-cl', 'slug-cl')
+      const convId = 'conv-claude-ctx'
+      createConversation(db, { id: convId, model: 'sonnet', kind: 'explore', provider: 'claude', contextScope: SPECRAILS_SCOPE })
+      const child = createMockChildProcess()
+      vi.mocked(mockSpawn).mockReturnValue(child as any)
+      const sendPromise = cmCl.sendMessage(convId, 'next spec', { lightweight: true })
+      await Promise.resolve(); await Promise.resolve()
+
+      const args = vi.mocked(mockSpawn).mock.calls[0][1] as string[]
+      // No user-prompt prepend marker — the scope rides on --system-prompt.
+      expect(args.some((a) => a.includes(PREPEND_MARKER))).toBe(false)
+      const sysIdx = args.indexOf('--system-prompt')
+      expect(sysIdx).toBeGreaterThanOrEqual(0)
+      expect(args[sysIdx + 1]).toContain('## Specrails Tickets')
+
+      pushLine(child, assistantEvent('ok'))
+      pushLine(child, resultEvent('sess'))
+      await finishProcess(child, 0)
+      await sendPromise
+    })
+
     it('injects --mcp-config when scope.userMcp=true (claude)', async () => {
       vi.mocked(mockBuildUserMcpArgs).mockReturnValue(['--mcp-config', '/fake/user-mcp.json'])
       const cmExplore = new ChatManager(

--- a/server/chat-manager.ts
+++ b/server/chat-manager.ts
@@ -633,7 +633,20 @@ export class ChatManager {
       )
     }
     let promptForAdapter = resolvedText
-    if (conversation.kind === 'explore' && adapter.id === 'codex' && conversationScope && this._cwd) {
+    // Providers WITHOUT a --system-prompt flag (codex AND gemini) drop
+    // opts.systemPrompt for chat turns, so the Explore scoped-context (the
+    // project's tickets/spec prefix the Add Spec scope toggle injects) would
+    // never reach them — gemini then ignores the real project and wanders the
+    // generic .gemini openspec tooling dir. Prepend the scoped context into the
+    // user turn for any `systemPromptArg: false` provider (capability-gated, not
+    // `id === 'codex'`, so it auto-covers future providers). Claude carries it
+    // via --system-prompt and must NOT get the prepend.
+    if (
+      conversation.kind === 'explore' &&
+      !adapter.capabilities.systemPromptArg &&
+      conversationScope &&
+      this._cwd
+    ) {
       const scopedContext = buildScopedSystemPromptPrefix(conversationScope, this._cwd, this._specrailsRoot())
       if (scopedContext) {
         promptForAdapter =


### PR DESCRIPTION
Two Explore-mode multi-provider defects (reported with a Gemini transcript where it explored generic OpenSpec tooling, proposed "openspec lint", and labelled its replies "Claude" on a Tetris project).

## 1. Gemini ignored the project (server)
Providers without a `--system-prompt` flag (**gemini AND codex**, `systemPromptArg: false`) drop `opts.systemPrompt` for chat turns. So the Explore scoped-context — the project's tickets/spec prefix the Add Spec scope toggle injects — never reached gemini. It booted with only the generic app-managed `GEMINI.md` stance, wandered the `.gemini/` openspec tooling dir inside the explore-cwd, and proposed an irrelevant "openspec lint" spec.

The codex path already compensated by prepending the scoped context into the user prompt, but the gate was `adapter.id === 'codex'`. **Fix:** the gate is now capability-driven — `!adapter.capabilities.systemPromptArg` — so gemini (and any future `systemPromptArg:false` provider) gets the same prepend. Claude is unchanged (it carries the context via `--system-prompt`). Consistent with the repo rule "never branch on `provider === 'X'`".

## 2. The bubble always said "Claude" (client)
The assistant author label was the hardcoded literal `'Claude'`, and the conversation's provider was never threaded to the client. **Fix:** `chat_conversations.provider` (already returned by the API) now flows `ChatConversationSummary` → `useChat`'s `ChatConversation` (all four construction sites; `startWithMessage` falls back to the requested engine so a fresh gemini/codex session labels correctly before any reload) → `TurnBubble`, which renders `providerLabel(provider)` (Claude/Codex/Gemini; null → Claude, preserving single-provider legacy).

## Tests
- `chat-manager.test.ts` — gemini + codex prepend the project tickets into the user prompt (`## Specrails Tickets` / "Tetris" / `## User turn`); claude does NOT (scope rides on `--system-prompt`).
- `ExploreSpecShell.test.tsx` — bubble renders "Gemini" / "Codex"; falls back to "Claude" when provider is null.

Gates: server 84.43/75.53/87.62/86.28 · client 85.19 lines / 81.13 branch / 72.66 funcs — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LauNZYteQ2qXCcVECoPMwp