### PR TITLE
fix(windows): resolve provider CLI to an absolute path at spawn (claude "no se reconoce")

### DIFF
--- a/server/path-resolver.test.ts
+++ b/server/path-resolver.test.ts
@@ -126,6 +126,37 @@ describe('resolveStartupPath (fast path)', () => {
     expect(diag.pathSources[0]).toBe('fast-path')
     expect(diag.pathSources[diag.pathSources.length - 1]).toBe('inherited')
   })
+
+  it('prepends non-npm provider-CLI install dirs on win32 (native installer / version managers)', () => {
+    // Claude Code's native Windows installer lands under %LOCALAPPDATA%\Programs
+    // and adds %USERPROFILE%\.local\bin to PATH; a GUI-launched process can lack
+    // these, so `where claude` / cross-spawn fail. They must be prepended too.
+    setPlatform('win32')
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'winbins-'))
+    const programs = path.join(tmp, 'Programs')
+    const localBin = path.join(tmp, '.local', 'bin')
+    fs.mkdirSync(programs, { recursive: true })
+    fs.mkdirSync(localBin, { recursive: true })
+    const prev = { APPDATA: process.env.APPDATA, LOCALAPPDATA: process.env.LOCALAPPDATA, USERPROFILE: process.env.USERPROFILE, PF: process.env.ProgramFiles }
+    delete process.env.APPDATA
+    delete process.env.ProgramFiles
+    process.env.LOCALAPPDATA = tmp
+    process.env.USERPROFILE = tmp
+    process.env.PATH = 'C:\\Windows\\System32'
+    try {
+      resolveStartupPath()
+      const segs = (process.env.PATH ?? '').split(';')
+      expect(segs).toContain(programs)
+      expect(segs).toContain(localBin)
+      expect(segs).toContain('C:\\Windows\\System32') // inherited preserved
+    } finally {
+      if (prev.APPDATA === undefined) delete process.env.APPDATA; else process.env.APPDATA = prev.APPDATA
+      if (prev.LOCALAPPDATA === undefined) delete process.env.LOCALAPPDATA; else process.env.LOCALAPPDATA = prev.LOCALAPPDATA
+      if (prev.USERPROFILE === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = prev.USERPROFILE
+      if (prev.PF === undefined) delete process.env.ProgramFiles; else process.env.ProgramFiles = prev.PF
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('parseLoginShellOutput', () => {

--- a/server/path-resolver.ts
+++ b/server/path-resolver.ts
@@ -133,10 +133,27 @@ function fastPathDirectories(): string[] {
 function windowsGlobalBinDirs(): string[] {
   if (process.platform !== 'win32') return []
   const dirs: string[] = []
+  const appData = process.env.APPDATA
+  const localAppData = process.env.LOCALAPPDATA
+  const userProfile = process.env.USERPROFILE
   // Default per-user npm prefix: shims (`claude.cmd` …) live in the prefix ROOT.
-  if (process.env.APPDATA) dirs.push(path.join(process.env.APPDATA, 'npm'))
+  if (appData) dirs.push(path.join(appData, 'npm'))
   // Machine-wide Node install (also where a machine-scope npm prefix points).
   if (process.env.ProgramFiles) dirs.push(path.join(process.env.ProgramFiles, 'nodejs'))
+  // Provider CLIs are NOT always npm-global. Claude Code's native Windows
+  // installer drops its shim under %LOCALAPPDATA%\Programs and adds
+  // %USERPROFILE%\.local\bin to PATH; version managers (Volta) and scoop use
+  // their own shim dirs. A GUI-launched process can inherit a PATH missing these
+  // (so `where claude` / cross-spawn fail → "claude no se reconoce"). Add the
+  // common locations; all are existence-gated + deduped by the callers.
+  if (localAppData) {
+    dirs.push(path.join(localAppData, 'Programs'))
+    dirs.push(path.join(localAppData, 'Volta', 'bin'))
+  }
+  if (userProfile) {
+    dirs.push(path.join(userProfile, '.local', 'bin'))
+    dirs.push(path.join(userProfile, 'scoop', 'shims'))
+  }
   return dirs
 }
 

--- a/server/util/win-spawn.test.ts
+++ b/server/util/win-spawn.test.ts
@@ -1,5 +1,31 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { spawnCli, resolveWindowsBinary, windowsSpawnEnv, stripWindowsVerbatimPrefix } from './win-spawn'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// Mock only execFileSync (the `where` resolver) — keep the real `spawn` so the
+// POSIX spawnCli tests still exercise a real child. Mock cross-spawn to capture
+// the binary handed to it on the win32 path.
+vi.mock('child_process', async (orig) => {
+  const actual = await orig<typeof import('child_process')>()
+  return { ...actual, execFileSync: vi.fn() }
+})
+vi.mock('cross-spawn', () => ({ default: vi.fn(() => ({ pid: 1, on: vi.fn() })) }))
+
+import { execFileSync } from 'child_process'
+import crossSpawn from 'cross-spawn'
+import {
+  spawnCli,
+  resolveWindowsBinary,
+  windowsSpawnEnv,
+  stripWindowsVerbatimPrefix,
+  __resetWindowsBinaryResolveCacheForTest,
+} from './win-spawn'
+
+const ORIGINAL_PLATFORM = process.platform
+function asWin32() {
+  Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+}
+function restorePlatform() {
+  Object.defineProperty(process, 'platform', { value: ORIGINAL_PLATFORM, configurable: true })
+}
 
 describe('stripWindowsVerbatimPrefix', () => {
   it('strips the \\\\?\\ drive-letter prefix', () => {
@@ -90,6 +116,70 @@ describe('resolveWindowsBinary', () => {
     expect(resolveWindowsBinary('claude')).toBe('claude')
     expect(resolveWindowsBinary('codex')).toBe('codex')
     expect(resolveWindowsBinary('does-not-exist-anywhere')).toBe('does-not-exist-anywhere')
+  })
+
+  describe('on win32 (mocked)', () => {
+    beforeEach(() => {
+      __resetWindowsBinaryResolveCacheForTest()
+      vi.mocked(execFileSync).mockReset()
+      asWin32()
+    })
+    afterEach(restorePlatform)
+
+    it('resolves a bare name to its absolute shim path via `where`', () => {
+      vi.mocked(execFileSync).mockReturnValue('C:\\Users\\u\\AppData\\Local\\Programs\\claude\\claude.cmd\r\n' as never)
+      expect(resolveWindowsBinary('claude')).toBe('C:\\Users\\u\\AppData\\Local\\Programs\\claude\\claude.cmd')
+      expect(vi.mocked(execFileSync)).toHaveBeenCalledWith('where', ['claude'], expect.objectContaining({ encoding: 'utf-8' }))
+    })
+
+    it('prefers a .cmd/.exe over a .ps1 when `where` lists several', () => {
+      vi.mocked(execFileSync).mockReturnValue('C:\\a\\claude.ps1\r\nC:\\b\\claude.cmd\r\n' as never)
+      expect(resolveWindowsBinary('claude')).toBe('C:\\b\\claude.cmd')
+    })
+
+    it('falls back to the bare name when `where` finds nothing / throws', () => {
+      vi.mocked(execFileSync).mockImplementation(() => { throw new Error('not found') })
+      expect(resolveWindowsBinary('claude')).toBe('claude')
+    })
+
+    it('does not resolve a name that is already an absolute path', () => {
+      expect(resolveWindowsBinary('C:\\tools\\claude.cmd')).toBe('C:\\tools\\claude.cmd')
+      expect(vi.mocked(execFileSync)).not.toHaveBeenCalled()
+    })
+
+    it('caches the resolution (second call does not re-invoke `where`)', () => {
+      vi.mocked(execFileSync).mockReturnValue('C:\\x\\claude.cmd\r\n' as never)
+      expect(resolveWindowsBinary('claude')).toBe('C:\\x\\claude.cmd')
+      expect(resolveWindowsBinary('claude')).toBe('C:\\x\\claude.cmd')
+      expect(vi.mocked(execFileSync)).toHaveBeenCalledTimes(1)
+    })
+  })
+})
+
+describe('spawnCli — win32 binary resolution (mocked)', () => {
+  beforeEach(() => {
+    __resetWindowsBinaryResolveCacheForTest()
+    vi.mocked(execFileSync).mockReset()
+    vi.mocked(crossSpawn).mockClear()
+    asWin32()
+  })
+  afterEach(restorePlatform)
+
+  it('hands cross-spawn the RESOLVED absolute path, not the bare name', () => {
+    vi.mocked(execFileSync).mockReturnValue('C:\\u\\claude.cmd\r\n' as never)
+    spawnCli('claude', ['-p', 'hi'], { env: { PATH: 'C:\\u' } as NodeJS.ProcessEnv })
+    expect(vi.mocked(crossSpawn)).toHaveBeenCalledTimes(1)
+    const [bin, args, opts] = vi.mocked(crossSpawn).mock.calls[0] as [string, string[], { env: NodeJS.ProcessEnv }]
+    expect(bin).toBe('C:\\u\\claude.cmd') // absolute → bypasses cmd.exe bare-name lookup
+    expect(args).toEqual(['-p', 'hi'])
+    expect(opts.env.PATH).toBe('C:\\u') // caller PATH preserved (+ SystemRoot backfill)
+    expect(opts.env.SystemRoot).toBeTruthy()
+  })
+
+  it('falls back to the bare name for cross-spawn when `where` fails', () => {
+    vi.mocked(execFileSync).mockImplementation(() => { throw new Error('nope') })
+    spawnCli('claude', [], {})
+    expect(vi.mocked(crossSpawn).mock.calls[0][0]).toBe('claude')
   })
 })
 

--- a/server/util/win-spawn.ts
+++ b/server/util/win-spawn.ts
@@ -20,7 +20,8 @@
 // args so newlines and shell metacharacters survive intact, and on
 // POSIX it falls through to the native `child_process.spawn`.
 
-import { spawn } from 'child_process'
+import { spawn, execFileSync } from 'child_process'
+import path from 'path'
 import type { ChildProcess, SpawnOptions } from 'child_process'
 import crossSpawn from 'cross-spawn'
 
@@ -29,13 +30,17 @@ export function spawnCli(
   args: string[],
   options: SpawnOptions = {},
 ): ChildProcess {
-  /* c8 ignore next 5 -- Windows-only branch; coverage runs on Linux/macOS */
+  /* c8 ignore next 8 -- Windows-only branch; coverage runs on Linux/macOS */
   if (process.platform === 'win32') {
-    // Guarantee SystemRoot/ComSpec so cmd.exe (which cross-spawn uses to run
-    // `.cmd` shims like claude.cmd/npm.cmd) can start even when the packaged
-    // sidecar inherited a stripped environment. Chokepoint for EVERY Windows
-    // spawn — protects rails, chat, setup and probes uniformly.
-    return crossSpawn(binary, args, { ...options, env: windowsSpawnEnv(options.env) })
+    // Resolve the bare CLI name (`claude`/`codex`/`gemini`/`npx`…) to its
+    // ABSOLUTE shim path first. cross-spawn's internal `which.sync` can fail to
+    // locate the `.cmd` even when the cmd.exe `where` builtin finds it (PATH
+    // format / reparse-point / resolver divergence); on a miss it silently
+    // degrades to `cmd.exe /c "claude …"`, and cmd.exe then re-resolves the bare
+    // name and prints `"claude" no se reconoce…` → the job dies with code 1.
+    // Spawning the resolved absolute path bypasses that bare-name lookup. Plus
+    // the SystemRoot/ComSpec backfill so cmd.exe can start under a stripped env.
+    return crossSpawn(resolveWindowsBinary(binary), args, { ...options, env: windowsSpawnEnv(options.env) })
   }
 
   return spawn(binary, args, options)
@@ -99,9 +104,62 @@ export function stripWindowsVerbatimPrefix(p: string): string {
   return p
 }
 
-// Back-compat for callsites that only need the resolved binary
-// (e.g. logging). Kept as a no-op identity on POSIX; on Windows
-// `where`-based resolution lives inside cross-spawn now.
+// Resolution cache: a binary's absolute shim path changes rarely, and `where`
+// is a synchronous subprocess. Memoize per-name with a short TTL (mirrors
+// binary-probe). A freshly (re)installed CLI is picked up after at most the TTL.
+const RESOLVE_TTL_MS = 30_000
+const _resolveCache = new Map<string, { at: number; resolved: string }>()
+
+/** Prefer a cmd.exe-runnable shim: `.cmd`/`.bat` and `.exe` over `.ps1`
+ *  (PowerShell scripts cannot be run by `cmd.exe /c` directly). */
+function rankWindowsExecExt(p: string): number {
+  const lower = p.toLowerCase()
+  if (lower.endsWith('.cmd') || lower.endsWith('.bat')) return 0
+  if (lower.endsWith('.exe') || lower.endsWith('.com')) return 1
+  if (lower.endsWith('.ps1')) return 3
+  return 2
+}
+
+/**
+ * Resolve a bare command name to its absolute path on Windows via the `where`
+ * builtin (PATHEXT-aware, the same resolver the pre-spawn `binaryOnPath` gate
+ * uses — so when that gate passed, this succeeds too). Returns the bare name
+ * unchanged on POSIX (byte-identical), when `name` is already a path, or on any
+ * failure (graceful fallback to the prior cross-spawn behaviour). Cached.
+ */
 export function resolveWindowsBinary(name: string): string {
-  return name
+  if (process.platform !== 'win32') return name
+  // Already a path (absolute or with a separator) → nothing to resolve. Use
+  // win32 path semantics: `where` output and Windows paths use `C:\…`, which the
+  // host's default `path` module would misjudge when these run under tests.
+  if (path.win32.isAbsolute(name) || name.includes('\\') || name.includes('/')) return name
+  const now = Date.now()
+  const hit = _resolveCache.get(name)
+  if (hit && now - hit.at < RESOLVE_TTL_MS) return hit.resolved
+  let resolved = name
+  try {
+    const out = execFileSync('where', [name], {
+      env: windowsSpawnEnv(),
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5000,
+    })
+    const candidates = out
+      .split(/\r?\n/)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0 && path.win32.isAbsolute(s))
+    if (candidates.length > 0) {
+      candidates.sort((a, b) => rankWindowsExecExt(a) - rankWindowsExecExt(b))
+      resolved = candidates[0]
+    }
+  } catch {
+    /* `where` missing/failed → keep the bare name; cross-spawn/cmd.exe will try. */
+  }
+  _resolveCache.set(name, { at: now, resolved })
+  return resolved
+}
+
+/** Test-only: clear the resolution memo so each test re-resolves. */
+export function __resetWindowsBinaryResolveCacheForTest(): void {
+  _resolveCache.clear()
 }


### PR DESCRIPTION
On Windows, running an **implement rail** (or any claude/codex/gemini spawn) dies immediately with cmd.exe's:
```
"claude" no se reconoce como un comando interno o externo, …
[process exited with code 1]
```

## Root cause
Every spawn passes the **bare name** `claude` to cross-spawn. cross-spawn resolves it with its bundled `which.sync`, which can fail to locate `claude.cmd` **even when the cmd.exe `where` builtin finds it** — and `where` *did* find it here, because the pre-spawn `binaryOnPath('claude')` gate (which uses `where`) had already PASSED, so the job reached the spawn at all. The divergence (PATH format / reparse-point / `which.sync` vs `where`), or claude's install dir simply not being on the GUI-inherited PATH, makes cross-spawn **silently degrade to `cmd.exe /c "claude …"`**; cmd.exe then re-resolves the bare name and prints the error.

The earlier #446 fix only added `%APPDATA%\npm` to PATH (the npm-global case). It did not cover the native installer / version-manager case, nor the bare-name→cmd.exe degradation. **The audit did not catch this** — it ran on macOS and couldn't observe the runtime cross-spawn→cmd.exe behaviour.

## Fix
- **`spawnCli`** (the single Windows spawn chokepoint — rails, chat, setup, probes) now resolves the bare name to its **absolute shim path** via `where` (the same resolver the passing gate uses) before cross-spawn. An absolute `claude.cmd` bypasses cmd.exe's bare-name lookup entirely. `resolveWindowsBinary` is cached (30s TTL), prefers `.cmd`/`.exe` over `.ps1`, and falls back to the bare name on any failure. **POSIX is a no-op (byte-identical).**
- **`windowsGlobalBinDirs()`** now also covers non-npm install locations — the native Claude installer (`%LOCALAPPDATA%\Programs`, `%USERPROFILE%\.local\bin`), Volta, scoop — so `where`/detection can find claude when the GUI PATH lacked it.

## Tests
- `win-spawn.test.ts` (win32-mocked): resolve-to-absolute via `where`; `.cmd`/`.exe` preferred over `.ps1`; `where`-fails → bare-name fallback; already-absolute → no-op; cached; **`spawnCli` hands cross-spawn the resolved absolute path** + preserves caller PATH.
- `path-resolver.test.ts`: prepends `%LOCALAPPDATA%\Programs` + `%USERPROFILE%\.local\bin` on win32 (macOS still `[]`, byte-identical).

Server: 4129 tests pass — 84.99% stmts / 76.16% branch / 88.14% funcs / 86.84% lines. No client changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LauNZYteQ2qXCcVECoPMwp