### PR TITLE
fix(windows): tell the rail agent the real repo path (was reading the wrong/"global" project)

### DIFF
--- a/server/queue-manager.test.ts
+++ b/server/queue-manager.test.ts
@@ -1593,6 +1593,47 @@ describe('QueueManager', () => {
       expect(args[idx + 1]).toBe(repo)
     })
 
+    it('RELOCATED: appends an explicit absolute-repo orientation to the system prompt', () => {
+      // Without it the agent follows the framework templates' ${SPECRAILS_REPO_DIR:-.}
+      // (which its Read/Grep/Glob tools can't expand), reads the empty workspace
+      // cwd, and hallucinates a wrong/"global" project (the Windows "Rails" bug).
+      seedRelocated('acme')
+      vi.mocked(mockExecSync).mockReturnValue(Buffer.from('/usr/bin/claude'))
+      vi.mocked(mockSpawn).mockReturnValue(createMockChildProcess() as any)
+      vi.mocked(mockUuidV4).mockReturnValue('orient-job' as any)
+
+      const db = initDb(':memory:')
+      const qm = new QueueManager(broadcast, db, [], repo, {
+        provider: 'claude', projectId: 'p1', projectSlug: 'acme',
+      })
+      qm.enqueue('/specrails:implement #1')
+
+      const args = vi.mocked(mockSpawn).mock.calls[0][1] as string[]
+      const sysIdx = args.findIndex((a) => a === '--append-system-prompt' || a === '--system-prompt')
+      expect(sysIdx).toBeGreaterThanOrEqual(0)
+      const sys = args[sysIdx + 1]
+      expect(sys).toContain('REPOSITORY LOCATION')
+      expect(sys).toContain(repo) // the concrete absolute repo path
+      expect(sys).toContain('${SPECRAILS_REPO_DIR:-.}') // warns not to use the literal
+    })
+
+    it('LEGACY: does NOT add the relocated repo orientation', () => {
+      vi.mocked(mockExecSync).mockReturnValue(Buffer.from('/usr/bin/claude'))
+      vi.mocked(mockSpawn).mockReturnValue(createMockChildProcess() as any)
+      vi.mocked(mockUuidV4).mockReturnValue('legacy-orient-job' as any)
+
+      const db = initDb(':memory:')
+      const qm = new QueueManager(broadcast, db, [], repo, {
+        provider: 'claude', projectId: 'p1', projectSlug: 'acme',
+      })
+      qm.enqueue('/specrails:implement #1')
+
+      const args = vi.mocked(mockSpawn).mock.calls[0][1] as string[]
+      const sysIdx = args.findIndex((a) => a === '--append-system-prompt' || a === '--system-prompt')
+      const sys = sysIdx >= 0 ? args[sysIdx + 1] : ''
+      expect(sys).not.toContain('REPOSITORY LOCATION')
+    })
+
     it('RELOCATED: prepends an openspec PATH shim that cds into the repo', () => {
       seedRelocated('acme')
       vi.mocked(mockExecSync).mockReturnValue(Buffer.from('/usr/bin/claude'))

--- a/server/queue-manager.ts
+++ b/server/queue-manager.ts
@@ -1107,6 +1107,34 @@ export class QueueManager {
     // into --append-system-prompt, keeping the user prompt clean.
     let systemAppend = ''
 
+    // Repository orientation (relocated projects only). The rail spawns from the
+    // WORKSPACE cwd, which holds only `.specrails/` config — NOT the source code.
+    // The repo is reachable via `--add-dir <repoDir>` (injected below) and the
+    // `./project` link. The framework templates point at `${SPECRAILS_REPO_DIR:-.}`,
+    // but the agent's Read/Grep/Glob/Edit tools do NOT expand that shell-var form
+    // (and PowerShell/cmd.exe don't expand POSIX `${VAR:-default}` either) — so on
+    // Windows the agent reads a bogus literal path, falls back to the empty
+    // workspace cwd, finds only framework files, and hallucinates a wrong/"global"
+    // project. Tell it the concrete absolute repo path explicitly. Mirrors the
+    // Explore-cwd orientation. Legacy (non-relocated) ⇒ cwd IS the repo ⇒ skipped
+    // (byte-identical). The `\${` keeps the shell-var form literal in this string.
+    if (execution.relocated && execution.repoDir) {
+      systemAppend +=
+        `REPOSITORY LOCATION — READ THIS FIRST:\n` +
+        `This pipeline runs from a workspace directory that contains ONLY specrails ` +
+        `configuration (.specrails/, agent definitions) — NOT your project's source code. ` +
+        `Your project's source repository is at this ABSOLUTE path:\n` +
+        `  ${execution.repoDir}\n` +
+        `It is also exposed to your tools as an additional working directory (via --add-dir) ` +
+        `and mounted in this cwd as ./project. Use the absolute repo path above (or ./project) ` +
+        `for ALL source reads, edits, greps and globs. Your Read/Grep/Glob/Edit tools do NOT ` +
+        `expand shell variables — NEVER pass a literal "\${SPECRAILS_REPO_DIR:-.}" or ` +
+        `"\${SPECRAILS_REPO_DIR}" as a path; substitute the absolute path above instead. ` +
+        `The spec/ticket store (.specrails/local-tickets.json) lives in THIS workspace cwd. ` +
+        `Do NOT look for source files under this cwd — they exist only under the repository ` +
+        `path above.\n\n`
+    }
+
     // Output chaining: inject previous step's output as context for dependent jobs
     if (job.dependsOnJobId) {
       const parentJob = this._jobs.get(job.dependsOnJobId)


### PR DESCRIPTION
On Windows, an implement rail now spawns correctly (after #450) but the claude agent reads the **wrong project** — it explored a phantom **"Rails"** project (another / the global one), found nothing, and wandered:
```
Let me explore the Rails project structure …
The agent found no Rails files. Let me check the additional working directory …
```

## Root cause
A relocated rail spawns from the **workspace** cwd, which holds only `.specrails/` config — **not** the source code. The repo is reachable via the already-injected `--add-dir <repoDir>` and the `./project` link, but **the agent is never told that**: specrails-core's framework templates point repo I/O at `${SPECRAILS_REPO_DIR:-.}`, a POSIX shell-var form that the agent's **Read/Grep/Glob/Edit tools do NOT expand** (and PowerShell/cmd.exe don't expand the POSIX `${VAR:-default}` form either). So the agent reads a bogus literal path, falls back to the empty workspace cwd, sees only framework files, and **hallucinates a wrong project**. The active project IS resolved correctly — "Rails" is a stranded-agent hallucination, not a mis-resolution.

(The audit did not catch this — relocation's repo-reach depends on runtime tool/shell behaviour the macOS audit couldn't observe.)

## Fix
When relocated, append an explicit **"REPOSITORY LOCATION"** orientation to the rail's `--append-system-prompt`, giving the **concrete absolute repo path** (= the `--add-dir` / `./project` target) and instructing the agent to use it for all source reads/edits and to never pass the literal `${SPECRAILS_REPO_DIR:-.}` to a file tool. Mirrors the Explore-cwd orientation that already works. **Legacy (cwd == repo) is skipped → byte-identical.** The deeper template fix belongs in specrails-core; this desktop orientation makes the agent reach the repo regardless.

## Tests
- Relocated rail's system prompt contains the absolute repo path + the orientation block + the `${SPECRAILS_REPO_DIR:-.}` warning.
- Legacy rail does **not** add the orientation.

Server: 4131 tests pass — 84.99% stmts / 76.17% branch / 88.14% funcs / 86.84% lines. No client changes.

> Note: a separate Windows bug (Cancel/Stop job → 500 + process keeps running) is being fixed in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LauNZYteQ2qXCcVECoPMwp