### PR TITLE
fix(windows): job Cancel/Stop now actually kills the rail (was 500 + process kept running)

### DIFF
--- a/server/path-resolver.ts
+++ b/server/path-resolver.ts
@@ -154,6 +154,16 @@ function windowsGlobalBinDirs(): string[] {
     dirs.push(path.join(userProfile, '.local', 'bin'))
     dirs.push(path.join(userProfile, 'scoop', 'shims'))
   }
+  // Windows system dirs. A GUI-launched / pkg-stripped sidecar can inherit a PATH
+  // missing %SystemRoot%\System32 — which holds `taskkill`/`where`, and \Wbem
+  // holds `wmic`. Without them, cmd.exe-mediated tools fail: `tree-kill`'s
+  // `taskkill` silently no-ops (a cancelled rail keeps running). Existence-gated
+  // by the callers; harmless when already present (the common case).
+  const systemRoot = process.env.SystemRoot || process.env.windir
+  if (systemRoot) {
+    dirs.push(path.join(systemRoot, 'System32'))
+    dirs.push(path.join(systemRoot, 'System32', 'Wbem'))
+  }
   return dirs
 }
 

--- a/server/project-router-jobs.ts
+++ b/server/project-router-jobs.ts
@@ -211,6 +211,11 @@ export function registerJobsRoutes(deps: ProjectRoutesDeps): void {
         deleteJob(ctx(req).db, req.params.id as string)
         res.json({ ok: true, status: 'deleted' })
       } else {
+        // Surface the real error (name/message/stack) so an unexpected cancel
+        // failure — e.g. a Windows kill throw — is identifiable instead of being
+        // masked as a bare "Internal server error".
+        const e = err as Error
+        console.error(`[jobs] cancel ${req.params.id} failed: ${e?.name}: ${e?.message}\n${e?.stack ?? ''}`)
         res.status(500).json({ error: 'Internal server error' })
       }
     }

--- a/server/queue-manager.test.ts
+++ b/server/queue-manager.test.ts
@@ -168,7 +168,7 @@ describe('QueueManager', () => {
       const result = qm.cancel('job-running')
 
       expect(result).toBe('canceling')
-      expect(vi.mocked(treeKill)).toHaveBeenCalledWith(12345, 'SIGTERM')
+      expect(vi.mocked(treeKill)).toHaveBeenCalledWith(12345, 'SIGTERM', expect.any(Function))
     })
 
     it('on a non-existent ID: throws JobNotFoundError', () => {
@@ -400,7 +400,7 @@ describe('QueueManager', () => {
       // Advance past 5s timeout
       vi.advanceTimersByTime(5100)
 
-      expect(vi.mocked(treeKill)).toHaveBeenCalledWith(12345, 'SIGTERM')
+      expect(vi.mocked(treeKill)).toHaveBeenCalledWith(12345, 'SIGTERM', expect.any(Function))
       expect(vi.mocked(treeKill)).toHaveBeenCalledWith(12345, 'SIGKILL', expect.any(Function))
 
       vi.useRealTimers()
@@ -460,7 +460,7 @@ describe('QueueManager', () => {
       // Advance past the 30s zombie timeout
       vi.advanceTimersByTime(30_100)
 
-      expect(vi.mocked(treeKill)).toHaveBeenCalledWith(12345, 'SIGTERM')
+      expect(vi.mocked(treeKill)).toHaveBeenCalledWith(12345, 'SIGTERM', expect.any(Function))
 
       vi.clearAllTimers()
       vi.useRealTimers()
@@ -534,7 +534,7 @@ describe('QueueManager', () => {
       qmCancel.cancel('job-cancel')
 
       // The cancel itself sends SIGTERM
-      expect(vi.mocked(treeKill)).toHaveBeenCalledWith(12345, 'SIGTERM')
+      expect(vi.mocked(treeKill)).toHaveBeenCalledWith(12345, 'SIGTERM', expect.any(Function))
 
       // Advance well past the zombie timeout — kill timer (5s) will fire SIGKILL,
       // but the zombie timer (30s) should have been cleared by cancel
@@ -605,7 +605,7 @@ describe('QueueManager', () => {
 
       vi.advanceTimersByTime(5_100)
 
-      expect(vi.mocked(treeKill)).toHaveBeenCalledWith(12345, 'SIGTERM')
+      expect(vi.mocked(treeKill)).toHaveBeenCalledWith(12345, 'SIGTERM', expect.any(Function))
 
       vi.clearAllTimers()
       vi.useRealTimers()
@@ -2181,7 +2181,7 @@ describe('QueueManager', () => {
       qm2.enqueue('/implement #1')
       qm2.shutdown()
 
-      expect(vi.mocked(treeKill)).toHaveBeenCalledWith(12345, 'SIGTERM')
+      expect(vi.mocked(treeKill)).toHaveBeenCalledWith(12345, 'SIGTERM', expect.any(Function))
 
       // Close the DB out from under the manager, then deliver the late 'close'
       // the dying child eventually emits. Pre-fix this threw "database

--- a/server/queue-manager.ts
+++ b/server/queue-manager.ts
@@ -3,7 +3,7 @@ import fsNode from 'fs'
 import pathNode from 'path'
 import { createInterface } from 'readline'
 import { newId as uuidv4 } from './ids'
-import treeKill from 'tree-kill'
+import { treeKillSafe } from './util/win-spawn'
 import type { WsMessage, LogMessage, Job, PhaseDefinition, JobPriority } from './types'
 import { PRIORITY_WEIGHT, VALID_PRIORITIES } from './types'
 import { resolveCommand } from './command-resolver'
@@ -358,11 +358,11 @@ export class QueueManager {
     if (proc && proc.pid) {
       const pid = proc.pid
       try {
-        treeKill(pid, 'SIGTERM')
+        treeKillSafe(pid, 'SIGTERM', () => { /* best-effort on shutdown */ })
       } catch { /* best-effort */ }
       const grace = setTimeout(() => {
         try {
-          treeKill(pid, 'SIGKILL', () => { /* ignore */ })
+          treeKillSafe(pid, 'SIGKILL', () => { /* ignore */ })
         } catch { /* best-effort */ }
       }, 5000)
       // Do not let the grace timer keep the process alive on real shutdown.
@@ -2003,11 +2003,21 @@ export class QueueManager {
       clearTimeout(this._killTimer)
       this._killTimer = null
     }
-    treeKill(this._activeProcess.pid, 'SIGTERM')
-
     const pid = this._activeProcess.pid
+    // treeKillSafe never throws synchronously, but wrap defensively so a kill
+    // failure can NEVER propagate into the cancel HTTP route as a 500. On Windows
+    // it invokes an absolute taskkill (PATH-independent) so the tree is actually
+    // killed; the callback surfaces any failure instead of swallowing it.
+    try {
+      treeKillSafe(pid, 'SIGTERM', (err) => {
+        if (err) console.error(`[kill] SIGTERM tree-kill failed for pid ${pid}: ${err.message}`)
+      })
+    } catch (err) {
+      console.error(`[kill] SIGTERM tree-kill threw for pid ${pid}: ${(err as Error).message}`)
+    }
+
     this._killTimer = setTimeout(() => {
-      treeKill(pid, 'SIGKILL', (err) => {
+      treeKillSafe(pid, 'SIGKILL', (err) => {
         if (err) {
           // SIGKILL failed — force cleanup so queue is not permanently blocked.
           console.error(`[kill] SIGKILL failed for pid ${pid}: ${err.message}`)

--- a/server/util/win-spawn.test.ts
+++ b/server/util/win-spawn.test.ts
@@ -5,17 +5,20 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 // the binary handed to it on the win32 path.
 vi.mock('child_process', async (orig) => {
   const actual = await orig<typeof import('child_process')>()
-  return { ...actual, execFileSync: vi.fn() }
+  return { ...actual, execFileSync: vi.fn(), execFile: vi.fn() }
 })
 vi.mock('cross-spawn', () => ({ default: vi.fn(() => ({ pid: 1, on: vi.fn() })) }))
+vi.mock('tree-kill', () => ({ default: vi.fn() }))
 
-import { execFileSync } from 'child_process'
+import { execFileSync, execFile } from 'child_process'
 import crossSpawn from 'cross-spawn'
+import treeKill from 'tree-kill'
 import {
   spawnCli,
   resolveWindowsBinary,
   windowsSpawnEnv,
   stripWindowsVerbatimPrefix,
+  treeKillSafe,
   __resetWindowsBinaryResolveCacheForTest,
 } from './win-spawn'
 
@@ -153,6 +156,44 @@ describe('resolveWindowsBinary', () => {
       expect(resolveWindowsBinary('claude')).toBe('C:\\x\\claude.cmd')
       expect(vi.mocked(execFileSync)).toHaveBeenCalledTimes(1)
     })
+  })
+})
+
+describe('treeKillSafe', () => {
+  beforeEach(() => {
+    vi.mocked(treeKill).mockReset()
+    vi.mocked(execFile).mockReset()
+  })
+  afterEach(restorePlatform)
+
+  it('on POSIX delegates to tree-kill (with a callback) and forwards the result', () => {
+    if (process.platform === 'win32') return
+    const cb = vi.fn()
+    treeKillSafe(4321, 'SIGTERM', cb)
+    expect(vi.mocked(treeKill)).toHaveBeenCalledWith(4321, 'SIGTERM', expect.any(Function))
+    expect(vi.mocked(execFile)).not.toHaveBeenCalled()
+    // tree-kill reports success → cb(undefined); error → cb(err).
+    const wrapped = vi.mocked(treeKill).mock.calls[0][2] as (e?: Error | null) => void
+    wrapped(null)
+    expect(cb).toHaveBeenCalledWith(undefined)
+    const err = new Error('boom')
+    wrapped(err)
+    expect(cb).toHaveBeenCalledWith(err)
+  })
+
+  it('on win32 invokes an ABSOLUTE taskkill.exe with a SystemRoot-backfilled env (PATH-independent)', () => {
+    asWin32()
+    const cb = vi.fn()
+    treeKillSafe(9988, 'SIGKILL', cb)
+    expect(vi.mocked(treeKill)).not.toHaveBeenCalled()
+    expect(vi.mocked(execFile)).toHaveBeenCalledTimes(1)
+    const [bin, args, opts] = vi.mocked(execFile).mock.calls[0] as [string, string[], { env: NodeJS.ProcessEnv }]
+    // Separator-agnostic: path.join uses '/' when the suite runs on macOS even
+    // with process.platform mocked to win32.
+    expect(/system32[\\/]taskkill\.exe$/i.test(bin)).toBe(true)
+    expect(bin.toLowerCase()).toContain('windows') // absolute, under %SystemRoot%
+    expect(args).toEqual(['/pid', '9988', '/T', '/F'])
+    expect(opts.env.SystemRoot).toBeTruthy() // windowsSpawnEnv applied
   })
 })
 

--- a/server/util/win-spawn.ts
+++ b/server/util/win-spawn.ts
@@ -20,10 +20,42 @@
 // args so newlines and shell metacharacters survive intact, and on
 // POSIX it falls through to the native `child_process.spawn`.
 
-import { spawn, execFileSync } from 'child_process'
+import { spawn, execFileSync, execFile } from 'child_process'
 import path from 'path'
 import type { ChildProcess, SpawnOptions } from 'child_process'
 import crossSpawn from 'cross-spawn'
+import treeKill from 'tree-kill'
+
+/**
+ * Kill a process tree, robustly on Windows. `tree-kill` shells out to
+ * `exec('taskkill /pid … /T /F')` through cmd.exe, which resolves `taskkill`
+ * against the spawn env's PATH — but `taskkill.exe` lives in
+ * `%SystemRoot%\System32`, which a GUI-launched / pkg-stripped sidecar's PATH can
+ * lack, so the kill silently no-ops (the rail keeps running) and, with no
+ * callback, the failure is swallowed. Here we instead invoke the ABSOLUTE
+ * `taskkill.exe` with a SystemRoot-backfilled env (`windowsSpawnEnv`), so the
+ * kill never depends on PATH. POSIX delegates to `tree-kill` unchanged
+ * (byte-identical). Errors are always surfaced via `callback`.
+ */
+export function treeKillSafe(pid: number, signal: string | undefined, callback?: (err?: Error) => void): void {
+  const done = (err?: Error) => { if (callback) callback(err) }
+  if (process.platform !== 'win32') {
+    treeKill(pid, signal, (err) => done(err ?? undefined))
+    return
+  }
+  /* c8 ignore start -- Windows-only branch; coverage runs on Linux/macOS */
+  try {
+    const env = windowsSpawnEnv()
+    const systemRoot = (env.SystemRoot || env.windir || 'C:\\Windows').replace(/[\\/]$/, '')
+    const taskkill = path.join(systemRoot, 'System32', 'taskkill.exe')
+    // /T = whole tree, /F = force. taskkill has no SIGTERM/SIGKILL distinction;
+    // `tree-kill` already always force-kills on win32, so behaviour is unchanged.
+    execFile(taskkill, ['/pid', String(pid), '/T', '/F'], { env }, (err) => done(err ?? undefined))
+  } catch (err) {
+    done(err as Error)
+  }
+  /* c8 ignore stop */
+}
 
 export function spawnCli(
   binary: string,


### PR DESCRIPTION
On Windows, **"Cancel Job"** returned **HTTP 500** and the rail kept running; **"Stop"** left the claude process alive.

## Root cause
`tree-kill` on Windows runs `exec('taskkill /pid … /T /F')` through cmd.exe, which resolves `taskkill` against the spawn env's PATH — but `taskkill.exe` lives in `%SystemRoot%\System32`, which a GUI-launched / pkg-stripped sidecar's PATH can lack. `taskkill` then fails to start, and because the SIGTERM `treeKill` call passed **no callback**, the failure was **silently swallowed** → the claude (+ MCP) process tree survives. The 5s SIGKILL escalation ran the identical command → same failure. The 500 was an unhandled failure surfacing through the cancel route (masking the real error).

(The audit flagged the Windows-taskkill theme — BUG-CHAT-01 / BUG-QUEUE-02 — but the concrete `taskkill`-not-on-PATH + swallowed-failure mechanism needed a Windows repro to pin down.)

## Fix
- **New `treeKillSafe(pid, signal, cb)`** (`server/util/win-spawn.ts`): on Windows invokes the **absolute** `%SystemRoot%\System32\taskkill.exe` with a SystemRoot-backfilled env (`windowsSpawnEnv`) so the kill never depends on PATH, and always surfaces errors via the callback. **POSIX delegates to `tree-kill` unchanged (byte-identical).**
- **`QueueManager._kill` / `shutdown`** route every kill through `treeKillSafe`, with the SIGTERM call wrapped in try/catch + a callback so a kill failure can never propagate into the cancel route as a 500, and the SIGKILL escalation (→ `_forceFailUnkillableJob`) is reliably reached.
- **`windowsGlobalBinDirs()`** now also puts `%SystemRoot%\System32` (+ `\Wbem`) on the startup PATH, so every cmd.exe-mediated tool (taskkill, wmic, where) — and `tree-kill` in the other managers — resolves.
- The **cancel route logs the real error** (name/message/stack) before any 500, so an unexpected failure is identifiable instead of masked.

## Tests
- `win-spawn.test.ts`: `treeKillSafe` POSIX-delegation (callback forwards success/error) + win32 invokes an absolute `…\System32\taskkill.exe` with `SystemRoot` in env.
- `queue-manager.test.ts`: kill assertions updated for the callback arg; existing SIGKILL-failure → `_forceFailUnkillableJob` path still green.

Server: 4133 tests pass — 84.98% stmts / 76.16% branch / 88.08% funcs / 86.83% lines. No client changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LauNZYteQ2qXCcVECoPMwp