### PR TITLE
fix(contract-refine): resume the Explore session from the same cwd it was created in (Desktop tier)

### DIFF
--- a/server/contract-refine-runner.test.ts
+++ b/server/contract-refine-runner.test.ts
@@ -25,6 +25,7 @@ import {
   type ContractLayer,
 } from './explore-contract-refine'
 import { mutateStore, resolveTicketStoragePath, type TicketStore, CURRENT_SCHEMA_VERSION } from './ticket-store'
+import { mirrorProjectEntry, workspaceLayout, resolveHome } from './artifact-registry'
 
 class FakeChild extends EventEmitter {
   stdout: Readable
@@ -172,6 +173,36 @@ describe('prepareContractRefineSpawn', () => {
       { model: 'sonnet', session_id: 'sess-1', context_scope: JSON.stringify({ mcp: true }) },
     )
     expect(out.cwd).toBe(projectPath)
+  })
+
+  it('RELOCATED + mcp: resumes from project.path, NOT the workspace (Desktop-tier session bug)', () => {
+    // The Explore turn that created the resumable session spawned from
+    // project.path (chat-manager _resolveSpawnCwd: mcp ⇒ this._cwd, NOT the
+    // relocated workspace). A relocated refine that resumed from exec.cwd (the
+    // workspace) made claude fail with "No conversation found with session ID …".
+    const prevHome = process.env.SPECRAILS_REGISTRY_HOME
+    const regHome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'cr-reloc-home-')))
+    fs.mkdirSync(path.join(regHome, '.specrails'), { recursive: true })
+    process.env.SPECRAILS_REGISTRY_HOME = regHome
+    const repo = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'cr-reloc-repo-')))
+    try {
+      mirrorProjectEntry({ repoPath: repo, slug: 'acme', providers: ['claude'] }, regHome)
+      const ws = workspaceLayout(resolveHome(regHome), 'acme', repo).workspaceDir
+      fs.mkdirSync(path.join(ws, '.specrails'), { recursive: true })
+      fs.writeFileSync(path.join(ws, '.specrails', 'specrails-version'), '4.10.0\n')
+
+      const out = prepareContractRefineSpawn(
+        { projectSlug: 'acme', projectPath: repo, projectName: 'Acme' },
+        { model: 'sonnet', session_id: 'sess-x', context_scope: JSON.stringify({ mcp: true }) },
+      )
+      expect(out.cwd).toBe(repo)   // project.path — matches the Explore session's cwd
+      expect(out.cwd).not.toBe(ws) // NOT the relocated workspace (the bug)
+    } finally {
+      if (prevHome !== undefined) process.env.SPECRAILS_REGISTRY_HOME = prevHome
+      else delete process.env.SPECRAILS_REGISTRY_HOME
+      fs.rmSync(regHome, { recursive: true, force: true })
+      fs.rmSync(repo, { recursive: true, force: true })
+    }
   })
 })
 

--- a/server/contract-refine-runner.ts
+++ b/server/contract-refine-runner.ts
@@ -141,22 +141,31 @@ export function prepareContractRefineSpawn(
       /* default false */
     }
   }
-  // Relocate-artifacts: when mcp is on, the spawn cwd is the project's spec root,
-  // which becomes the workspace when relocated (else project.path). When mcp is
-  // off the explore-cwd is used as before. Env carries SPECRAILS_REPO_DIR for the
-  // relocated case so source/openspec I/O re-points into the repo.
+  // The refine `--resume`s the Explore conversation's session, so it MUST spawn
+  // from the SAME cwd the Explore turn used — otherwise claude looks in a
+  // different per-cwd session store and fails with "No conversation found with
+  // session ID …" (the Desktop-tier bug). chat-manager `_resolveSpawnCwd` for an
+  // Explore turn uses:
+  //   - mcp ON  → `project.path` (NOT the relocated workspace),
+  //   - mcp OFF → the app-managed explore-cwd.
+  // We mirror that EXACTLY here. The refine uses no file tools (`--disallowedTools
+  // Read,Grep,Glob,Bash`) and its prompt rides on `--system-prompt`, so it needs
+  // neither the workspace's `.mcp.json` nor its `.claude/commands`. Env still
+  // carries SPECRAILS_REPO_DIR when relocated (harmless; no tools consume it).
   const exec = resolveProjectExecution({ slug: deps.projectSlug, path: deps.projectPath })
-  let cwd = exec.cwd
   let env: NodeJS.ProcessEnv | undefined = exec.relocated ? { ...process.env, ...exec.env } : undefined
-  if (!mcpEnabled) {
+  let cwd: string
+  if (mcpEnabled) {
+    // Match the Explore mcp-on spawn cwd (`this._cwd` = project.path), even when
+    // relocated (where exec.cwd would be the workspace ≠ project.path).
+    cwd = deps.projectPath
+  } else {
     try {
       cwd = ensureExploreCwd({
         slug: deps.projectSlug,
         projectPath: deps.projectPath,
         projectName: deps.projectName,
       })
-      // explore-cwd reaches the repo via its own `./project` link; keep the
-      // relocation env so SPECRAILS_REPO_DIR is still exported when relocated.
     } catch {
       cwd = exec.cwd
     }


### PR DESCRIPTION
Creating a spec with the **Desktop tier** (the only preset with `mcp:true` + `contractRefine:true`) failed Contract Refine on **relocated** projects:
```
result subtype=error_during_execution is_error=true num_turns=0
errors: ["No conversation found with session ID: 1be8f9ef-…"]
```

## Root cause — per-cwd session-store mismatch
claude stores/looks up sessions by the spawn **cwd**. The Explore turn that creates the resumable session spawns, for `mcp:true`, from **`project.path`** (chat-manager `_resolveSpawnCwd` returns `this._cwd`, **not** the relocated workspace). But the contract-refine runner resumed from **`exec.cwd`**, which on a relocated project is the **workspace** (`~/.specrails/projects/<slug>/workspace`) ≠ `project.path`. So `--resume <id>` looked in the workspace's session store and never found the session created under `project.path` → exit 1.

- **Legacy** (non-relocated): unaffected — `exec.cwd === project.path`.
- **Max tier**: unaffected — `mcp:false` (explore-cwd in both Explore and refine).
- → only **Desktop tier on relocated projects**.

(The `is_error`/`error_during_execution` was surfaced correctly thanks to the audit's BUG-PARSER-04 fix — that's the runner *reporting* the real failure, not the cause.)

## Fix
The refine now mirrors chat-manager's Explore spawn cwd **exactly**: `mcp` on ⇒ `project.path` (even when relocated), `mcp` off ⇒ explore-cwd. The refine uses no file tools (`--disallowedTools Read,Grep,Glob,Bash`) and its prompt rides on `--system-prompt`, so it needs neither the workspace's `.mcp.json` nor its `.claude/commands`.

## Test
A relocated project with `mcp:true` now resolves the refine cwd to `project.path`, not the workspace — the regression the prior test missed (it only exercised the non-relocated case where the two coincide).

Server: 4134 tests pass — 84.98 / 76.17 / 88.08 / 86.83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LauNZYteQ2qXCcVECoPMwp