### PR TITLE
fix(windows): self-heal empty workspace agents on rail spawn (current-junction repair)

### DIFF
--- a/server/queue-manager.ts
+++ b/server/queue-manager.ts
@@ -31,6 +31,7 @@ import type { CommandInfo } from './config'
 import { attachmentManager, USER_ATTACHMENT_SYSTEM_NOTE } from './attachment-manager'
 import { extractTicketIdsFromCommand, readStore, resolveTicketStoragePath } from './ticket-store'
 import { binaryOnPath } from './binary-probe'
+import { ensureFrameworkAgents } from './workspace-manager'
 import { resolveProjectExecution, type ProjectExecution } from './workspace-resolution'
 import { readCurrentFrameworkVersion } from './framework-manager'
 import { ensureOpenspecShim, prependShimToPath, removeOpenspecShim, openspecShimDir } from './openspec-shim'
@@ -1085,6 +1086,19 @@ export class QueueManager {
     const execution = this._resolveExecution()
     this._jobExecution.set(jobId, execution)
     const spawnCwd = execution.cwd
+
+    // Windows repair: a relocated workspace whose `.claude/agents` was left empty
+    // by the broken `current`-junction read during assemble has no sr-* agents,
+    // so the implement pipeline can't delegate and runs inline. Self-heal here
+    // (per rail spawn) by copying the agents from the real version dir. NO-OP on
+    // POSIX (assemble's per-file symlinks already populate them).
+    if (execution.relocated) {
+      try {
+        ensureFrameworkAgents(execution.cwd, adapter.projectDirName)
+      } catch {
+        /* best-effort — never block a rail spawn on the repair */
+      }
+    }
 
     job.status = 'running'
     job.startedAt = new Date().toISOString()

--- a/server/workspace-manager.test.ts
+++ b/server/workspace-manager.test.ts
@@ -7,6 +7,7 @@ import {
   removeWorkspace,
   workspacePathFor,
   assembleWorkspaceFramework,
+  ensureFrameworkAgents,
 } from './workspace-manager'
 import { FrameworkManager } from './framework-manager'
 
@@ -31,6 +32,62 @@ describe('workspace-manager', () => {
     expect(workspacePathFor('myslug', home)).toBe(
       path.join(home, '.specrails', 'projects', 'myslug', 'workspace'),
     )
+  })
+
+  describe('ensureFrameworkAgents (win32 repair)', () => {
+    const ORIG = process.platform
+    const win32 = () => Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    afterEach(() => Object.defineProperty(process, 'platform', { value: ORIG, configurable: true }))
+
+    function seedFramework(version = '4.10.0', agents = ['sr-architect', 'sr-developer', 'sr-reviewer']): void {
+      const dir = path.join(home, '.specrails', 'framework', version, '.claude', 'agents')
+      fs.mkdirSync(dir, { recursive: true })
+      for (const a of agents) fs.writeFileSync(path.join(dir, `${a}.md`), `# ${a}\n`)
+    }
+
+    it('copies the framework sr-* agents from the version dir into an empty workspace', () => {
+      win32()
+      seedFramework()
+      const ws = workspacePathFor('acme', home)
+      fs.mkdirSync(path.join(ws, '.claude', 'agents'), { recursive: true })
+      expect(ensureFrameworkAgents(ws, '.claude', home)).toBe(3)
+      expect(fs.existsSync(path.join(ws, '.claude', 'agents', 'sr-architect.md'))).toBe(true)
+      expect(fs.readFileSync(path.join(ws, '.claude', 'agents', 'sr-developer.md'), 'utf8')).toBe('# sr-developer\n')
+    })
+
+    it('preserves user custom-*.md and is idempotent', () => {
+      win32()
+      seedFramework()
+      const ws = workspacePathFor('acme', home)
+      const agentsDir = path.join(ws, '.claude', 'agents')
+      fs.mkdirSync(agentsDir, { recursive: true })
+      fs.writeFileSync(path.join(agentsDir, 'custom-mine.md'), 'mine\n')
+      expect(ensureFrameworkAgents(ws, '.claude', home)).toBe(3)
+      expect(fs.readFileSync(path.join(agentsDir, 'custom-mine.md'), 'utf8')).toBe('mine\n') // preserved
+      expect(ensureFrameworkAgents(ws, '.claude', home)).toBe(0) // idempotent
+    })
+
+    it('picks the highest framework version dir', () => {
+      win32()
+      seedFramework('4.9.0', ['sr-architect'])
+      seedFramework('4.10.0', ['sr-architect', 'sr-developer'])
+      const ws = workspacePathFor('acme', home)
+      expect(ensureFrameworkAgents(ws, '.claude', home)).toBe(2) // from 4.10.0, not 4.9.0
+    })
+
+    it('is a NO-OP on POSIX (the assemble symlinks already populate agents)', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+      seedFramework()
+      const ws = workspacePathFor('acme', home)
+      expect(ensureFrameworkAgents(ws, '.claude', home)).toBe(0)
+      expect(fs.existsSync(path.join(ws, '.claude', 'agents', 'sr-architect.md'))).toBe(false)
+    })
+
+    it('no-op when the framework agents source is absent', () => {
+      win32()
+      const ws = workspacePathFor('acme', home)
+      expect(ensureFrameworkAgents(ws, '.claude', home)).toBe(0)
+    })
   })
 
   it('BUG-ARTREG-01: honors SPECRAILS_REGISTRY_HOME (matches artifact-registry) when no explicit home is threaded', () => {

--- a/server/workspace-manager.ts
+++ b/server/workspace-manager.ts
@@ -1,9 +1,82 @@
 import fs from 'fs'
 import path from 'path'
 
-import { FrameworkManager } from './framework-manager'
+import { FrameworkManager, frameworkRoot } from './framework-manager'
 import { migrateWorkspaceToSymlinks } from './framework-migration'
 import { resolveHome } from './artifact-registry'
+
+/** Highest-first semver-ish sort for framework version dir names. */
+function compareFrameworkVersionDesc(a: string, b: string): number {
+  const pa = a.split('.').map((n) => parseInt(n, 10))
+  const pb = b.split('.').map((n) => parseInt(n, 10))
+  for (let i = 0; i < 3; i++) {
+    const x = pa[i] ?? 0
+    const y = pb[i] ?? 0
+    if (x !== y) return y - x
+  }
+  return 0
+}
+
+/**
+ * Windows repair: ensure the workspace's `<providerDir>/agents` holds the
+ * framework's `sr-*` agent definitions, copied from the REAL versioned framework
+ * dir (`~/.specrails/framework/<version>/<providerDir>/agents`).
+ *
+ * Why: on Windows the `framework/current` JUNCTION can be untraversable by Node's
+ * `fs` ("UNKNOWN: scandir" / "untrusted mount point"); the bundled core's
+ * `assemble` sources the agents THROUGH `current`, so `linkAgentFiles` reads
+ * nothing and the workspace ends up with NO `sr-*` agents — the implement
+ * pipeline then has no sub-agents to delegate to (architect/developer/reviewer)
+ * and silently runs everything inline. The versioned dir is a real, traversable
+ * directory, so we read it directly. (The proper fix lives in core's `assemble`;
+ * this repairs already-broken installs without waiting for a core republish, and
+ * mirrors exactly what the fixed core does on Windows — copy from the version
+ * dir.) `assemble` never re-runs on a rail spawn, so a workspace broken at setup
+ * stays broken; this runs per rail spawn to self-heal it.
+ *
+ * NO-OP on POSIX (per-file symlinks already populate the workspace correctly;
+ * byte-identical). Additive (never touches user `custom-*.md`) + idempotent.
+ * Returns the number of agents copied.
+ */
+export function ensureFrameworkAgents(workspaceDir: string, providerDir: string, home?: string): number {
+  if (process.platform !== 'win32') return 0
+  const root = frameworkRoot(home)
+  // Resolve the framework version by listing REAL version dirs — NOT via the
+  // `current` junction (which is the very thing that may be untraversable here).
+  let version: string | undefined
+  try {
+    version = fs
+      .readdirSync(root)
+      .filter((n) => /^\d+\.\d+\.\d+$/.test(n))
+      .sort(compareFrameworkVersionDesc)[0]
+  } catch {
+    return 0
+  }
+  if (!version) return 0
+  const src = path.join(root, version, providerDir, 'agents')
+  let entries: string[]
+  try {
+    entries = fs.readdirSync(src)
+  } catch {
+    return 0 // framework agents not materialized for this provider
+  }
+  const dest = path.join(workspaceDir, providerDir, 'agents')
+  let copied = 0
+  for (const name of entries) {
+    // Framework agents only; never clobber a user/plugin `custom-*.md`.
+    if (!name.endsWith('.md') || name.startsWith('custom-')) continue
+    const destFile = path.join(dest, name)
+    if (fs.existsSync(destFile)) continue
+    try {
+      fs.mkdirSync(dest, { recursive: true })
+      fs.copyFileSync(path.join(src, name), destFile)
+      copied += 1
+    } catch {
+      /* best-effort per file — one failure must never abort the rail spawn */
+    }
+  }
+  return copied
+}
 
 /**
  * WorkspaceManager — a reusable materializer for the per-project workspace dir


### PR DESCRIPTION
The desktop-side stopgap for the Windows "implement runs inline instead of delegating to sub-agents" bug.

## Root cause (confirmed on the user's box)
The bundled core's `assemble` sources the framework subtrees **through** the `~/.specrails/framework/current` junction. On Windows that junction can be **untraversable** by Node's fs:
```
node fs.readdirSync(framework/current/.claude/agents) → ERR UNKNOWN: scandir
node fs.readdirSync(framework/4.10.0/.claude/agents)  → 14   (real version dir, fine)
```
So `linkAgentFiles` reads nothing → the workspace gets **no `sr-*` agents** → the implement orchestrator has nothing to delegate to and runs architect→developer→reviewer inline in one session.

## Fix (win32-only, POSIX byte-identical)
`assemble` never re-runs on a rail spawn, so a workspace broken at setup stays broken. New **`ensureFrameworkAgents()`** copies the framework `sr-*` agents from the **real version dir** (`framework/<version>/<providerDir>/agents`, traversable) into the workspace's `<providerDir>/agents` when missing; `QueueManager` runs it before every **relocated** rail spawn to self-heal already-installed boxes. It mirrors exactly what the fixed core does on Windows (copy from the version dir), so it converges with the core change. Additive (never touches user `custom-*.md`), idempotent, **NO-OP on POSIX**.

> The proper, upstream fix is core-side — specrails-core PR #317 makes `assemble` read the version dir instead of `current`. This desktop stopgap fixes existing installs **without** waiting for a core republish + re-bundle, so it ships in this release.

## Tests
`workspace-manager.test.ts`: copies sr-* from the highest version dir; preserves `custom-*.md`; idempotent; no-op on POSIX and when the source is absent.

Server: 4139 tests pass — 84.99 / 76.17 / 88.11 / 86.84. No client changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LauNZYteQ2qXCcVECoPMwp