### PR TITLE
feat: From-website in Explore + global browser cookies, fix PNG attach & Jira Done status

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -45,6 +45,7 @@ import { WS_URL } from './lib/ws-url'
 import { TerminalsProvider, useTerminals } from './context/TerminalsContext'
 import { MinimizedChatsProvider } from './context/MinimizedChatsContext'
 import { TicketDetailModalProvider } from './context/TicketDetailModalContext'
+import { WebViewModalProvider } from './context/WebViewModalContext'
 import { useCompareUrlSync } from './hooks/useCompareUrlSync'
 import { ThemeProvider, useTheme } from './context/ThemeContext'
 import { LanguageProvider } from './context/LanguageContext'
@@ -404,8 +405,10 @@ export default function App() {
                   <TerminalsProviderWithDesktop>
                     <MinimizedChatsProvider>
                       <TicketDetailModalProvider>
-                        <DesktopApp />
-                        <ThemedToaster />
+                        <WebViewModalProvider>
+                          <DesktopApp />
+                          <ThemedToaster />
+                        </WebViewModalProvider>
                       </TicketDetailModalProvider>
                     </MinimizedChatsProvider>
                   </TerminalsProviderWithDesktop>

--- a/client/src/components/TicketDetailModal.tsx
+++ b/client/src/components/TicketDetailModal.tsx
@@ -19,6 +19,7 @@ import { DiscardSpecDialog } from './jira/DiscardSpecDialog'
 import { JiraSpecDetailsPanel } from './jira/JiraSpecDetailsPanel'
 import { parseAcceptanceCriteria } from './explore-spec/acceptance-criteria'
 import { canRefineTicket } from '../lib/ticket-refine'
+import { genPendingSpecId } from '../lib/pending-spec-id'
 import { useDesktop } from '../hooks/useDesktop'
 import { SmashActions } from './specs-smash/SmashActions'
 import { EpicBreadcrumb } from './specs-smash/EpicChildrenSection'
@@ -841,7 +842,10 @@ function ContinueEditingButton({ ticket, title, description, priority, labels, o
       restoreRoute: '/',
       params: {
         initialIdea: '',
-        pendingSpecId: '',
+        // A real, filesystem-safe id (NOT '') so attachment uploads and the
+        // "From a website" capture work in edit mode (an empty id 400s capture
+        // with "pendingSpecId is required").
+        pendingSpecId: genPendingSpecId(),
         initialAttachmentIds: [],
         resumeConversationId: ticket.origin_conversation_id ?? undefined,
         editTicket: {

--- a/client/src/components/TicketDetailModal.tsx
+++ b/client/src/components/TicketDetailModal.tsx
@@ -20,6 +20,7 @@ import { JiraSpecDetailsPanel } from './jira/JiraSpecDetailsPanel'
 import { parseAcceptanceCriteria } from './explore-spec/acceptance-criteria'
 import { canRefineTicket } from '../lib/ticket-refine'
 import { genPendingSpecId } from '../lib/pending-spec-id'
+import { useWebViewModal } from '../context/WebViewModalContext'
 import { useDesktop } from '../hooks/useDesktop'
 import { SmashActions } from './specs-smash/SmashActions'
 import { EpicBreadcrumb } from './specs-smash/EpicChildrenSection'
@@ -986,8 +987,29 @@ interface DescriptionRenderProps {
 
 function DescriptionRender({ description, onEdit }: DescriptionRenderProps) {
   const { t } = useTranslation('tickets')
+  const { openWebView } = useWebViewModal()
   const { user, contract } = splitDescriptionAtContractLayer(description)
   const userPart = user || description
+  // Open http(s) links from the description inside the app's embedded browser
+  // modal (sharing the global cookies/profile), instead of navigating away.
+  const markdownComponents = useMemo(() => ({
+    a: ({ href, children }: { href?: string; children?: React.ReactNode }) => (
+      <a
+        href={href}
+        target="_blank"
+        rel="noreferrer"
+        onClick={(e) => {
+          if (typeof href === 'string' && /^https?:\/\//i.test(href)) {
+            e.preventDefault()
+            e.stopPropagation() // don't trigger the card's enter-edit onClick
+            openWebView(href)
+          }
+        }}
+      >
+        {children}
+      </a>
+    ),
+  }), [openWebView])
   return (
     <div
       className="flex-1 rounded-lg bg-muted/20 px-3 py-2 overflow-y-auto transition-colors"
@@ -1000,7 +1022,7 @@ function DescriptionRender({ description, onEdit }: DescriptionRenderProps) {
       style={{ cursor: 'pointer' }}
     >
       <div className="prose prose-invert prose-xs max-w-none prose-p:my-1 prose-headings:mt-2 prose-headings:mb-1 prose-headings:text-sm prose-headings:font-semibold prose-ul:my-1 prose-ol:my-1 prose-li:my-0 prose-code:text-cyan-300 prose-code:text-[10px] prose-code:bg-muted/40 prose-code:px-1 prose-code:py-0.5 prose-code:rounded text-foreground/80 text-xs">
-        <ReactMarkdown remarkPlugins={[remarkGfm]}>{userPart}</ReactMarkdown>
+        <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>{userPart}</ReactMarkdown>
       </div>
       {contract && (
         <details
@@ -1015,7 +1037,7 @@ function DescriptionRender({ description, onEdit }: DescriptionRenderProps) {
             </span>
           </summary>
           <div className="mt-2 prose prose-invert prose-xs max-w-none prose-p:my-1 prose-headings:mt-2 prose-headings:mb-1 prose-headings:text-sm prose-headings:font-semibold prose-ul:my-1 prose-ol:my-1 prose-li:my-0 prose-code:text-cyan-300 prose-code:text-[10px] prose-code:bg-muted/40 prose-code:px-1 prose-code:py-0.5 prose-code:rounded text-foreground/80 text-xs">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{contract}</ReactMarkdown>
+            <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>{contract}</ReactMarkdown>
           </div>
         </details>
       )}

--- a/client/src/components/TicketPostitCard.tsx
+++ b/client/src/components/TicketPostitCard.tsx
@@ -9,6 +9,7 @@ import { useMinimizedChats } from '../context/MinimizedChatsContext'
 import { useDesktop } from '../hooks/useDesktop'
 import { parseAcceptanceCriteria } from './explore-spec/acceptance-criteria'
 import { canRefineTicket } from '../lib/ticket-refine'
+import { genPendingSpecId } from '../lib/pending-spec-id'
 import type { LocalTicket, TicketPriority } from '../types'
 import type { RailState } from './RailsBoard'
 
@@ -141,7 +142,9 @@ export function TicketPostitCard({
       restoreRoute: '/',
       params: {
         initialIdea: '',
-        pendingSpecId: '',
+        // A real, filesystem-safe id (NOT '') so attachment uploads + "From a
+        // website" capture work in edit mode (empty 400s capture).
+        pendingSpecId: genPendingSpecId(),
         initialAttachmentIds: [],
         resumeConversationId: ticket.origin_conversation_id ?? undefined,
         editTicket: {

--- a/client/src/components/browser-capture/AnnotationEditor.tsx
+++ b/client/src/components/browser-capture/AnnotationEditor.tsx
@@ -21,6 +21,10 @@ interface AnnotationEditorProps {
   pendingSpecId: string
   /** Reserve the macOS traffic-light gutter on the floating toolbar. */
   macOverlay?: boolean
+  /** Label for the primary confirm button when the user has drawn annotations.
+   *  Lets the caller reflect context ("Crear spec" vs "Actualizar spec");
+   *  defaults to the generic create label. */
+  confirmLabel?: string
   /** Flattens + uploads, then hands back an augmented CaptureResult. */
   onConfirm: (augmented: CaptureResult) => void
   /** Discard markup, return to the rubber-band selection step. */
@@ -53,7 +57,7 @@ const newId = () => `a${++idSeq}-${Date.now().toString(36)}`
  * coverage — canvas + pointer drag is not exercisable under jsdom; the model and
  * geometry live in `lib/annotations.ts` and are unit-tested.
  */
-export function AnnotationEditor({ result, pendingSpecId, macOverlay, onConfirm, onReselect, onCancel }: AnnotationEditorProps) {
+export function AnnotationEditor({ result, pendingSpecId, macOverlay, confirmLabel, onConfirm, onReselect, onCancel }: AnnotationEditorProps) {
   const { t } = useTranslation('browser')
   const [state, dispatch] = useReducer(annotationReducer, initialEditorState)
   const [tool, setTool] = useState<AnnotationTool>('arrow')
@@ -354,7 +358,7 @@ export function AnnotationEditor({ result, pendingSpecId, macOverlay, onConfirm,
           <X className="w-3.5 h-3.5" /> {t('common:actions.cancel')}
         </Button>
         <Button size="sm" className="gap-1.5" onClick={() => void handleConfirm()} disabled={busy} data-testid="annotation-confirm">
-          <Check className="w-3.5 h-3.5" /> {objects.length > 0 ? t('editor.createSpec') : t('editor.skipContinue')}
+          <Check className="w-3.5 h-3.5" /> {objects.length > 0 ? (confirmLabel ?? t('editor.createSpec')) : t('editor.skipContinue')}
         </Button>
       </div>
     </div>

--- a/client/src/components/browser-capture/BrowserCaptureModal.tsx
+++ b/client/src/components/browser-capture/BrowserCaptureModal.tsx
@@ -37,6 +37,9 @@ interface BrowserCaptureModalProps {
   projectId: string
   pendingSpecId: string
   onCaptured: (result: CaptureResult) => void
+  /** Label for the annotation editor's primary confirm button, so the caller can
+   *  reflect context ("Crear spec" vs "Actualizar spec"). */
+  confirmLabel?: string
 }
 
 interface SelectionBox {
@@ -60,7 +63,7 @@ const PRESET_DIMS: Record<Exclude<ViewportPreset, 'fit'>, { w: number; h: number
  * select mode a drag rectangle is captured (screenshot + DOM) and handed back to
  * Add Spec. Excluded from coverage (canvas + WS + pointer drag is not jsdom-able).
  */
-export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, onCaptured }: BrowserCaptureModalProps) {
+export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, onCaptured, confirmLabel }: BrowserCaptureModalProps) {
   const { t } = useTranslation('browser')
   const session = useBrowserCaptureSession({ projectId, open })
   const { canvasRef, viewport, status, errorMsg, url, title, hoverRect, hoverSelector, hoverPath } = session
@@ -397,6 +400,7 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
           result={markup}
           pendingSpecId={pendingSpecId}
           macOverlay={macOverlay}
+          confirmLabel={confirmLabel}
           onConfirm={(aug) => { onCaptured(aug); onClose() }}
           onReselect={() => { setMarkup(null); setSelecting(true) }}
           onCancel={() => { setMarkup(null); onClose() }}

--- a/client/src/components/browser-capture/BrowserCaptureModal.tsx
+++ b/client/src/components/browser-capture/BrowserCaptureModal.tsx
@@ -11,6 +11,7 @@ import {
   mapRectToDisplay,
   rectFromPoints,
   isUsableSelection,
+  clampRectToViewport,
   BREAKPOINT_DIMS,
   type CaptureRect,
   type CaptureResult,
@@ -256,7 +257,11 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
 
   // ─── Select mode: hover-to-select an element, or drag a custom rectangle ──────
 
-  const runCapture = useCallback(async (rect: CaptureRect) => {
+  const runCapture = useCallback(async (rawRect: CaptureRect) => {
+    // Clamp into the viewport so a hovered/locked element rect that starts off-screen
+    // (negative x/y) or overflows the viewport never trips the server's parseRect
+    // guard → "Capture failed (400)". A real drag is already clamped by toViewport.
+    const rect = clampRectToViewport(rawRect, viewport)
     setCapturing(true)
     setCaptureError(null)
     try {
@@ -285,7 +290,7 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
       setLocked(null)
       session.clearHover()
     }
-  }, [session, pendingSpecId, captureNetwork, captureAllSizes, onCaptured, onClose, t])
+  }, [session, pendingSpecId, captureNetwork, captureAllSizes, onCaptured, onClose, t, viewport])
 
   const onBreadcrumbClick = useCallback((segment: BreadcrumbSegment) => {
     void session.navigateElement(segment.selector, 'self').then((probe) => { if (probe) setLocked(probe) })

--- a/client/src/components/browser-capture/BrowserCaptureModal.tsx
+++ b/client/src/components/browser-capture/BrowserCaptureModal.tsx
@@ -76,6 +76,10 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
   const [captureAllSizes, setCaptureAllSizes] = useState(false)
   // When set, a single capture is frozen and the markup editor is shown over it.
   const [markup, setMarkup] = useState<CaptureResult | null>(null)
+  // Last capture error, shown as a visible banner INSIDE the modal (a sonner toast
+  // would be occluded by this z-[80] portal, so a failure looked like "nothing
+  // happened"). Cleared when a new selection starts or a capture succeeds.
+  const [captureError, setCaptureError] = useState<string | null>(null)
   // Breadcrumb lock: when the user steps up/down the DOM tree (arrows / clicking a
   // segment) the selection locks to that element until the cursor moves again.
   const [locked, setLocked] = useState<ElementProbe | null>(null)
@@ -254,6 +258,7 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
 
   const runCapture = useCallback(async (rect: CaptureRect) => {
     setCapturing(true)
+    setCaptureError(null)
     try {
       if (captureAllSizes) {
         // Multi-breakpoint = 3 reference images; no markup step.
@@ -267,7 +272,11 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
         const result = await session.capture(rect, pendingSpecId, { captureNetwork })
         setMarkup(result)
       }
-    } catch {
+    } catch (err) {
+      // Surface the REAL failure (with its HTTP status) inside the modal — a
+      // sonner toast here is painted under the z-[80] portal and never seen.
+      const detail = err instanceof Error ? err.message : String(err)
+      setCaptureError(detail)
       toast.error(t('modal.toast.captureFailed'))
     } finally {
       setCapturing(false)
@@ -284,6 +293,7 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
 
   const onSelectDown = useCallback((e: React.PointerEvent) => {
     ;(e.target as HTMLElement).setPointerCapture?.(e.pointerId)
+    setCaptureError(null) // clear any stale failure banner on a fresh selection
     setBox({ startX: e.clientX, startY: e.clientY, curX: e.clientX, curY: e.clientY })
   }, [])
 
@@ -388,6 +398,12 @@ export function BrowserCaptureModal({ open, onClose, projectId, pendingSpecId, o
         />
       ) : (
       <>
+      {captureError && (
+        <div role="alert" data-testid="capture-error-banner" className="flex items-center gap-2 px-3 py-2 text-xs bg-destructive/10 text-destructive border-b border-destructive/30 shrink-0">
+          <span className="font-medium">{t('modal.toast.captureFailed')}</span>
+          <span className="opacity-80 font-mono truncate">{captureError}</span>
+        </div>
+      )}
       {/* Toolbar */}
       <div className={`flex items-center gap-2 py-1.5 border-b border-border/50 bg-surface/80 shrink-0 ${macOverlay ? 'pr-3' : 'px-3'}`}>
         {/* On macOS desktop the native traffic-light controls float over the top-left;

--- a/client/src/components/browser-capture/WebViewModal.tsx
+++ b/client/src/components/browser-capture/WebViewModal.tsx
@@ -1,0 +1,178 @@
+import { useCallback, useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useTranslation } from 'react-i18next'
+import { ArrowLeft, ArrowRight, RotateCw, Globe, X, AlertTriangle } from 'lucide-react'
+import { Button } from '../ui/button'
+import { useBrowserCaptureSession } from './useBrowserCaptureSession'
+import { mapPointToViewport, type BrowserInputEvent } from '../../lib/browser-capture'
+
+interface WebViewModalProps {
+  open: boolean
+  /** URL to open. */
+  url: string
+  projectId: string
+  onClose: () => void
+}
+
+/**
+ * Read-only embedded-browser modal: opens a link from a spec description inside
+ * the app (instead of the OS browser), reusing the SAME headless-Chromium session
+ * machinery as "From a website". It therefore shares the global browser profile
+ * (cookies/logins) via the SharedBrowserContextPool — no separate auth. This is a
+ * browse-only variant of BrowserCaptureModal (no select / capture / annotate).
+ *
+ * Excluded from coverage like the other browser-capture components (canvas + WS +
+ * pointer input are not exercisable under jsdom).
+ */
+export function WebViewModal({ open, url, projectId, onClose }: WebViewModalProps) {
+  const { t } = useTranslation('browser')
+  const session = useBrowserCaptureSession({ projectId, open, initialUrl: url })
+  const { canvasRef, viewport, status, errorMsg, url: pageUrl, title } = session
+  const [addressValue, setAddressValue] = useState(url)
+
+  // Reflect the page's real URL (after redirects / in-page navigation).
+  useEffect(() => { if (pageUrl) setAddressValue(pageUrl) }, [pageUrl])
+
+  // Esc closes the modal.
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  const toViewport = useCallback((clientX: number, clientY: number) => {
+    const r = canvasRef.current?.getBoundingClientRect()
+    if (!r) return { x: 0, y: 0 }
+    return mapPointToViewport({ x: clientX, y: clientY }, { left: r.left, top: r.top, width: r.width, height: r.height }, viewport)
+  }, [canvasRef, viewport])
+
+  const buttonOf = (b: number): 'left' | 'middle' | 'right' => (b === 2 ? 'right' : b === 1 ? 'middle' : 'left')
+
+  const onPointerMove = useCallback((e: React.PointerEvent) => {
+    const p = toViewport(e.clientX, e.clientY)
+    session.forwardInput({ type: 'mouse', action: 'move', x: p.x, y: p.y })
+  }, [toViewport, session])
+  const onPointerDown = useCallback((e: React.PointerEvent) => {
+    const p = toViewport(e.clientX, e.clientY)
+    session.forwardInput({ type: 'mouse', action: 'down', x: p.x, y: p.y, button: buttonOf(e.button), clickCount: e.detail || 1 })
+  }, [toViewport, session])
+  const onPointerUp = useCallback((e: React.PointerEvent) => {
+    const p = toViewport(e.clientX, e.clientY)
+    session.forwardInput({ type: 'mouse', action: 'up', x: p.x, y: p.y, button: buttonOf(e.button), clickCount: e.detail || 1 })
+  }, [toViewport, session])
+  const onWheel = useCallback((e: React.WheelEvent) => {
+    const p = toViewport(e.clientX, e.clientY)
+    session.forwardInput({ type: 'wheel', x: p.x, y: p.y, deltaX: e.deltaX, deltaY: e.deltaY })
+  }, [toViewport, session])
+
+  const onKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') return
+    const meta = e.metaKey || e.ctrlKey
+    if (meta && (e.key === 'c' || e.key === 'v' || e.key === 'x')) {
+      e.preventDefault()
+      const key = e.key
+      void (async () => {
+        try {
+          if (key === 'v') {
+            const text = await navigator.clipboard.readText()
+            if (text) await session.clipboard('paste', text)
+          } else {
+            const { text } = await session.clipboard(key === 'x' ? 'cut' : 'copy')
+            if (text) await navigator.clipboard.writeText(text)
+          }
+        } catch { /* clipboard unavailable — ignore */ }
+      })()
+      return
+    }
+    const ev: BrowserInputEvent = { type: 'key', action: 'down', key: e.key, code: e.code, text: !meta && e.key.length === 1 ? e.key : undefined }
+    session.forwardInput(ev)
+    if (e.key === 'Tab' || e.key === ' ' || e.key.startsWith('Arrow')) e.preventDefault()
+  }, [session])
+  const onKeyUp = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') return
+    session.forwardInput({ type: 'key', action: 'up', key: e.key, code: e.code })
+  }, [session])
+
+  const go = useCallback(() => { void session.navigate('goto', addressValue) }, [session, addressValue])
+
+  if (!open || typeof document === 'undefined') return null
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[80] bg-background-deep/50 backdrop-blur-sm pointer-events-auto"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+      data-testid="webview-modal"
+    >
+      <div
+        className="absolute inset-2 flex flex-col border border-border rounded-lg bg-background-deep overflow-hidden"
+        role="dialog"
+        aria-modal="true"
+        aria-label={t('modal.dialogLabel')}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Toolbar */}
+        <div className="flex items-center gap-2 px-3 py-1.5 border-b border-border/50 bg-surface/80 shrink-0">
+          <div className="flex items-center gap-1">
+            <Button variant="ghost" size="icon" className="h-7 w-7" aria-label={t('common:actions.back')} onClick={() => session.navigate('back')}><ArrowLeft className="w-4 h-4" /></Button>
+            <Button variant="ghost" size="icon" className="h-7 w-7" aria-label={t('modal.nav.forward')} onClick={() => session.navigate('forward')}><ArrowRight className="w-4 h-4" /></Button>
+            <Button variant="ghost" size="icon" className="h-7 w-7" aria-label={t('modal.nav.reload')} onClick={() => session.navigate('reload')}><RotateCw className="w-4 h-4" /></Button>
+          </div>
+          <form className="flex-1 flex items-center gap-2 min-w-0" onSubmit={(e) => { e.preventDefault(); go() }}>
+            <div className="flex items-center gap-2 flex-1 min-w-0 rounded-md border border-border bg-background px-2.5 py-1">
+              <Globe className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+              <input
+                value={addressValue}
+                onChange={(e) => setAddressValue(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); go() } }}
+                placeholder={t('modal.address.placeholder')}
+                aria-label={t('modal.address.label')}
+                className="flex-1 min-w-0 bg-transparent outline-none text-sm"
+              />
+            </div>
+            <Button type="submit" size="sm" variant="secondary" className="shrink-0" disabled={status === 'error'}>{t('modal.address.go')}</Button>
+          </form>
+          <Button variant="ghost" size="icon" className="h-7 w-7" aria-label={t('modal.closeBrowser')} onClick={onClose}><X className="w-4 h-4" /></Button>
+        </div>
+
+        {/* Status line */}
+        <div className="px-3 py-1 text-[11px] text-muted-foreground truncate shrink-0 flex items-center gap-2">
+          <span
+            className={`inline-block w-2 h-2 rounded-full shrink-0 ${status === 'ready' ? 'bg-accent-success' : status === 'error' ? 'bg-destructive' : 'bg-accent-warning animate-pulse'}`}
+            aria-hidden
+          />
+          <span className="truncate">
+            {status === 'connecting' ? t('modal.status.connecting') : status === 'error' ? (errorMsg ?? t('modal.status.unavailable')) : (title || '')}
+          </span>
+        </div>
+
+        {/* Viewport (browse-only) */}
+        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
+        <div
+          className="relative flex-1 min-h-0 overflow-hidden flex items-center justify-center outline-none"
+          tabIndex={0}
+          onKeyDown={onKeyDown}
+          onKeyUp={onKeyUp}
+        >
+          {status === 'error' ? (
+            <div className="flex flex-col items-center gap-2 text-center max-w-md px-6">
+              <AlertTriangle className="w-8 h-8 text-accent-warning" />
+              <p className="text-sm text-foreground/90">{errorMsg ?? t('modal.error.unavailable')}</p>
+            </div>
+          ) : (
+            <canvas
+              ref={canvasRef}
+              className="max-w-full max-h-full block shadow-2xl cursor-default"
+              onPointerMove={onPointerMove}
+              onPointerDown={onPointerDown}
+              onPointerUp={onPointerUp}
+              onContextMenu={(e) => e.preventDefault()}
+              onWheel={onWheel}
+            />
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/client/src/components/browser-capture/useBrowserCaptureSession.ts
+++ b/client/src/components/browser-capture/useBrowserCaptureSession.ts
@@ -70,6 +70,10 @@ export function useBrowserCaptureSession(opts: {
   const wsRef = useRef<WebSocket | null>(null)
   const sessionIdRef = useRef<string | null>(null)
   const drawingRef = useRef(false)
+  // True while a capture POST is awaiting. The effect cleanup must NOT kill the
+  // session out from under an in-flight capture (a transient effect re-run /
+  // StrictMode double-invoke would otherwise 404 the capture).
+  const capturingRef = useRef(false)
 
   const [state, setState] = useState<BrowserSessionState>({
     status: 'connecting',
@@ -177,7 +181,10 @@ export function useBrowserCaptureSession(opts: {
       wsRef.current = null
       const sid = sessionIdRef.current
       sessionIdRef.current = null
-      if (sid) void killBrowserSession(sid)
+      // Never kill a session with a capture in flight — a transient re-run/unmount
+      // would otherwise make the awaiting POST hit a dead session (404). The server
+      // sweeps idle sessions, so deferring this kill is safe.
+      if (sid && !capturingRef.current) void killBrowserSession(sid)
     }
   }, [open, projectId, initialUrl, drawFrame])
 
@@ -202,13 +209,23 @@ export function useBrowserCaptureSession(opts: {
   const capture = useCallback(async (rect: CaptureRect, pendingSpecId: string, opts?: { captureNetwork?: boolean }): Promise<CaptureResult> => {
     const sid = sessionIdRef.current
     if (!sid) throw new Error('No active browser session')
-    return captureBrowserRegion(sid, rect, pendingSpecId, opts)
+    capturingRef.current = true
+    try {
+      return await captureBrowserRegion(sid, rect, pendingSpecId, opts)
+    } finally {
+      capturingRef.current = false
+    }
   }, [])
 
   const captureBreakpoints = useCallback(async (rect: CaptureRect, anchorPoint: { x: number; y: number }, pendingSpecId: string, breakpoints?: Record<string, { width: number; height: number }>): Promise<CaptureResult> => {
     const sid = sessionIdRef.current
     if (!sid) throw new Error('No active browser session')
-    return captureBrowserBreakpoints(sid, rect, anchorPoint, pendingSpecId, breakpoints)
+    capturingRef.current = true
+    try {
+      return await captureBrowserBreakpoints(sid, rect, anchorPoint, pendingSpecId, breakpoints)
+    } finally {
+      capturingRef.current = false
+    }
   }, [])
 
   const clipboard = useCallback(async (action: 'copy' | 'paste' | 'cut', text?: string): Promise<{ text: string }> => {

--- a/client/src/components/explore-spec/ExploreSpecShell.tsx
+++ b/client/src/components/explore-spec/ExploreSpecShell.tsx
@@ -1083,6 +1083,7 @@ export function ExploreSpecShell({
           projectId={activeProjectId}
           pendingSpecId={pendingSpecId}
           onCaptured={handleCaptured}
+          confirmLabel={isEditingExisting ? t('shell.updateSpec') : t('shell.createSpec')}
         />
       )}
     </div>

--- a/client/src/components/explore-spec/ExploreSpecShell.tsx
+++ b/client/src/components/explore-spec/ExploreSpecShell.tsx
@@ -384,6 +384,11 @@ export function ExploreSpecShell({
   }, [chat, conversationId])
 
   const turnCount = conversation?.messages.length ?? 0
+  // Live ref so the window-level Esc handler (bound once) always reads the CURRENT
+  // turnCount. Tying it to `requestClose`'s deps made the "Esc doesn't close
+  // mid-conversation" guard rebind-racy under load (flaky in CI).
+  const turnCountRef = useRef(turnCount)
+  turnCountRef.current = turnCount
 
   // Char-by-char smoothing: render a steady ~60fps animation over the raw
   // (often bursty) streaming text. Falls back to raw when the feature flag
@@ -484,14 +489,16 @@ export function ExploreSpecShell({
   }, [seedDraftOverrides, setField, editTicket])
 
   const requestClose = useCallback(() => {
-    // Only confirm when the conversation has progressed beyond the initial user idea
-    const beyondIntro = turnCount > 1
+    // Only confirm when the conversation has progressed beyond the initial user idea.
+    // Read from the ref so this callback is stable and the Esc listener never goes
+    // stale on a turnCount change.
+    const beyondIntro = turnCountRef.current > 1
     if (beyondIntro) {
       setConfirmDiscard(true)
     } else {
       onClose()
     }
-  }, [turnCount, onClose])
+  }, [onClose])
 
   const sendComposer = useCallback(async (text: string) => {
     const v = text.trim()

--- a/client/src/components/explore-spec/ExploreSpecShell.tsx
+++ b/client/src/components/explore-spec/ExploreSpecShell.tsx
@@ -206,10 +206,13 @@ export function ExploreSpecShell({
   // True only when editing a ticket that is ALREADY a real spec (todo/backlog).
   // A draft opened via Continue Editing has `editTicket.status === 'draft'`, so
   // it is NOT a "real spec edit": its primary commit PUBLISHES (flips draft →
-  // todo) rather than PATCHing in place, and the button reads "Create Spec".
-  // editTicket without a status (legacy callers / tests) ⇒ real-spec edit, so
-  // the prior PATCH behaviour is preserved unchanged.
+  // todo) rather than PATCHing in place. editTicket without a status (legacy
+  // callers / tests) ⇒ real-spec edit, so the prior PATCH behaviour is preserved.
+  // NOTE: this flag drives the COMMIT BEHAVIOUR only. The button LABEL uses
+  // `isEditingExisting` below so editing ANY existing spec (draft included) reads
+  // "Update Spec", not "Create Spec" (only a fresh Explore reads "Create Spec").
   const isRealSpecEdit = !!editTicket && editTicket.status !== 'draft'
+  const isEditingExisting = !!editTicket
   const composerRef = useRef<RichAttachmentEditorHandle | null>(null)
   const conversationScrollRef = useRef<HTMLDivElement | null>(null)
   const conversationBottomRef = useRef<HTMLDivElement | null>(null)
@@ -784,7 +787,7 @@ export function ExploreSpecShell({
             onClick={handleCreate}
             disabled={!draft.title.trim() || isCreating}
             className="gap-1.5"
-            aria-label={isRealSpecEdit ? t('shell.updateSpecAriaLabel') : t('shell.createSpecAriaLabel')}
+            aria-label={isEditingExisting ? t('shell.updateSpecAriaLabel') : t('shell.createSpecAriaLabel')}
             data-testid="explore-spec-create"
             title={!draft.title.trim() ? t('shell.createSpecDisabledTitle') : undefined}
           >
@@ -795,7 +798,7 @@ export function ExploreSpecShell({
             ) : (
               <Check className="w-3.5 h-3.5" />
             )}
-            {isRealSpecEdit ? t('shell.updateSpec') : t('shell.createSpec')}
+            {isEditingExisting ? t('shell.updateSpec') : t('shell.createSpec')}
           </Button>
           {onMinimize && (
             <Button
@@ -1064,7 +1067,7 @@ export function ExploreSpecShell({
             priority: draft.priority ?? null,
             acceptanceCriteria: draft.acceptanceCriteria ?? [],
           } satisfies ReviewProposed}
-          mode={isRealSpecEdit ? 'edit' : 'create'}
+          mode={isEditingExisting ? 'edit' : 'create'}
           isCommitting={isCreating}
           onBack={() => setReviewOpen(false)}
           onCommit={async () => {

--- a/client/src/components/explore-spec/ExploreSpecShell.tsx
+++ b/client/src/components/explore-spec/ExploreSpecShell.tsx
@@ -247,11 +247,14 @@ export function ExploreSpecShell({
   }, [refreshAttachments])
 
   // ─── "From a website" capture ───────────────────────────────────────────────
+  // Wired after the send path is defined (avoids a TDZ on conversation/sendComposer).
+  const sendCaptureFeedbackRef = useRef<((ids: string[]) => void) | null>(null)
+  const canAutoSendCaptureRef = useRef(false)
+
   const handleCaptured = useCallback((result: CaptureResult) => {
-    // A capture contributes a screenshot image + a DOM JSON attachment. Track both
-    // (NOT as editor pills) so they can be removed together and merged into the
-    // next turn. If the user annotated, drop the raw screenshot the flattened one
-    // replaced so only the annotated image + DOM ride along.
+    // A capture contributes a screenshot image + a DOM JSON attachment. If the
+    // user annotated, drop the raw screenshot the flattened one replaced so only
+    // the annotated image + DOM ride along.
     if (result.rawScreenshot && result.rawScreenshot.id !== result.screenshot.id) {
       const pid = activeProjectIdRef.current
       fetch(`${API_ORIGIN}/api/projects/${pid}/tickets/${pendingSpecId}/attachments/${result.rawScreenshot.id}`, { method: 'DELETE' }).catch(() => {})
@@ -259,16 +262,28 @@ export function ExploreSpecShell({
     const breakpoints = result.breakpoints
       ? Object.entries(result.breakpoints).map(([key, b]) => ({ key, attachmentId: b.attachment.id, dataUrl: b.dataUrl, width: b.viewport.width }))
       : undefined
-    setCaptures((c) => [...c, {
-      screenshotId: result.screenshot.id,
-      screenshotName: result.screenshot.filename,
-      screenshotDataUrl: result.screenshotDataUrl,
-      domAttachmentId: result.domAttachment.id,
-      dom: result.dom,
-      breakpoints,
-    }])
     // Surface the new attachments in the Draft panel immediately.
     void refreshAttachments()
+    const captureIds = [
+      ...(breakpoints ? breakpoints.map((b) => b.attachmentId) : [result.screenshot.id]),
+      result.domAttachment.id,
+    ]
+    // Drop the capture straight into the conversation and ask for feedback NOW so
+    // the AI reacts to what it sees and cross-references the conversation + (in edit
+    // mode) the spec being edited. If a turn is mid-stream we can't interrupt → queue
+    // it as a chip that rides the user's next message instead.
+    if (canAutoSendCaptureRef.current && sendCaptureFeedbackRef.current) {
+      sendCaptureFeedbackRef.current(captureIds)
+    } else {
+      setCaptures((c) => [...c, {
+        screenshotId: result.screenshot.id,
+        screenshotName: result.screenshot.filename,
+        screenshotDataUrl: result.screenshotDataUrl,
+        domAttachmentId: result.domAttachment.id,
+        dom: result.dom,
+        breakpoints,
+      }])
+    }
   }, [pendingSpecId, refreshAttachments])
 
   const removeCapture = useCallback((entry: BrowserCaptureEntry) => {
@@ -540,6 +555,45 @@ export function ExploreSpecShell({
       attachments: attIds.length > 0 ? { ticketKey: pendingSpecId, ids: attIds } : undefined,
     })
   }, [conversation, chat, clearManualOverrides, pendingSpecId, refreshAttachments, editTicket, initialModel, captureAttachmentIds, captures.length])
+
+  // Auto-send a feedback turn for a "From a website" capture: drop the screenshot +
+  // DOM into the conversation and ask the AI to react to it in context — the
+  // conversation so far AND, in edit mode, the spec being edited. Mirrors
+  // sendComposer's edit-first-turn wrapping but never touches the composer draft.
+  const sendCaptureFeedback = useCallback(async (captureIds: string[]) => {
+    if (!chat || captureIds.length === 0) return
+    const feedbackText = t('shell.captureFeedbackPrompt')
+    const attachments = { ticketKey: pendingSpecId, ids: captureIds }
+    setPendingTurn(true)
+    clearManualOverrides()
+    if (editTicket && !editFirstSendRef.current) {
+      editFirstSendRef.current = true
+      const ticketBlock = [
+        `## Spec context`,
+        `Ticket #${editTicket.id}: ${editTicket.title}`,
+        '',
+        editTicket.description || '(no description)',
+      ].join('\n')
+      const prompt = `/specrails:explore-spec\n\n${ticketBlock}\n\n---\n\n## Instruction\n\n${feedbackText}`
+      if (conversation) {
+        await chat.sendMessage(conversation.id, prompt, { lightweight: true, maxTurns: 20, attachments })
+      } else {
+        void chat.startWithMessage(prompt, { lightweight: true, maxTurns: 20, attachments }, initialModel, 'explore', undefined, initialProvider).then((id) => {
+          if (id) setConversationId(id)
+        })
+      }
+      return
+    }
+    if (!conversation || conversation.isStreaming) return
+    await chat.sendMessage(conversation.id, feedbackText, { lightweight: true, maxTurns: 20, attachments })
+  }, [chat, conversation, editTicket, pendingSpecId, initialModel, initialProvider, clearManualOverrides, t])
+
+  // Keep the capture handler's refs current (handleCaptured is defined earlier and
+  // must not depend on `conversation`/`sendCaptureFeedback` to avoid a TDZ).
+  useEffect(() => { sendCaptureFeedbackRef.current = sendCaptureFeedback }, [sendCaptureFeedback])
+  useEffect(() => {
+    canAutoSendCaptureRef.current = !!chat && (conversation ? !conversation.isStreaming : (!!editTicket && !editFirstSendRef.current))
+  }, [chat, conversation, editTicket])
 
   // Clear the optimistic skeleton flag as soon as the real streaming state
   // takes over (or surfaces an error). Without this, the skeleton would

--- a/client/src/components/explore-spec/ExploreSpecShell.tsx
+++ b/client/src/components/explore-spec/ExploreSpecShell.tsx
@@ -18,6 +18,7 @@ import { RichAttachmentEditor, type RichAttachmentEditorHandle } from '../RichAt
 import { BrowserCaptureModal } from '../browser-capture/BrowserCaptureModal'
 import { CapturedDomPanel } from '../browser-capture/CapturedDomPanel'
 import { isBrowserCaptureEnabled, type CaptureResult, type CapturedDom } from '../../lib/browser-capture'
+import { genPendingSpecId } from '../../lib/pending-spec-id'
 import { SpecDraftPanel } from './SpecDraftPanel'
 import { ExploreStatusPills } from './ExploreStatusPills'
 import { useSmoothStream } from './useSmoothStream'
@@ -142,7 +143,7 @@ export interface EditTicketSeed {
 
 export function ExploreSpecShell({
   initialIdea,
-  pendingSpecId,
+  pendingSpecId: pendingSpecIdProp,
   initialAttachmentIds,
   initialModel,
   initialProvider,
@@ -164,6 +165,13 @@ export function ExploreSpecShell({
   const jira = useJiraConnection()
   const chat = useChatContext()
   const { activeProjectId } = useDesktop()
+  // Bulletproof the attachment/capture key: some edit-mode launchers historically
+  // passed '' (which 400s the "From a website" capture with "pendingSpecId is
+  // required" and breaks attachment uploads). Always resolve to a real,
+  // filesystem-safe id; stable for the shell's lifetime.
+  const [pendingSpecId] = useState(() =>
+    pendingSpecIdProp && pendingSpecIdProp.trim() ? pendingSpecIdProp : genPendingSpecId(),
+  )
   const [conversationId, setConversationId] = useState<string | null>(
     resumeConversationId ?? null,
   )

--- a/client/src/components/explore-spec/ExploreSpecShell.tsx
+++ b/client/src/components/explore-spec/ExploreSpecShell.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ArrowLeft, Check, Send, Loader2, Minus, Sparkles, X, Plug } from 'lucide-react'
+import { ArrowLeft, Check, Send, Loader2, Minus, Sparkles, X, Plug, Globe, Ratio } from 'lucide-react'
 import { toast } from 'sonner'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -15,6 +15,9 @@ import { getApiBase } from '../../lib/api'
 import { API_ORIGIN } from '../../lib/origin'
 import { markSpecGenInFlight, unmarkSpecGenInFlight } from '../../lib/spec-gen-suppression'
 import { RichAttachmentEditor, type RichAttachmentEditorHandle } from '../RichAttachmentEditor'
+import { BrowserCaptureModal } from '../browser-capture/BrowserCaptureModal'
+import { CapturedDomPanel } from '../browser-capture/CapturedDomPanel'
+import { isBrowserCaptureEnabled, type CaptureResult, type CapturedDom } from '../../lib/browser-capture'
 import { SpecDraftPanel } from './SpecDraftPanel'
 import { ExploreStatusPills } from './ExploreStatusPills'
 import { useSmoothStream } from './useSmoothStream'
@@ -25,6 +28,26 @@ function isMacTauriOverlay(): boolean {
   if (typeof window === 'undefined') return false
   if (!('__TAURI_INTERNALS__' in window)) return false
   return /mac/i.test(navigator.platform)
+}
+
+interface BrowserCaptureBreakpoint {
+  key: string
+  attachmentId: string
+  dataUrl: string
+  width: number
+}
+
+/** A "From a website" capture: a screenshot attachment + a DOM JSON attachment,
+ *  tracked separately from the editor's own pills (mirrors ProposeSpecModal) so
+ *  both ids can be merged into the next turn and cleanly removed together. */
+interface BrowserCaptureEntry {
+  screenshotId: string
+  screenshotName: string
+  screenshotDataUrl: string
+  domAttachmentId: string
+  dom: CapturedDom
+  /** Present for a multi-breakpoint capture: one screenshot per device size. */
+  breakpoints?: BrowserCaptureBreakpoint[]
 }
 
 export interface ExploreSpecShellProps {
@@ -159,6 +182,14 @@ export function ExploreSpecShell({
   const REVIEW_ENABLED = ((typeof import.meta !== 'undefined' &&
     (import.meta as unknown as { env?: Record<string, string> }).env?.VITE_FEATURE_EXPLORE_REVIEW) ?? 'true') !== 'false'
   const [accumulatedAttachments, setAccumulatedAttachments] = useState<Attachment[]>([])
+  // "From a website" capture (Globe button on the composer). Mirrors the Add Spec
+  // modal: captured screenshot/DOM ids ride the NEXT turn then clear. Gated on the
+  // same client+server browser-capture flags as Add Spec.
+  const browserCaptureEnabled = isBrowserCaptureEnabled()
+  const [browserOpen, setBrowserOpen] = useState(false)
+  const [captures, setCaptures] = useState<BrowserCaptureEntry[]>([])
+  const activeProjectIdRef = useRef(activeProjectId)
+  useEffect(() => { activeProjectIdRef.current = activeProjectId }, [activeProjectId])
   const previousFocusRef = useRef<Element | null>(null)
   const startedRef = useRef(false)
   // Tracks whether the current edit-mode shell session has already sent its
@@ -203,6 +234,49 @@ export function ExploreSpecShell({
   useEffect(() => {
     void refreshAttachments()
   }, [refreshAttachments])
+
+  // ─── "From a website" capture ───────────────────────────────────────────────
+  const handleCaptured = useCallback((result: CaptureResult) => {
+    // A capture contributes a screenshot image + a DOM JSON attachment. Track both
+    // (NOT as editor pills) so they can be removed together and merged into the
+    // next turn. If the user annotated, drop the raw screenshot the flattened one
+    // replaced so only the annotated image + DOM ride along.
+    if (result.rawScreenshot && result.rawScreenshot.id !== result.screenshot.id) {
+      const pid = activeProjectIdRef.current
+      fetch(`${API_ORIGIN}/api/projects/${pid}/tickets/${pendingSpecId}/attachments/${result.rawScreenshot.id}`, { method: 'DELETE' }).catch(() => {})
+    }
+    const breakpoints = result.breakpoints
+      ? Object.entries(result.breakpoints).map(([key, b]) => ({ key, attachmentId: b.attachment.id, dataUrl: b.dataUrl, width: b.viewport.width }))
+      : undefined
+    setCaptures((c) => [...c, {
+      screenshotId: result.screenshot.id,
+      screenshotName: result.screenshot.filename,
+      screenshotDataUrl: result.screenshotDataUrl,
+      domAttachmentId: result.domAttachment.id,
+      dom: result.dom,
+      breakpoints,
+    }])
+    // Surface the new attachments in the Draft panel immediately.
+    void refreshAttachments()
+  }, [pendingSpecId, refreshAttachments])
+
+  const removeCapture = useCallback((entry: BrowserCaptureEntry) => {
+    setCaptures((c) => c.filter((e) => e.domAttachmentId !== entry.domAttachmentId))
+    const ids = new Set<string>([entry.screenshotId, entry.domAttachmentId, ...(entry.breakpoints?.map((b) => b.attachmentId) ?? [])])
+    const pid = activeProjectIdRef.current
+    for (const id of ids) {
+      fetch(`${API_ORIGIN}/api/projects/${pid}/tickets/${pendingSpecId}/attachments/${id}`, { method: 'DELETE' }).catch(() => {})
+    }
+    setAccumulatedAttachments((prev) => prev.filter((a) => !ids.has(a.id)))
+  }, [pendingSpecId])
+
+  // Flatten the pending captures' attachment ids for the next turn.
+  const captureAttachmentIds = useCallback((): string[] => {
+    return captures.flatMap((c) => [
+      ...(c.breakpoints ? c.breakpoints.map((b) => b.attachmentId) : [c.screenshotId]),
+      c.domAttachmentId,
+    ])
+  }, [captures])
 
   // Re-fetch when the conversation becomes ready: by then the modal handoff
   // has flushed and any files uploaded in the Add Spec step are guaranteed
@@ -403,12 +477,13 @@ export function ExploreSpecShell({
     // The wrapper is invisible in the bubble thanks to stripSlashPrefix.
     if (editTicket && !editFirstSendRef.current) {
       editFirstSendRef.current = true
-      const attIds = composerRef.current?.getAttachmentIds() ?? []
+      const attIds = [...(composerRef.current?.getAttachmentIds() ?? []), ...captureAttachmentIds()]
       composerRef.current?.clear()
       setHasComposerText(false)
       setComposerText('')
       setPendingTurn(true)
       clearManualOverrides()
+      if (captures.length > 0) { setCaptures([]); void refreshAttachments() }
       const ticketBlock = [
         `## Spec context`,
         `Ticket #${editTicket.id}: ${editTicket.title}`,
@@ -433,13 +508,16 @@ export function ExploreSpecShell({
     }
     if (!conversation || conversation.isStreaming) return
     // Pull current attachments off the editor (rich editor lets the user
-    // drop / paste files mid-conversation; each turn carries its own list).
-    const attIds = composerRef.current?.getAttachmentIds() ?? []
+    // drop / paste files mid-conversation; each turn carries its own list) PLUS
+    // any "From a website" captures taken since the last turn.
+    const attIds = [...(composerRef.current?.getAttachmentIds() ?? []), ...captureAttachmentIds()]
     composerRef.current?.clear()
     setHasComposerText(false)
     setComposerText('')
     setPendingTurn(true) // optimistic skeleton at T+0
     clearManualOverrides()
+    // Captures ride this turn only — clear so they aren't re-sent next turn.
+    if (captures.length > 0) setCaptures([])
     if (attIds.length > 0) {
       // New uploads went into pendingSpecId/, so refresh the accumulated list
       // so the user sees them in the Draft panel right away.
@@ -450,7 +528,7 @@ export function ExploreSpecShell({
       maxTurns: 20,
       attachments: attIds.length > 0 ? { ticketKey: pendingSpecId, ids: attIds } : undefined,
     })
-  }, [conversation, chat, clearManualOverrides, pendingSpecId, refreshAttachments, editTicket, initialModel])
+  }, [conversation, chat, clearManualOverrides, pendingSpecId, refreshAttachments, editTicket, initialModel, captureAttachmentIds, captures.length])
 
   // Clear the optimistic skeleton flag as soon as the real streaming state
   // takes over (or surfaces an error). Without this, the skeleton would
@@ -816,7 +894,62 @@ export function ExploreSpecShell({
                 void refreshAttachments()
               }}
               onSubmit={submitComposer}
+              footerExtra={browserCaptureEnabled && activeProjectId ? (
+                <button
+                  type="button"
+                  onClick={() => setBrowserOpen(true)}
+                  data-testid="explore-from-browser-btn"
+                  title={t('shell.fromWebsiteTitle')}
+                  className="inline-flex items-center gap-1 px-2 py-1 rounded-md border border-accent-info/50 text-accent-info hover:bg-accent-info/10 transition-colors font-medium"
+                >
+                  <Globe className="w-3.5 h-3.5" />
+                  <span>{t('shell.fromWebsite')}</span>
+                </button>
+              ) : undefined}
             />
+            {captures.length > 0 && (
+              <div className="space-y-3 mt-2" data-testid="explore-captured-dom-list">
+                {captures.map((c) => (
+                  <div key={c.domAttachmentId} className="space-y-1.5">
+                    <div className="rounded-lg border border-accent-secondary/40 bg-accent-secondary/5 p-2 space-y-1.5">
+                      {c.breakpoints ? (
+                        <div className="space-y-1.5" data-testid="explore-capture-breakpoints">
+                          <div className="flex items-center gap-1 text-[10px] font-medium text-accent-highlight">
+                            <Ratio className="w-3 h-3 shrink-0" />
+                            {t('shell.captureResponsiveSizes', { count: c.breakpoints.length })}
+                          </div>
+                          <div className="flex items-end justify-center gap-2 flex-wrap">
+                            {c.breakpoints.map((b) => (
+                              <div key={b.key} className="flex flex-col items-center gap-1">
+                                <img
+                                  src={b.dataUrl}
+                                  alt={`${b.key} (${b.width}px)`}
+                                  className="max-h-28 w-auto max-w-[9rem] object-contain rounded border border-border/60 bg-background-deep block"
+                                />
+                                <span className="text-[10px] text-muted-foreground tabular-nums">{b.key} · {b.width}px</span>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      ) : (
+                        <img
+                          src={c.screenshotDataUrl}
+                          alt={c.screenshotName}
+                          className="max-h-36 w-auto max-w-full object-contain rounded border border-border/60 bg-background-deep mx-auto block"
+                        />
+                      )}
+                      {c.dom.url && c.dom.url !== 'about:blank' && (
+                        <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground" title={c.dom.url}>
+                          <Globe className="w-3 h-3 shrink-0" />
+                          <span className="truncate">{c.dom.url}</span>
+                        </div>
+                      )}
+                    </div>
+                    <CapturedDomPanel dom={c.dom} onRemove={() => removeCapture(c)} />
+                  </div>
+                ))}
+              </div>
+            )}
             <div className="flex items-center justify-between mt-2 gap-3">
               <span />
               {/* Streaming indicator removed — ExploreStatusPills covers this state. */}
@@ -930,6 +1063,15 @@ export function ExploreSpecShell({
             await handleCreate()
             setReviewOpen(false)
           }}
+        />
+      )}
+      {browserCaptureEnabled && browserOpen && activeProjectId && (
+        <BrowserCaptureModal
+          open={browserOpen}
+          onClose={() => setBrowserOpen(false)}
+          projectId={activeProjectId}
+          pendingSpecId={pendingSpecId}
+          onCaptured={handleCaptured}
         />
       )}
     </div>

--- a/client/src/components/explore-spec/__tests__/ExploreSpecShell.fromWebsite.test.tsx
+++ b/client/src/components/explore-spec/__tests__/ExploreSpecShell.fromWebsite.test.tsx
@@ -182,6 +182,30 @@ describe('ExploreSpecShell — From a website', () => {
     await waitFor(() => expect(screen.queryByTestId('explore-captured-dom-list')).not.toBeInTheDocument())
   })
 
+  it('falls back to a real pendingSpecId when launched with an empty one (edit-mode 400 fix)', async () => {
+    // Some edit-mode launchers passed pendingSpecId: '' which 400s the capture
+    // with "pendingSpecId is required". The shell must mint a valid id so the
+    // captured attachments still ride the turn with a non-empty, safe ticketKey.
+    const ws = makeFakeWs()
+    readyConversation()
+    render(<ExploreSpecShell initialIdea="hi" pendingSpecId="" initialAttachmentIds={[]} onClose={onClose} />, { wrapper: wrap(ws) })
+    await screen.findByText('ok')
+
+    fireEvent.click(screen.getByTestId('explore-from-browser-btn'))
+    fireEvent.click(screen.getByTestId('mock-do-capture'))
+    await screen.findByTestId('explore-captured-dom-list')
+
+    const textarea = screen.getByLabelText('Spec idea')
+    fireEvent.change(textarea, { target: { value: 'use this' } })
+    fireEvent.keyDown(textarea, { key: 'Enter', metaKey: true })
+
+    await waitFor(() => expect(mockSendMessage).toHaveBeenCalled())
+    const opts = mockSendMessage.mock.calls[0][2] as { attachments?: { ticketKey: string; ids: string[] } }
+    expect(opts.attachments?.ticketKey).toBeTruthy()
+    expect(opts.attachments?.ticketKey).not.toBe('')
+    expect(/^[A-Za-z0-9_-]{1,128}$/.test(opts.attachments!.ticketKey)).toBe(true)
+  })
+
   it('removing a capture drops the chip and DELETEs its attachments', async () => {
     const ws = makeFakeWs()
     readyConversation()

--- a/client/src/components/explore-spec/__tests__/ExploreSpecShell.fromWebsite.test.tsx
+++ b/client/src/components/explore-spec/__tests__/ExploreSpecShell.fromWebsite.test.tsx
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import React from 'react'
+import { ExploreSpecShell } from '../ExploreSpecShell'
+import { SharedWebSocketContext } from '../../../hooks/useSharedWebSocket'
+
+const mockStartWithMessage = vi.fn().mockResolvedValue('conv-1')
+const mockSendMessage = vi.fn().mockResolvedValue(undefined)
+const conversationsRef: { value: Array<{
+  id: string; title: string | null; model: string; provider?: string | null;
+  messages: Array<{ role: 'user' | 'assistant' | 'system'; content: string }>;
+  isStreaming: boolean; streamingText: string; commandProposals: string[]
+}> } = { value: [] }
+
+vi.mock('../../../hooks/useChat', () => ({
+  useChatContext: () => ({
+    conversations: conversationsRef.value,
+    activeTabIndex: 0,
+    startWithMessage: mockStartWithMessage,
+    sendMessage: mockSendMessage,
+    abortStream: vi.fn(),
+    confirmCommand: vi.fn(),
+    dismissCommandProposal: vi.fn(),
+    changeConversationModel: vi.fn(),
+    createConversation: vi.fn(),
+    deleteConversation: vi.fn(),
+    isPanelOpen: false,
+    togglePanel: vi.fn(),
+    setActiveTabIndex: vi.fn(),
+  }),
+}))
+
+vi.mock('../../../hooks/useDesktop', () => ({
+  useDesktop: () => ({ activeProjectId: 'proj-1', projects: [] }),
+}))
+
+vi.mock('../../../lib/api', () => ({
+  getApiBase: () => '/api/projects/proj-1',
+}))
+
+// Editor mock that renders footerExtra (the Globe button lives there) and lets a
+// test drive plain text. getAttachmentIds returns [] so any ids sent come purely
+// from the "From a website" captures.
+vi.mock('../../RichAttachmentEditor', () => ({
+  RichAttachmentEditor: React.forwardRef(function MockEditor(
+    props: { placeholder?: string; ariaLabel?: string; onChange?: () => void; onSubmit?: () => void; footerExtra?: React.ReactNode },
+    ref: React.Ref<unknown>,
+  ) {
+    const inputRef = React.useRef<HTMLTextAreaElement>(null)
+    React.useImperativeHandle(ref, () => ({
+      getPlainText: () => inputRef.current?.value ?? '',
+      getAttachmentIds: () => [],
+      insertPill: () => {},
+      focus: () => {},
+      resetHeight: () => {},
+      clear: () => { if (inputRef.current) inputRef.current.value = '' },
+      setPlainText: () => {},
+    }))
+    return (
+      <div>
+        <textarea
+          ref={inputRef}
+          aria-label={props.ariaLabel}
+          placeholder={props.placeholder}
+          onChange={() => props.onChange?.()}
+          onKeyDown={(e) => { if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) props.onSubmit?.() }}
+        />
+        {props.footerExtra}
+      </div>
+    )
+  }),
+}))
+
+// Mock the heavy headless-Chromium modal: expose a button that fires onCaptured
+// with a deterministic capture (screenshot + DOM attachments).
+vi.mock('../../browser-capture/BrowserCaptureModal', () => ({
+  BrowserCaptureModal: ({ onCaptured, onClose }: { onCaptured: (r: unknown) => void; onClose: () => void }) => (
+    <div data-testid="mock-capture-modal">
+      <button
+        data-testid="mock-do-capture"
+        onClick={() => onCaptured({
+          screenshot: { id: 'shot-1', filename: 'screen-capture.png', storedName: 's', mimeType: 'image/png', size: 10, addedAt: '' },
+          domAttachment: { id: 'dom-1', filename: 'dom.json', storedName: 'd', mimeType: 'application/json', size: 5, addedAt: '' },
+          dom: { url: 'https://example.com', title: 'Example', viewport: { width: 1280, height: 800 }, rect: { x: 0, y: 0, width: 100, height: 100 }, html: '<div></div>', htmlTruncated: false, css: '', cssTruncated: false, nodes: [], capturedAt: '' },
+          screenshotDataUrl: 'data:image/png;base64,AAAA',
+        })}
+      >
+        capture
+      </button>
+      <button data-testid="mock-close-capture" onClick={onClose}>close</button>
+    </div>
+  ),
+}))
+
+vi.mock('../../browser-capture/CapturedDomPanel', () => ({
+  CapturedDomPanel: ({ onRemove }: { onRemove?: () => void }) => (
+    <button data-testid="mock-remove-capture" onClick={onRemove}>remove</button>
+  ),
+}))
+
+function makeFakeWs() {
+  const handlers = new Map<string, (m: unknown) => void>()
+  return {
+    registerHandler: (id: string, fn: (m: unknown) => void) => handlers.set(id, fn),
+    unregisterHandler: (id: string) => handlers.delete(id),
+    connectionStatus: 'connected' as const,
+    handlerCount: () => handlers.size,
+    emit: (msg: unknown) => handlers.forEach((h) => h(msg)),
+  }
+}
+
+function wrap(ws: ReturnType<typeof makeFakeWs>) {
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(SharedWebSocketContext.Provider, { value: ws }, children)
+}
+
+function readyConversation() {
+  conversationsRef.value = [{
+    id: 'conv-1', title: null, model: 'sonnet',
+    messages: [{ role: 'user', content: 'hi' }, { role: 'assistant', content: 'ok' }],
+    isStreaming: false, streamingText: '', commandProposals: [],
+  }]
+}
+
+describe('ExploreSpecShell — From a website', () => {
+  let onClose: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    onClose = vi.fn()
+    conversationsRef.value = []
+    mockStartWithMessage.mockClear()
+    mockStartWithMessage.mockResolvedValue('conv-1')
+    mockSendMessage.mockClear()
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ attachments: [] }) }) as unknown as typeof fetch
+  })
+
+  it('renders the From-a-website (Globe) button on the composer', async () => {
+    const ws = makeFakeWs()
+    readyConversation()
+    render(<ExploreSpecShell initialIdea="hi" pendingSpecId="pending-1" initialAttachmentIds={[]} onClose={onClose} />, { wrapper: wrap(ws) })
+    await screen.findByText('ok')
+    expect(screen.getByTestId('explore-from-browser-btn')).toBeInTheDocument()
+  })
+
+  it('opens the capture modal and renders a captured chip + DOM panel after a capture', async () => {
+    const ws = makeFakeWs()
+    readyConversation()
+    render(<ExploreSpecShell initialIdea="hi" pendingSpecId="pending-1" initialAttachmentIds={[]} onClose={onClose} />, { wrapper: wrap(ws) })
+    await screen.findByText('ok')
+
+    fireEvent.click(screen.getByTestId('explore-from-browser-btn'))
+    expect(screen.getByTestId('mock-capture-modal')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('mock-do-capture'))
+    expect(await screen.findByTestId('explore-captured-dom-list')).toBeInTheDocument()
+    expect(screen.getByTestId('mock-remove-capture')).toBeInTheDocument()
+  })
+
+  it('merges captured attachment ids into the next sent turn, then clears them', async () => {
+    const ws = makeFakeWs()
+    readyConversation()
+    render(<ExploreSpecShell initialIdea="hi" pendingSpecId="pending-1" initialAttachmentIds={[]} onClose={onClose} />, { wrapper: wrap(ws) })
+    await screen.findByText('ok')
+
+    // Capture, then send a reply.
+    fireEvent.click(screen.getByTestId('explore-from-browser-btn'))
+    fireEvent.click(screen.getByTestId('mock-do-capture'))
+    await screen.findByTestId('explore-captured-dom-list')
+
+    const textarea = screen.getByLabelText('Spec idea')
+    fireEvent.change(textarea, { target: { value: 'use this layout' } })
+    fireEvent.keyDown(textarea, { key: 'Enter', metaKey: true })
+
+    await waitFor(() => {
+      expect(mockSendMessage).toHaveBeenCalledWith(
+        'conv-1',
+        'use this layout',
+        expect.objectContaining({ attachments: { ticketKey: 'pending-1', ids: ['shot-1', 'dom-1'] } }),
+      )
+    })
+    // Captures ride one turn only — the chip list disappears after sending.
+    await waitFor(() => expect(screen.queryByTestId('explore-captured-dom-list')).not.toBeInTheDocument())
+  })
+
+  it('removing a capture drops the chip and DELETEs its attachments', async () => {
+    const ws = makeFakeWs()
+    readyConversation()
+    render(<ExploreSpecShell initialIdea="hi" pendingSpecId="pending-1" initialAttachmentIds={[]} onClose={onClose} />, { wrapper: wrap(ws) })
+    await screen.findByText('ok')
+
+    fireEvent.click(screen.getByTestId('explore-from-browser-btn'))
+    fireEvent.click(screen.getByTestId('mock-do-capture'))
+    await screen.findByTestId('explore-captured-dom-list')
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockClear()
+    fireEvent.click(screen.getByTestId('mock-remove-capture'))
+
+    await waitFor(() => expect(screen.queryByTestId('explore-captured-dom-list')).not.toBeInTheDocument())
+    const deletes = fetchMock.mock.calls.filter((c) => (c[1] as { method?: string } | undefined)?.method === 'DELETE')
+    expect(deletes.length).toBeGreaterThanOrEqual(2) // screenshot + dom attachments
+  })
+})

--- a/client/src/components/explore-spec/__tests__/ExploreSpecShell.fromWebsite.test.tsx
+++ b/client/src/components/explore-spec/__tests__/ExploreSpecShell.fromWebsite.test.tsx
@@ -122,6 +122,14 @@ function readyConversation() {
   }]
 }
 
+function streamingConversation() {
+  conversationsRef.value = [{
+    id: 'conv-1', title: null, model: 'sonnet',
+    messages: [{ role: 'user', content: 'hi' }, { role: 'assistant', content: 'ok' }],
+    isStreaming: true, streamingText: '…', commandProposals: [],
+  }]
+}
+
 describe('ExploreSpecShell — From a website', () => {
   let onClose: ReturnType<typeof vi.fn>
 
@@ -142,50 +150,29 @@ describe('ExploreSpecShell — From a website', () => {
     expect(screen.getByTestId('explore-from-browser-btn')).toBeInTheDocument()
   })
 
-  it('opens the capture modal and renders a captured chip + DOM panel after a capture', async () => {
+  it('auto-sends a feedback turn with the capture when the conversation is idle', async () => {
     const ws = makeFakeWs()
     readyConversation()
     render(<ExploreSpecShell initialIdea="hi" pendingSpecId="pending-1" initialAttachmentIds={[]} onClose={onClose} />, { wrapper: wrap(ws) })
     await screen.findByText('ok')
 
     fireEvent.click(screen.getByTestId('explore-from-browser-btn'))
-    expect(screen.getByTestId('mock-capture-modal')).toBeInTheDocument()
-
     fireEvent.click(screen.getByTestId('mock-do-capture'))
-    expect(await screen.findByTestId('explore-captured-dom-list')).toBeInTheDocument()
-    expect(screen.getByTestId('mock-remove-capture')).toBeInTheDocument()
-  })
 
-  it('merges captured attachment ids into the next sent turn, then clears them', async () => {
-    const ws = makeFakeWs()
-    readyConversation()
-    render(<ExploreSpecShell initialIdea="hi" pendingSpecId="pending-1" initialAttachmentIds={[]} onClose={onClose} />, { wrapper: wrap(ws) })
-    await screen.findByText('ok')
-
-    // Capture, then send a reply.
-    fireEvent.click(screen.getByTestId('explore-from-browser-btn'))
-    fireEvent.click(screen.getByTestId('mock-do-capture'))
-    await screen.findByTestId('explore-captured-dom-list')
-
-    const textarea = screen.getByLabelText('Spec idea')
-    fireEvent.change(textarea, { target: { value: 'use this layout' } })
-    fireEvent.keyDown(textarea, { key: 'Enter', metaKey: true })
-
+    // The capture goes straight into the conversation as a feedback turn carrying
+    // the screenshot + DOM attachment ids (no manual message needed).
     await waitFor(() => {
       expect(mockSendMessage).toHaveBeenCalledWith(
         'conv-1',
-        'use this layout',
+        expect.stringContaining('feedback'),
         expect.objectContaining({ attachments: { ticketKey: 'pending-1', ids: ['shot-1', 'dom-1'] } }),
       )
     })
-    // Captures ride one turn only — the chip list disappears after sending.
-    await waitFor(() => expect(screen.queryByTestId('explore-captured-dom-list')).not.toBeInTheDocument())
+    // Auto-sent, so no pending chip is left behind.
+    expect(screen.queryByTestId('explore-captured-dom-list')).not.toBeInTheDocument()
   })
 
-  it('falls back to a real pendingSpecId when launched with an empty one (edit-mode 400 fix)', async () => {
-    // Some edit-mode launchers passed pendingSpecId: '' which 400s the capture
-    // with "pendingSpecId is required". The shell must mint a valid id so the
-    // captured attachments still ride the turn with a non-empty, safe ticketKey.
+  it('auto-send uses a real pendingSpecId even when launched with an empty one', async () => {
     const ws = makeFakeWs()
     readyConversation()
     render(<ExploreSpecShell initialIdea="hi" pendingSpecId="" initialAttachmentIds={[]} onClose={onClose} />, { wrapper: wrap(ws) })
@@ -193,11 +180,6 @@ describe('ExploreSpecShell — From a website', () => {
 
     fireEvent.click(screen.getByTestId('explore-from-browser-btn'))
     fireEvent.click(screen.getByTestId('mock-do-capture'))
-    await screen.findByTestId('explore-captured-dom-list')
-
-    const textarea = screen.getByLabelText('Spec idea')
-    fireEvent.change(textarea, { target: { value: 'use this' } })
-    fireEvent.keyDown(textarea, { key: 'Enter', metaKey: true })
 
     await waitFor(() => expect(mockSendMessage).toHaveBeenCalled())
     const opts = mockSendMessage.mock.calls[0][2] as { attachments?: { ticketKey: string; ids: string[] } }
@@ -206,9 +188,25 @@ describe('ExploreSpecShell — From a website', () => {
     expect(/^[A-Za-z0-9_-]{1,128}$/.test(opts.attachments!.ticketKey)).toBe(true)
   })
 
-  it('removing a capture drops the chip and DELETEs its attachments', async () => {
+  it('queues the capture as a chip (rides the next turn) while a turn is streaming', async () => {
     const ws = makeFakeWs()
-    readyConversation()
+    streamingConversation()
+    render(<ExploreSpecShell initialIdea="hi" pendingSpecId="pending-1" initialAttachmentIds={[]} onClose={onClose} />, { wrapper: wrap(ws) })
+    await screen.findByText('ok')
+    mockSendMessage.mockClear()
+
+    fireEvent.click(screen.getByTestId('explore-from-browser-btn'))
+    fireEvent.click(screen.getByTestId('mock-do-capture'))
+
+    // Mid-stream we can't interrupt → the capture is queued as a chip, not auto-sent.
+    expect(await screen.findByTestId('explore-captured-dom-list')).toBeInTheDocument()
+    expect(screen.getByTestId('mock-remove-capture')).toBeInTheDocument()
+    expect(mockSendMessage).not.toHaveBeenCalled()
+  })
+
+  it('removing a queued capture drops the chip and DELETEs its attachments', async () => {
+    const ws = makeFakeWs()
+    streamingConversation()
     render(<ExploreSpecShell initialIdea="hi" pendingSpecId="pending-1" initialAttachmentIds={[]} onClose={onClose} />, { wrapper: wrap(ws) })
     await screen.findByText('ok')
 

--- a/client/src/components/explore-spec/__tests__/ExploreSpecShell.publishDraft.test.tsx
+++ b/client/src/components/explore-spec/__tests__/ExploreSpecShell.publishDraft.test.tsx
@@ -169,7 +169,7 @@ describe('ExploreSpecShell — publish vs update on Continue Editing', () => {
     return fetchMock
   }
 
-  it('draft edit: button reads "Create Spec" and commit flips the draft via from-draft', async () => {
+  it('draft edit: button reads "Update Spec" but commit still flips the draft via from-draft', async () => {
     const fetchMock = renderShell({
       id: 42,
       title: 'Saved draft',
@@ -181,8 +181,10 @@ describe('ExploreSpecShell — publish vs update on Continue Editing', () => {
     })
 
     const createBtn = await screen.findByTestId('explore-spec-create')
-    expect(createBtn).toHaveTextContent('Create Spec')
-    expect(createBtn).not.toHaveTextContent('Update Spec')
+    // Editing an existing spec (draft included) reads "Update Spec" — the COMMIT
+    // BEHAVIOUR (publish via from-draft) is unchanged, only the label.
+    expect(createBtn).toHaveTextContent('Update Spec')
+    expect(createBtn).not.toHaveTextContent('Create Spec')
 
     fireEvent.click(createBtn)
 

--- a/client/src/context/WebViewModalContext.test.tsx
+++ b/client/src/context/WebViewModalContext.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { WebViewModalProvider, useWebViewModal } from './WebViewModalContext'
+
+vi.mock('../hooks/useDesktop', () => ({ useDesktop: () => ({ activeProjectId: 'proj-1' }) }))
+vi.mock('../lib/browser-capture', () => ({ isBrowserCaptureEnabled: () => true }))
+vi.mock('../components/browser-capture/WebViewModal', () => ({
+  WebViewModal: ({ url, onClose }: { url: string; onClose: () => void }) => (
+    <div data-testid="mock-webview">
+      <span data-testid="webview-url">{url}</span>
+      <button data-testid="webview-close" onClick={onClose}>close</button>
+    </div>
+  ),
+}))
+
+function Opener() {
+  const { openWebView } = useWebViewModal()
+  return <button data-testid="open" onClick={() => openWebView('https://example.com/page')}>open</button>
+}
+
+describe('WebViewModalProvider', () => {
+  it('opens the embedded browser modal with the url, then closes it', () => {
+    render(<WebViewModalProvider><Opener /></WebViewModalProvider>)
+    expect(screen.queryByTestId('mock-webview')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('open'))
+    expect(screen.getByTestId('mock-webview')).toBeInTheDocument()
+    expect(screen.getByTestId('webview-url')).toHaveTextContent('https://example.com/page')
+
+    fireEvent.click(screen.getByTestId('webview-close'))
+    expect(screen.queryByTestId('mock-webview')).not.toBeInTheDocument()
+  })
+
+  it('useWebViewModal is a safe no-op without a provider', () => {
+    function Bare() {
+      const { openWebView } = useWebViewModal()
+      return <button data-testid="bare" onClick={() => openWebView('https://x.com')}>bare</button>
+    }
+    render(<Bare />)
+    expect(() => fireEvent.click(screen.getByTestId('bare'))).not.toThrow()
+  })
+})

--- a/client/src/context/WebViewModalContext.tsx
+++ b/client/src/context/WebViewModalContext.tsx
@@ -1,0 +1,37 @@
+import { createContext, useCallback, useContext, useState, type ReactNode } from 'react'
+import { useDesktop } from '../hooks/useDesktop'
+import { WebViewModal } from '../components/browser-capture/WebViewModal'
+import { isBrowserCaptureEnabled } from '../lib/browser-capture'
+
+interface WebViewModalApi {
+  /** Open an http(s) URL in the in-app embedded browser modal (shares the global
+   *  browser profile / cookies). */
+  openWebView: (url: string) => void
+}
+
+const WebViewModalContext = createContext<WebViewModalApi | null>(null)
+
+export function WebViewModalProvider({ children }: { children: ReactNode }) {
+  const { activeProjectId } = useDesktop()
+  const [url, setUrl] = useState<string | null>(null)
+  const openWebView = useCallback((u: string) => setUrl(u), [])
+  const enabled = isBrowserCaptureEnabled()
+
+  return (
+    <WebViewModalContext.Provider value={{ openWebView }}>
+      {children}
+      {enabled && url && activeProjectId && (
+        <WebViewModal open url={url} projectId={activeProjectId} onClose={() => setUrl(null)} />
+      )}
+    </WebViewModalContext.Provider>
+  )
+}
+
+/**
+ * Open links in the in-app embedded browser. Falls back to a no-op when no
+ * provider is mounted (e.g. unit tests), so consumers can call it unconditionally
+ * and the link keeps its default behaviour.
+ */
+export function useWebViewModal(): WebViewModalApi {
+  return useContext(WebViewModalContext) ?? { openWebView: () => {} }
+}

--- a/client/src/lib/__tests__/attachments.test.ts
+++ b/client/src/lib/__tests__/attachments.test.ts
@@ -155,5 +155,21 @@ describe('attachments lib', () => {
       const file = new File([''], 'video.mp4', { type: 'video/mp4' })
       expect(isSupportedAttachmentFile(file)).toBe(false)
     })
+
+    it('accepts a PNG with an empty mime type (drag source / OS quirk)', () => {
+      const file = new File([''], 'screenshot.png', { type: '' })
+      expect(isSupportedAttachmentFile(file)).toBe(true)
+    })
+
+    it('accepts a PNG reported with the legacy image/x-png mime (Windows)', () => {
+      const file = new File([''], 'shot.PNG', { type: 'image/x-png' })
+      expect(isSupportedAttachmentFile(file)).toBe(true)
+    })
+
+    it('accepts jpg/jpeg/gif/webp by extension even with no mime', () => {
+      for (const name of ['a.jpg', 'b.jpeg', 'c.gif', 'd.webp']) {
+        expect(isSupportedAttachmentFile(new File([''], name, { type: '' }))).toBe(true)
+      }
+    })
   })
 })

--- a/client/src/lib/__tests__/pending-spec-id.test.ts
+++ b/client/src/lib/__tests__/pending-spec-id.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { genPendingSpecId } from '../pending-spec-id'
+
+// Mirrors the server guard SAFE_PENDING_ID (project-router-terminals.ts).
+const SAFE_PENDING_ID = /^[A-Za-z0-9_-]{1,128}$/
+
+describe('genPendingSpecId', () => {
+  it('returns a non-empty, server-safe id (never the empty value that 400s capture)', () => {
+    const id = genPendingSpecId()
+    expect(id).toBeTruthy()
+    expect(SAFE_PENDING_ID.test(id)).toBe(true)
+  })
+
+  it('returns distinct ids', () => {
+    expect(genPendingSpecId()).not.toBe(genPendingSpecId())
+  })
+})

--- a/client/src/lib/attachments.ts
+++ b/client/src/lib/attachments.ts
@@ -60,7 +60,17 @@ const SUPPORTED_ATTACHMENT_MIMES = new Set(
   ATTACHMENT_ACCEPT_MIME.split(',').filter((part) => !part.startsWith('.')),
 )
 const SQL_EXTENSION_RE = /\.sql$/i
+// Accept images by file extension even when the browser reports an empty or
+// non-canonical MIME (e.g. Windows reporting a PNG as `image/x-png`, or some
+// drag sources providing an empty `file.type`). This mirrors the server's
+// normalizeUploadedMimeType fallback so the client never blocks a file the
+// server would accept — the root cause of "won't let me add .png".
+const IMAGE_EXTENSION_RE = /\.(png|jpe?g|gif|webp)$/i
 
 export function isSupportedAttachmentFile(file: Pick<File, 'name' | 'type'>): boolean {
-  return SUPPORTED_ATTACHMENT_MIMES.has(file.type) || SQL_EXTENSION_RE.test(file.name)
+  return (
+    SUPPORTED_ATTACHMENT_MIMES.has(file.type) ||
+    SQL_EXTENSION_RE.test(file.name) ||
+    IMAGE_EXTENSION_RE.test(file.name)
+  )
 }

--- a/client/src/lib/browser-capture.test.ts
+++ b/client/src/lib/browser-capture.test.ts
@@ -5,6 +5,7 @@ import {
   mapPointToViewport,
   rectFromPoints,
   isUsableSelection,
+  clampRectToViewport,
   mapRectToDisplay,
   domSummary,
   browserWsUrl,
@@ -79,6 +80,32 @@ describe('browser-capture lib', () => {
     it('rejects tiny selections', () => {
       expect(isUsableSelection({ x: 0, y: 0, width: 4, height: 50 })).toBe(false)
       expect(isUsableSelection({ x: 0, y: 0, width: 20, height: 20 })).toBe(true)
+    })
+
+    describe('clampRectToViewport', () => {
+      const vp = { width: 1280, height: 800 }
+
+      it('leaves an in-bounds rect unchanged', () => {
+        expect(clampRectToViewport({ x: 100, y: 50, width: 200, height: 120 }, vp)).toEqual({ x: 100, y: 50, width: 200, height: 120 })
+      })
+
+      it('clamps a negative origin to 0 while preserving the far edge (the 400 cause)', () => {
+        // An element that starts above/left of the viewport: x=-40,y=-10 → 0,0 with
+        // the right/bottom edge preserved. parseRect would have rejected x<0/y<0.
+        expect(clampRectToViewport({ x: -40, y: -10, width: 240, height: 110 }, vp)).toEqual({ x: 0, y: 0, width: 200, height: 100 })
+      })
+
+      it('caps a rect that overflows the viewport to the far edge', () => {
+        expect(clampRectToViewport({ x: 1200, y: 760, width: 400, height: 400 }, vp)).toEqual({ x: 1200, y: 760, width: 80, height: 40 })
+      })
+
+      it('always yields a positive size and non-negative origin', () => {
+        const out = clampRectToViewport({ x: -5, y: -5, width: 2, height: 2 }, vp)
+        expect(out.x).toBeGreaterThanOrEqual(0)
+        expect(out.y).toBeGreaterThanOrEqual(0)
+        expect(out.width).toBeGreaterThanOrEqual(1)
+        expect(out.height).toBeGreaterThanOrEqual(1)
+      })
     })
 
     it('maps a viewport rect back to displayed canvas coordinates (inverse of point map)', () => {

--- a/client/src/lib/browser-capture.ts
+++ b/client/src/lib/browser-capture.ts
@@ -193,8 +193,19 @@ export async function captureBrowserRegion(
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ rect, pendingSpecId, captureNetwork: opts?.captureNetwork ?? true }),
   })
-  if (!res.ok) throw new Error(`Capture failed (${res.status})`)
+  if (!res.ok) throw new Error(await captureErrorMessage(res))
   return (await res.json()) as CaptureResult
+}
+
+/** Build a capture error that includes the server's reason (e.g. an invalid-rect
+ *  or invalid-pendingSpecId 400) so the in-modal banner is actionable, not a bare
+ *  status code. */
+async function captureErrorMessage(res: Response): Promise<string> {
+  const detail = await res
+    .json()
+    .then((b) => (b as { error?: string }).error)
+    .catch(() => undefined)
+  return detail ? `Capture failed (${res.status}): ${detail}` : `Capture failed (${res.status})`
 }
 
 export async function captureBrowserBreakpoints(
@@ -209,7 +220,7 @@ export async function captureBrowserBreakpoints(
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ rect, anchorPoint, pendingSpecId, breakpoints }),
   })
-  if (!res.ok) throw new Error(`Capture failed (${res.status})`)
+  if (!res.ok) throw new Error(await captureErrorMessage(res))
   return (await res.json()) as CaptureResult
 }
 
@@ -347,6 +358,25 @@ export function rectFromPoints(a: Point, b: Point): CaptureRect {
  *  clicks producing 1px captures). */
 export function isUsableSelection(rect: CaptureRect, minPx = 8): boolean {
   return rect.width >= minPx && rect.height >= minPx
+}
+
+/**
+ * Clamp a capture rect into the page viewport so the server's `parseRect` guard
+ * (which REJECTS negative or out-of-bounds coords) never 400s a legitimate
+ * selection. A hovered/locked element's rect — taken from the page's own
+ * getBoundingClientRect — can legitimately start above/left of the viewport
+ * (x/y < 0) or extend past it; clamping keeps x,y ≥ 0 with a positive size and
+ * the far edge in bounds, screenshotting the visible region. (This was the cause
+ * of "Capture failed (400)" when selecting an edge element from Explore.)
+ */
+export function clampRectToViewport(rect: CaptureRect, viewport: { width: number; height: number }): CaptureRect {
+  const vw = Math.max(1, viewport.width)
+  const vh = Math.max(1, viewport.height)
+  const left = Math.max(0, Math.min(rect.x, vw - 1))
+  const top = Math.max(0, Math.min(rect.y, vh - 1))
+  const right = Math.min(vw, Math.max(left + 1, rect.x + rect.width))
+  const bottom = Math.min(vh, Math.max(top + 1, rect.y + rect.height))
+  return { x: Math.round(left), y: Math.round(top), width: Math.round(right - left), height: Math.round(bottom - top) }
 }
 
 /** Count populated (non-empty) facets of a captured DOM for the panel badge. */

--- a/client/src/lib/pending-spec-id.ts
+++ b/client/src/lib/pending-spec-id.ts
@@ -1,0 +1,20 @@
+/**
+ * A pending-spec id is the stable per-Explore-session key used for the attachment
+ * directory (`~/.specrails/projects/<slug>/attachments/<pendingSpecId>/`) and for
+ * the "From a website" browser capture. It MUST be a non-empty, filesystem-safe
+ * opaque token (the server validates it against `^[A-Za-z0-9_-]{1,128}$`); an
+ * empty value breaks attachment upload and makes capture 400 with
+ * "pendingSpecId is required".
+ */
+export function genPendingSpecId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  // Fallback for environments without crypto.randomUUID (should not hit in a
+  // modern webview, but keeps this id-generation total).
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0
+    const v = c === 'x' ? r : (r & 0x3) | 0x8
+    return v.toString(16)
+  })
+}

--- a/client/src/locales/de/explore.json
+++ b/client/src/locales/de/explore.json
@@ -42,7 +42,11 @@
       "createNetworkError": "Netzwerkfehler beim Erstellen der Spec",
       "unsupportedFileType": "Nicht unterstützter Dateityp: {{name}}",
       "uploadFailed": "Upload fehlgeschlagen für {{name}}: {{message}}"
-    }
+    },
+    "fromWebsite": "Von einer Website",
+    "fromWebsiteTitle": "Öffne eine echte Webseite, wähle einen Bereich aus und mach daraus eine Spec",
+    "captureResponsiveSizes_one": "Responsive · {{count}} Größe",
+    "captureResponsiveSizes_other": "Responsive · {{count}} Größen"
   },
   "draftPanel": {
     "ready": "Entwurf bereit",

--- a/client/src/locales/de/explore.json
+++ b/client/src/locales/de/explore.json
@@ -46,7 +46,8 @@
     "fromWebsite": "Von einer Website",
     "fromWebsiteTitle": "Öffne eine echte Webseite, wähle einen Bereich aus und mach daraus eine Spec",
     "captureResponsiveSizes_one": "Responsive · {{count}} Größe",
-    "captureResponsiveSizes_other": "Responsive · {{count}} Größen"
+    "captureResponsiveSizes_other": "Responsive · {{count}} Größen",
+    "captureFeedbackPrompt": "Ich habe gerade einen Teil einer Webseite erfasst (Screenshot und Inhalt sind angehängt). Kurz: Was siehst du, und wie hängt es mit unserem bisherigen Gespräch und der Spec zusammen, die wir gerade gestalten? Gib mir dein Feedback."
   },
   "draftPanel": {
     "ready": "Entwurf bereit",

--- a/client/src/locales/en/explore.json
+++ b/client/src/locales/en/explore.json
@@ -42,7 +42,11 @@
       "createNetworkError": "Network error creating spec",
       "unsupportedFileType": "Unsupported file type: {{name}}",
       "uploadFailed": "Upload failed for {{name}}: {{message}}"
-    }
+    },
+    "fromWebsite": "From a website",
+    "fromWebsiteTitle": "Open a real web page, select an area, and turn it into a spec",
+    "captureResponsiveSizes_one": "Responsive · {{count}} size",
+    "captureResponsiveSizes_other": "Responsive · {{count}} sizes"
   },
   "draftPanel": {
     "ready": "Draft ready",

--- a/client/src/locales/en/explore.json
+++ b/client/src/locales/en/explore.json
@@ -46,7 +46,8 @@
     "fromWebsite": "From a website",
     "fromWebsiteTitle": "Open a real web page, select an area, and turn it into a spec",
     "captureResponsiveSizes_one": "Responsive · {{count}} size",
-    "captureResponsiveSizes_other": "Responsive · {{count}} sizes"
+    "captureResponsiveSizes_other": "Responsive · {{count}} sizes",
+    "captureFeedbackPrompt": "I've just captured part of a web page (its screenshot and content are attached). Briefly: what do you see, and how does it relate to what we've discussed so far and to the spec we're shaping? Give me your feedback."
   },
   "draftPanel": {
     "ready": "Draft ready",

--- a/client/src/locales/es/explore.json
+++ b/client/src/locales/es/explore.json
@@ -46,7 +46,8 @@
     "fromWebsite": "Desde una web",
     "fromWebsiteTitle": "Abre una página web real, selecciona un área y conviértela en una spec",
     "captureResponsiveSizes_one": "Responsive · {{count}} tamaño",
-    "captureResponsiveSizes_other": "Responsive · {{count}} tamaños"
+    "captureResponsiveSizes_other": "Responsive · {{count}} tamaños",
+    "captureFeedbackPrompt": "Acabo de capturar parte de una web (su imagen y contenido van adjuntos). Brevemente: ¿qué ves y cómo se relaciona con lo que hemos hablado y con la spec que estamos definiendo? Dame tu feedback."
   },
   "draftPanel": {
     "ready": "Borrador listo",

--- a/client/src/locales/es/explore.json
+++ b/client/src/locales/es/explore.json
@@ -42,7 +42,11 @@
       "createNetworkError": "Error de red al crear la spec",
       "unsupportedFileType": "Tipo de archivo no compatible: {{name}}",
       "uploadFailed": "Error al subir {{name}}: {{message}}"
-    }
+    },
+    "fromWebsite": "Desde una web",
+    "fromWebsiteTitle": "Abre una página web real, selecciona un área y conviértela en una spec",
+    "captureResponsiveSizes_one": "Responsive · {{count}} tamaño",
+    "captureResponsiveSizes_other": "Responsive · {{count}} tamaños"
   },
   "draftPanel": {
     "ready": "Borrador listo",

--- a/client/src/locales/fr/explore.json
+++ b/client/src/locales/fr/explore.json
@@ -46,7 +46,8 @@
     "fromWebsite": "Depuis un site web",
     "fromWebsiteTitle": "Ouvrez une vraie page web, sélectionnez une zone et transformez-la en spec",
     "captureResponsiveSizes_one": "Responsive · {{count}} taille",
-    "captureResponsiveSizes_other": "Responsive · {{count}} tailles"
+    "captureResponsiveSizes_other": "Responsive · {{count}} tailles",
+    "captureFeedbackPrompt": "Je viens de capturer une partie d'une page web (sa capture d'écran et son contenu sont joints). Brièvement : que vois-tu, et quel rapport avec ce dont nous avons parlé et avec la spec que nous élaborons ? Donne-moi ton retour."
   },
   "draftPanel": {
     "ready": "Brouillon prêt",

--- a/client/src/locales/fr/explore.json
+++ b/client/src/locales/fr/explore.json
@@ -42,7 +42,11 @@
       "createNetworkError": "Erreur réseau lors de la création de la spec",
       "unsupportedFileType": "Type de fichier non pris en charge : {{name}}",
       "uploadFailed": "Échec de l'envoi de {{name}} : {{message}}"
-    }
+    },
+    "fromWebsite": "Depuis un site web",
+    "fromWebsiteTitle": "Ouvrez une vraie page web, sélectionnez une zone et transformez-la en spec",
+    "captureResponsiveSizes_one": "Responsive · {{count}} taille",
+    "captureResponsiveSizes_other": "Responsive · {{count}} tailles"
   },
   "draftPanel": {
     "ready": "Brouillon prêt",

--- a/client/src/locales/it/explore.json
+++ b/client/src/locales/it/explore.json
@@ -42,7 +42,11 @@
       "createNetworkError": "Errore di rete durante la creazione della spec",
       "unsupportedFileType": "Tipo di file non supportato: {{name}}",
       "uploadFailed": "Caricamento non riuscito per {{name}}: {{message}}"
-    }
+    },
+    "fromWebsite": "Da un sito web",
+    "fromWebsiteTitle": "Apri una pagina web reale, seleziona un'area e trasformala in una spec",
+    "captureResponsiveSizes_one": "Responsive · {{count}} dimensione",
+    "captureResponsiveSizes_other": "Responsive · {{count}} dimensioni"
   },
   "draftPanel": {
     "ready": "Bozza pronta",

--- a/client/src/locales/it/explore.json
+++ b/client/src/locales/it/explore.json
@@ -46,7 +46,8 @@
     "fromWebsite": "Da un sito web",
     "fromWebsiteTitle": "Apri una pagina web reale, seleziona un'area e trasformala in una spec",
     "captureResponsiveSizes_one": "Responsive · {{count}} dimensione",
-    "captureResponsiveSizes_other": "Responsive · {{count}} dimensioni"
+    "captureResponsiveSizes_other": "Responsive · {{count}} dimensioni",
+    "captureFeedbackPrompt": "Ho appena catturato una parte di una pagina web (screenshot e contenuto sono allegati). In breve: cosa vedi e come si collega a ciò di cui abbiamo parlato e alla spec che stiamo definendo? Dammi il tuo feedback."
   },
   "draftPanel": {
     "ready": "Bozza pronta",

--- a/client/src/locales/ja/explore.json
+++ b/client/src/locales/ja/explore.json
@@ -42,7 +42,11 @@
       "createNetworkError": "スペック作成中にネットワークエラーが発生しました",
       "unsupportedFileType": "未対応のファイル形式: {{name}}",
       "uploadFailed": "{{name}} のアップロードに失敗しました: {{message}}"
-    }
+    },
+    "fromWebsite": "ウェブサイトから",
+    "fromWebsiteTitle": "実際のウェブページを開き、範囲を選択してスペックに変換",
+    "captureResponsiveSizes_one": "レスポンシブ · {{count}} サイズ",
+    "captureResponsiveSizes_other": "レスポンシブ · {{count}} サイズ"
   },
   "draftPanel": {
     "ready": "下書き準備完了",

--- a/client/src/locales/ja/explore.json
+++ b/client/src/locales/ja/explore.json
@@ -46,7 +46,8 @@
     "fromWebsite": "ウェブサイトから",
     "fromWebsiteTitle": "実際のウェブページを開き、範囲を選択してスペックに変換",
     "captureResponsiveSizes_one": "レスポンシブ · {{count}} サイズ",
-    "captureResponsiveSizes_other": "レスポンシブ · {{count}} サイズ"
+    "captureResponsiveSizes_other": "レスポンシブ · {{count}} サイズ",
+    "captureFeedbackPrompt": "ウェブページの一部をキャプチャしました（スクリーンショットと内容を添付しています）。手短に: 何が見えますか？これまでの会話や、今まとめているスペックとどう関係しますか？フィードバックをください。"
   },
   "draftPanel": {
     "ready": "下書き準備完了",

--- a/client/src/locales/pt/explore.json
+++ b/client/src/locales/pt/explore.json
@@ -46,7 +46,8 @@
     "fromWebsite": "A partir de um website",
     "fromWebsiteTitle": "Abra uma página web real, selecione uma área e converta-a numa spec",
     "captureResponsiveSizes_one": "Responsivo · {{count}} tamanho",
-    "captureResponsiveSizes_other": "Responsivo · {{count}} tamanhos"
+    "captureResponsiveSizes_other": "Responsivo · {{count}} tamanhos",
+    "captureFeedbackPrompt": "Acabei de capturar parte de uma página web (a imagem e o conteúdo estão anexados). Brevemente: o que vês e como se relaciona com o que falámos e com a spec que estamos a definir? Dá-me o teu feedback."
   },
   "draftPanel": {
     "ready": "Rascunho pronto",

--- a/client/src/locales/pt/explore.json
+++ b/client/src/locales/pt/explore.json
@@ -42,7 +42,11 @@
       "createNetworkError": "Erro de rede ao criar a spec",
       "unsupportedFileType": "Tipo de ficheiro não suportado: {{name}}",
       "uploadFailed": "Falha no upload de {{name}}: {{message}}"
-    }
+    },
+    "fromWebsite": "A partir de um website",
+    "fromWebsiteTitle": "Abra uma página web real, selecione uma área e converta-a numa spec",
+    "captureResponsiveSizes_one": "Responsivo · {{count}} tamanho",
+    "captureResponsiveSizes_other": "Responsivo · {{count}} tamanhos"
   },
   "draftPanel": {
     "ready": "Rascunho pronto",

--- a/client/src/locales/zh/explore.json
+++ b/client/src/locales/zh/explore.json
@@ -46,7 +46,8 @@
     "fromWebsite": "从网站创建",
     "fromWebsiteTitle": "打开真实网页，框选一块区域，把它变成 spec",
     "captureResponsiveSizes_one": "响应式 · {{count}} 个尺寸",
-    "captureResponsiveSizes_other": "响应式 · {{count}} 个尺寸"
+    "captureResponsiveSizes_other": "响应式 · {{count}} 个尺寸",
+    "captureFeedbackPrompt": "我刚刚截取了一个网页的一部分（截图和内容已附上）。简要说说：你看到了什么？它与我们目前的讨论以及我们正在定义的 spec 有什么关联？给我你的反馈。"
   },
   "draftPanel": {
     "ready": "草稿就绪",

--- a/client/src/locales/zh/explore.json
+++ b/client/src/locales/zh/explore.json
@@ -42,7 +42,11 @@
       "createNetworkError": "创建 Spec 时网络错误",
       "unsupportedFileType": "不支持的文件类型：{{name}}",
       "uploadFailed": "{{name}} 上传失败：{{message}}"
-    }
+    },
+    "fromWebsite": "从网站创建",
+    "fromWebsiteTitle": "打开真实网页，框选一块区域，把它变成 spec",
+    "captureResponsiveSizes_one": "响应式 · {{count}} 个尺寸",
+    "captureResponsiveSizes_other": "响应式 · {{count}} 个尺寸"
   },
   "draftPanel": {
     "ready": "草稿就绪",

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -62,6 +62,9 @@ export default defineConfig({
         // lib/browser-capture.ts and CapturedDomPanel, both unit-tested.
         'src/components/browser-capture/useBrowserCaptureSession.ts',
         'src/components/browser-capture/BrowserCaptureModal.tsx',
+        // Read-only embedded-browser modal for opening spec-description links —
+        // same canvas/WS/pointer machinery as BrowserCaptureModal (not jsdom-able).
+        'src/components/browser-capture/WebViewModal.tsx',
         // Annotation markup editor: canvas flatten + pointer-drag drawing; the
         // model/geometry/undo-reducer live in lib/annotations.ts and are tested.
         'src/components/browser-capture/AnnotationEditor.tsx',

--- a/server/attachment-manager.test.ts
+++ b/server/attachment-manager.test.ts
@@ -228,6 +228,18 @@ describe('AttachmentManager', () => {
       expect(attachment.mimeType).toBe('text/plain')
     })
 
+    it('accepts a PNG reported with a non-standard MIME and stores it as image/png', async () => {
+      const attachment = await manager.upload({
+        slug: 'proj',
+        ticketKey: '1',
+        ticketStorePath: null,
+        file: makeFile({ originalname: 'shot.png', mimetype: 'image/x-png', buffer: Buffer.from('PNG') }),
+      })
+
+      expect(attachment.filename).toBe('shot.png')
+      expect(attachment.mimeType).toBe('image/png')
+    })
+
     it('skips store mutation for missing ticket when projectPath provided', async () => {
       const projPath = makeProjectDir(tmpDir)
       // ticket key 999 doesn't exist in the store - should not throw
@@ -633,6 +645,33 @@ describe('AttachmentManager', () => {
       expect(normalizeUploadedMimeType('application/sql', 'schema.sql')).toBe('text/plain')
       expect(normalizeUploadedMimeType('', 'schema.sql')).toBe('text/plain')
       expect(isSupportedUploadedFile({ mimetype: '', originalname: 'schema.sql' })).toBe(true)
+    })
+
+    it('canonicalizes non-standard/empty image MIMEs by extension (PNG add bug)', () => {
+      // Windows legacy MIME for PNG.
+      expect(normalizeUploadedMimeType('image/x-png', 'shot.png')).toBe('image/png')
+      // Empty type from some drag sources.
+      expect(normalizeUploadedMimeType('', 'shot.PNG')).toBe('image/png')
+      expect(normalizeUploadedMimeType('', 'photo.jpeg')).toBe('image/jpeg')
+      expect(normalizeUploadedMimeType('application/octet-stream', 'pic.jpg')).toBe('image/jpeg')
+      expect(normalizeUploadedMimeType('', 'anim.gif')).toBe('image/gif')
+      expect(normalizeUploadedMimeType('', 'img.webp')).toBe('image/webp')
+    })
+
+    it('leaves an already-canonical image MIME untouched', () => {
+      expect(normalizeUploadedMimeType('image/png', 'shot.png')).toBe('image/png')
+      expect(normalizeUploadedMimeType('image/jpeg', 'photo.jpg')).toBe('image/jpeg')
+    })
+
+    it('does not misclassify non-image files as images', () => {
+      expect(normalizeUploadedMimeType('application/pdf', 'doc.pdf')).toBe('application/pdf')
+      expect(normalizeUploadedMimeType('text/csv', 'data.csv')).toBe('text/csv')
+    })
+
+    it('treats a PNG with a non-standard/empty MIME as supported', () => {
+      expect(isSupportedUploadedFile({ mimetype: 'image/x-png', originalname: 'shot.png' })).toBe(true)
+      expect(isSupportedUploadedFile({ mimetype: '', originalname: 'shot.png' })).toBe(true)
+      expect(isSupportedUploadedFile({ mimetype: '', originalname: 'photo.jpg' })).toBe(true)
     })
   })
 })

--- a/server/attachment-manager.test.ts
+++ b/server/attachment-manager.test.ts
@@ -668,6 +668,15 @@ describe('AttachmentManager', () => {
       expect(normalizeUploadedMimeType('text/csv', 'data.csv')).toBe('text/csv')
     })
 
+    it('does NOT clobber a correct non-image MIME that has an image-looking name', () => {
+      // A PDF/CSV/XLSX uploaded with a .png name must keep its real MIME so it is
+      // text-extracted for the agent and rendered correctly — not turned into a
+      // broken image/png.
+      expect(normalizeUploadedMimeType('application/pdf', 'report.png')).toBe('application/pdf')
+      expect(normalizeUploadedMimeType('text/csv', 'data.png')).toBe('text/csv')
+      expect(normalizeUploadedMimeType('application/vnd.ms-excel', 'sheet.jpg')).toBe('application/vnd.ms-excel')
+    })
+
     it('treats a PNG with a non-standard/empty MIME as supported', () => {
       expect(isSupportedUploadedFile({ mimetype: 'image/x-png', originalname: 'shot.png' })).toBe(true)
       expect(isSupportedUploadedFile({ mimetype: '', originalname: 'shot.png' })).toBe(true)

--- a/server/attachment-manager.ts
+++ b/server/attachment-manager.ts
@@ -28,6 +28,17 @@ const SQL_MIME_TYPES = new Set<string>([
   'text/x-sql',
 ])
 const SQL_EXTENSION_RE = /\.sql$/i
+// Map an image file extension to its canonical MIME. Used as a fallback when the
+// reported MIME is non-canonical or empty (e.g. Windows legacy `image/x-png`, or
+// an empty type from certain drag sources) so PNG/JPEG/GIF/WebP are still
+// accepted — and stored with a canonical mime so the image @-ref path + chip
+// icon work. Fixes "won't let me add .png".
+const IMAGE_EXTENSION_MIME: ReadonlyArray<readonly [RegExp, string]> = [
+  [/\.png$/i, 'image/png'],
+  [/\.jpe?g$/i, 'image/jpeg'],
+  [/\.gif$/i, 'image/gif'],
+  [/\.webp$/i, 'image/webp'],
+]
 const INLINE_TEXT_MIME_TYPES = new Set<string>([
   'text/csv',
   'text/plain',
@@ -49,6 +60,15 @@ export interface UploadedFile {
 export function normalizeUploadedMimeType(mimetype: string, originalname: string): string {
   if (SQL_MIME_TYPES.has(mimetype) || SQL_EXTENSION_RE.test(originalname)) {
     return 'text/plain'
+  }
+  // When the reported MIME isn't already a supported image type, fall back to the
+  // file extension so non-canonical/empty image MIMEs (e.g. `image/x-png`) are
+  // accepted and stored canonically.
+  const isSupportedImageMime = SUPPORTED_MIME_TYPES.has(mimetype) && mimetype.startsWith(IMAGE_MIME_PREFIX)
+  if (!isSupportedImageMime) {
+    for (const [re, canonical] of IMAGE_EXTENSION_MIME) {
+      if (re.test(originalname)) return canonical
+    }
   }
   return mimetype
 }

--- a/server/attachment-manager.ts
+++ b/server/attachment-manager.ts
@@ -61,11 +61,12 @@ export function normalizeUploadedMimeType(mimetype: string, originalname: string
   if (SQL_MIME_TYPES.has(mimetype) || SQL_EXTENSION_RE.test(originalname)) {
     return 'text/plain'
   }
-  // When the reported MIME isn't already a supported image type, fall back to the
-  // file extension so non-canonical/empty image MIMEs (e.g. `image/x-png`) are
-  // accepted and stored canonically.
-  const isSupportedImageMime = SUPPORTED_MIME_TYPES.has(mimetype) && mimetype.startsWith(IMAGE_MIME_PREFIX)
-  if (!isSupportedImageMime) {
+  // Only fall back to the file extension when the reported MIME is NOT already a
+  // supported type. This accepts non-canonical/empty image MIMEs (e.g.
+  // `image/x-png`, '') by extension WITHOUT clobbering a correct non-image MIME
+  // that merely has an image-looking name (e.g. a PDF uploaded as `report.png`
+  // must stay `application/pdf`, not become a broken `image/png`).
+  if (!SUPPORTED_MIME_TYPES.has(mimetype)) {
     for (const [re, canonical] of IMAGE_EXTENSION_MIME) {
       if (re.test(originalname)) return canonical
     }

--- a/server/browser-capture-manager.test.ts
+++ b/server/browser-capture-manager.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { initDb, type DbInstance } from './db'
 import { BrowserCaptureManager, type BrowserWsClient } from './browser-capture-manager'
+import { SharedBrowserContextPool } from './browser-context-pool'
 import {
   BrowserLimitExceededError,
   BrowserLaunchError,
@@ -571,5 +572,56 @@ describe('BrowserCaptureManager', () => {
     closed.close()
     const { mgr } = makeManager({ db: closed })
     expect(mgr.getLastUrl()).toBeNull()
+  })
+})
+
+// ─── Shared global browser context (cookies shared across projects) ────────────
+
+describe('BrowserCaptureManager with a shared context pool', () => {
+  function makePooledManager(pool: SharedBrowserContextPool, projectSlug: string) {
+    return new BrowserCaptureManager({
+      projectId: `proj-${projectSlug}`,
+      projectSlug,
+      db: initDb(':memory:'),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      attachments: makeAttachments() as any,
+      contextPool: pool,
+    })
+  }
+
+  it('opens pages from TWO projects in the SAME shared context (shared cookies)', async () => {
+    const shared = new FakeContext()
+    const launcher: ContextLauncher = vi.fn(async () => shared)
+    const pool = new SharedBrowserContextPool({ launcher, profileDir: '/tmp/global' })
+
+    const mgrA = makePooledManager(pool, 'a')
+    const mgrB = makePooledManager(pool, 'b')
+    await mgrA.create()
+    await mgrB.create()
+
+    // One launch for the whole app, two pages in the one shared context.
+    expect(launcher).toHaveBeenCalledTimes(1)
+    expect(shared.pages).toHaveLength(2)
+  })
+
+  it('per-project shutdown closes only its pages, NOT the shared context', async () => {
+    const shared = new FakeContext()
+    const pool = new SharedBrowserContextPool({ launcher: vi.fn(async () => shared), profileDir: '/tmp/global' })
+
+    const mgrA = makePooledManager(pool, 'a')
+    const mgrB = makePooledManager(pool, 'b')
+    const a = await mgrA.create()
+    void a
+    await mgrB.create()
+
+    await mgrA.shutdown()
+    // mgrA's page is closed; the shared context survives for mgrB + globally.
+    expect(shared.closed).toBe(false)
+    expect(shared.pages[0].closed).toBe(true)
+    expect(shared.pages[1].closed).toBe(false)
+
+    // The pool owner (registry) closes the shared context exactly once at the end.
+    await pool.dispose()
+    expect(shared.closed).toBe(true)
   })
 })

--- a/server/browser-capture-manager.ts
+++ b/server/browser-capture-manager.ts
@@ -16,6 +16,7 @@ import {
   type CapturedDom,
   type ContextLauncher,
   type ElementProbe,
+  type SharedBrowserContext,
 } from './browser-capture-types'
 import { createPlaywrightLauncher } from './browser-playwright'
 
@@ -88,9 +89,16 @@ export interface BrowserCaptureManagerOptions {
   launcher?: ContextLauncher
   /** Injectable for tests — defaults to the shared AttachmentManager. */
   attachments?: AttachmentManager
-  /** Override the persistent-profile dir (tests). */
+  /** Override the persistent-profile dir (tests). Ignored when `contextPool` is
+   *  set — the global shared profile owns the dir. */
   profileDir?: string
   homeDir?: string
+  /** App-wide shared persistent context (GLOBAL cookies/logins across projects).
+   *  When provided, this manager opens pages in the shared context and never
+   *  owns/closes it — only its own pages. When omitted, the manager keeps the
+   *  legacy behaviour of launching + owning a per-project context (used by tests
+   *  and any non-pooled caller). */
+  contextPool?: SharedBrowserContext
 }
 
 /**
@@ -112,6 +120,9 @@ export class BrowserCaptureManager {
   private readonly launcher: ContextLauncher
   private readonly attachments: AttachmentManager
   private readonly profileDir: string
+  /** When set, pages are opened in this app-wide shared context (global cookies)
+   *  and this manager never owns/closes the context — only its own pages. */
+  private readonly contextPool: SharedBrowserContext | null
 
   private context: BrowserContextHandle | null = null
   private contextPromise: Promise<BrowserContextHandle> | null = null
@@ -128,6 +139,7 @@ export class BrowserCaptureManager {
     this.broadcast = opts.broadcast
     this.launcher = opts.launcher ?? createPlaywrightLauncher()
     this.attachments = opts.attachments ?? defaultAttachmentManager
+    this.contextPool = opts.contextPool ?? null
     this.profileDir =
       opts.profileDir ??
       path.join(opts.homeDir ?? os.homedir(), '.specrails', 'projects', opts.projectSlug, 'browser-profile')
@@ -158,6 +170,11 @@ export class BrowserCaptureManager {
 
   private async ensureContext(): Promise<BrowserContextHandle> {
     if (this.disposed) throw new BrowserLaunchError('manager disposed')
+    // Shared global profile: acquire the app-wide context (cookies/logins shared
+    // across every project). Never cached as `this.context`, so shutdown()/kill()
+    // close only this manager's pages and leave the shared context alive for the
+    // other projects (it's disposed once, by the pool owner, at app shutdown).
+    if (this.contextPool) return this.contextPool.acquire()
     if (this.context) return this.context
     if (this.contextPromise) return this.contextPromise
     this.contextPromise = (async () => {

--- a/server/browser-capture-types.ts
+++ b/server/browser-capture-types.ts
@@ -204,6 +204,11 @@ export interface BrowserPageHandle {
 export interface BrowserContextHandle {
   newPage(): Promise<BrowserPageHandle>
   close(): Promise<void>
+  /** False once the underlying browser/context has died (crash, OOM, killed). The
+   *  shared-context pool uses this to drop a dead handle and re-launch instead of
+   *  handing out a corpse forever. Optional: handles that don't implement it are
+   *  treated as always-alive. */
+  isConnected?(): boolean
 }
 
 export interface LaunchContextOptions {

--- a/server/browser-capture-types.ts
+++ b/server/browser-capture-types.ts
@@ -214,6 +214,16 @@ export interface LaunchContextOptions {
 
 export type ContextLauncher = (opts: LaunchContextOptions) => Promise<BrowserContextHandle>
 
+/**
+ * App-wide provider of ONE shared persistent Chromium context (global profile =
+ * shared cookies/logins across every project). Per-project capture managers
+ * `acquire()` this handle and open their own pages in it; they never close it —
+ * only the pool's owner (the registry, at app shutdown) does.
+ */
+export interface SharedBrowserContext {
+  acquire(): Promise<BrowserContextHandle>
+}
+
 // ─── Error classes (mirror terminal-manager's typed errors) ───────────────────
 
 export class BrowserLimitExceededError extends Error {

--- a/server/browser-context-pool.test.ts
+++ b/server/browser-context-pool.test.ts
@@ -4,12 +4,14 @@ import type { BrowserContextHandle, BrowserPageHandle, ContextLauncher } from '.
 
 class FakeContext implements BrowserContextHandle {
   closed = false
+  alive = true
   newPageCalls = 0
   async newPage(): Promise<BrowserPageHandle> {
     this.newPageCalls++
     return {} as BrowserPageHandle
   }
   async close() { this.closed = true }
+  isConnected() { return this.alive }
 }
 
 describe('SharedBrowserContextPool', () => {
@@ -67,6 +69,34 @@ describe('SharedBrowserContextPool', () => {
     resolveLaunch(ctx)
     await Promise.allSettled([acquiring, disposing])
     expect(ctx.closed).toBe(true)
+  })
+
+  it('re-launches a fresh context after the shared one dies (crash recovery)', async () => {
+    const dead = new FakeContext()
+    const fresh = new FakeContext()
+    const launcher = vi.fn()
+      .mockResolvedValueOnce(dead)
+      .mockResolvedValueOnce(fresh) as unknown as ContextLauncher
+    const pool = new SharedBrowserContextPool({ launcher })
+
+    const first = await pool.acquire()
+    expect(first).toBe(dead)
+    // The shared Chromium dies (crash / OOM / killed).
+    dead.alive = false
+    // Next acquire must NOT hand back the corpse — it re-launches.
+    const second = await pool.acquire()
+    expect(second).toBe(fresh)
+    expect(launcher).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps returning the same context while it stays connected', async () => {
+    const ctx = new FakeContext()
+    const launcher = vi.fn(async () => ctx)
+    const pool = new SharedBrowserContextPool({ launcher })
+    await pool.acquire()
+    await pool.acquire()
+    await pool.acquire()
+    expect(launcher).toHaveBeenCalledTimes(1)
   })
 
   it('acquire after dispose throws', async () => {

--- a/server/browser-context-pool.test.ts
+++ b/server/browser-context-pool.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest'
+import { SharedBrowserContextPool } from './browser-context-pool'
+import type { BrowserContextHandle, BrowserPageHandle, ContextLauncher } from './browser-capture-types'
+
+class FakeContext implements BrowserContextHandle {
+  closed = false
+  newPageCalls = 0
+  async newPage(): Promise<BrowserPageHandle> {
+    this.newPageCalls++
+    return {} as BrowserPageHandle
+  }
+  async close() { this.closed = true }
+}
+
+describe('SharedBrowserContextPool', () => {
+  it('launches exactly once and returns the same shared context', async () => {
+    const ctx = new FakeContext()
+    const launcher: ContextLauncher = vi.fn(async () => ctx)
+    const pool = new SharedBrowserContextPool({ launcher, profileDir: '/tmp/global-profile' })
+
+    const a = await pool.acquire()
+    const b = await pool.acquire()
+    expect(a).toBe(ctx)
+    expect(b).toBe(ctx)
+    expect(launcher).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes the GLOBAL profile dir to the launcher', async () => {
+    const ctx = new FakeContext()
+    const launcher = vi.fn(async () => ctx) as unknown as ContextLauncher
+    const pool = new SharedBrowserContextPool({ launcher, profileDir: '/tmp/global-profile' })
+    await pool.acquire()
+    expect((launcher as unknown as { mock: { calls: Array<[{ userDataDir: string }]> } }).mock.calls[0][0].userDataDir).toBe('/tmp/global-profile')
+  })
+
+  it('defaults the profile dir to ~/.specrails/browser-profile (global, not per-project)', () => {
+    const pool = new SharedBrowserContextPool({ launcher: vi.fn() as unknown as ContextLauncher, homeDir: '/home/u' })
+    expect(pool.profileDir).toBe('/home/u/.specrails/browser-profile')
+  })
+
+  it('concurrent acquires share a single in-flight launch', async () => {
+    const ctx = new FakeContext()
+    const launcher: ContextLauncher = vi.fn(async () => ctx)
+    const pool = new SharedBrowserContextPool({ launcher })
+    const [a, b, c] = await Promise.all([pool.acquire(), pool.acquire(), pool.acquire()])
+    expect(a).toBe(ctx)
+    expect(b).toBe(ctx)
+    expect(c).toBe(ctx)
+    expect(launcher).toHaveBeenCalledTimes(1)
+  })
+
+  it('dispose closes the shared context', async () => {
+    const ctx = new FakeContext()
+    const pool = new SharedBrowserContextPool({ launcher: vi.fn(async () => ctx) })
+    await pool.acquire()
+    await pool.dispose()
+    expect(ctx.closed).toBe(true)
+  })
+
+  it('dispose resolves an in-flight launch before closing (no leaked browser)', async () => {
+    const ctx = new FakeContext()
+    let resolveLaunch!: (c: BrowserContextHandle) => void
+    const launcher: ContextLauncher = vi.fn(() => new Promise<BrowserContextHandle>((r) => { resolveLaunch = r }))
+    const pool = new SharedBrowserContextPool({ launcher })
+    const acquiring = pool.acquire()
+    const disposing = pool.dispose()
+    resolveLaunch(ctx)
+    await Promise.allSettled([acquiring, disposing])
+    expect(ctx.closed).toBe(true)
+  })
+
+  it('acquire after dispose throws', async () => {
+    const pool = new SharedBrowserContextPool({ launcher: vi.fn(async () => new FakeContext()) })
+    await pool.dispose()
+    await expect(pool.acquire()).rejects.toThrow(/disposed/)
+  })
+
+  it('a failed launch is retryable (promise cleared)', async () => {
+    const ctx = new FakeContext()
+    const launcher = vi.fn()
+      .mockRejectedValueOnce(new Error('chromium boom'))
+      .mockResolvedValueOnce(ctx) as unknown as ContextLauncher
+    const pool = new SharedBrowserContextPool({ launcher })
+    await expect(pool.acquire()).rejects.toThrow(/failed to launch shared browser/)
+    const second = await pool.acquire()
+    expect(second).toBe(ctx)
+  })
+})

--- a/server/browser-context-pool.ts
+++ b/server/browser-context-pool.ts
@@ -47,7 +47,17 @@ export class SharedBrowserContextPool implements SharedBrowserContext {
    *  await the same in-flight launch. */
   async acquire(): Promise<BrowserContextHandle> {
     if (this.disposed) throw new BrowserLaunchError('browser context pool disposed')
-    if (this.context) return this.context
+    if (this.context) {
+      // If the shared Chromium died (crash / OOM / killed / dev-server restart),
+      // drop the dead handle so this acquire re-launches a fresh one. Without this
+      // a single crash would poison capture for EVERY project until app restart.
+      if (this.context.isConnected?.() === false) {
+        this.context = null
+        this.contextPromise = null // also drop the resolved promise → force a fresh launch
+      } else {
+        return this.context
+      }
+    }
     if (this.contextPromise) return this.contextPromise
     this.contextPromise = (async () => {
       try {

--- a/server/browser-context-pool.ts
+++ b/server/browser-context-pool.ts
@@ -1,0 +1,81 @@
+// App-wide owner of a SINGLE persistent Chromium context for "Add Spec from a
+// website". Its profile (cookies, logins, localStorage) lives in ONE GLOBAL dir
+// under $HOME, so the captured browser shares its session across every project —
+// log in once, and any project's capture window sees those cookies.
+//
+// Why a shared singleton (not per-project): a persistent Chromium profile takes
+// an EXCLUSIVE on-disk lock, so exactly one context may open a given userDataDir.
+// Pointing every project at one global dir therefore REQUIRES a single shared
+// context; each per-project BrowserCaptureManager opens its own pages in it
+// (pages are isolated enough for capture, cookies are shared). The context is
+// launched lazily on first use and closed once at app shutdown.
+
+import os from 'os'
+import path from 'path'
+import { BrowserLaunchError, type BrowserContextHandle, type ContextLauncher, type SharedBrowserContext } from './browser-capture-types'
+import { createPlaywrightLauncher } from './browser-playwright'
+
+const DEFAULT_VIEWPORT = { width: 1280, height: 800 }
+
+export interface SharedBrowserContextPoolOptions {
+  /** Injectable for tests — defaults to the real Playwright launcher. */
+  launcher?: ContextLauncher
+  /** Override the global persistent-profile dir (tests). */
+  profileDir?: string
+  homeDir?: string
+}
+
+export class SharedBrowserContextPool implements SharedBrowserContext {
+  private readonly launcher: ContextLauncher
+  private readonly _profileDir: string
+  private context: BrowserContextHandle | null = null
+  private contextPromise: Promise<BrowserContextHandle> | null = null
+  private disposed = false
+
+  constructor(opts: SharedBrowserContextPoolOptions = {}) {
+    this.launcher = opts.launcher ?? createPlaywrightLauncher()
+    this._profileDir =
+      opts.profileDir ?? path.join(opts.homeDir ?? os.homedir(), '.specrails', 'browser-profile')
+  }
+
+  /** The global profile dir backing the shared cookies/logins. */
+  get profileDir(): string {
+    return this._profileDir
+  }
+
+  /** Lazily launch (once) and return the shared context. Concurrent callers all
+   *  await the same in-flight launch. */
+  async acquire(): Promise<BrowserContextHandle> {
+    if (this.disposed) throw new BrowserLaunchError('browser context pool disposed')
+    if (this.context) return this.context
+    if (this.contextPromise) return this.contextPromise
+    this.contextPromise = (async () => {
+      try {
+        const ctx = await this.launcher({ userDataDir: this._profileDir, viewport: DEFAULT_VIEWPORT })
+        this.context = ctx
+        return ctx
+      } catch (err) {
+        this.contextPromise = null
+        throw new BrowserLaunchError('failed to launch shared browser', err)
+      }
+    })()
+    return this.contextPromise
+  }
+
+  /** Close the shared context. Called ONCE at app shutdown — never by a
+   *  per-project manager. Resolves an in-flight launch first so a shutdown that
+   *  races the lazy launch can't leak a headless Chromium. */
+  async dispose(): Promise<void> {
+    if (this.disposed) return
+    this.disposed = true
+    let ctx = this.context
+    if (!ctx && this.contextPromise) {
+      try { ctx = await this.contextPromise } catch { ctx = null }
+    }
+    if (ctx) {
+      try { await ctx.close() } catch { /* ignore */ }
+    }
+    this.context = null
+    this.contextPromise = null
+  }
+}

--- a/server/browser-playwright.ts
+++ b/server/browser-playwright.ts
@@ -834,7 +834,16 @@ class PlaywrightContextHandle implements BrowserContextHandle {
   // mount→unmount→mount double-create) share one page — killing the throwaway
   // first session then closed the page out from under the live second session.
   private usedInitial = false
-  constructor(private readonly context: any) {}
+  // Flipped false when the underlying Chromium dies, so the shared-context pool
+  // drops this handle and re-launches instead of reusing a dead context.
+  private alive = true
+  constructor(private readonly context: any) {
+    try { context.on('close', () => { this.alive = false }) } catch { /* ignore */ }
+    try { context.browser()?.on('disconnected', () => { this.alive = false }) } catch { /* ignore */ }
+  }
+  isConnected(): boolean {
+    return this.alive
+  }
   async newPage(): Promise<BrowserPageHandle> {
     let page: any
     if (!this.usedInitial) {

--- a/server/jira/jira-materializer.test.ts
+++ b/server/jira/jira-materializer.test.ts
@@ -161,6 +161,13 @@ describe('mapStatus', () => {
     expect(mapStatus(makeIssue({ statusCategoryKey: 'done', statusName: name }))).toBe('cancelled')
   })
 
+  it('does NOT misclassify a done status whose name merely CONTAINS a cancel substring', () => {
+    // Whole-word matching: 'invalid' must not flag "Invalidate Cache", 'duplicate'
+    // must not flag a status like "Deduplicated" — these are legitimately done.
+    expect(mapStatus(makeIssue({ statusCategoryKey: 'done', statusName: 'Invalidate Cache' }))).toBe('done')
+    expect(mapStatus(makeIssue({ statusCategoryKey: 'done', statusName: 'Deduplicated' }))).toBe('done')
+  })
+
   it('maps done with no status name → done (no cancel match)', () => {
     // statusCategoryKey present but status.name absent → done branch, empty name.
     const issue = makeIssue({ statusCategoryKey: 'done' })

--- a/server/jira/jira-materializer.test.ts
+++ b/server/jira/jira-materializer.test.ts
@@ -155,6 +155,8 @@ describe('mapStatus', () => {
     'Duplicate',
     'Declined',
     'WONT DO',
+    'Discarded',
+    'Discard',
   ])('maps done + %s → cancelled', (name) => {
     expect(mapStatus(makeIssue({ statusCategoryKey: 'done', statusName: name }))).toBe('cancelled')
   })

--- a/server/jira/jira-materializer.ts
+++ b/server/jira/jira-materializer.ts
@@ -22,10 +22,19 @@ import { adfToText } from './jira-adf'
 import { getLinkByIssueId, insertLinkWithId, updateLinkStatusCategory } from './jira-db'
 import type { JiraConnection, JiraIssue, JiraStatusCategory } from './types'
 
-// Keep in sync with CANCEL_LEXICON in jira-status-resolver.ts. 'discard' covers
-// "Discard"/"Discarded" so an inbound issue parked in a Discarded status reads
-// back as `cancelled`, not a successful `done`.
-const CANCEL_NAMES = ['won\'t do', 'wont do', 'cancelled', 'canceled', 'rejected', 'abandoned', 'invalid', 'duplicate', 'declined', 'discard']
+// Keep in sync with CANCEL_LEXICON in jira-status-resolver.ts. 'discard'/'discarded'
+// cover "Discard"/"Discarded" so an inbound issue parked in a Discarded status reads
+// back as `cancelled`, not a successful `done`. Matched WHOLE-WORD (see below) so a
+// token never flags a larger word (e.g. 'invalid' must not match "Invalidate").
+const CANCEL_NAMES = ['won\'t do', 'wont do', 'cancelled', 'canceled', 'rejected', 'abandoned', 'invalid', 'duplicate', 'declined', 'discard', 'discarded']
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function nameIsCancel(name: string): boolean {
+  return CANCEL_NAMES.some((w) => new RegExp(`\\b${escapeRegExp(w)}\\b`, 'i').test(name))
+}
 
 export function issueStatusCategory(issue: JiraIssue): JiraStatusCategory {
   const k = issue.fields.status?.statusCategory?.key
@@ -39,7 +48,7 @@ export function mapStatus(issue: JiraIssue): TicketStatus {
   if (cat === 'indeterminate') return 'in_progress'
   // done category: distinguish a cancelled/rejected resolution from a real ship.
   const name = (issue.fields.status?.name ?? '').toLowerCase()
-  return CANCEL_NAMES.some((w) => name.includes(w)) ? 'cancelled' : 'done'
+  return nameIsCancel(name) ? 'cancelled' : 'done'
 }
 
 /** Map a Jira priority name to a Specrails priority (best-effort, defaults medium). */

--- a/server/jira/jira-materializer.ts
+++ b/server/jira/jira-materializer.ts
@@ -22,7 +22,10 @@ import { adfToText } from './jira-adf'
 import { getLinkByIssueId, insertLinkWithId, updateLinkStatusCategory } from './jira-db'
 import type { JiraConnection, JiraIssue, JiraStatusCategory } from './types'
 
-const CANCEL_NAMES = ['won\'t do', 'wont do', 'cancelled', 'canceled', 'rejected', 'abandoned', 'invalid', 'duplicate', 'declined']
+// Keep in sync with CANCEL_LEXICON in jira-status-resolver.ts. 'discard' covers
+// "Discard"/"Discarded" so an inbound issue parked in a Discarded status reads
+// back as `cancelled`, not a successful `done`.
+const CANCEL_NAMES = ['won\'t do', 'wont do', 'cancelled', 'canceled', 'rejected', 'abandoned', 'invalid', 'duplicate', 'declined', 'discard']
 
 export function issueStatusCategory(issue: JiraIssue): JiraStatusCategory {
   const k = issue.fields.status?.statusCategory?.key

--- a/server/jira/jira-status-resolver.test.ts
+++ b/server/jira/jira-status-resolver.test.ts
@@ -123,14 +123,16 @@ describe('pickDirectTransition', () => {
     expect(got!.id).toBe('tB')
   })
 
-  it('explicit target that does not match falls back to category', () => {
+  it('explicit target that does not match returns null (never substitutes another status)', () => {
     const transitions = [
       tx({ id: 'tA', toId: 's-new', toName: 'New', category: 'new' }),
       tx({ id: 'tB', toId: 's-prog', toName: 'In Progress', category: 'indeterminate' }),
     ]
-    // explicit 'nonexistent' won't match → category for 'todo' = new → tA
+    // An explicit configured target that isn't directly reachable must NOT be
+    // silently swapped for a category candidate — the walker should step forward
+    // and look for the real target instead. Returning null signals "no direct".
     const got = pickDirectTransition(transitions, 'todo', 'nonexistent')
-    expect(got!.id).toBe('tA')
+    expect(got).toBeNull()
   })
 
   it('category match for non-done target returns first candidate', () => {
@@ -202,20 +204,57 @@ describe('pickDirectTransition', () => {
       expect(got!.id).toBe('tNeutral')
     })
 
-    it('falls back to first candidate when every done is a cancel word', () => {
+    it('returns null when every done candidate is a reject status (never auto-ship to a reject)', () => {
       const transitions = [
         tx({ id: 'tCancel1', toId: 's-rej', toName: 'Rejected', category: 'done' }),
         tx({ id: 'tCancel2', toId: 's-inv', toName: 'Invalid', category: 'done' }),
       ]
-      // No ship, no nonCancel → candidates[0]
+      // No ship, no nonCancel → null (a successful job must not be marked rejected).
       const got = pickDirectTransition(transitions, 'done')
-      expect(got!.id).toBe('tCancel1')
+      expect(got).toBeNull()
     })
 
     it('picks the ship transition when only a generic Done exists', () => {
       const transitions = [tx({ id: 'tDone', toId: 's-done', toName: 'Done', category: 'done' })]
       const got = pickDirectTransition(transitions, 'done')
       expect(got!.id).toBe('tDone')
+    })
+
+    it('picks "On Review" over "Discarded" for a successful done (the reported bug)', () => {
+      // Both are done-category and neither carries a ship word. "Discarded" is a
+      // reject status, so the success path must skip it and land on "On Review".
+      const transitions = [
+        tx({ id: 'tDiscard', toId: 's-disc', toName: 'Discarded', category: 'done' }),
+        tx({ id: 'tReview', toId: 's-rev', toName: 'On Review', category: 'done' }),
+      ]
+      const got = pickDirectTransition(transitions, 'done')
+      expect(got!.id).toBe('tReview')
+    })
+
+    it('returns null when the only done transition is "Discarded"', () => {
+      const transitions = [tx({ id: 'tDiscard', toId: 's-disc', toName: 'Discarded', category: 'done' })]
+      const got = pickDirectTransition(transitions, 'done')
+      expect(got).toBeNull()
+    })
+
+    it('honors an explicit "On Review" target even when a Discarded edge is present', () => {
+      const transitions = [
+        tx({ id: 'tDiscard', toId: 's-disc', toName: 'Discarded', category: 'done' }),
+        tx({ id: 'tReview', toId: 's-rev', toName: 'On Review', category: 'done' }),
+      ]
+      const got = pickDirectTransition(transitions, 'done', 'On Review')
+      expect(got!.id).toBe('tReview')
+    })
+  })
+
+  describe('done category disambiguation — discard recognised as a reject', () => {
+    it('selects "Discarded" for a cancelled spec', () => {
+      const transitions = [
+        tx({ id: 'tShip', toId: 's-released', toName: 'Released', category: 'done' }),
+        tx({ id: 'tDiscard', toId: 's-disc', toName: 'Discarded', category: 'done' }),
+      ]
+      const got = pickDirectTransition(transitions, 'cancelled')
+      expect(got!.id).toBe('tDiscard')
     })
   })
 
@@ -339,6 +378,24 @@ describe('pickProgressTransition', () => {
 
   it('returns null on empty transitions', () => {
     expect(pickProgressTransition([], 'new', 'done', new Set())).toBeNull()
+  })
+
+  it('avoidCancelNames skips a reject (Discarded) done edge', () => {
+    // From indeterminate toward done: the only forward edge is "Discarded".
+    // With avoidance on, it must not be taken (returns null → walk dead-letters).
+    const transitions = [tx({ id: 'tDisc', toId: 's-disc', toName: 'Discarded', category: 'done' })]
+    expect(pickProgressTransition(transitions, 'indeterminate', 'done', new Set(), { avoidCancelNames: true })).toBeNull()
+    // Without avoidance (legacy default) it is still eligible.
+    expect(pickProgressTransition(transitions, 'indeterminate', 'done', new Set())!.id).toBe('tDisc')
+  })
+
+  it('avoidCancelNames still takes a non-reject forward edge', () => {
+    const transitions = [
+      tx({ id: 'tDisc', toId: 's-disc', toName: 'Discarded', category: 'done' }),
+      tx({ id: 'tDone', toId: 's-done', toName: 'Done', category: 'done' }),
+    ]
+    const got = pickProgressTransition(transitions, 'indeterminate', 'done', new Set(), { avoidCancelNames: true })
+    expect(got!.id).toBe('tDone')
   })
 })
 
@@ -826,6 +883,42 @@ describe('walkToCategory', () => {
     })
     expect(out).toMatchObject({ status: 'applied', transitions: ['tExplicit'] })
     expect(applyTransition).toHaveBeenCalledWith(explicit, expect.anything())
+  })
+
+  it('done walk lands on the configured "On Review" target, not the Discarded edge', async () => {
+    // The reported scenario: a completed job whose statusMap.done = "On Review".
+    // From In Progress both an "On Review" and a "Discarded" done edge exist; the
+    // explicit target must win.
+    const review = tx({ id: 'tReview', toId: 's-rev', toName: 'On Review', category: 'done' })
+    const discard = tx({ id: 'tDiscard', toId: 's-disc', toName: 'Discarded', category: 'done' })
+    const getTransitions = vi.fn(async () => [discard, review])
+    const applied: JiraTransition[] = []
+    const applyTransition = vi.fn(async (t: JiraTransition) => { applied.push(t) })
+    const out = await walkToCategory({
+      state: 'done',
+      currentCategory: 'indeterminate',
+      explicitTarget: 'On Review',
+      getTransitions,
+      applyTransition,
+    })
+    expect(out).toMatchObject({ status: 'applied', transitions: ['tReview'] })
+    expect(applied.map((t) => t.id)).toEqual(['tReview'])
+  })
+
+  it('done walk dead-letters (no_path) rather than discarding when only a Discarded edge exists', async () => {
+    // No statusMap target; the only done-category edge is a reject status. A
+    // successful job must NOT be auto-discarded — it dead-letters for a manual move.
+    const discard = tx({ id: 'tDiscard', toId: 's-disc', toName: 'Discarded', category: 'done' })
+    const getTransitions = vi.fn(async () => [discard])
+    const applyTransition = vi.fn(async () => {})
+    const out = await walkToCategory({
+      state: 'done',
+      currentCategory: 'indeterminate',
+      getTransitions,
+      applyTransition,
+    })
+    expect(out.status).toBe('no_path')
+    expect(applyTransition).not.toHaveBeenCalled()
   })
 
   it('progress step updates current category and reaches target via category check', async () => {

--- a/server/jira/jira-status-resolver.test.ts
+++ b/server/jira/jira-status-resolver.test.ts
@@ -256,6 +256,27 @@ describe('pickDirectTransition', () => {
       const got = pickDirectTransition(transitions, 'cancelled')
       expect(got!.id).toBe('tDiscard')
     })
+
+    it('"Discard" (without -ed) is also recognised as a reject for cancelled', () => {
+      const transitions = [tx({ id: 'tDiscard', toId: 's-disc', toName: 'Discard', category: 'done' })]
+      expect(pickDirectTransition(transitions, 'cancelled')!.id).toBe('tDiscard')
+    })
+  })
+
+  describe('whole-word lexicon matching (no substring false positives)', () => {
+    it('does NOT treat "Invalidate Cache" as a reject (substring "invalid")', () => {
+      // Old substring matching flagged this as cancel → a successful job would
+      // dead-letter. Whole-word matching treats it as a normal done status.
+      const transitions = [tx({ id: 'tInval', toId: 's-inval', toName: 'Invalidate Cache', category: 'done' })]
+      expect(pickDirectTransition(transitions, 'done')!.id).toBe('tInval')
+    })
+
+    it('does NOT treat "Completed Review" ship-word inside a larger word incorrectly', () => {
+      // 'complete'/'completed' are whole words here → ship; sanity that the
+      // success path still selects a legitimately ship-named status.
+      const transitions = [tx({ id: 'tDone', toId: 's-done', toName: 'Completed', category: 'done' })]
+      expect(pickDirectTransition(transitions, 'done')!.id).toBe('tDone')
+    })
   })
 
   describe('done category disambiguation — cancelled state', () => {
@@ -903,6 +924,46 @@ describe('walkToCategory', () => {
     })
     expect(out).toMatchObject({ status: 'applied', transitions: ['tReview'] })
     expect(applied.map((t) => t.id)).toEqual(['tReview'])
+  })
+
+  it('reaches a multi-hop explicit target (new → In Progress → On Review) without overshooting', async () => {
+    // statusMap.done = "On Review" reachable only via In Progress. The walk must
+    // step through the indeterminate status and direct-match On Review, never a
+    // generic done edge.
+    const hop0 = tx({ id: 'h1', toId: 's-prog', toName: 'In Progress', category: 'indeterminate' })
+    const hop1Review = tx({ id: 'h2', toId: 's-rev', toName: 'On Review', category: 'done' })
+    const hop1Closed = tx({ id: 'hClosed', toId: 's-closed', toName: 'Closed', category: 'done' })
+    const calls = [[hop0], [hop1Closed, hop1Review]]
+    let idx = 0
+    const getTransitions = vi.fn(async () => calls[idx++] ?? [])
+    const applied: string[] = []
+    const applyTransition = vi.fn(async (t: JiraTransition) => { applied.push(t.id) })
+    const out = await walkToCategory({ state: 'done', currentCategory: 'new', explicitTarget: 'On Review', getTransitions, applyTransition })
+    expect(out).toMatchObject({ status: 'applied' })
+    expect(applied).toEqual(['h1', 'h2']) // stepped through In Progress, landed On Review (not Closed)
+  })
+
+  it('explicit target unreachable + a generic ship edge present → dead-letters, never overshoots onto the ship status', async () => {
+    // statusMap.done = "On Review" but only a direct "Closed" (ship) done edge
+    // exists. The walk must NOT silently land on Closed — it dead-letters.
+    const closed = tx({ id: 'tClosed', toId: 's-closed', toName: 'Closed', category: 'done' })
+    const getTransitions = vi.fn(async () => [closed])
+    const applyTransition = vi.fn(async () => {})
+    const out = await walkToCategory({ state: 'done', currentCategory: 'indeterminate', explicitTarget: 'On Review', getTransitions, applyTransition })
+    expect(out.status).toBe('no_path')
+    expect(applyTransition).not.toHaveBeenCalled()
+  })
+
+  it('discard with an unreachable explicit discard status does NOT overshoot onto a ship status', async () => {
+    // discardSpec: state 'cancelled', explicitTarget = discardStatus "Discarded".
+    // Only a generic "Done" (ship) edge is reachable → must dead-letter, never
+    // mark the discarded spec as shipped.
+    const done = tx({ id: 'tDone', toId: 's-done', toName: 'Done', category: 'done' })
+    const getTransitions = vi.fn(async () => [done])
+    const applyTransition = vi.fn(async () => {})
+    const out = await walkToCategory({ state: 'cancelled', currentCategory: 'indeterminate', explicitTarget: 'Discarded', getTransitions, applyTransition })
+    expect(out.status).toBe('no_path')
+    expect(applyTransition).not.toHaveBeenCalled()
   })
 
   it('done walk dead-letters (no_path) rather than discarding when only a Discarded edge exists', async () => {

--- a/server/jira/jira-status-resolver.ts
+++ b/server/jira/jira-status-resolver.ts
@@ -16,10 +16,12 @@
 
 import type { JiraStatusCategory, JiraTransition, SpecLogicalState } from './types'
 
-// 'discard' covers "Discard"/"Discarded" — a rejection status, never a success
-// target. Without it the success resolver treated "Discarded" as a valid ship
-// target and a completed job could be sent there (the reported Done→Discarded bug).
-const CANCEL_LEXICON = ['won\'t do', 'wont do', 'cancelled', 'canceled', 'rejected', 'abandoned', 'invalid', 'duplicate', 'declined', 'discard']
+// 'discard'/'discarded' cover "Discard"/"Discarded" — a rejection status, never a
+// success target. Without them the success resolver treated "Discarded" as a valid
+// ship target and a completed job could be sent there (the reported Done→Discarded
+// bug). Matching is WHOLE-WORD (see nameMatches) so a token never flags a larger
+// word (e.g. 'invalid' must not match "Invalidate", 'complete' not "incomplete").
+const CANCEL_LEXICON = ['won\'t do', 'wont do', 'cancelled', 'canceled', 'rejected', 'abandoned', 'invalid', 'duplicate', 'declined', 'discard', 'discarded']
 const SHIP_LEXICON = ['done', 'closed', 'released', 'resolved', 'complete', 'completed', 'shipped', 'merged']
 
 export function targetCategoryFor(state: SpecLogicalState): JiraStatusCategory {
@@ -38,16 +40,31 @@ export function categoryRank(cat: JiraStatusCategory): number {
   return cat === 'new' ? 0 : cat === 'indeterminate' ? 1 : 2
 }
 
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 function nameMatches(name: string | undefined, lexicon: string[]): boolean {
   if (!name) return false
   const n = name.toLowerCase()
-  return lexicon.some((w) => n.includes(w))
+  // Whole-word match (\b…\b) so a lexicon token never matches INSIDE a larger word
+  // ('invalid' must not flag "Invalidate", 'complete' not "incomplete"). Multi-word
+  // phrases ("won't do") still match as a whole.
+  return lexicon.some((w) => new RegExp(`\\b${escapeRegExp(w)}\\b`, 'i').test(n))
 }
 
 /** A status whose NAME reads as a cancellation/rejection (e.g. "Discarded",
  *  "Won't Do"). A successful (done) outcome must never auto-land on one of these. */
 function isCancelName(name: string | undefined): boolean {
   return nameMatches(name, CANCEL_LEXICON)
+}
+
+/** Does this transition's destination match the user's explicitly configured
+ *  target (by status id, status name, or transition id)? Case-insensitive on name.
+ *  The explicit config ALWAYS wins over the cancel/ship lexicon heuristics. */
+function matchesExplicit(t: JiraTransition, explicitTarget: string): boolean {
+  const e = explicitTarget.toLowerCase()
+  return t.to.id === explicitTarget || t.to.name.toLowerCase() === e || t.id === explicitTarget
 }
 
 function transitionCategory(t: JiraTransition): JiraStatusCategory | null {
@@ -68,10 +85,7 @@ export function pickDirectTransition(
   explicitTarget?: string
 ): JiraTransition | null {
   if (explicitTarget) {
-    const e = explicitTarget.toLowerCase()
-    const t = transitions.find(
-      (tr) => tr.to.id === explicitTarget || tr.to.name.toLowerCase() === e || tr.id === explicitTarget
-    )
+    const t = transitions.find((tr) => matchesExplicit(tr, explicitTarget))
     if (t) return t
     // The user explicitly configured a target status (e.g. statusMap.done =
     // "On Review") but there is no direct edge to it from here. NEVER substitute
@@ -114,7 +128,7 @@ export function pickProgressTransition(
   currentCategory: JiraStatusCategory,
   targetCategory: JiraStatusCategory,
   visitedStatusIds: Set<string>,
-  opts?: { avoidCancelNames?: boolean }
+  opts?: { avoidCancelNames?: boolean; explicitTarget?: string }
 ): JiraTransition | null {
   const goal = categoryRank(targetCategory)
   const cur = categoryRank(currentCategory)
@@ -128,6 +142,13 @@ export function pickProgressTransition(
     // done-category "Discarded"): it would terminate the issue in the wrong
     // place. Better to dead-letter than overshoot onto a cancellation.
     if (opts?.avoidCancelNames && isCancelName(t.to.name)) continue
+    // When the user configured an explicit target, never STEP onto a terminal
+    // done-category status that isn't that target — landing on a different done
+    // status (a generic "Done"/"Released", or for a discard the wrong terminal)
+    // would strand the issue on the wrong status. The configured target itself is
+    // reached via pickDirectTransition; here we only walk THROUGH non-terminal
+    // statuses toward it, dead-lettering if it's unreachable.
+    if (opts?.explicitTarget && transitionCategory(t) === 'done' && !matchesExplicit(t, opts.explicitTarget)) continue
     const cat = transitionCategory(t)
     if (!cat) continue
     const rank = categoryRank(cat)
@@ -234,6 +255,7 @@ export async function walkToCategory(args: {
     // "Discarded"-style terminal status while reaching for the real target.
     const step = pickProgressTransition(transitions, currentCategory, target, visited, {
       avoidCancelNames: args.state !== 'cancelled',
+      explicitTarget: args.explicitTarget,
     })
     if (!step) {
       return {

--- a/server/jira/jira-status-resolver.ts
+++ b/server/jira/jira-status-resolver.ts
@@ -16,7 +16,10 @@
 
 import type { JiraStatusCategory, JiraTransition, SpecLogicalState } from './types'
 
-const CANCEL_LEXICON = ['won\'t do', 'wont do', 'cancelled', 'canceled', 'rejected', 'abandoned', 'invalid', 'duplicate', 'declined']
+// 'discard' covers "Discard"/"Discarded" — a rejection status, never a success
+// target. Without it the success resolver treated "Discarded" as a valid ship
+// target and a completed job could be sent there (the reported Done→Discarded bug).
+const CANCEL_LEXICON = ['won\'t do', 'wont do', 'cancelled', 'canceled', 'rejected', 'abandoned', 'invalid', 'duplicate', 'declined', 'discard']
 const SHIP_LEXICON = ['done', 'closed', 'released', 'resolved', 'complete', 'completed', 'shipped', 'merged']
 
 export function targetCategoryFor(state: SpecLogicalState): JiraStatusCategory {
@@ -41,6 +44,12 @@ function nameMatches(name: string | undefined, lexicon: string[]): boolean {
   return lexicon.some((w) => n.includes(w))
 }
 
+/** A status whose NAME reads as a cancellation/rejection (e.g. "Discarded",
+ *  "Won't Do"). A successful (done) outcome must never auto-land on one of these. */
+function isCancelName(name: string | undefined): boolean {
+  return nameMatches(name, CANCEL_LEXICON)
+}
+
 function transitionCategory(t: JiraTransition): JiraStatusCategory | null {
   const k = t.to.statusCategory?.key
   if (k === 'new' || k === 'indeterminate' || k === 'done') return k
@@ -59,10 +68,18 @@ export function pickDirectTransition(
   explicitTarget?: string
 ): JiraTransition | null {
   if (explicitTarget) {
+    const e = explicitTarget.toLowerCase()
     const t = transitions.find(
-      (tr) => tr.to.id === explicitTarget || tr.to.name.toLowerCase() === explicitTarget.toLowerCase() || tr.id === explicitTarget
+      (tr) => tr.to.id === explicitTarget || tr.to.name.toLowerCase() === e || tr.id === explicitTarget
     )
     if (t) return t
+    // The user explicitly configured a target status (e.g. statusMap.done =
+    // "On Review") but there is no direct edge to it from here. NEVER substitute
+    // a different status from the target category — silently sending a completed
+    // job to some other done status (e.g. "Discarded") is exactly the bug this
+    // guards against. Signal "no direct" so the walker steps forward and looks
+    // for the configured target on the next hop, or dead-letters cleanly.
+    return null
   }
   const target = targetCategoryFor(state)
   const candidates = transitions.filter((t) => transitionCategory(t) === target)
@@ -72,17 +89,18 @@ export function pickDirectTransition(
   // Disambiguate the `done` category: cancelled prefers the cancel lexicon and
   // avoids ship words; done/success prefers ship words and avoids cancel words.
   if (state === 'cancelled') {
-    const cancel = candidates.find((t) => nameMatches(t.to.name, CANCEL_LEXICON))
-    if (cancel) return cancel
     // No explicit cancel status → do NOT fall back to a generic Done (that would
     // mark a cancelled spec as shipped). Signal "no suitable transition".
-    return null
+    return candidates.find((t) => isCancelName(t.to.name)) ?? null
   }
   // success
-  const ship = candidates.find((t) => nameMatches(t.to.name, SHIP_LEXICON) && !nameMatches(t.to.name, CANCEL_LEXICON))
+  const ship = candidates.find((t) => nameMatches(t.to.name, SHIP_LEXICON) && !isCancelName(t.to.name))
   if (ship) return ship
-  const nonCancel = candidates.find((t) => !nameMatches(t.to.name, CANCEL_LEXICON))
-  return nonCancel ?? candidates[0]
+  // Never auto-ship a successful job onto a cancel/reject status (e.g.
+  // "Discarded"). If every available done transition is a reject status, signal
+  // "no suitable transition" so the walk dead-letters rather than marking
+  // success as rejected.
+  return candidates.find((t) => !isCancelName(t.to.name)) ?? null
 }
 
 /**
@@ -95,7 +113,8 @@ export function pickProgressTransition(
   transitions: JiraTransition[],
   currentCategory: JiraStatusCategory,
   targetCategory: JiraStatusCategory,
-  visitedStatusIds: Set<string>
+  visitedStatusIds: Set<string>,
+  opts?: { avoidCancelNames?: boolean }
 ): JiraTransition | null {
   const goal = categoryRank(targetCategory)
   const cur = categoryRank(currentCategory)
@@ -105,6 +124,10 @@ export function pickProgressTransition(
   let bestRank = cur
   for (const t of transitions) {
     if (visitedStatusIds.has(t.to.id)) continue
+    // During a non-cancel walk never STEP onto a reject status (e.g. a
+    // done-category "Discarded"): it would terminate the issue in the wrong
+    // place. Better to dead-letter than overshoot onto a cancellation.
+    if (opts?.avoidCancelNames && isCancelName(t.to.name)) continue
     const cat = transitionCategory(t)
     if (!cat) continue
     const rank = categoryRank(cat)
@@ -206,8 +229,12 @@ export async function walkToCategory(args: {
       return { status: 'applied', finalCategory: target, transitions: applied }
     }
 
-    // No direct edge → step toward the target category.
-    const step = pickProgressTransition(transitions, currentCategory, target, visited)
+    // No direct edge → step toward the target category. For any non-cancel walk
+    // the step must avoid reject statuses so the issue never overshoots onto a
+    // "Discarded"-style terminal status while reaching for the real target.
+    const step = pickProgressTransition(transitions, currentCategory, target, visited, {
+      avoidCancelNames: args.state !== 'cancelled',
+    })
     if (!step) {
       return {
         status: 'no_path',

--- a/server/jira/jira-sync-manager.test.ts
+++ b/server/jira/jira-sync-manager.test.ts
@@ -1130,6 +1130,49 @@ describe('drainOnce()', () => {
     expect(listOutbox(db, { state: 'done' }).length).toBe(1)
   })
 
+  it('transition: honors statusMap.done="On Review" over a Discarded edge (reported bug)', async () => {
+    // The user configured Done → "On Review"; both On Review and Discarded are
+    // done-category. The drained transition must land on On Review, never Discarded.
+    seedConnection({ statusMap: { done: 'On Review' } })
+    enqueueTransition('T-rev', 'done', 'k-onreview')
+    const fake = makeFakeFetch()
+    fake.on('GET', '/issue/T-rev?', { status: 200, body: { id: 'T-rev', fields: { status: { statusCategory: { key: 'indeterminate' } } } } })
+    fake.on('GET', '/issue/T-rev/transitions', {
+      status: 200,
+      body: {
+        transitions: [
+          { id: '90', name: 'Discard', to: { id: 's-disc', name: 'Discarded', statusCategory: { key: 'done' } } },
+          { id: '32', name: 'Review', to: { id: 's-rev', name: 'On Review', statusCategory: { key: 'done' } } },
+        ],
+      },
+    })
+    fake.on('POST', '/issue/T-rev/transitions', { status: 204 })
+    const mgr = makeManager(fake.fetchImpl)
+    await mgr.drainOnce()
+    const post = fake.calls.find((c) => c.method === 'POST' && c.url.includes('/issue/T-rev/transitions'))
+    expect(post?.body?.transition?.id).toBe('32') // On Review, not '90' Discarded
+    expect(listOutbox(db, { state: 'done' }).length).toBe(1)
+  })
+
+  it('transition: success dead-letters instead of moving to Discarded when no ship/On Review edge', async () => {
+    // No statusMap; the only done edge is a reject status. A completed job must
+    // NOT be auto-discarded — it dead-letters for a manual move.
+    seedConnection()
+    enqueueTransition('T-disc', 'done', 'k-disc-only')
+    const fake = makeFakeFetch()
+    fake.on('GET', '/issue/T-disc?', { status: 200, body: { id: 'T-disc', fields: { status: { statusCategory: { key: 'indeterminate' } } } } })
+    fake.on('GET', '/issue/T-disc/transitions', {
+      status: 200,
+      body: { transitions: [{ id: '90', name: 'Discard', to: { id: 's-disc', name: 'Discarded', statusCategory: { key: 'done' } } }] },
+    })
+    const mgr = makeManager(fake.fetchImpl)
+    await mgr.drainOnce()
+    const post = fake.calls.find((c) => c.method === 'POST' && c.url.includes('/issue/T-disc/transitions'))
+    expect(post).toBeUndefined() // never applied the Discarded transition
+    expect(listOutbox(db, { state: 'dead' }).length).toBe(1)
+    expect(typesOf()).toContain('jira.degraded')
+  })
+
   it('transition: no path to target → dead + jira.degraded', async () => {
     seedConnection()
     enqueueTransition('T-3', 'done', 'k-nopath')

--- a/server/project-registry.ts
+++ b/server/project-registry.ts
@@ -17,6 +17,7 @@ import { WebhookManager } from './webhook-manager'
 import { TicketWatcher } from './ticket-watcher'
 import { getTerminalManager } from './terminal-manager'
 import { BrowserCaptureManager } from './browser-capture-manager'
+import { SharedBrowserContextPool } from './browser-context-pool'
 import { removeExploreCwd } from './explore-cwd-manager'
 import { dropPhaseScope } from './hooks'
 import { killTransientChildren } from './transient-children'
@@ -77,6 +78,10 @@ export class ProjectRegistry {
   // M9: projects whose per-project DB failed to load at startup (corrupt, locked,
   // or migration-stuck). They stay registered but have no live context.
   private _failedProjects: Map<string, { project: ProjectRow; error: string }>
+  // App-wide shared browser context for "Add Spec from a website": ONE persistent
+  // Chromium profile under ~/.specrails/browser-profile, so cookies/logins are
+  // shared across every project. Launched lazily, disposed once at shutdown().
+  private _browserContextPool: SharedBrowserContextPool
 
   constructor(broadcast: (msg: WsMessage) => void, desktopDbPath?: string, desktopPort?: number) {
     this._broadcast = broadcast
@@ -85,6 +90,7 @@ export class ProjectRegistry {
     this._webhookManager = new WebhookManager(this._desktopDb)
     this._desktopPort = desktopPort ?? 4200
     this._failedProjects = new Map()
+    this._browserContextPool = new SharedBrowserContextPool()
   }
 
   get desktopDb(): DbInstance {
@@ -310,6 +316,9 @@ export class ProjectRegistry {
       try { ctx.fileSummaryManager.dispose() } catch { /* ignore */ }
       ctx.ticketWatcher.close().catch(() => { /* ignore */ })
     }
+    // Close the shared browser context once, after every per-project manager has
+    // released its pages (they never close the shared context themselves).
+    void this._browserContextPool.dispose().catch(() => { /* ignore */ })
   }
 
   touchProject(id: string): void {
@@ -604,6 +613,9 @@ export class ProjectRegistry {
       projectSlug: project.slug,
       db,
       broadcast: boundBroadcast,
+      // Share ONE persistent Chromium profile (global cookies/logins) across all
+      // projects instead of a per-project profile.
+      contextPool: this._browserContextPool,
     })
 
     const ctx: ProjectContext = { project, db, queueManager, chatManager, setupManager, proposalManager, agentRefineManager, fileSummaryManager, specLauncherManager, ticketWatcher, browserCaptureManager, jiraSyncManager, broadcast: boundBroadcast, railJobs }

--- a/server/project-router-tickets.ts
+++ b/server/project-router-tickets.ts
@@ -1839,9 +1839,15 @@ export function registerTicketsRoutes(deps: ProjectRoutesDeps): void {
   const attachmentUpload = multer({
     storage: multer.memoryStorage(),
     limits: { fileSize: 25 * 1024 * 1024 }, // 25 MB per file
-    fileFilter: (_req, file, cb) => {
-      if (isSupportedUploadedFile({ mimetype: file.mimetype, originalname: file.originalname })) cb(null, true)
-      else cb(null, false)
+    fileFilter: (req, file, cb) => {
+      if (isSupportedUploadedFile({ mimetype: file.mimetype, originalname: file.originalname })) {
+        cb(null, true)
+      } else {
+        // Record what was rejected so the route can return a clear error instead
+        // of the ambiguous "No file uploaded or file type unsupported".
+        ;(req as unknown as { fileRejected?: string }).fileRejected = file.mimetype || file.originalname || 'unknown'
+        cb(null, false)
+      }
     },
   })
 
@@ -1865,7 +1871,8 @@ export function registerTicketsRoutes(deps: ProjectRoutesDeps): void {
       }
       const file = (req as unknown as { file?: Express.Multer.File }).file
       if (!file) {
-        res.status(400).json({ error: 'No file uploaded or file type unsupported' })
+        const rejected = (req as unknown as { fileRejected?: string }).fileRejected
+        res.status(400).json({ error: rejected ? `Unsupported file type: ${rejected}` : 'No file uploaded' })
         return
       }
       if (!parsed.isPending) {

--- a/server/project-router-tickets.ts
+++ b/server/project-router-tickets.ts
@@ -1863,6 +1863,18 @@ export function registerTicketsRoutes(deps: ProjectRoutesDeps): void {
   router.post(
     '/:projectId/tickets/:ticketId/attachments',
     attachmentUpload.single('file'),
+    // Translate multer's own errors (which bypass the handler via next(err)) into
+    // a clear 400 instead of the generic 500 from the global error handler. The
+    // 25 MB cap is the common case (a big screenshot/PDF).
+    (err: unknown, _req: Request, res: Response, next: NextFunction) => {
+      if (err instanceof multer.MulterError) {
+        const msg = err.code === 'LIMIT_FILE_SIZE' ? 'File too large (max 25 MB)' : `Upload rejected: ${err.code}`
+        res.status(400).json({ error: msg })
+        return
+      }
+      if (err) { next(err); return }
+      next()
+    },
     async (req: Request, res: Response) => {
       const parsed = parseTicketKey(req.params.ticketId as string)
       if (!parsed) {


### PR DESCRIPTION
Eight commits. Original four changes + four audit-driven hardening fixes found by an adversarial multi-agent review of this PR.

## Features
- **feat(explore)**: "From a website" browser-capture (Globe button) in the Explore composer; captured screenshot + DOM ride the next turn. Client-only wiring + 8-locale i18n + tests.
- **feat(browser-capture)**: one global Chromium profile (`~/.specrails/browser-profile`) shared across all projects via `SharedBrowserContextPool` (a persistent profile takes an exclusive lock → one shared context). Per-project shutdown closes only its pages.

## Fixes
- **fix(jira)** ×2: never auto-move a completed job to a reject status (`Discarded`); the configured `statusMap.done` target is authoritative across **multi-hop** walks (never overshoots onto another done status — dead-letters if unreachable); whole-word lexicon matching (`invalid` no longer flags `Invalidate`), inbound + outbound.
- **fix(attachments)** ×2: accept PNG/images by extension when the MIME is empty or `image/x-png` (Windows); but never relabel a correct non-image MIME by an image-looking name (`report.png` that is a PDF stays a PDF); clear 400 on >25 MB instead of a generic 500.
- **fix(browser-capture)** ×2: recover the shared context after a crash (was poisoned for ALL projects until app restart); surface capture errors visibly + guard the session against teardown during an in-flight capture.

## Audit (adversarial multi-agent review)
Ran a 15-agent workflow that root-caused the Explore capture report and audited all four changes; it confirmed 7 real defects — all fixed in the four `fix(...)` follow-up commits above. The Explore "capture modal not appearing" was a hidden error (a sonner toast occluded by the z-[80] capture portal) → now surfaced; the session is also hardened against any teardown-during-capture race.

## Known v1 limitation
A capture taken but not yet sent, then minimized + restored, won't auto-ride the next turn (the file is NOT lost — it reaches the committed spec via attachment migration). Deferred per the original design.

## Verification
- `npm run typecheck` clean
- Server: 4176 tests pass; coverage 84.98 / 76.17 / 88.08 / 86.83 (gate 80/70)
- Client: 2725 tests pass; coverage 85.2 / 81.18 / 72.72 / 85.2 (gate 80/70)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RD87Yb8z7xSa3CFTvrWoMZ