### PR TITLE
feat: OpenSpec-lifecycle loop template + openspec carve-out fix

### DIFF
--- a/openspec/changes/archive/2026-06-29-opsx-lifecycle-loop-template/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-29-opsx-lifecycle-loop-template/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-29

--- a/openspec/changes/archive/2026-06-29-opsx-lifecycle-loop-template/design.md
+++ b/openspec/changes/archive/2026-06-29-opsx-lifecycle-loop-template/design.md
@@ -1,0 +1,66 @@
+## Context
+
+The Specrails loop subsystem is a published directed graph of typed nodes (`start | ai-step | shell | decider | condition | end`) executed by the **app-driven** `LoopRunManager` (`server/loop-run-manager.ts`). The app owns the iteration loop; an **AI Loop Decider** node (`server/loop-decider.ts`) returns a `continue`/`stop` verdict and the engine routes the matching branch edge. Loop-back (cycles) is a first-class, designed feature bounded by `maxIterations` (counted at the decider), a wall-clock deadline, an optional cost cap, a step-cap backstop, and an AI fail-fast. Starter templates are either hand-authored `LoopTemplate` graphs in `LOOP_TEMPLATES` (`server/loop-templates.ts`) or `PortSpec` records compiled by `aiLoopGraph`/`fixLoopGraph`. Step prompts resolve three token families in fixed order: `{{cmd:*}}` (`server/loop-command-catalog.ts`) → `{{spec.*}}` (ticket data, `server/loop-graph.ts` `interpolateSpec`) → `{{const:*}}` (`server/loop-constants.ts`).
+
+This change adds an end-to-end **OpenSpec lifecycle** template. The engine, decider, loop-back, bounds, and ticket interpolation already exist and are reused unchanged. The gap is declarative (a catalog command + a template graph) plus one small engine capability (a run-scoped captured variable).
+
+The `opsx:*` commands themselves are OpenSpec-generated Markdown command/skill files (`.claude/commands/opsx/*.md` + `.claude/skills/openspec-*`), **not** part of the specrails framework (framework 4.10.0 ships only `opsx-diff` for each provider). `SpecLauncherManager` already proves `/opsx:ff` runs headlessly under `--dangerously-skip-permissions` and that the created change id is detectable by regex on `openspec/changes/<id>`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One launchable loop template that takes a Specrails ticket and drives `ff → apply → verify → (loop-back | archive)` with a single agent, fully unattended.
+- Reuse the existing decider/loop-back/bounds machinery; add no new node type and no new conditional engine.
+- `opsx:verify` is the authority on "does the implementation match the ticket"; the decider only routes its verdict.
+- Iterating on a FAIL verdict amends the **same** OpenSpec change (no duplicate change folders) and carries the "what is still missing" gaps into the re-pass.
+- Unattended close via the `openspec` CLI's native `archive -y` (which syncs main specs by default).
+- Provider-aware command expansion (claude/gemini `/opsx:`, codex `$opsx:`).
+
+**Non-Goals:**
+- No multi-agent pipeline (this is intentionally the lighter, single-agent, artifact-centric counterpart to `specrails:implement`).
+- No `opsx:new` step (redundant with `opsx:ff`).
+- No use of `opsx:bulk-archive` (interactive, no unattended flag).
+- No new `condition` (AND/OR) node evaluation (it remains a deliberate no-op; the decider covers the single satisfied/not-satisfied decision).
+- No client UI work; the template surfaces through the existing gallery and an existing category.
+- No `specrails-core` changes.
+- Full codex/gemini parity for the opsx lifecycle commands (claude-first; tracked as a risk).
+
+## Decisions
+
+### D1 — Start at `opsx:ff`, drop `opsx:new`
+`opsx:new` only scaffolds the change directory then explicitly STOPS without generating artifacts; `opsx:ff` calls `openspec new change` internally and generates all apply-required artifacts. Chaining `new → ff` is redundant and risks ff's "change already exists" branch. **Alternative considered:** keep `new` for an explicit scaffold step — rejected because it adds an interactive stop point and a duplicate-creation hazard for zero benefit.
+
+### D2 — `opsx:verify` produces the verdict; the decider routes it
+The bare decider receives only `title`+`description` (capped ~2000 chars) + run history — it judges the prompt text, not reality. `opsx:verify` loads the actual artifacts/tasks/code and checks implementation against the specs. So the graph is `ff → apply → verify → decider`, where the decider's goal is "stop iff `verify` reported PASS" and it consumes verify's output (in history). **Alternative considered:** decider-only (cheaper, one fewer step) — rejected: it cannot honestly assess implementation completeness from spec text alone.
+
+### D3 — Capture the change id into a run-scoped `{{run.changeId}}` token
+On `loopBack:'first'` the engine resets the AI session, so the re-pass cannot rely on session memory to find the change. The runner captures the change id from the first `opsx:ff` step's stdout via regex on `openspec/changes/<id>` (same pattern as `SpecLauncherManager`) and stores it on run state. A new token `{{run.changeId}}` resolves it in: (a) the loop-back `opsx:ff` prompt ("continue change `<id>`, address the gaps below"), and (b) the terminal `openspec archive <id> -y` shell node. Token resolution is added to the existing prompt/shell substitution pipeline (after `{{spec.*}}`, before/with `{{const:*}}`); unresolved `{{run.*}}` before capture resolves to empty string. **Alternatives considered:** (1) derive a stable kebab name from the ticket title — rejected (breaks if the title changes or collides); (2) rely on the agent to auto-select the single active change — rejected (fragile if ff creates a second change). This is the only non-declarative piece.
+
+### D4 — Unattended archive via a `shell` node running `openspec archive <id> -y`
+The `openspec` CLI's `archive -y` is non-interactive and syncs main specs by default — exactly the "yes-to-all + sync" close. A `shell` node is deterministic (no AI, no prompt) and the engine already supports shell nodes. `opsx:bulk-archive` is hard-wired interactive ("never auto-select", final confirm) with no unattended flag, and is framework-generated (edits would not survive regeneration). One ticket → one change → a single archive, so bulk is unnecessary. **Alternative considered:** a forked unattended `opsx:bulk-archive` ai-step — rejected (non-deterministic, touches generated framework files, only needed for multi-change batches this loop never produces).
+
+### D5 — `providerNative` magic commands, not `coreCommand`
+`coreCommand` entries expand to `/specrails:<name>` (claude) / `$<name>` (codex); opsx commands are `/opsx:<name>`. So the three new `LoopCommand`s use `providerNative` maps `{claude:'/opsx:ff', gemini:'/opsx:ff', codex:'$opsx:ff'}` plus a `template` fallback prompt for providers without the native command. `archive` is invoked via the `openspec` CLI in a shell node and is provider-independent, so it needs no magic command. **Alternative considered:** raw free-text `/opsx:ff` in the prompt — rejected (loses the per-provider `$`/`/` swap and ticket-id auto-injection that the catalog gives).
+
+### D6 — Momentum override in step prompts
+`opsx:ff`/`opsx:apply` have pause-and-ask escape hatches (unclear task / design issue / error). A headless loop has no human to answer, so the template's step prompts instruct "make reasonable decisions and keep momentum; never block or ask". `opsx:ff` is already momentum-biased; `apply` is reinforced by the prompt. (Durable framework-level overrides are out of scope; v1 lives in the template text.)
+
+### D7 — Positioning vs `specrails:implement`
+`specrails:implement` is the existing multi-agent (architect→developer→reviewer→archive) pipeline that goes ticket→code. This template is the single-agent, **OpenSpec-artifact-centric** lane whose deliverable is `openspec/changes/*`. The proposal/spec call this out so the two are understood as complementary, not duplicative.
+
+## Risks / Trade-offs
+
+- **[opsx commands are claude-only today]** → Ship claude-first; the `template` fallback gives codex/gemini a best-effort autonomous prompt. Document the limitation; real parity rides OpenSpec's multi-provider command generation (out of scope).
+- **[Change-id regex could miss / multiple matches]** → Capture the FIRST `openspec/changes/<id>` match; if no id is captured, `{{run.changeId}}` is empty → the loop-back prompt falls back to "find the single active change" wording and the archive shell node is guarded (skip + fail the run with a clear message rather than archiving the wrong change).
+- **[Infinite re-implementation]** → Already bounded by `maxIterations` (counted at the decider) + timeout + cost cap + fail-fast; the template sets a conservative `maxIterations` (e.g. 3) so it never spins.
+- **[`archive -y` spec-merge fidelity]** → CLI archive syncs main specs programmatically; if a future change needs the agent-driven intelligent merge, that is a follow-up. For a single change per ticket the CLI merge is sufficient.
+- **[Momentum override lets the agent guess on genuinely ambiguous tickets]** → Acceptable for an unattended loop; the verify→decider gate catches a wrong guess and loops back, and the user reviews the final change before merge.
+
+## Migration Plan
+
+Purely additive. New catalog command entries, a new template, and a new run-token capture; no schema migration, no data changes, no client changes. Rollback = remove the template + command entries + the capture block (the `{{run.changeId}}` resolution is inert when no template uses it).
+
+## Open Questions
+
+- Should `{{run.changeId}}` generalize to a small family of run-captured variables (a regex→token registry) for future templates, or stay a single special-cased capture for v1? (Leaning single-purpose for v1, with the capture written so it can generalize.)
+- Should the template be hard-gated to claude (hidden for codex/gemini projects) until opsx parity exists, or shown everywhere relying on the fallback prompt? (Leaning: shown, claude-first, with a description note.)

--- a/openspec/changes/archive/2026-06-29-opsx-lifecycle-loop-template/proposal.md
+++ b/openspec/changes/archive/2026-06-29-opsx-lifecycle-loop-template/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Driving a Specrails ticket all the way through the OpenSpec lifecycle (scaffold → generate artifacts → implement → verify → archive) is today a manual, multi-command chore. The loop engine already has every primitive needed to automate it — an app-driven runner, an AI decider that judges completeness against the ticket, bounded loop-back, and provider-aware magic commands — but there is no template that wires them into a single-agent, ticket-to-archive lifecycle, and no `opsx:*` commands in the magic-command catalog. This change ships that template so a user can launch one rail and walk away.
+
+## What Changes
+
+- **New loop template `opsx-lifecycle`** in the catalog (category `Automation`): a hand-authored `LoopGraph` that runs, per ticket, `opsx:ff` → `opsx:apply` → `opsx:verify` → decider; on a FAIL verdict it loops back to `opsx:ff` (amending the same change with the gaps `verify` reported); on PASS it runs an unattended `openspec archive <id> -y` shell node, then ends. Single agent, no multi-agent pipeline.
+- **`opsx:verify` is the loop condition.** The `verify` step reads the real artifacts/tasks/code and produces the PASS/FAIL verdict; the decider node is a thin gate that routes that verdict. (Deliberately NOT a bare decider judging only `title`+`description`.)
+- **Three new provider-aware magic commands** — `{{cmd:opsx:ff}}`, `{{cmd:opsx:apply}}`, `{{cmd:opsx:verify}}` — expanding to `/opsx:ff` (claude, gemini) and `$opsx:ff` (codex), with a template fallback for providers lacking the native command. (`archive` uses the `openspec` CLI directly via a shell node, so it needs no magic command.)
+- **New run-scoped token `{{run.changeId}}`.** The engine captures the OpenSpec change id from the first `opsx:ff` step's output (regex on `openspec/changes/<id>`, the pattern `SpecLauncherManager` already uses) and exposes it to later prompts — used both in the loop-back `opsx:ff` prompt ("continue change `<id>`, address: …") and in the `openspec archive <id> -y` shell node. This is the only non-declarative addition.
+- **Momentum override** baked into the step prompts so `opsx:ff`/`opsx:apply` never block on "unclear/design issue/error" in a headless run.
+- **NOT** starting at `opsx:new` (it only scaffolds then stops; `opsx:ff` scaffolds + generates internally — chaining both risks the "change already exists" branch). **NOT** using `opsx:bulk-archive` (it is hard-wired interactive with no yes-to-all; one ticket → one change → single unattended `openspec archive`).
+
+## Capabilities
+
+### New Capabilities
+- `opsx-lifecycle-loop`: the end-to-end behavioral contract of the `opsx-lifecycle` loop template — its graph shape, `verify`-as-verdict + decider-as-router semantics, FAIL→loop-back-amend and PASS→unattended-archive routing, iteration/timeout/cost bounds, and the claude-first provider scope.
+
+### Modified Capabilities
+- `loop-magic-commands`: the magic-command catalog gains the `opsx:ff`, `opsx:apply`, `opsx:verify` provider-native commands (claude/gemini `/opsx:`, codex `$opsx:`, plus template fallback).
+- `loop-execution`: the runner gains a run-scoped capture variable surfaced as `{{run.changeId}}`, extracted by regex from a step's output and resolvable in subsequent ai-step prompts and shell-node commands.
+- `loop-template-catalog`: the catalog exposes the `opsx-lifecycle` template under the `Automation` category and serves it for instantiation like any other starter template.
+
+## Impact
+
+- **Server**: `server/loop-command-catalog.ts` (3 new commands), `server/loop-templates.ts` (`LOOP_TEMPLATES` hand-authored graph), `server/loop-run-manager.ts` (`{{run.changeId}}` capture + resolution in ai-step prompts and shell commands).
+- **Tests**: new unit tests for the three providers' command expansion, the template's graph validation/compilation/launch, the change-id capture + resolution, and the archive shell node. Must hold the mandatory coverage gates (80% server lines/functions/statements, 70% branches).
+- **No client changes required** for v1 (the template appears in the existing gallery via `GET /loop-templates`; `Automation` is an existing category, so no taxonomy edit on client or server).
+- **No `specrails-core` changes.** The `opsx:*` commands are installed by OpenSpec, not the specrails framework.
+- **Open risk (tracked, not blocking)**: `opsx:ff/apply/verify` are OpenSpec-generated commands confirmed only for claude in framework 4.10.0 (codex/gemini ship only `opsx-diff`). The template is therefore **claude-first**; the template fallback only partially covers codex/gemini. Full multi-provider parity depends on OpenSpec's own multi-provider command generation and is out of scope here.

--- a/openspec/changes/archive/2026-06-29-opsx-lifecycle-loop-template/specs/loop-execution/spec.md
+++ b/openspec/changes/archive/2026-06-29-opsx-lifecycle-loop-template/specs/loop-execution/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Run-Scoped Captured Variables
+
+The loop runner SHALL support capturing a value from an ai-step's output during a run and exposing it to subsequent token resolution as a `{{run.<name>}}` token. The first capture defined by this change is `{{run.changeId}}`: after the first `opsx:ff` step, the runner SHALL extract the OpenSpec change id by matching `openspec/changes/<id>` in the step output (the same detection pattern used by `SpecLauncherManager`) and store it on run state. The token SHALL be resolvable in later ai-step prompts AND in `shell` node commands. Before any value is captured, `{{run.<name>}}` SHALL resolve to an empty string rather than remaining as a literal token. Run-token resolution SHALL be applied within the existing prompt/shell substitution pipeline (after `{{cmd:*}}` and `{{spec.*}}`).
+
+#### Scenario: Change id captured from ff output
+- **WHEN** the first `opsx:ff` step emits output containing `openspec/changes/my-change`
+- **THEN** the runner stores `my-change` as the run's `changeId`
+
+#### Scenario: Captured token resolves in a later step
+- **WHEN** a later ai-step prompt or shell command contains `{{run.changeId}}` after capture
+- **THEN** the token resolves to the captured change id
+
+#### Scenario: Uncaptured token resolves to empty
+- **WHEN** `{{run.changeId}}` is resolved before any change id has been captured
+- **THEN** the token resolves to an empty string
+
+#### Scenario: First match wins on multiple ids
+- **WHEN** the ff output mentions more than one `openspec/changes/<id>` path
+- **THEN** the runner captures the first matched id

--- a/openspec/changes/archive/2026-06-29-opsx-lifecycle-loop-template/specs/loop-magic-commands/spec.md
+++ b/openspec/changes/archive/2026-06-29-opsx-lifecycle-loop-template/specs/loop-magic-commands/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: OpenSpec Lifecycle Magic Commands
+
+The magic-command catalog SHALL include provider-aware commands `opsx:ff`, `opsx:apply`, and `opsx:verify`. Each SHALL be a `providerNative` command mapping `claude` and `gemini` to the slash form `/opsx:<name>` and `codex` to the dollar form `$opsx:<name>`, with a `template` fallback prompt for any provider not in the map. These commands SHALL NOT be modeled as `coreCommand` entries (which emit `/specrails:<name>`), because the OpenSpec commands live under the `/opsx:` namespace. No `opsx:archive`/`opsx:bulk-archive` command is added (archive is invoked via the `openspec` CLI in a shell node and is provider-independent).
+
+#### Scenario: opsx commands expand per provider
+- **WHEN** `{{cmd:opsx:ff}}` is expanded for the `claude` provider
+- **THEN** the result is `/opsx:ff`
+
+#### Scenario: codex uses the dollar form
+- **WHEN** `{{cmd:opsx:apply}}` is expanded for the `codex` provider
+- **THEN** the result is `$opsx:apply`
+
+#### Scenario: gemini uses the slash form
+- **WHEN** `{{cmd:opsx:verify}}` is expanded for the `gemini` provider
+- **THEN** the result is `/opsx:verify`
+
+#### Scenario: unknown provider falls back to the template prompt
+- **WHEN** `{{cmd:opsx:ff}}` is expanded for a provider absent from the providerNative map
+- **THEN** the result is the command's fallback template prompt, not an empty string

--- a/openspec/changes/archive/2026-06-29-opsx-lifecycle-loop-template/specs/loop-template-catalog/spec.md
+++ b/openspec/changes/archive/2026-06-29-opsx-lifecycle-loop-template/specs/loop-template-catalog/spec.md
@@ -1,0 +1,13 @@
+## ADDED Requirements
+
+### Requirement: OpenSpec Lifecycle Template Registration
+
+The loop template catalog SHALL register the `opsx-lifecycle` template under the existing `Automation` category (no new category is introduced) and serve it through the template-listing endpoint exactly like any other starter template, so it can be cloned into an editable draft loop. Registering it SHALL NOT require changes to the closed category taxonomy on server or client.
+
+#### Scenario: Template listed under Automation
+- **WHEN** the template catalog is listed
+- **THEN** the `opsx-lifecycle` template appears with category `Automation`
+
+#### Scenario: Template can be instantiated
+- **WHEN** a draft loop is created from the `opsx-lifecycle` template
+- **THEN** the new draft contains the template's full graph (ff → apply → verify → decider → archive → end)

--- a/openspec/changes/archive/2026-06-29-opsx-lifecycle-loop-template/specs/opsx-lifecycle-loop/spec.md
+++ b/openspec/changes/archive/2026-06-29-opsx-lifecycle-loop-template/specs/opsx-lifecycle-loop/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: OpenSpec Lifecycle Loop Template
+
+The system SHALL provide a starter loop template named `opsx-lifecycle` that, given a single Specrails ticket, drives the full OpenSpec lifecycle (generate artifacts → implement → verify → archive) with a single AI agent and no multi-agent pipeline. The template SHALL be a hand-authored `LoopGraph` (not a compiled `PortSpec`) because it combines an AI-step spine, a decider, a `shell` archive node, and a terminal action on the decider's `stop` branch — a shape the stock `aiLoopGraph`/`fixLoopGraph` builders do not produce.
+
+#### Scenario: Template is offered in the catalog
+- **WHEN** a client requests the loop template catalog
+- **THEN** an `opsx-lifecycle` template is present with a valid graph that passes `validateLoopGraph`
+
+#### Scenario: Template is launchable from a ticket
+- **WHEN** a rail launches the `opsx-lifecycle` template with a ticket
+- **THEN** the run starts at the first `opsx:ff` step with the ticket's `{{spec.title}}` and `{{spec.description}}` interpolated into the prompt
+
+### Requirement: Lifecycle Step Sequence
+
+Within one iteration the template SHALL execute, in order, an `opsx:ff` ai-step (generate/amend artifacts), an `opsx:apply` ai-step (implement), and an `opsx:verify` ai-step (verify implementation against the change's specs), followed by a decider node. The template SHALL NOT include an `opsx:new` step.
+
+#### Scenario: Steps run in lifecycle order
+- **WHEN** an `opsx-lifecycle` run executes an iteration
+- **THEN** the engine visits the `opsx:ff` node, then the `opsx:apply` node, then the `opsx:verify` node, then the decider node
+
+#### Scenario: No opsx:new step exists
+- **WHEN** the `opsx-lifecycle` graph is inspected
+- **THEN** no ai-step expands to an `opsx:new` invocation
+
+### Requirement: Verify-Sourced Completion Verdict
+
+The completion decision SHALL be sourced from the `opsx:verify` step's output, not from a decider that judges only the ticket text. The decider node SHALL route to `stop` when verify reported the change complete (PASS) and to `continue` when verify reported remaining gaps (FAIL).
+
+#### Scenario: Verify PASS exits the loop
+- **WHEN** the `opsx:verify` step reports the implementation satisfies the change
+- **THEN** the decider routes the `stop` branch toward the archive node
+
+#### Scenario: Verify FAIL continues the loop
+- **WHEN** the `opsx:verify` step reports remaining gaps
+- **THEN** the decider routes the `continue` branch back to the `opsx:ff` step
+
+### Requirement: Loop-Back Amends The Same Change
+
+On a `continue` (FAIL) verdict the loop SHALL re-enter at the `opsx:ff` step targeting the SAME OpenSpec change captured on the first pass (via `{{run.changeId}}`), instructing it to continue that change and address the gaps reported by verify — never creating a duplicate change directory.
+
+#### Scenario: Re-pass continues the existing change
+- **WHEN** the loop re-enters `opsx:ff` after a FAIL verdict and a change id was captured
+- **THEN** the resolved prompt names the captured change id and instructs continuation of that change with the outstanding gaps
+
+### Requirement: Unattended Archive On Pass
+
+On the decider's `stop` branch the template SHALL run a `shell` node executing `openspec archive <id> -y` (using `{{run.changeId}}`) — non-interactive and syncing main specs by default — and then reach the `end` node. The template SHALL NOT use `opsx:bulk-archive`.
+
+#### Scenario: Archive runs unattended after PASS
+- **WHEN** the decider routes `stop` and a change id was captured
+- **THEN** a shell node runs `openspec archive <id> -y` and the run settles successfully
+
+#### Scenario: Archive is guarded when no change id was captured
+- **WHEN** the decider routes `stop` but no change id was captured
+- **THEN** the archive command is not executed against an unknown change and the run settles with a clear failure reason instead of archiving the wrong change
+
+### Requirement: Bounded Iteration
+
+The template SHALL set a conservative `maxIterations` so a never-satisfied verify can never spin indefinitely, relying on the engine's existing iteration counter, wall-clock timeout, and optional cost cap.
+
+#### Scenario: Loop stops at the iteration ceiling
+- **WHEN** verify reports FAIL on every pass up to `maxIterations`
+- **THEN** the run settles with outcome `max-iterations` rather than looping forever
+
+### Requirement: Claude-First Provider Scope
+
+The template SHALL function natively on providers whose CLI resolves `/opsx:*` commands (claude, and gemini per its `/opsx:` syntax). For providers lacking the native command (codex), the magic commands SHALL fall back to a template prompt rather than emitting an unresolved token. The template's description SHALL state that full multi-provider parity is claude-first.
+
+#### Scenario: Native expansion on claude
+- **WHEN** the template's `opsx:ff` command is expanded for the claude provider
+- **THEN** it expands to the native `/opsx:ff` invocation
+
+#### Scenario: Fallback expansion on a provider without the native command
+- **WHEN** the template's `opsx:ff` command is expanded for a provider that has no native opsx command
+- **THEN** it expands to the fallback template prompt, never to an empty string or a raw unresolved token

--- a/openspec/changes/archive/2026-06-29-opsx-lifecycle-loop-template/tasks.md
+++ b/openspec/changes/archive/2026-06-29-opsx-lifecycle-loop-template/tasks.md
@@ -1,0 +1,30 @@
+## 1. Magic commands (loop-magic-commands)
+
+- [x] 1.1 Add `opsx:ff`, `opsx:apply`, `opsx:verify` as `providerNative` `LoopCommand`s in `server/loop-command-catalog.ts` (claude/gemini → `/opsx:<name>`, codex → `$opsx:<name>`, plus a `template` fallback prompt). Do NOT model them as `coreCommand`.
+- [x] 1.2 Give each a clear `label`/`description`/`ticketScope` consistent with existing entries; ensure they are appended (registry is append-only).
+
+## 2. Run-scoped capture (loop-execution)
+
+- [x] 2.1 Add a run-scoped captured-variable store to the loop run state in `server/loop-run-manager.ts` (map of `{{run.<name>}}` values, empty until captured).
+- [x] 2.2 After an `opsx:ff` ai-step completes, capture the change id by regex on `openspec/changes/<id>` (first match wins) into `run.changeId`.
+- [x] 2.3 Extend the token-resolution pipeline so `{{run.<name>}}` resolves in ai-step prompts AND `shell` node commands, applied after `{{cmd:*}}` and `{{spec.*}}`; unresolved → empty string (never a literal token).
+
+## 3. Template graph (loop-template-catalog + opsx-lifecycle-loop)
+
+- [x] 3.1 Author the `opsx-lifecycle` `LoopTemplate` (hand-written `LoopGraph`) in `server/loop-templates.ts` `LOOP_TEMPLATES`, category `Automation`: START → ai `{{cmd:opsx:ff}}` (with `{{spec.title}}`/`{{spec.description}}` and a loop-back continuation note referencing `{{run.changeId}}`) → ai `{{cmd:opsx:apply}}` → ai `{{cmd:opsx:verify}}` → decider → (`continue`→back to ff with `loopBack:'first'` session reset; `stop`→shell `openspec archive {{run.changeId}} -y`) → END.
+- [x] 3.2 Set a conservative `maxIterations` (e.g. 3) + sensible `timeoutMinutes`; write the decider `goal` to stop iff `verify` reported PASS.
+- [x] 3.3 Bake the momentum override ("decide and keep momentum; never block/ask") into the ff/apply step prompts.
+- [x] 3.4 Guard the archive shell node so it does not run `openspec archive` against an empty/unknown change id (skip + settle with a clear failure reason).
+- [x] 3.5 Verify the graph passes `validateLoopGraph` and compiles/serves via the existing template-listing path.
+
+## 4. Tests (coverage gates)
+
+- [x] 4.1 Unit-test `opsx:ff/apply/verify` expansion for claude, gemini, codex, and an unknown provider (fallback).
+- [x] 4.2 Unit-test `{{run.changeId}}` capture (match, first-of-many, no-match→empty) and its resolution in prompts and shell commands.
+- [x] 4.3 Test the `opsx-lifecycle` template: graph validates, lists under `Automation`, instantiates, and a simulated run routes FAIL→loop-back-to-ff and PASS→archive shell node (using injected executors, no real spawn).
+- [x] 4.4 Test the archive-guard path (no change id → no archive command, clear failure).
+- [x] 4.5 Run `npm run typecheck`, `npm test`, and `npm run test:coverage`; iterate until server coverage holds (80% lines/functions/statements, 70% branches) and global ≥70%.
+
+## 5. Docs / positioning
+
+- [x] 5.1 Add a one-line note (template description and/or relevant doc) positioning `opsx-lifecycle` as the single-agent, OpenSpec-artifact-centric counterpart to `specrails:implement`, and stating the claude-first multi-provider caveat.

--- a/openspec/specs/loop-execution/spec.md
+++ b/openspec/specs/loop-execution/spec.md
@@ -192,3 +192,23 @@ A loop run SHALL be backed by a job row (`jobs` table, job id === run id) so it 
 - **THEN** the engine SHALL call `finishJob` with status `completed` for `success`, `canceled` for `stopped`, and `failed` for `failed`/`max-iterations`
 - **AND** SHALL broadcast `job.finalized` so an open Job Detail re-fetches and stops the live stream
 
+### Requirement: Run-Scoped Captured Variables
+
+The loop runner SHALL support capturing a value from an ai-step's output during a run and exposing it to subsequent token resolution as a `{{run.<name>}}` token. The first capture defined by this change is `{{run.changeId}}`: after the first `opsx:ff` step, the runner SHALL extract the OpenSpec change id by matching `openspec/changes/<id>` in the step output (the same detection pattern used by `SpecLauncherManager`) and store it on run state. The token SHALL be resolvable in later ai-step prompts AND in `shell` node commands. Before any value is captured, `{{run.<name>}}` SHALL resolve to an empty string rather than remaining as a literal token. Run-token resolution SHALL be applied within the existing prompt/shell substitution pipeline (after `{{cmd:*}}` and `{{spec.*}}`).
+
+#### Scenario: Change id captured from ff output
+- **WHEN** the first `opsx:ff` step emits output containing `openspec/changes/my-change`
+- **THEN** the runner stores `my-change` as the run's `changeId`
+
+#### Scenario: Captured token resolves in a later step
+- **WHEN** a later ai-step prompt or shell command contains `{{run.changeId}}` after capture
+- **THEN** the token resolves to the captured change id
+
+#### Scenario: Uncaptured token resolves to empty
+- **WHEN** `{{run.changeId}}` is resolved before any change id has been captured
+- **THEN** the token resolves to an empty string
+
+#### Scenario: First match wins on multiple ids
+- **WHEN** the ff output mentions more than one `openspec/changes/<id>` path
+- **THEN** the runner captures the first matched id
+

--- a/openspec/specs/loop-magic-commands/spec.md
+++ b/openspec/specs/loop-magic-commands/spec.md
@@ -69,3 +69,23 @@ The catalog SHALL provide reusable, provider-invariant magic commands for the wo
 - **WHEN** the builder requests the command catalog via `GET /api/loops/commands`
 - **THEN** the response SHALL include each newly added command's `name`, `label`, and `description`
 
+### Requirement: OpenSpec Lifecycle Magic Commands
+
+The magic-command catalog SHALL include provider-aware commands `opsx:ff`, `opsx:apply`, and `opsx:verify`. Each SHALL be a `providerNative` command mapping `claude` and `gemini` to the slash form `/opsx:<name>` and `codex` to the dollar form `$opsx:<name>`, with a `template` fallback prompt for any provider not in the map. These commands SHALL NOT be modeled as `coreCommand` entries (which emit `/specrails:<name>`), because the OpenSpec commands live under the `/opsx:` namespace. No `opsx:archive`/`opsx:bulk-archive` command is added (archive is invoked via the `openspec` CLI in a shell node and is provider-independent).
+
+#### Scenario: opsx commands expand per provider
+- **WHEN** `{{cmd:opsx:ff}}` is expanded for the `claude` provider
+- **THEN** the result is `/opsx:ff`
+
+#### Scenario: codex uses the dollar form
+- **WHEN** `{{cmd:opsx:apply}}` is expanded for the `codex` provider
+- **THEN** the result is `$opsx:apply`
+
+#### Scenario: gemini uses the slash form
+- **WHEN** `{{cmd:opsx:verify}}` is expanded for the `gemini` provider
+- **THEN** the result is `/opsx:verify`
+
+#### Scenario: unknown provider falls back to the template prompt
+- **WHEN** `{{cmd:opsx:ff}}` is expanded for a provider absent from the providerNative map
+- **THEN** the result is the command's fallback template prompt, not an empty string
+

--- a/openspec/specs/loop-template-catalog/spec.md
+++ b/openspec/specs/loop-template-catalog/spec.md
@@ -67,3 +67,15 @@ Templates SHALL be generated from a declarative per-template specification via a
 - **WHEN** a template contains a step that modifies code or tests
 - **THEN** that step's prompt SHALL include the `{{const:GUARDRAILS}}` token
 
+### Requirement: OpenSpec Lifecycle Template Registration
+
+The loop template catalog SHALL register the `opsx-lifecycle` template under the existing `Automation` category (no new category is introduced) and serve it through the template-listing endpoint exactly like any other starter template, so it can be cloned into an editable draft loop. Registering it SHALL NOT require changes to the closed category taxonomy on server or client.
+
+#### Scenario: Template listed under Automation
+- **WHEN** the template catalog is listed
+- **THEN** the `opsx-lifecycle` template appears with category `Automation`
+
+#### Scenario: Template can be instantiated
+- **WHEN** a draft loop is created from the `opsx-lifecycle` template
+- **THEN** the new draft contains the template's full graph (ff → apply → verify → decider → archive → end)
+

--- a/openspec/specs/opsx-lifecycle-loop/spec.md
+++ b/openspec/specs/opsx-lifecycle-loop/spec.md
@@ -1,0 +1,81 @@
+# opsx-lifecycle-loop Specification
+
+## Purpose
+TBD - created by archiving change opsx-lifecycle-loop-template. Update Purpose after archive.
+## Requirements
+### Requirement: OpenSpec Lifecycle Loop Template
+
+The system SHALL provide a starter loop template named `opsx-lifecycle` that, given a single Specrails ticket, drives the full OpenSpec lifecycle (generate artifacts → implement → verify → archive) with a single AI agent and no multi-agent pipeline. The template SHALL be a hand-authored `LoopGraph` (not a compiled `PortSpec`) because it combines an AI-step spine, a decider, a `shell` archive node, and a terminal action on the decider's `stop` branch — a shape the stock `aiLoopGraph`/`fixLoopGraph` builders do not produce.
+
+#### Scenario: Template is offered in the catalog
+- **WHEN** a client requests the loop template catalog
+- **THEN** an `opsx-lifecycle` template is present with a valid graph that passes `validateLoopGraph`
+
+#### Scenario: Template is launchable from a ticket
+- **WHEN** a rail launches the `opsx-lifecycle` template with a ticket
+- **THEN** the run starts at the first `opsx:ff` step with the ticket's `{{spec.title}}` and `{{spec.description}}` interpolated into the prompt
+
+### Requirement: Lifecycle Step Sequence
+
+Within one iteration the template SHALL execute, in order, an `opsx:ff` ai-step (generate/amend artifacts), an `opsx:apply` ai-step (implement), and an `opsx:verify` ai-step (verify implementation against the change's specs), followed by a decider node. The template SHALL NOT include an `opsx:new` step.
+
+#### Scenario: Steps run in lifecycle order
+- **WHEN** an `opsx-lifecycle` run executes an iteration
+- **THEN** the engine visits the `opsx:ff` node, then the `opsx:apply` node, then the `opsx:verify` node, then the decider node
+
+#### Scenario: No opsx:new step exists
+- **WHEN** the `opsx-lifecycle` graph is inspected
+- **THEN** no ai-step expands to an `opsx:new` invocation
+
+### Requirement: Verify-Sourced Completion Verdict
+
+The completion decision SHALL be sourced from the `opsx:verify` step's output, not from a decider that judges only the ticket text. The decider node SHALL route to `stop` when verify reported the change complete (PASS) and to `continue` when verify reported remaining gaps (FAIL).
+
+#### Scenario: Verify PASS exits the loop
+- **WHEN** the `opsx:verify` step reports the implementation satisfies the change
+- **THEN** the decider routes the `stop` branch toward the archive node
+
+#### Scenario: Verify FAIL continues the loop
+- **WHEN** the `opsx:verify` step reports remaining gaps
+- **THEN** the decider routes the `continue` branch back to the `opsx:ff` step
+
+### Requirement: Loop-Back Amends The Same Change
+
+On a `continue` (FAIL) verdict the loop SHALL re-enter at the `opsx:ff` step targeting the SAME OpenSpec change captured on the first pass (via `{{run.changeId}}`), instructing it to continue that change and address the gaps reported by verify — never creating a duplicate change directory.
+
+#### Scenario: Re-pass continues the existing change
+- **WHEN** the loop re-enters `opsx:ff` after a FAIL verdict and a change id was captured
+- **THEN** the resolved prompt names the captured change id and instructs continuation of that change with the outstanding gaps
+
+### Requirement: Unattended Archive On Pass
+
+On the decider's `stop` branch the template SHALL run a `shell` node executing `openspec archive <id> -y` (using `{{run.changeId}}`) — non-interactive and syncing main specs by default — and then reach the `end` node. The template SHALL NOT use `opsx:bulk-archive`.
+
+#### Scenario: Archive runs unattended after PASS
+- **WHEN** the decider routes `stop` and a change id was captured
+- **THEN** a shell node runs `openspec archive <id> -y` and the run settles successfully
+
+#### Scenario: Archive is guarded when no change id was captured
+- **WHEN** the decider routes `stop` but no change id was captured
+- **THEN** the archive command is not executed against an unknown change and the run settles with a clear failure reason instead of archiving the wrong change
+
+### Requirement: Bounded Iteration
+
+The template SHALL set a conservative `maxIterations` so a never-satisfied verify can never spin indefinitely, relying on the engine's existing iteration counter, wall-clock timeout, and optional cost cap.
+
+#### Scenario: Loop stops at the iteration ceiling
+- **WHEN** verify reports FAIL on every pass up to `maxIterations`
+- **THEN** the run settles with outcome `max-iterations` rather than looping forever
+
+### Requirement: Claude-First Provider Scope
+
+The template SHALL function natively on providers whose CLI resolves `/opsx:*` commands (claude, and gemini per its `/opsx:` syntax). For providers lacking the native command (codex), the magic commands SHALL fall back to a template prompt rather than emitting an unresolved token. The template's description SHALL state that full multi-provider parity is claude-first.
+
+#### Scenario: Native expansion on claude
+- **WHEN** the template's `opsx:ff` command is expanded for the claude provider
+- **THEN** it expands to the native `/opsx:ff` invocation
+
+#### Scenario: Fallback expansion on a provider without the native command
+- **WHEN** the template's `opsx:ff` command is expanded for a provider that has no native opsx command
+- **THEN** it expands to the fallback template prompt, never to an empty string or a raw unresolved token
+

--- a/server/loop-command-catalog.ts
+++ b/server/loop-command-catalog.ts
@@ -143,6 +143,34 @@ export const LOOP_COMMANDS: LoopCommand[] = [
     template: LOOP_FALLBACK_PROMPT,
   },
 
+  // ── OpenSpec lifecycle (opsx:*) — provider-native slash commands ─────────────
+  // The opsx commands are installed by OpenSpec itself (NOT the specrails
+  // framework) and live under the `/opsx:` namespace, so they are `providerNative`
+  // — NOT `coreCommand` (which would wrongly emit `/specrails:<name>`). claude and
+  // gemini use the slash form; codex uses the `$`-skill form. Providers without a
+  // native opsx command fall back to the `template` prompt. Archive is invoked via
+  // the `openspec` CLI in a shell node (provider-independent) and has no command.
+  // NOTE: opsx commands are confirmed on claude today; codex/gemini lean on the
+  // fallback until OpenSpec ships their native commands (see opsx-lifecycle loop).
+  {
+    name: 'opsx:ff', label: 'opsx:ff', ticketScope: 'per-ticket',
+    description: 'OpenSpec fast-forward: create (or continue) a change and generate all its artifacts (proposal, specs, design, tasks). Native /opsx:ff (claude/gemini) or $opsx:ff (codex).',
+    providerNative: { claude: '/opsx:ff', gemini: '/opsx:ff', codex: '$opsx:ff' },
+    template: 'Create or continue an OpenSpec change for the work described next and generate all of its artifacts (proposal, specs, design, and tasks) so it is ready to implement.',
+  },
+  {
+    name: 'opsx:apply', label: 'opsx:apply', ticketScope: 'per-ticket',
+    description: 'OpenSpec apply: implement all pending tasks of the active change. Native /opsx:apply (claude/gemini) or $opsx:apply (codex).',
+    providerNative: { claude: '/opsx:apply', gemini: '/opsx:apply', codex: '$opsx:apply' },
+    template: 'Implement every pending task of the active OpenSpec change, editing the code as needed and marking each task complete as you finish it.',
+  },
+  {
+    name: 'opsx:verify', label: 'opsx:verify', ticketScope: 'per-ticket',
+    description: "OpenSpec verify: check the active change's implementation against its specs/tasks; ends with VERIFICATION: PASS|FAIL. Native /opsx:verify (claude/gemini) or $opsx:verify (codex).",
+    providerNative: { claude: '/opsx:verify', gemini: '/opsx:verify', codex: '$opsx:verify' },
+    template: 'Verify the active OpenSpec change: inspect the REAL implementation against its specs, design, and tasks. Finish with exactly `VERIFICATION: PASS` when nothing required is missing, or `VERIFICATION: FAIL — <what is still missing>` otherwise.',
+  },
+
   // ── Merge-resolver (parallel rails: integrate worktree branches back) ───────
   {
     name: 'resolve-merge', label: 'resolve-merge', ticketScope: 'per-ticket',
@@ -216,7 +244,9 @@ export function getLoopCommand(name: string): LoopCommand | undefined {
   return COMMANDS_BY_NAME.get(name)
 }
 
-const CMD_TOKEN_RE = /\{\{\s*cmd:([\w-]+)\s*\}\}/g
+// Allow `:` in the command name so namespaced commands like `{{cmd:opsx:ff}}`
+// (whose name is literally `opsx:ff`) tokenize — colon-free names are unaffected.
+const CMD_TOKEN_RE = /\{\{\s*cmd:([\w:-]+)\s*\}\}/g
 
 export interface ExpandCommandOpts {
   /** The provider the loop run will spawn (rail-governed). */

--- a/server/loop-run-manager.ts
+++ b/server/loop-run-manager.ts
@@ -170,6 +170,29 @@ export function truncate(s: string, max = 600): string {
   return s.slice(0, head) + '\n…\n' + s.slice(s.length - tail)
 }
 
+// ── Run-scoped captured variables ({{run.<name>}}) ───────────────────────────
+// A run can capture values from a step's output and reference them in LATER
+// ai-step prompts and shell commands as `{{run.<name>}}`. v1 captures exactly one
+// — `changeId`, the OpenSpec change id — written so the family can generalize.
+
+const RUN_TOKEN_RE = /\{\{\s*run\.(\w+)\s*\}\}/g
+/** First `openspec/changes/<id>` path mentioned in a step's output (the same
+ *  detection SpecLauncherManager uses). The id stops at the first `/`. */
+const CHANGE_ID_RE = /openspec\/changes\/([A-Za-z0-9._-]+)/
+
+/** Replace `{{run.<name>}}` with the captured value; uncaptured → '' (never a
+ *  leaked literal token). Applied AFTER `{{cmd:*}}` and `{{spec.*}}`. */
+export function resolveRunVars(text: string, vars: Record<string, string>): string {
+  return text.replace(RUN_TOKEN_RE, (_m, key: string) => vars[key] ?? '')
+}
+
+/** Extract the OpenSpec change id from a step's output (first match wins), or
+ *  undefined when none is present. */
+export function extractChangeId(text: string): string | undefined {
+  const m = CHANGE_ID_RE.exec(text)
+  return m ? m[1] : undefined
+}
+
 export class LoopRunManager {
   private readonly _cancelled = new Set<string>()
   /** The currently-spawned child per run, so cancel/stop can actually KILL a
@@ -317,6 +340,10 @@ export class LoopRunManager {
     // values layer on top. Used to expand `{{const:*}}` in every node's text.
     const constMap = { ...BUILTIN_CONSTANTS, ...(req.constants ?? {}) }
     const history: string[] = []
+    // Run-scoped captured variables ({{run.<name>}}). Populated as steps run
+    // (e.g. `changeId` from the first opsx:ff step's output) and resolved in later
+    // ai-step prompts and shell commands. Empty until something is captured.
+    const runVars: Record<string, string> = {}
     // Backstop against a cycle with no Decider (would otherwise never increment
     // `iteration`): cap total node executions well above any honest run.
     const stepCap = (maxIterations + 1) * (req.graph.nodes.length + 2) + 16
@@ -458,9 +485,12 @@ export class LoopRunManager {
             // data tokens and finally `{{const:*}}` library constants.
             const rawTemplate = String(node.data?.prompt ?? '')
             const base = resolveConstants(
-              interpolateSpec(
-                expandCommands(rawTemplate, { provider: nodeProvider, ticketIds: req.spec?.ticketIds, specId: req.spec?.id }),
-                req.spec
+              resolveRunVars(
+                interpolateSpec(
+                  expandCommands(rawTemplate, { provider: nodeProvider, ticketIds: req.spec?.ticketIds, specId: req.spec?.id }),
+                  req.spec
+                ),
+                runVars
               ),
               constMap
             )
@@ -488,6 +518,14 @@ export class LoopRunManager {
             if (res.sessionId && !res.failed) aiSessionId = res.sessionId
             history.push(`AI Step: ${truncate(res.text)}`)
             record(`loop:${runId}`, res, aiStepStart)
+            // Capture the OpenSpec change id from a step's output the FIRST time it
+            // appears (first-match-wins, kept stable across loop-back iterations so
+            // the re-pass amends the same change). Used by `{{run.changeId}}` in the
+            // loop-back ff prompt and the unattended archive shell node.
+            if (!runVars.changeId) {
+              const cid = extractChangeId(res.text)
+              if (cid) { runVars.changeId = cid; logLine(`↪ Captured OpenSpec change id: ${cid}`) }
+            }
             // Fail-fast: a hard-failed step (non-zero exit / spawn error) that
             // produced NO output means the provider never really ran — quota,
             // auth, crash. One can be transient; AI_FAILFAST_THRESHOLD in a row
@@ -508,7 +546,23 @@ export class LoopRunManager {
             break
           }
           case 'shell': {
-            const command = resolveConstants(interpolateSpec(String(node.data?.command ?? ''), req.spec), constMap)
+            // Guard: refuse to run when a declared run-variable was never captured
+            // (e.g. an archive node whose `{{run.changeId}}` is empty) — running
+            // `openspec archive  -y` against an unknown change would archive the
+            // wrong thing. Settle the run failed with a clear reason instead.
+            const reqVarsRaw = node.data?.requireRunVars
+            const requireRunVars = Array.isArray(reqVarsRaw)
+              ? reqVarsRaw.filter((v): v is string => typeof v === 'string')
+              : []
+            const missingRunVars = requireRunVars.filter((name) => !runVars[name])
+            if (missingRunVars.length > 0) {
+              emitStep('shell', `⚡ ${nodeLabel || 'Shell'}`)
+              logLine(`Skipped: required run variable(s) not captured: ${missingRunVars.map((n) => `{{run.${n}}}`).join(', ')} — refusing to run the command against an unknown target.`, 'stderr')
+              outcome = 'failed'
+              settled = true
+              break
+            }
+            const command = resolveConstants(resolveRunVars(interpolateSpec(String(node.data?.command ?? ''), req.spec), runVars), constMap)
             emitStep('shell', `⚡ ${nodeLabel || 'Shell'}`)
             logLine(`$ ${command}`)
             const sh = await this.executors.runShell({ command, cwd: req.cwd, onLine: logLine, onSpawn: (c) => this._activeChild.set(runId, c) })

--- a/server/loop-templates.test.ts
+++ b/server/loop-templates.test.ts
@@ -68,8 +68,17 @@ describe('loop templates', () => {
     expect(String(aiStep.data?.prompt)).toContain('{{cmd:implement}}')
   })
 
-  it('verification is agent-driven — NO template hardcodes a Shell node', () => {
+  it('verification is agent-driven — NO template hardcodes a Shell node (except the opsx-lifecycle archive)', () => {
+    // The opsx-lifecycle template intentionally uses ONE shell node for the
+    // deterministic, unattended `openspec archive -y` close — a CLI call, not test
+    // verification (which stays agent-driven everywhere). Exempt it precisely.
     for (const tpl of LOOP_TEMPLATES) {
+      if (tpl.id === 'opsx-lifecycle') {
+        const shells = tpl.graph.nodes.filter((n) => n.type === 'shell')
+        expect(shells.length).toBe(1)
+        expect(String(shells[0].data?.command)).toContain('openspec archive')
+        continue
+      }
       expect(tpl.graph.nodes.some((n) => n.type === 'shell'), `${tpl.id} should not use a Shell node`).toBe(false)
     }
   })

--- a/server/loop-templates.ts
+++ b/server/loop-templates.ts
@@ -168,7 +168,85 @@ export function fixLoopGraph(mainPrompts: string[], deciderGoal: string, maxIter
   return { nodes, edges, config: { maxIterations, timeoutMinutes, ...(aiStepTimeoutMinutes != null ? { aiStepTimeoutMinutes } : {}) } }
 }
 
+// ── OpenSpec lifecycle loop ──────────────────────────────────────────────────
+// A hand-authored graph (NOT a PortSpec) because it combines an AI-step spine, a
+// Decider, a `shell` archive node, AND a terminal action on the Decider's `stop`
+// branch — a shape the stock aiLoopGraph/fixLoopGraph builders do not produce.
+// Per iteration: opsx:ff → opsx:apply → opsx:verify → Decider. The Decider stops
+// when verify reports PASS (→ unattended `openspec archive <id> -y` shell node);
+// otherwise it loops back to opsx:ff, which AMENDS the same change ({{run.changeId}}
+// captured by the engine from ff's first-pass output) using the gaps verify found.
+const OPSX_FF_PROMPT = [
+  '{{cmd:opsx:ff}} {{spec.title}}',
+  '',
+  '{{spec.description}}',
+  '',
+  'If a change id appears here — "{{run.changeId}}" — an OpenSpec change for this ticket already exists: CONTINUE that change (do NOT create a new one) and address only what the verification reported as still missing (see the context below). If it is blank, create the change and generate all required artifacts.',
+  '',
+  'Run fully unattended: make reasonable decisions to keep momentum and NEVER stop to ask — there is no human to answer. When something is unclear, pick the most sensible option, proceed, and note the assumption.',
+].join('\n')
+
+const OPSX_APPLY_PROMPT = [
+  '{{cmd:opsx:apply}}',
+  '',
+  'Implement every pending task of the active OpenSpec change for ticket "{{spec.title}}", editing code as needed and marking tasks complete as you finish them.',
+  '',
+  'Run fully unattended: decide and keep momentum, never pause to ask. If you hit an ambiguity or blocker, make the most reasonable choice, implement it, and continue.',
+].join('\n')
+
+const OPSX_VERIFY_PROMPT = [
+  '{{cmd:opsx:verify}}',
+  '',
+  'Verify the active OpenSpec change against its specs, design, and tasks for ticket "{{spec.title}}". Be strict and honest — inspect the REAL code and tests, not any step\'s self-report.',
+  '',
+  'Finish with a clear final line: exactly `{{const:VERIFICATION_PASS}}` when the change fully matches the ticket with nothing required missing, or `{{const:VERIFICATION_FAIL}} — <what is still missing>` otherwise.',
+].join('\n')
+
+const OPSX_DECIDER_GOAL =
+  'The verify step reported {{const:VERIFICATION_PASS}} — the implementation fully matches ticket "{{spec.title}}" and nothing required is missing.'
+
+/** The OpenSpec-lifecycle graph (see comment above). Exported for unit testing. */
+export function opsxLifecycleGraph(): LoopGraph {
+  return {
+    nodes: [
+      { id: 'start', type: 'start', position: { x: COL_X, y: 0 } },
+      { id: 'ff', type: 'ai-step', position: { x: COL_X, y: ROW_GAP * 1 }, data: { label: 'opsx:ff', prompt: OPSX_FF_PROMPT } },
+      { id: 'apply', type: 'ai-step', position: { x: COL_X, y: ROW_GAP * 2 }, data: { label: 'opsx:apply', prompt: OPSX_APPLY_PROMPT } },
+      { id: 'verify', type: 'ai-step', position: { x: COL_X, y: ROW_GAP * 3 }, data: { label: 'opsx:verify', prompt: OPSX_VERIFY_PROMPT } },
+      { id: 'decide', type: 'decider', position: { x: COL_X, y: ROW_GAP * 4 }, data: { goal: OPSX_DECIDER_GOAL } },
+      // Unattended archive: deterministic CLI, no AI, no prompt. `requireRunVars`
+      // makes the engine REFUSE to run if no change id was captured (never archive
+      // an unknown change); `openspec archive -y` syncs the main specs by default.
+      { id: 'archive', type: 'shell', position: { x: COL_X, y: ROW_GAP * 5 }, data: { label: 'archive', command: 'openspec archive {{run.changeId}} -y', requireRunVars: ['changeId'] } },
+      { id: 'done', type: 'end', position: { x: COL_X, y: ROW_GAP * 6 }, data: { outcome: 'success' } },
+    ],
+    edges: [
+      { id: 'e-start', source: 'start', target: 'ff' },
+      { id: 'e-ff', source: 'ff', target: 'apply' },
+      { id: 'e-apply', source: 'apply', target: 'verify' },
+      { id: 'e-verify', source: 'verify', target: 'decide' },
+      // not-done (verify FAIL) → loop back to ff (firstStepId ⇒ session resets, the
+      // pass re-reads disk; verify's gaps ride in the injected history).
+      { id: 'e-continue', source: 'decide', target: 'ff', branch: 'continue' },
+      // done (verify PASS) → archive then end.
+      { id: 'e-stop', source: 'decide', target: 'archive', branch: 'stop' },
+      { id: 'e-archive', source: 'archive', target: 'done' },
+    ],
+    // Conservative bounds so a never-satisfied verify can't spin: at most 3 full
+    // lifecycle passes; per-step cap raised (apply can implement a whole change).
+    config: { maxIterations: 3, timeoutMinutes: 180, aiStepTimeoutMinutes: 45 },
+  }
+}
+
 export const LOOP_TEMPLATES: LoopTemplate[] = [
+  {
+    id: 'opsx-lifecycle',
+    name: 'OpenSpec Lifecycle',
+    description: 'Single-agent, ticket-to-archive OpenSpec lifecycle: generate artifacts (opsx:ff) → implement (opsx:apply) → verify (opsx:verify); on a FAIL verdict loop back to amend the SAME change, on PASS archive it unattended. The artifact-centric counterpart to the implement pipeline. Claude-first — codex/gemini fall back to a generic prompt until OpenSpec ships their native opsx commands.',
+    category: 'Automation',
+    tags: ['Automation', 'openspec', 'lifecycle'],
+    graph: opsxLifecycleGraph(),
+  },
   {
     id: 'ship-and-green',
     name: 'Ship & Green',

--- a/server/opsx-lifecycle-loop.test.ts
+++ b/server/opsx-lifecycle-loop.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for the OpenSpec-lifecycle loop template (opsx-lifecycle) and the engine
+ * support it relies on: the opsx:* provider-native magic commands, the
+ * `{{run.changeId}}` run-scoped capture, and the shell `requireRunVars` archive
+ * guard. See openspec/changes/opsx-lifecycle-loop-template.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { initDb, type DbInstance } from './db'
+import { expandCommands, getLoopCommand } from './loop-command-catalog'
+import {
+  LoopRunManager,
+  resolveRunVars,
+  extractChangeId,
+  type LoopExecutors,
+} from './loop-run-manager'
+import { getLoopTemplate, opsxLifecycleGraph } from './loop-templates'
+import { validateLoopGraph } from './loop-graph'
+import type { WsMessage } from './types'
+
+// ── opsx:* magic commands (loop-magic-commands) ──────────────────────────────
+describe('opsx magic commands', () => {
+  for (const name of ['opsx:ff', 'opsx:apply', 'opsx:verify']) {
+    it(`${name} is a providerNative command (not coreCommand)`, () => {
+      const cmd = getLoopCommand(name)
+      expect(cmd).toBeDefined()
+      expect(cmd!.coreCommand).toBeUndefined()
+      expect(cmd!.providerNative).toBeDefined()
+      expect(cmd!.template).toBeTruthy() // fallback exists
+    })
+  }
+
+  it('expands to the slash form on claude and gemini', () => {
+    expect(expandCommands('{{cmd:opsx:ff}}', { provider: 'claude' })).toBe('/opsx:ff')
+    expect(expandCommands('{{cmd:opsx:apply}}', { provider: 'gemini' })).toBe('/opsx:apply')
+    expect(expandCommands('{{cmd:opsx:verify}}', { provider: 'gemini' })).toBe('/opsx:verify')
+  })
+
+  it('expands to the dollar form on codex', () => {
+    expect(expandCommands('{{cmd:opsx:ff}}', { provider: 'codex' })).toBe('$opsx:ff')
+    expect(expandCommands('{{cmd:opsx:apply}}', { provider: 'codex' })).toBe('$opsx:apply')
+  })
+
+  it('falls back to the template prompt for an unknown provider (never empty/raw)', () => {
+    const out = expandCommands('{{cmd:opsx:ff}}', { provider: 'someNewProvider' })
+    expect(out).toBe(getLoopCommand('opsx:ff')!.template)
+    expect(out).not.toBe('')
+    expect(out).not.toContain('{{cmd')
+  })
+
+  it('tokenizes a namespaced command alongside surrounding text', () => {
+    const out = expandCommands('{{cmd:opsx:ff}} {{spec.title}}', { provider: 'claude' })
+    expect(out).toBe('/opsx:ff {{spec.title}}') // spec token left for interpolateSpec
+  })
+})
+
+// ── run-scoped capture (loop-execution) ──────────────────────────────────────
+describe('extractChangeId', () => {
+  it('captures the id from an openspec/changes path', () => {
+    expect(extractChangeId('Created change at openspec/changes/my-change/')).toBe('my-change')
+  })
+  it('captures the FIRST id when several are mentioned', () => {
+    expect(extractChangeId('openspec/changes/aaa and openspec/changes/bbb')).toBe('aaa')
+  })
+  it('returns undefined when no change path is present', () => {
+    expect(extractChangeId('nothing to see here')).toBeUndefined()
+  })
+})
+
+describe('resolveRunVars', () => {
+  it('resolves a captured token', () => {
+    expect(resolveRunVars('archive {{run.changeId}} now', { changeId: 'abc' })).toBe('archive abc now')
+  })
+  it('resolves an uncaptured token to empty (never a literal token)', () => {
+    expect(resolveRunVars('archive {{run.changeId}} now', {})).toBe('archive  now')
+  })
+})
+
+// ── template registration (loop-template-catalog) ────────────────────────────
+describe('opsx-lifecycle template', () => {
+  it('is registered under the Automation category', () => {
+    const t = getLoopTemplate('opsx-lifecycle')
+    expect(t).toBeDefined()
+    expect(t!.category).toBe('Automation')
+  })
+  it('has a valid graph', () => {
+    expect(validateLoopGraph(opsxLifecycleGraph()).valid).toBe(true)
+  })
+  it('contains the lifecycle steps (ff → apply → verify → decider → archive shell → end)', () => {
+    const g = opsxLifecycleGraph()
+    const prompts = g.nodes.filter((n) => n.type === 'ai-step').map((n) => String(n.data?.prompt))
+    expect(prompts.some((p) => p.includes('{{cmd:opsx:ff}}'))).toBe(true)
+    expect(prompts.some((p) => p.includes('{{cmd:opsx:apply}}'))).toBe(true)
+    expect(prompts.some((p) => p.includes('{{cmd:opsx:verify}}'))).toBe(true)
+    expect(g.nodes.some((n) => n.type === 'decider')).toBe(true)
+    const shell = g.nodes.find((n) => n.type === 'shell')
+    expect(shell?.data?.command).toContain('openspec archive {{run.changeId}} -y')
+    expect(shell?.data?.requireRunVars).toEqual(['changeId'])
+    expect(g.nodes.some((n) => n.type === 'end')).toBe(true)
+    // No opsx:new step.
+    expect(prompts.some((p) => p.includes('opsx:new'))).toBe(false)
+  })
+})
+
+// ── engine integration: run the real template graph ──────────────────────────
+let db: DbInstance
+let broadcasts: WsMessage[]
+
+beforeEach(() => {
+  db = initDb(':memory:')
+  broadcasts = []
+})
+
+function manager(executors: LoopExecutors): LoopRunManager {
+  return new LoopRunManager(db, (m) => broadcasts.push(m), executors, () => 1000)
+}
+
+function baseReq() {
+  return {
+    loopId: 'opsx-lifecycle',
+    loopName: 'OpenSpec Lifecycle',
+    graph: opsxLifecycleGraph(),
+    projectId: 'p1',
+    cwd: '/repo',
+    railIndex: 1,
+    ticketId: 7,
+    spec: { id: 7, title: 'Feature X', description: 'Build feature X' },
+    provider: 'claude',
+    model: 'sonnet',
+  }
+}
+
+/** An ai-step mock where the ff step emits a change path (so changeId captures). */
+function aiStepMock(opts: { ffEmitsChangeId?: boolean } = {}) {
+  const ffEmits = opts.ffEmitsChangeId ?? true
+  const prompts: string[] = []
+  const fn = vi.fn(async (input: { prompt: string }) => {
+    prompts.push(input.prompt)
+    const isFf = input.prompt.includes('/opsx:ff')
+    const text = isFf && ffEmits
+      ? 'Created change at openspec/changes/my-change/ — generated artifacts.'
+      : 'did the work'
+    return { text, sessionId: 's1', cost: 0.01, tokens: 100, provider: 'claude', model: 'sonnet' }
+  })
+  return { fn, prompts }
+}
+
+describe('opsx-lifecycle run (engine integration)', () => {
+  it('PASS on the first pass → captures change id and runs the unattended archive', async () => {
+    const ai = aiStepMock()
+    const runShell = vi.fn(async () => ({ stdout: 'archived', stderr: '', exitCode: 0, durationMs: 5 }))
+    const runDecider = vi.fn(async () => ({ continue: false, reasoning: 'verify PASS', parsed: true, cost: 0.001, provider: 'claude', model: 'sonnet' }))
+    const ex: LoopExecutors = { runAiStep: ai.fn, runShell, runDecider }
+
+    const res = await manager(ex).run(baseReq())
+
+    expect(res.outcome).toBe('success')
+    expect(runShell).toHaveBeenCalledTimes(1)
+    expect(runShell.mock.calls[0][0].command).toBe('openspec archive my-change -y')
+  })
+
+  it('FAIL then PASS → loops back to ff (same change id) and finally archives', async () => {
+    const ai = aiStepMock()
+    const runShell = vi.fn(async () => ({ stdout: 'archived', stderr: '', exitCode: 0, durationMs: 5 }))
+    // First decider: FAIL (continue → loop back). Second: PASS (stop → archive).
+    const runDecider = vi.fn()
+      .mockResolvedValueOnce({ continue: true, reasoning: 'missing X', parsed: true })
+      .mockResolvedValueOnce({ continue: false, reasoning: 'now complete', parsed: true })
+    const ex: LoopExecutors = { runAiStep: ai.fn, runShell, runDecider }
+
+    const res = await manager(ex).run(baseReq())
+
+    expect(res.outcome).toBe('success')
+    expect(runDecider).toHaveBeenCalledTimes(2)
+    // ff ran twice (initial + loop-back).
+    const ffPrompts = ai.prompts.filter((p) => p.includes('/opsx:ff'))
+    expect(ffPrompts.length).toBe(2)
+    // The second ff names the captured change id (continue the SAME change) and
+    // carries the cross-iteration context (verify's gaps).
+    expect(ffPrompts[1]).toContain('my-change')
+    expect(ffPrompts[1]).toContain('Context from previous iterations')
+    expect(runShell.mock.calls[0][0].command).toBe('openspec archive my-change -y')
+  })
+
+  it('archive guard: no change id captured → refuses to archive and fails', async () => {
+    const ai = aiStepMock({ ffEmitsChangeId: false })
+    const runShell = vi.fn(async () => ({ stdout: '', stderr: '', exitCode: 0 }))
+    const runDecider = vi.fn(async () => ({ continue: false, reasoning: 'PASS', parsed: true }))
+    const ex: LoopExecutors = { runAiStep: ai.fn, runShell, runDecider }
+
+    const res = await manager(ex).run(baseReq())
+
+    expect(res.outcome).toBe('failed')
+    expect(runShell).not.toHaveBeenCalled()
+    // A clear, honest reason was logged.
+    const logs = broadcasts.filter((m): m is Extract<WsMessage, { type: 'log' }> => m.type === 'log')
+    expect(logs.some((l) => l.line.includes('required run variable'))).toBe(true)
+  })
+})

--- a/server/workspace-manager.test.ts
+++ b/server/workspace-manager.test.ts
@@ -163,6 +163,70 @@ describe('workspace-manager', () => {
     expect(fs.existsSync(fallback)).toBe(false)
   })
 
+  describe('openspec carve-out link', () => {
+    it('links <ws>/openspec to the repo openspec (created if absent); writes land in the repo', () => {
+      const ws = ensureWorkspace('osp1', projectRoot, home)
+      const link = path.join(ws, 'openspec')
+      expect(fs.lstatSync(link).isSymbolicLink()).toBe(true)
+      expect(path.resolve(ws, fs.readlinkSync(link))).toBe(path.join(projectRoot, 'openspec'))
+      // The carve-out target was created in the repo.
+      expect(fs.existsSync(path.join(projectRoot, 'openspec'))).toBe(true)
+      // A write through the link lands in the user's repo (the whole point).
+      fs.writeFileSync(path.join(link, 'probe.txt'), 'x')
+      expect(fs.existsSync(path.join(projectRoot, 'openspec', 'probe.txt'))).toBe(true)
+    })
+
+    it('is idempotent — an already-correct link is left untouched', () => {
+      ensureWorkspace('osp2', projectRoot, home)
+      const ws = ensureWorkspace('osp2', projectRoot, home)
+      const link = path.join(ws, 'openspec')
+      expect(fs.lstatSync(link).isSymbolicLink()).toBe(true)
+      expect(path.resolve(ws, fs.readlinkSync(link))).toBe(path.join(projectRoot, 'openspec'))
+    })
+
+    it('migrates a pre-carve-out REAL openspec dir into the repo, then links (non-destructive)', () => {
+      const ws = workspacePathFor('osp3', home)
+      // A workspace stranded by the openspec binary writing to its cwd.
+      const stranded = path.join(ws, 'openspec', 'changes', 'archive', 'my-change')
+      fs.mkdirSync(stranded, { recursive: true })
+      fs.writeFileSync(path.join(stranded, 'proposal.md'), '# stranded\n')
+      // The repo already has a committed file that must NOT be clobbered.
+      fs.mkdirSync(path.join(projectRoot, 'openspec'), { recursive: true })
+      fs.writeFileSync(path.join(projectRoot, 'openspec', 'project.md'), '# committed\n')
+
+      ensureWorkspace('osp3', projectRoot, home)
+
+      expect(fs.lstatSync(path.join(ws, 'openspec')).isSymbolicLink()).toBe(true)
+      // Stranded artifact rescued into the repo.
+      expect(
+        fs.readFileSync(path.join(projectRoot, 'openspec', 'changes', 'archive', 'my-change', 'proposal.md'), 'utf8'),
+      ).toContain('stranded')
+      // Repo's committed file untouched.
+      expect(fs.readFileSync(path.join(projectRoot, 'openspec', 'project.md'), 'utf8')).toContain('committed')
+    })
+
+    it('migration never clobbers an existing repo file on a name collision (repo wins)', () => {
+      const ws = workspacePathFor('osp4', home)
+      fs.mkdirSync(path.join(ws, 'openspec'), { recursive: true })
+      fs.writeFileSync(path.join(ws, 'openspec', 'config.yaml'), 'workspace-version\n')
+      fs.mkdirSync(path.join(projectRoot, 'openspec'), { recursive: true })
+      fs.writeFileSync(path.join(projectRoot, 'openspec', 'config.yaml'), 'repo-version\n')
+
+      ensureWorkspace('osp4', projectRoot, home)
+      expect(fs.readFileSync(path.join(projectRoot, 'openspec', 'config.yaml'), 'utf8')).toBe('repo-version\n')
+    })
+
+    it('removeWorkspace unlinks the openspec link WITHOUT deleting the repo openspec', () => {
+      const ws = ensureWorkspace('osp5', projectRoot, home)
+      fs.writeFileSync(path.join(ws, 'openspec', 'keep.md'), '# keep\n') // lands in the repo via the link
+      expect(fs.existsSync(path.join(projectRoot, 'openspec', 'keep.md'))).toBe(true)
+      removeWorkspace('osp5', home)
+      expect(fs.existsSync(ws)).toBe(false)
+      // Repo openspec + its files survive (link unlinked, never followed).
+      expect(fs.readFileSync(path.join(projectRoot, 'openspec', 'keep.md'), 'utf8')).toContain('keep')
+    })
+  })
+
   describe('assembleWorkspaceFramework', () => {
     it('no-ops (assembled=false) when no bundled core is present, but still ensures the workspace', () => {
       const prev = process.env.SPECRAILS_BUNDLED_CORE_PATH

--- a/server/workspace-manager.ts
+++ b/server/workspace-manager.ts
@@ -124,6 +124,7 @@ export function ensureWorkspace(slug: string, projectPath: string, home?: string
   const ws = workspacePathFor(slug, home)
   fs.mkdirSync(ws, { recursive: true })
   ensureProjectLink(ws, projectPath)
+  ensureOpenspecLink(ws, projectPath)
   return ws
 }
 
@@ -205,17 +206,21 @@ export function removeWorkspace(slug: string, home?: string): void {
   const ws = workspacePathFor(slug, home)
   if (!fs.existsSync(ws)) return
 
-  const linkPath = path.join(ws, 'project')
-  try {
-    const st = fs.lstatSync(linkPath)
-    if (st.isSymbolicLink() || (process.platform === 'win32' && st.isDirectory())) {
-      // unlink works on POSIX symlinks; rmdir on Windows junctions
-      try { fs.unlinkSync(linkPath) } catch {
-        try { fs.rmdirSync(linkPath) } catch { /* best-effort */ }
+  // Unlink the carve-out links BEFORE the recursive remove so the user's repo is
+  // never followed/deleted: `project` → the repo, and `openspec` → the repo's
+  // openspec carve-out. (POSIX symlinks unlink; Windows junctions rmdir.)
+  for (const name of ['project', 'openspec']) {
+    const linkPath = path.join(ws, name)
+    try {
+      const st = fs.lstatSync(linkPath)
+      if (st.isSymbolicLink() || (process.platform === 'win32' && st.isDirectory())) {
+        try { fs.unlinkSync(linkPath) } catch {
+          try { fs.rmdirSync(linkPath) } catch { /* best-effort */ }
+        }
       }
+    } catch {
+      /* link may not exist */
     }
-  } catch {
-    /* link may not exist */
   }
 
   fs.rmSync(ws, { recursive: true, force: true })
@@ -276,5 +281,80 @@ function ensureProjectLink(cwd: string, projectPath: string): void {
   // fallback file from a prior failed attempt.
   if (fs.existsSync(fallbackPath)) {
     try { fs.unlinkSync(fallbackPath) } catch { /* ignore */ }
+  }
+}
+
+/**
+ * Ensure `<ws>/openspec` is a LINK to `<repo>/openspec` — the openspec carve-out.
+ *
+ * openspec is a repo-resident deliverable (CLAUDE.md: "openspec/** … the versioned
+ * spec deliverable … repo-relative by design"). For specrails-core's own slash
+ * commands the `${SPECRAILS_REPO_DIR:-.}` indirection re-points openspec I/O to the
+ * repo — but the EXTERNAL `openspec` binary (invoked as `openspec new change` /
+ * `openspec archive` by the opsx lifecycle) does NOT read that env var; it writes
+ * relative to its cwd. Since relocated rails/loops spawn with cwd = the WORKSPACE,
+ * without this link every `openspec` write would strand the change under
+ * `~/.specrails/projects/<slug>/workspace/openspec` instead of the user's repo.
+ *
+ * Mirrors `ensureProjectLink` (symlink on POSIX, junction on Windows) and adds a
+ * one-time, NON-DESTRUCTIVE migration: a pre-carve-out workspace that already holds
+ * a REAL `openspec/` dir (created by the binary writing to the workspace cwd) has
+ * its contents rescued into the repo — never clobbering the repo's own files —
+ * before the dir is replaced by the link. Idempotent: a no-op once the correct
+ * link exists. Best-effort throughout — a link failure must never abort a spawn.
+ */
+function ensureOpenspecLink(cwd: string, projectPath: string): void {
+  const linkPath = path.join(cwd, 'openspec')
+  const repoOpenspec = path.join(projectPath, 'openspec')
+
+  try {
+    const st = fs.lstatSync(linkPath)
+    if (st.isSymbolicLink()) {
+      const current = fs.readlinkSync(linkPath)
+      if (path.resolve(cwd, current) === path.resolve(repoOpenspec)) return // already correct
+      try { fs.unlinkSync(linkPath) } catch { /* replaced below */ }
+    } else if (st.isDirectory()) {
+      // Pre-carve-out workspace: a real openspec/ dir the binary wrote to the
+      // workspace cwd. Rescue its contents into the repo, then replace with a link.
+      mergeDirInto(linkPath, repoOpenspec)
+      try { fs.rmSync(linkPath, { recursive: true, force: true }) } catch { return }
+    } else {
+      try { fs.unlinkSync(linkPath) } catch { return }
+    }
+  } catch {
+    /* does not exist — create below */
+  }
+
+  // The carve-out target must exist for the link to resolve (the binary expects to
+  // write under it). openspec/** is an intentional repo carve-out, so creating it
+  // does not violate the pristine-repo guarantee.
+  try { fs.mkdirSync(repoOpenspec, { recursive: true }) } catch { /* best-effort */ }
+
+  if (process.platform === 'win32') {
+    try { fs.symlinkSync(repoOpenspec, linkPath, 'junction'); return } catch { /* fall through to POSIX symlink */ }
+  }
+  try { fs.symlinkSync(repoOpenspec, linkPath) } catch { /* best-effort: a failed link just means the binary writes a fresh workspace dir next run */ }
+}
+
+/**
+ * Recursively copy `src` into `dest`, creating directories and copying only files
+ * that do NOT already exist in `dest` (the repo's own copy always wins). Used by
+ * the openspec carve-out migration to rescue workspace-stranded artifacts into the
+ * repo without overwriting committed content. Best-effort per entry.
+ */
+function mergeDirInto(src: string, dest: string): void {
+  let entries: fs.Dirent[]
+  try { entries = fs.readdirSync(src, { withFileTypes: true }) } catch { return }
+  try { fs.mkdirSync(dest, { recursive: true }) } catch { /* best-effort */ }
+  for (const e of entries) {
+    const s = path.join(src, e.name)
+    const d = path.join(dest, e.name)
+    if (e.isDirectory()) {
+      mergeDirInto(s, d)
+    } else if (e.isSymbolicLink()) {
+      if (!fs.existsSync(d)) { try { fs.symlinkSync(fs.readlinkSync(s), d) } catch { /* skip */ } }
+    } else if (!fs.existsSync(d)) {
+      try { fs.copyFileSync(s, d) } catch { /* skip */ }
+    }
   }
 }


### PR DESCRIPTION
## What

Adds a new starter loop template, **`opsx-lifecycle`** (category *Automation*): a single-agent, ticket-to-archive OpenSpec lifecycle.

```
START → opsx:ff → opsx:apply → opsx:verify → Decider
                                               ├─ continue (verify FAIL) → back to opsx:ff (amend SAME change)
                                               └─ stop (verify PASS) → shell: openspec archive <id> -y → END
```

`opsx:verify` produces the PASS/FAIL verdict (it inspects the real artifacts/code); the Decider only routes it. On FAIL the loop re-enters `opsx:ff` to amend the **same** change (no duplicate folders) carrying verify's gaps; on PASS it archives unattended. Bounded by `maxIterations: 3` + timeout + cost cap.

Validated end-to-end on a live ticket (built a browser Asteroids game): it caught a real CSS-scaling miss on pass 1, looped back, fixed only that, re-verified PASS, and archived — 2 iterations.

## Changes

**Loop subsystem**
- `loop-command-catalog.ts` — three provider-native commands `opsx:ff` / `opsx:apply` / `opsx:verify` (claude + gemini `/opsx:`, codex `$opsx:`, with a `template` fallback for providers without a native opsx command — **not** `coreCommand`, which emits `/specrails:`). The cmd-token regex now accepts `:` so namespaced tokens parse.
- `loop-run-manager.ts` — run-scoped `{{run.changeId}}` capture (regex on `openspec/changes/<id>`, first-match-wins) resolved in ai-step prompts **and** shell commands; a `shell` `requireRunVars` guard refuses to run `openspec archive` against an uncaptured change id.
- `loop-templates.ts` — hand-authored `opsx-lifecycle` graph (it needs a shell node + a terminal action on the Decider's stop branch, which the stock `aiLoopGraph`/`fixLoopGraph` builders don't produce).

**Artifact-relocation fix (root cause of stranded deliverables)**
- The external `openspec` binary writes relative to its **cwd** (the workspace on relocated projects) and ignores `SPECRAILS_REPO_DIR`, so opsx runs stranded the change under `~/.specrails/.../workspace/openspec` instead of the user's repo. `ensureWorkspace` now links `<ws>/openspec` → `<repo>/openspec` (the documented `openspec/**` carve-out, mirroring the `./project` link) with a **non-destructive** migration of a pre-existing real dir (rescues contents into the repo, repo wins on collision). `removeWorkspace` unlinks it without following. This runs on every relocated spawn (`workspace-resolution.ts`), so it self-heals existing projects.

## Tests / gates
- New `server/opsx-lifecycle-loop.test.ts` (provider expansion, run-var capture/resolution, graph validation, full simulated run FAIL→loop-back / PASS→archive, archive guard).
- New openspec carve-out tests in `server/workspace-manager.test.ts` (link, idempotency, non-destructive migration, collision = repo wins, safe removal).
- `typecheck` clean · **4553 tests pass** · server coverage **85.25 / 88.18 / 87.23** lines/functions/statements + **76.45** branches (gates 80 / 70).

## Open risk (tracked, not blocking)
`opsx:*` lifecycle commands are confirmed only on claude in framework 4.10.0 (codex/gemini ship only `opsx-diff`); the template is **claude-first** and leans on the `template` fallback elsewhere until OpenSpec ships native multi-provider opsx commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018g2VCCS3itXULip86xNuab
