### PR TITLE
feat: enable parallel-rail worktree isolation by default

### DIFF
--- a/server/rail-isolation.test.ts
+++ b/server/rail-isolation.test.ts
@@ -17,21 +17,21 @@ describe('mutatesRepo', () => {
   })
 })
 
-describe('isRailWorktreesEnabled (opt-in during rollout, default off)', () => {
-  it('is OFF when unset', () => {
+describe('isRailWorktreesEnabled (default-on kill-switch)', () => {
+  it('is ON when unset (default-on)', () => {
     delete process.env.SPECRAILS_RAIL_WORKTREES
-    expect(isRailWorktreesEnabled()).toBe(false)
+    expect(isRailWorktreesEnabled()).toBe(true)
   })
-  it('on for 1/true/on (case-insensitive)', () => {
-    for (const v of ['1', 'true', 'on', 'ON', 'True']) {
-      process.env.SPECRAILS_RAIL_WORKTREES = v
-      expect(isRailWorktreesEnabled()).toBe(true)
-    }
-  })
-  it('off for any other value', () => {
-    for (const v of ['0', 'false', 'off', 'yes', '']) {
+  it('OFF only for 0/false/off (case-insensitive)', () => {
+    for (const v of ['0', 'false', 'off', 'OFF', 'False']) {
       process.env.SPECRAILS_RAIL_WORKTREES = v
       expect(isRailWorktreesEnabled()).toBe(false)
+    }
+  })
+  it('ON for explicit truthy AND any unrecognized value (incl. empty)', () => {
+    for (const v of ['1', 'true', 'on', 'yes', '']) {
+      process.env.SPECRAILS_RAIL_WORKTREES = v
+      expect(isRailWorktreesEnabled()).toBe(true)
     }
   })
 })
@@ -59,8 +59,12 @@ describe('isolationApplies', () => {
   it('false when loops disabled', () => {
     expect(isolationApplies({ ...base, loopsEnabled: false })).toBe(false)
   })
-  it('false when the flag is not set (default off)', () => {
+  it('true when the flag is not set (default-on)', () => {
     delete process.env.SPECRAILS_RAIL_WORKTREES
+    expect(isolationApplies(base)).toBe(true)
+  })
+  it('false when explicitly disabled with the kill-switch', () => {
+    process.env.SPECRAILS_RAIL_WORKTREES = '0'
     expect(isolationApplies(base)).toBe(false)
   })
 })

--- a/server/rail-isolation.ts
+++ b/server/rail-isolation.ts
@@ -25,16 +25,17 @@ export function mutatesRepo(loop: { readOnly?: boolean }): boolean {
 }
 
 /**
- * The isolation gate flag. **Opt-in during rollout**: worktree isolation runs
- * ONLY when `SPECRAILS_RAIL_WORKTREES` is `1`/`true`/`on`; otherwise every loop run
- * keeps the legacy single shared cwd (byte-identical to before this feature). This
- * lets the integration land inert and be validated on a live rail before it is
- * flipped to default-on. Read per-call so a test can flip the env without
- * re-importing.
+ * The isolation gate flag. **Default-on kill-switch**: worktree isolation runs for
+ * every repo-mutating per-ticket rail UNLESS `SPECRAILS_RAIL_WORKTREES` is set to
+ * `0`/`false`/`off`, which restores the legacy single shared cwd (byte-identical to
+ * before this feature). Default-on is safe because the launch path degrades
+ * gracefully when isolation is unavailable — a non-git repo, an unborn HEAD, or a
+ * worktree-allocation error all fall back to the shared cwd (see rails-router).
+ * Read per-call so a test can flip the env without re-importing.
  */
 export function isRailWorktreesEnabled(): boolean {
   const v = (process.env.SPECRAILS_RAIL_WORKTREES ?? '').trim().toLowerCase()
-  return v === '1' || v === 'true' || v === 'on'
+  return v !== '0' && v !== 'false' && v !== 'off'
 }
 
 export interface IsolationDecisionInput {

--- a/server/rails-router.ts
+++ b/server/rails-router.ts
@@ -365,11 +365,11 @@ export function createRailsRouter(): Router {
         }
         const scope = dominantTicketScope(promptsText)
 
-        // Parallel isolation (opt-in via SPECRAILS_RAIL_WORKTREES): a per-ticket
-        // rail fanning out >1 ticket on a repo-mutating loop runs each ticket in
-        // its own git worktree, then merges the branches back. Inert by default —
-        // falls through to the shared-cwd path below unless the flag is on; a
-        // worktree-allocation failure also falls back. See rail-isolation.ts.
+        // Parallel isolation (default-on; disable with SPECRAILS_RAIL_WORKTREES=0):
+        // a per-ticket rail on a repo-mutating loop runs each ticket in its own git
+        // worktree, then merges the branches back. Degrades gracefully — a non-git
+        // repo, an unborn HEAD, or a worktree-allocation failure all fall through to
+        // the shared-cwd path below. See rail-isolation.ts.
         let isolationUnavailable: string | undefined
         if (isolationApplies({ loopsEnabled: isLoopsEnabled(), scope, ticketCount: rail.ticketIds.length, readOnly: false })) {
           // Worktree isolation needs a git repo WITH at least one commit (an


### PR DESCRIPTION
## What

Enables **parallel-rail worktree isolation by default**. `SPECRAILS_RAIL_WORKTREES` flips from an opt-in rollout flag to a **default-on kill-switch**: isolation now runs for every repo-mutating per-ticket rail unless the var is set to `0`/`false`/`off`. This matches the feature's original design intent (the archived `parallel-implementation-worktrees` change specified default-on).

## Why now

The feature is **already complete and tested end-to-end** — the opt-in gate was only a rollout precaution ("land inert, validate on a live rail, then flip"):

- **Server**: `worktree-manager`, `merge-manager`, `rail-merge-orchestrator`, `rail-worktrees-store`, `rail-isolated-launch` (allocate all-or-nothing → fan out one worktree per ticket → commit → serialized merge-back with merged/needs-review/skipped states → cleanup + `reconcileRailWorktrees` for orphans on restart).
- **Client**: `worktree-progress` accumulator + merge-back summaries in `RailRow`/`RailsBoard` + `rail.worktree_progress` handling in `DashboardPage` (toasts on needs-review), all i18n'd and tested.

## Why it's safe

Default-on degrades gracefully — `rails-router` checks `repoIsolationStatus` and a **non-git repo**, an **unborn HEAD** (no commits), or any **worktree-allocation error** all fall back to the legacy shared-cwd path. Single-writer launches (`scope: all`, standalone runs) and read-only loops never isolate. The existing `rails-router` tests pass unchanged (their non-git test projects exercise exactly this fallback).

## Changes

- `rail-isolation.ts` — `isRailWorktreesEnabled()` returns `true` unless `0`/`false`/`off` (was: `true` only for `1`/`true`/`on`).
- `rail-isolation.test.ts` — updated for the default-on semantics (unset → on; off only for the kill-switch values).
- `rails-router.ts` — comment updated to "default-on; disable with `SPECRAILS_RAIL_WORKTREES=0`".

## Rollback

Set `SPECRAILS_RAIL_WORKTREES=0` to restore the legacy shared-cwd behavior (byte-identical to before the feature).

## Gates
`typecheck` clean · **4531 tests pass** · server coverage **85.29 / 88.25 / 87.25** + **76.5** branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018g2VCCS3itXULip86xNuab
