### PR TITLE
fix: wire in-app agent MCP in packaged app (bundle bridge path)

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/javi/repos/specrails-desktop/node_modules

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -519,6 +519,37 @@ pub fn run() {
                 sidecar
             };
 
+            // Resolve the bundled specrails-mcp stdio bridge from Tauri's resource
+            // directory (mirrors the blocks above). Without this env the sidecar's
+            // resolveBridgeScript() falls back to a repo-relative climb
+            // (src-tauri/binaries/specrails-mcp.js) that only exists in dev — in the
+            // packaged .app it returns null, so the in-app agent chat spawns WITHOUT
+            // --mcp-config and can't see any specrails_* tools. The bridge JS is
+            // declared as `binaries/specrails-mcp.js` in tauri.conf.json.
+            //   On macOS:   <app>.app/Contents/Resources/binaries/specrails-mcp.js
+            //   On Windows: <install-dir>/resources/binaries/specrails-mcp.js
+            let mcp_bridge_path = app_handle
+                .path()
+                .resource_dir()
+                .ok()
+                .map(|p| {
+                    p.join("binaries")
+                        .join("specrails-mcp.js")
+                        .to_string_lossy()
+                        .into_owned()
+                })
+                .unwrap_or_default();
+
+            // EXISTENCE-GATE exactly like the bundled core/openspec: only export the
+            // env when the bridge JS actually exists on disk, so a build that somehow
+            // shipped without it falls back to the relative climb rather than pointing
+            // the server at a non-existent file.
+            let sidecar = if std::path::Path::new(&mcp_bridge_path).exists() {
+                sidecar.env("SPECRAILS_BUNDLED_MCP_BRIDGE_PATH", &mcp_bridge_path)
+            } else {
+                sidecar
+            };
+
             // On macOS, GUI apps launched from Finder/Dock inherit a minimal PATH
             // from launchd that omits user tool dirs (homebrew, cargo, bun,
             // ~/.local/bin). We rebuild PATH from a zsh login shell and prepend


### PR DESCRIPTION
## Problem

Installing the packaged app on a fresh machine, the in-app agent chat reported no `specrails_*` tools — only the user's claude.ai account connectors (Atlassian/OneTrust) were visible. Worked in dev, failed in the packaged `.app`.

## Root cause

The Tauri host (`src-tauri/src/lib.rs`) exports `SPECRAILS_BUNDLED_{RUNTIMES,CORE,OPENSPEC,DOCS}_PATH` but **never** `SPECRAILS_BUNDLED_MCP_BRIDGE_PATH`. The bridge JS *is* bundled (`binaries/specrails-mcp.js` in `tauri.conf.json` resources), but the server never learned where it landed.

`resolveBridgeScript()` (`server/agent-mcp-config.ts`) tries the env var first, then falls back to a repo-relative climb (`src-tauri/binaries/specrails-mcp.js`). That relative path only exists in a dev checkout — in the packaged app it resolves to `null`, so `buildAgentMcpArgs()` returns `[]`, the agent spawns without `--mcp-config`, and it sees zero specrails tools.

## Fix

Export `SPECRAILS_BUNDLED_MCP_BRIDGE_PATH = <resource_dir>/binaries/specrails-mcp.js`, existence-gated exactly like the bundled core/openspec/docs blocks. The server already reads this env first, so the in-app agent gets its MCP wired **by default, zero config**.

## Verification

- Rust edit mirrors the existing bundled-path blocks (same `resource_dir().map()` + `Path::exists()` + `sidecar.env()` shape).
- Full validation requires a packaged build (`npm run build:desktop:local`) and install on a fresh machine — this is host-side Rust, outside the vitest harness.

## Follow-ups (not in this PR)

- The `resolveBridgeScript()` null fallback is silent (agent degrades to tool-less with no log). A startup `[mcp] bridge not found` warning would make future regressions visible instead of mute.
- The external-client path (`/api/mcp-admin/config` → `bridgeCommand: 'specrails-mcp'`) still hands out a bare command name that isn't on PATH. Separate surface from the in-app agent; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)