### PR TITLE
fix: in-app agent MCP truly zero-config (recover lost toggle-bypass + rebuild bridge)

### DIFF
--- a/server/mcp/mcp-server.test.ts
+++ b/server/mcp/mcp-server.test.ts
@@ -66,6 +66,22 @@ describe('McpServerManager (embedded MCP server)', () => {
     expect(res.status).toBe(404)
   })
 
+  it('serves the first-party in-app agent (agent-tier header) even when the toggle is disabled', async () => {
+    expect(manager.isEnabledSetting()).toBe(false)
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+        'x-specrails-agent-tier': 'observe',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1, params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 't', version: '1' } } }),
+    })
+    // Not the 404 the toggle would otherwise produce — the initialize is handled.
+    expect(res.status).not.toBe(404)
+    expect(res.headers.get('mcp-session-id')).toBeTruthy()
+  })
+
   it('initializes and lists the tool catalog when enabled', async () => {
     setDesktopSetting(db, 'mcp_enabled', 'true')
     const client = await connectClient(url)

--- a/server/mcp/mcp-server.ts
+++ b/server/mcp/mcp-server.ts
@@ -7,6 +7,7 @@ import type { ProjectRegistry } from '../project-registry'
 import type { WsMessage } from '../types'
 import { getMobileEventBus, type MobileEventBus } from '../mobile/mobile-event-bus'
 import { isMcpEnabled, MCP_ENABLED_KEY } from './mcp-tiers'
+import { AGENT_TIER_HEADER } from '../agent-tier'
 import { setDesktopSetting } from '../desktop-db'
 import { buildToolSpecs } from './tools/catalog'
 import { registerTieredTool, type McpToolContext } from './tools/types'
@@ -114,7 +115,17 @@ export class McpServerManager {
    * carry the `mcp-session-id` header.
    */
   async handleHttp(req: Request, res: Response): Promise<void> {
-    if (!this.isEnabledSetting()) {
+    // The external Settings ▸ MCP toggle gates THIRD-PARTY clients only. The
+    // in-app agent chat is first-party: it reaches this loopback endpoint through
+    // the bundled bridge, which always forwards the `x-specrails-agent-tier`
+    // header. Serving that request regardless of the toggle means the in-app
+    // agent gets its MCP by default with zero config on a fresh install (the
+    // toggle defaults OFF). Third-party clients (no agent-tier header) still get
+    // 404 until the user explicitly opts in. Both paths already sit behind
+    // requireLoopback + requireMcpAuth (scoped token), so this is not an auth
+    // relaxation — only the enable-toggle is bypassed for the first-party agent.
+    const isFirstPartyAgent = Boolean(req.headers[AGENT_TIER_HEADER])
+    if (!this.isEnabledSetting() && !isFirstPartyAgent) {
       res.status(404).json(jsonRpcError('MCP is disabled. Enable it in the Specrails app under Settings ▸ MCP.', -32004))
       return
     }

--- a/src-tauri/binaries/specrails-mcp.js
+++ b/src-tauri/binaries/specrails-mcp.js
@@ -7034,6 +7034,10 @@ function connectBridge(clientFacing, appFacing) {
 async function main() {
   const token = readMcpToken();
   const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  const agentTier = process.env.SPECRAILS_AGENT_TIER;
+  if (agentTier && agentTier.trim()) headers["x-specrails-agent-tier"] = agentTier.trim();
+  const activeProject = process.env.SPECRAILS_ACTIVE_PROJECT;
+  if (activeProject && activeProject.trim()) headers["x-specrails-active-project"] = activeProject.trim();
   const appFacing = new StreamableHTTPClientTransport(appUrl(), { requestInit: { headers } });
   const clientFacing = new StdioServerTransport();
   connectBridge(clientFacing, appFacing);


### PR DESCRIPTION
## Why

PR #472 was squash-merged while its branch only had the **bridge-path** commit; the follow-up **toggle-bypass** commit was pushed afterwards and never landed. So `main` (and release v2.18.1) is missing the piece that actually makes the in-app agent zero-config, plus the tracked bridge artifact drifted from source. This PR recovers both.

## What's in `main` already
- `SPECRAILS_BUNDLED_MCP_BRIDGE_PATH` exported by the Tauri host (`lib.rs`) — the packaged `.app` can now *find* the bundled bridge. ✅

## What was missing (this PR)

1. **`server/mcp/mcp-server.ts` — first-party toggle bypass.** The `Settings ▸ MCP` toggle defaults OFF and is meant to gate THIRD-PARTY clients. The in-app agent reaches the same loopback `/api/mcp` through the bundled bridge, so with the toggle off it got a 404 and saw zero `specrails_*` tools on a fresh install. `handleHttp` now serves a request carrying the loopback-only `x-specrails-agent-tier` header (which only the first-party agent sends) even when the toggle is off; third-party clients still get 404 until the user opts in. Both paths remain behind `requireLoopback` + `requireMcpAuth` — only the enable-toggle is bypassed, not auth.

2. **`server/mcp/mcp-server.test.ts`** — test for the first-party path (disabled toggle + agent-tier header → served).

3. **`src-tauri/binaries/specrails-mcp.js`** — rebuilt. The tracked artifact was stale vs `mcp-bridge/src/index.ts`: it didn't forward `x-specrails-agent-tier` / `x-specrails-active-project`. Without those headers the bypass in (1) can't fire. CI rebuilds the bridge before `tauri build` so shipped DMGs weren't affected, but the repo artifact drifted.

## Net effect

Fresh install, toggle OFF → the in-app agent gets its MCP wired **by default, zero config**. Verified locally (packaged build) end-to-end.

## Verification
- `vitest server/mcp/mcp-server.test.ts` → 9/9
- `tsc --noEmit` (server) → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)