### PR TITLE
feat: Mission Control suite — message queue, background missions, jobs pane, git bar

### DIFF
--- a/client/src/components/ArcSidebar.tsx
+++ b/client/src/components/ArcSidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useRef } from 'react'
+import { useState, useEffect, useMemo, useRef, lazy, Suspense } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { PanelLeft, FolderOpen, Plus, BarChart2, BookOpen, Settings, X, Workflow, ChevronRight, ChevronDown, MessageSquare, Bot, LayoutGrid, Search, Home } from 'lucide-react'
@@ -10,6 +10,10 @@ import { useUiMode } from '../context/UiModeContext'
 import { useAgentChat } from '../context/AgentChatContext'
 import type { AgentConversation } from '../lib/agent-api'
 import { FEATURE_LOOPS_SECTION, FEATURE_AGENT_MODE } from '../lib/feature-flags'
+
+const ProjectSettingsDialog = lazy(() =>
+  import('./settings/ProjectSettingsDialog').then((m) => ({ default: m.ProjectSettingsDialog })),
+)
 
 const TREE_EXPAND_KEY = 'specrails-desktop:agentTreeExpanded'
 
@@ -182,9 +186,10 @@ function ProjectItem({
   onToggleTree,
   conversations = [],
   activeConversationId = null,
-  streamingConversationId = null,
+  streamingConversationIds,
   onSelectConversation,
   onDeleteConversation,
+  onOpenProjectSettings,
 }: {
   project: DesktopProject
   isActive: boolean
@@ -197,9 +202,13 @@ function ProjectItem({
   onToggleTree?: () => void
   conversations?: AgentConversation[]
   activeConversationId?: string | null
-  streamingConversationId?: string | null
+  /** Ids of EVERY conversation with a live agent turn — background threads keep
+   *  their title shimmer, not just the focused one. */
+  streamingConversationIds?: ReadonlySet<string>
   onSelectConversation?: (id: string) => void
   onDeleteConversation?: (id: string) => void
+  /** Hover gear (Agent Mode): open this project's settings modal. */
+  onOpenProjectSettings?: () => void
 }) {
   const { t } = useTranslation('nav')
   const [confirming, setConfirming] = useState(false)
@@ -274,6 +283,20 @@ function ProjectItem({
         {expanded && (
           <>
             <span className="text-xs truncate flex-1 text-left">{project.name}</span>
+            {onOpenProjectSettings && (
+              <button
+                type="button"
+                onClick={(e) => { e.stopPropagation(); onOpenProjectSettings() }}
+                className={cn(
+                  'flex-shrink-0 flex items-center justify-center rounded-sm transition-all w-3.5 h-3.5',
+                  'opacity-0 group-hover:opacity-50 hover:!opacity-100 hover:bg-muted',
+                )}
+                aria-label={t('projects.settings', { name: project.name })}
+                title={t('projects.settings', { name: project.name })}
+              >
+                <Settings className="w-2.5 h-2.5" />
+              </button>
+            )}
             <button
               type="button"
               onClick={handleRemoveClick}
@@ -298,7 +321,7 @@ function ProjectItem({
               key={c.id}
               conversation={c}
               active={c.id === activeConversationId}
-              streaming={c.id === streamingConversationId}
+              streaming={streamingConversationIds?.has(c.id) ?? false}
               expanded={expanded}
               onSelect={() => onSelectConversation?.(c.id)}
               onDelete={() => onDeleteConversation?.(c.id)}
@@ -353,6 +376,8 @@ export function ArcSidebar({
   const homeConversations = grouped.get(HOME_KEY) ?? []
 
   const [expandedTree, setExpandedTree] = useState<Set<string>>(loadExpanded)
+  // Per-project settings modal (Agent Mode hover gear on a project folder).
+  const [projectSettingsOpen, setProjectSettingsOpen] = useState(false)
   // Default-expand the active project the first time we enter Agent Mode.
   useEffect(() => {
     if (!agentMode || !activeProjectId) return
@@ -440,7 +465,9 @@ export function ArcSidebar({
       className={cn(
         'relative flex flex-col h-full border-r border-border bg-background flex-shrink-0',
         'transition-all duration-200 ease-in-out overflow-hidden',
-        expanded ? 'w-52' : 'w-11'
+        // w-60: wide enough for the localized mode-toggle labels ("Cambiar a
+        // Control de misiones") without clipping.
+        expanded ? 'w-60' : 'w-11'
       )}
       onMouseEnter={() => { if (leftMode === 'unpinned') setHovered(true) }}
       onMouseLeave={() => { if (leftMode === 'unpinned') setHovered(false) }}
@@ -505,13 +532,13 @@ export function ArcSidebar({
               expanded ? 'px-2' : 'px-0 justify-center',
             )}
             aria-label={agentMode ? tAgent('switchToKanban') : tAgent('switchToAgent')}
-            title={!expanded ? (agentMode ? tAgent('switchToKanban') : tAgent('switchToAgent')) : undefined}
+            title={agentMode ? tAgent('switchToKanban') : tAgent('switchToAgent')}
           >
             {agentMode
               ? <LayoutGrid className="w-4 h-4 flex-shrink-0" />
               : <Bot className="w-4 h-4 flex-shrink-0 text-accent-primary" />}
             {expanded && (
-              <span className="text-xs whitespace-nowrap">
+              <span className="min-w-0 truncate text-xs">
                 {agentMode ? tAgent('switchToKanban') : tAgent('switchToAgent')}
               </span>
             )}
@@ -590,7 +617,7 @@ export function ArcSidebar({
                     key={c.id}
                     conversation={c}
                     active={c.id === agentChat.active?.id}
-                    streaming={agentChat.isStreaming && c.id === agentChat.active?.id}
+                    streaming={agentChat.streamingConversationIds.has(c.id)}
                     expanded={expanded}
                     onSelect={() => handleSelectConversation(c.id)}
                     onDelete={() => handleDeleteConversation(c.id)}
@@ -616,9 +643,16 @@ export function ArcSidebar({
               onToggleTree={() => toggleTree(project.id)}
               conversations={convs}
               activeConversationId={agentChat.active?.id ?? null}
-              streamingConversationId={agentChat.isStreaming ? agentChat.active?.id ?? null : null}
+              streamingConversationIds={agentChat.streamingConversationIds}
               onSelectConversation={handleSelectConversation}
               onDeleteConversation={handleDeleteConversation}
+              onOpenProjectSettings={agentMode ? () => {
+                // The settings sections talk to the ACTIVE project's API base —
+                // opening a project's settings selects it first (same semantics
+                // as clicking the folder).
+                setActiveProjectId(project.id)
+                setProjectSettingsOpen(true)
+              } : undefined}
             />
           )
         })}
@@ -660,6 +694,12 @@ export function ArcSidebar({
           </button>
         ))}
       </div>
+
+      {projectSettingsOpen && (
+        <Suspense fallback={null}>
+          <ProjectSettingsDialog open onClose={() => setProjectSettingsOpen(false)} />
+        </Suspense>
+      )}
     </div>
   )
 }

--- a/client/src/components/JobDetailModal.tsx
+++ b/client/src/components/JobDetailModal.tsx
@@ -7,7 +7,7 @@ import { toast } from 'sonner'
 import { X, ExternalLink } from 'lucide-react'
 import { Badge } from './ui/badge'
 import { Button } from './ui/button'
-import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip'
+import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from './ui/tooltip'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogDescription } from './ui/dialog'
 import { PipelineProgress } from './PipelineProgress'
 import { LogViewer } from './LogViewer'
@@ -177,6 +177,10 @@ export function JobDetailModal({ jobId, onClose }: JobDetailModalProps) {
   const { panelRef, panelStyle, headerHandleProps, resizeHandles, isFloating, guardBackdrop } = useMovableResizableModal()
 
   return (
+    // Own TooltipProvider: this modal mounts from trees WITHOUT one (the
+    // Agent-Mode surface bypasses ProjectLayout) — without it Radix throws and
+    // blanks the whole app on open.
+    <TooltipProvider delayDuration={400}>
     <div className="fixed inset-0 z-50 flex items-stretch justify-center">
       {/* Backdrop */}
       <div
@@ -301,5 +305,6 @@ export function JobDetailModal({ jobId, onClose }: JobDetailModalProps) {
         </DialogContent>
       </Dialog>
     </div>
+    </TooltipProvider>
   )
 }

--- a/client/src/components/__tests__/ArcSidebarAgentConversations.test.tsx
+++ b/client/src/components/__tests__/ArcSidebarAgentConversations.test.tsx
@@ -9,11 +9,12 @@ const mockProjects: DesktopProject[] = [
   { id: 'proj-1', slug: 'proj-1', name: 'Project Alpha', path: '/alpha', db_path: '/alpha/.db', added_at: '', last_seen_at: '' },
 ]
 
+const mockSetActiveProjectId = vi.fn()
 vi.mock('../../hooks/useDesktop', () => ({
   useDesktop: () => ({
     projects: mockProjects,
     activeProjectId: 'proj-1',
-    setActiveProjectId: vi.fn(),
+    setActiveProjectId: mockSetActiveProjectId,
     removeProject: vi.fn(),
     isLoading: false,
     setupProjectIds: new Set(),
@@ -21,6 +22,11 @@ vi.mock('../../hooks/useDesktop', () => ({
     completeSetupWizard: vi.fn(),
     addProject: vi.fn(),
   }),
+}))
+
+vi.mock('../settings/ProjectSettingsDialog', () => ({
+  ProjectSettingsDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="project-settings-dialog" /> : null,
 }))
 
 vi.mock('../../context/UiModeContext', () => ({
@@ -38,16 +44,17 @@ const mockDeleteConversation = vi.fn(() => Promise.resolve())
 const mockSelectConversation = vi.fn(() => Promise.resolve())
 
 // Mutable so individual tests can activate a conversation / streaming state.
-const agentChatState: { active: AgentConversation | null; isStreaming: boolean } = {
+const agentChatState: { active: AgentConversation | null; streamingIds: Set<string> } = {
   active: null,
-  isStreaming: false,
+  streamingIds: new Set(),
 }
 
 vi.mock('../../context/AgentChatContext', () => ({
   useAgentChat: () => ({
     conversations: [conv('c-1', 'Fix the build', 'proj-1'), conv('c-2', null, null)],
     active: agentChatState.active,
-    isStreaming: agentChatState.isStreaming,
+    isStreaming: agentChatState.active ? agentChatState.streamingIds.has(agentChatState.active.id) : false,
+    streamingConversationIds: agentChatState.streamingIds,
     selectConversation: mockSelectConversation,
     deleteConversation: mockDeleteConversation,
     startNewConversation: vi.fn(),
@@ -72,7 +79,7 @@ beforeEach(() => {
   window.localStorage.clear()
   vi.clearAllMocks()
   agentChatState.active = null
-  agentChatState.isStreaming = false
+  agentChatState.streamingIds = new Set()
 })
 
 describe('ArcSidebar agent-mode conversation rows', () => {
@@ -134,7 +141,7 @@ describe('ArcSidebar agent-mode conversation rows', () => {
 
   it('sweeps the title shimmer while the active conversation streams', () => {
     agentChatState.active = conv('c-1', 'Fix the build', 'proj-1')
-    agentChatState.isStreaming = true
+    agentChatState.streamingIds = new Set(['c-1'])
     renderExpanded()
     const overlay = document.querySelector('.title-shimmer')
     expect(overlay).toBeInTheDocument()
@@ -142,9 +149,30 @@ describe('ArcSidebar agent-mode conversation rows', () => {
     expect(overlay?.className).toContain('opacity-100')
   })
 
+  it('keeps the shimmer on a BACKGROUND conversation that is still streaming', () => {
+    // Focus moved to c-2 (Home) while c-1's agent keeps working — the c-1 row
+    // must keep its luminous working cue.
+    agentChatState.active = conv('c-2', null, null)
+    agentChatState.streamingIds = new Set(['c-1'])
+    renderExpanded()
+    const overlay = document.querySelector('.title-shimmer')
+    expect(overlay).toBeInTheDocument()
+    expect(overlay?.textContent).toBe('Fix the build')
+    expect(overlay?.className).toContain('opacity-100')
+  })
+
+  it('hover gear opens the project settings modal and selects the project', async () => {
+    renderExpanded()
+    fireEvent.click(screen.getByRole('button', { name: 'Settings for Project Alpha' }))
+    expect(mockSetActiveProjectId).toHaveBeenCalledWith('proj-1')
+    expect(await screen.findByTestId('project-settings-dialog')).toBeInTheDocument()
+    // The gear never selects the row itself.
+    expect(mockSelectConversation).not.toHaveBeenCalled()
+  })
+
   it('no shimmer overlay when idle', () => {
     agentChatState.active = conv('c-1', 'Fix the build', 'proj-1')
-    agentChatState.isStreaming = false
+    agentChatState.streamingIds = new Set()
     renderExpanded()
     expect(document.querySelector('.title-shimmer')).not.toBeInTheDocument()
   })

--- a/client/src/components/__tests__/JobDetailModal.test.tsx
+++ b/client/src/components/__tests__/JobDetailModal.test.tsx
@@ -91,6 +91,17 @@ describe('JobDetailModal', () => {
     })
   })
 
+  it('mounts WITHOUT an ancestor TooltipProvider (Agent-Mode jobs pane)', async () => {
+    // Regression: opening the modal from the Agent-Mode surface (a tree with no
+    // ProjectLayout TooltipProvider) crashed Radix Tooltip and blanked the app.
+    // test-utils wraps providers, so this renders BARE on purpose.
+    const { render: bareRender, screen: bareScreen, waitFor: bareWaitFor } = await import('@testing-library/react')
+    bareRender(<JobDetailModal jobId="job-abc123" onClose={onClose} />)
+    await bareWaitFor(() => {
+      expect(bareScreen.getByText('/specrails:implement --spec SPEA-001')).toBeInTheDocument()
+    })
+  })
+
   it('renders status badge for completed job', async () => {
     render(<JobDetailModal jobId="job-abc123" onClose={onClose} />)
     await waitFor(() => {

--- a/client/src/components/agent-chat/AgentComposer.tsx
+++ b/client/src/components/agent-chat/AgentComposer.tsx
@@ -1,15 +1,28 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
-import { SendHorizontal, History, Square, Paperclip, X } from 'lucide-react'
+import { SendHorizontal, History, Square, Paperclip, X, Clock } from 'lucide-react'
 import { useAgentChat } from '../../context/AgentChatContext'
 import { useAgentWorkspace } from '../../context/AgentWorkspaceContext'
 import { uploadAgentAttachment, deleteAgentAttachment, getAgentModels, type AgentAttachment } from '../../lib/agent-api'
 import { AgentProjectSelector } from './AgentProjectSelector'
 import { AgentTierChip } from './AgentTierChip'
 import { AgentModelSelector } from './AgentModelSelector'
+import { AgentGitBar } from './AgentGitBar'
 
 const PROVIDERS = ['claude', 'codex', 'gemini'] as const
+
+// Session-scoped composer drafts (design D15 — context/session state, never the
+// URL): the Mission⇄Board mode switch UNMOUNTS the composer, so a typed-but-
+// unsent prompt must survive outside component state. Keyed per conversation;
+// the EMPTY "new mission" compose screen shares one draft slot.
+const composerDrafts = new Map<string, string>()
+const NEW_MISSION_DRAFT_KEY = '__new-mission__'
+
+/** Test-only: reset the session draft store between cases. */
+export function __clearComposerDrafts(): void {
+  composerDrafts.clear()
+}
 
 /**
  * Shared agent composer — controls row (project · provider · model · tier),
@@ -35,7 +48,15 @@ export function AgentComposer({
     send, abort, cycleTier, setProvider, setModel, setPinnedProject,
   } = useAgentChat()
   const { pendingCaptures, consumePendingCaptures } = useAgentWorkspace()
-  const [input, setInput] = useState('')
+  const draftKey = active?.id ?? NEW_MISSION_DRAFT_KEY
+  const [input, setInputState] = useState(() => composerDrafts.get(draftKey) ?? '')
+  // Every keystroke mirrors into the session draft store so an unmount
+  // (mode switch, panel close) never loses a typed-but-unsent prompt.
+  const setInput = (v: string): void => {
+    setInputState(v)
+    if (v) composerDrafts.set(draftKey, v)
+    else composerDrafts.delete(draftKey)
+  }
   const [histIndex, setHistIndex] = useState<number | null>(null)
   const [attached, setAttached] = useState<AgentAttachment[]>([])
   const [uploading, setUploading] = useState(false)
@@ -50,6 +71,9 @@ export function AgentComposer({
   // once a conversation exists (EMPTY state has none — send once to create it).
   const canAttach = !!active && !blocked
   const provider = active?.provider ?? draftProvider
+  // The git strip follows the MISSION's pinned project (or the draft pin on the
+  // EMPTY compose screen) — never the app's active project.
+  const gitProjectId = active ? active.pinned_project_id : draftPinnedProjectId
 
   const activeId = active?.id ?? null
   // The composer survives conversation switches (no key/remount): pending chips
@@ -58,6 +82,8 @@ export function AgentComposer({
   useEffect(() => {
     setAttached([])
     setHistIndex(null)
+    // Restore the target conversation's own unsent draft (or the new-mission one).
+    setInputState(composerDrafts.get(activeId ?? NEW_MISSION_DRAFT_KEY) ?? '')
   }, [activeId])
 
   // Browser captures land as already-uploaded agent attachments — adopt them as
@@ -127,6 +153,16 @@ export function AgentComposer({
     setInput(history[i])
   }
   const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // Shift+Tab cycles the tier ladder from INSIDE the textarea too. Handled
+    // here (not only on the conversation-view wrapper) because the EMPTY
+    // compose card renders the composer without that wrapper — there the
+    // browser default (focus previous element) was winning on macOS.
+    if (e.key === 'Tab' && e.shiftKey) {
+      e.preventDefault()
+      e.stopPropagation() // the view wrapper also listens — don't cycle twice
+      void cycleTier()
+      return
+    }
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
       submit()
@@ -158,7 +194,10 @@ export function AgentComposer({
 
   return (
     <div className="shrink-0">
-      <div className="mb-2 flex items-center gap-2">
+      {/* flex-wrap: with a workspace pane (Jobs/Code) narrowing the center
+          column, the tier chip must wrap under the selectors instead of
+          overflowing the composer card. */}
+      <div className="mb-2 flex flex-wrap items-center gap-2">
         {/* The project pin is chosen while composing a NEW conversation (EMPTY
             state); once a conversation exists the pin is fixed here. The Kanban
             floating panel hides this copy — its header carries the selector. */}
@@ -272,14 +311,17 @@ export function AgentComposer({
           }}
           rows={2}
           disabled={blocked}
-          placeholder={blocked ? t('noProvider.placeholder') : t('composerPlaceholder')}
+          placeholder={blocked ? t('noProvider.placeholder') : isStreaming ? t('queue.placeholder') : t('composerPlaceholder')}
           data-agent-interactive
           title={inHistory ? t('history.hint') : undefined}
           className={`min-h-[3.25rem] max-h-64 flex-1 resize-y bg-transparent text-sm outline-none placeholder:text-foreground/40 disabled:opacity-60 ${
             inHistory ? 'italic text-foreground/50' : 'text-foreground'
           }`}
         />
-        {isStreaming ? (
+        {/* Tri-state action: idle → send; streaming + empty box → red stop;
+            streaming + text → "send to queue" (the agent keeps working, the
+            message parks behind the in-flight turn). */}
+        {isStreaming && !input.trim() ? (
           <button
             type="button"
             onClick={() => void abort()}
@@ -288,6 +330,20 @@ export function AgentComposer({
             className="rounded-lg bg-destructive p-1.5 text-white transition-colors hover:opacity-90"
           >
             <Square className="h-4 w-4" fill="currentColor" />
+          </button>
+        ) : isStreaming ? (
+          <button
+            type="button"
+            onClick={submit}
+            disabled={blocked}
+            aria-label={t('queue.send')}
+            title={t('queue.sendHint')}
+            className="relative rounded-lg bg-accent-info p-1.5 text-white transition-colors hover:opacity-90"
+          >
+            <SendHorizontal className="h-4 w-4" />
+            <span className="absolute -right-1 -top-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-background ring-1 ring-border">
+              <Clock className="h-2.5 w-2.5 text-accent-info" />
+            </span>
           </button>
         ) : (
           <button
@@ -301,6 +357,9 @@ export function AgentComposer({
           </button>
         )}
       </div>
+      {/* Git strip: current branch (switchable) + last commit of the mission's
+          pinned project. Hidden without a project or outside a git repo. */}
+      {gitProjectId && <AgentGitBar projectId={gitProjectId} />}
     </div>
   )
 }

--- a/client/src/components/agent-chat/AgentConversationView.tsx
+++ b/client/src/components/agent-chat/AgentConversationView.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { motion } from 'motion/react'
-import { Bot, ShieldAlert, PackageOpen } from 'lucide-react'
+import { Bot, ShieldAlert, PackageOpen, Clock } from 'lucide-react'
 import { useAgentChat } from '../../context/AgentChatContext'
 import { useActiveTheme } from '../../context/ThemeContext'
 import { useSmoothStream } from '../explore-spec/useSmoothStream'
@@ -18,7 +18,7 @@ import { AgentComposer } from './AgentComposer'
 export function AgentConversationView({ variant }: { variant: 'floating' | 'inline' }) {
   const { t } = useTranslation('agent')
   const {
-    messages, streamingText, isStreaming, liveTools,
+    messages, streamingText, isStreaming, liveTools, queuedMessages,
     mcpEnabled, enablingMcp, enableMcpServer, providersReady, cycleTier, send,
   } = useAgentChat()
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -36,7 +36,7 @@ export function AgentConversationView({ variant }: { variant: 'floating' | 'inli
   useEffect(() => {
     if (!pinnedRef.current) return
     scrollRef.current?.scrollTo?.({ top: scrollRef.current.scrollHeight, behavior: 'auto' })
-  }, [messages.length, smoothed, liveTools.length])
+  }, [messages.length, smoothed, liveTools.length, queuedMessages.length])
 
   // Shift+Tab anywhere in the view (incl. the composer) cycles the tier ladder.
   const onKeyDown = (e: React.KeyboardEvent) => {
@@ -108,6 +108,23 @@ export function AgentConversationView({ variant }: { variant: 'floating' | 'inli
             <div className="space-y-2">
               {smoothed && <AgentMessage role="assistant" content={smoothed} streaming />}
               <AgentActivityChip tool={liveTools.length ? liveTools[liveTools.length - 1].tool : null} />
+            </div>
+          )}
+          {/* Messages parked behind the in-flight turn — dimmed user-style chips
+              pinned below the stream; each becomes a real bubble on dequeue. */}
+          {queuedMessages.length > 0 && (
+            <div className="space-y-2" data-testid="agent-queued-messages">
+              {queuedMessages.map((q) => (
+                <div key={q.queueId} className="flex justify-end">
+                  <div className="max-w-[85%] whitespace-pre-wrap rounded-2xl rounded-br-sm border border-dashed border-border/70 bg-foreground/[0.03] px-3.5 py-2 text-sm text-foreground/60">
+                    <span className="mb-0.5 flex items-center justify-end gap-1 text-[10px] font-medium uppercase tracking-wide text-foreground/45">
+                      <Clock className="h-3 w-3" />
+                      {t('queue.queued')}
+                    </span>
+                    {q.text}
+                  </div>
+                </div>
+              ))}
             </div>
           )}
         </motion.div>

--- a/client/src/components/agent-chat/AgentGitBar.tsx
+++ b/client/src/components/agent-chat/AgentGitBar.tsx
@@ -1,0 +1,248 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import { motion, AnimatePresence } from 'motion/react'
+import { GitBranch, ChevronDown, Check, Search, Loader2, FolderGit2, Copy } from 'lucide-react'
+import { API_ORIGIN } from '../../lib/origin'
+import { useAgentChat } from '../../context/AgentChatContext'
+
+interface GitWorktree {
+  path: string
+  branch: string | null
+  head: string
+  isMain: boolean
+}
+
+interface GitInfo {
+  git: boolean
+  branch: string | null
+  detached: boolean
+  dirty: boolean
+  branches: string[]
+  lastCommit: { hash: string; subject: string; at: string } | null
+  worktrees?: GitWorktree[]
+}
+
+/**
+ * Git strip under the composer: current branch (a THEMED dropdown — picking
+ * another LOCAL branch checks it out in the project repo) + the last commit
+ * subject. Styled with semantic tokens (never the native OS select) so every
+ * theme restyles it. Hidden when the pinned project is not a git repo.
+ * Refreshes when the mission's turn settles (the agent itself may have
+ * switched branches or committed).
+ */
+export function AgentGitBar({ projectId }: { projectId: string }) {
+  const { t } = useTranslation('agent')
+  const { isStreaming } = useAgentChat()
+  const [info, setInfo] = useState<GitInfo | null>(null)
+  const [switching, setSwitching] = useState(false)
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const rootRef = useRef<HTMLDivElement>(null)
+  const base = `${API_ORIGIN}/api/projects/${projectId}/git`
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch(base)
+      if (!res.ok) return
+      setInfo(await res.json() as GitInfo)
+    } catch {
+      /* transient — keep last known */
+    }
+  }, [base])
+
+  useEffect(() => {
+    setInfo(null)
+    void refresh()
+  }, [refresh])
+
+  // Turn settled → the agent may have committed or switched branches.
+  const prevStreamingRef = useRef(isStreaming)
+  useEffect(() => {
+    if (prevStreamingRef.current && !isStreaming) void refresh()
+    prevStreamingRef.current = isStreaming
+  }, [isStreaming, refresh])
+
+  // Click-away closes the dropdown (same pattern as AgentProjectSelector).
+  useEffect(() => {
+    if (!open) return
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', onDown)
+    return () => document.removeEventListener('mousedown', onDown)
+  }, [open])
+
+  const checkout = useCallback(async (branch: string) => {
+    setOpen(false)
+    setQuery('')
+    if (!branch || branch === info?.branch) return
+    setSwitching(true)
+    try {
+      const res = await fetch(`${base}/checkout`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ branch }),
+      })
+      const data = await res.json().catch(() => ({})) as GitInfo & { error?: string }
+      if (!res.ok) {
+        // git refused (dirty tree, unknown branch, …) and touched NOTHING —
+        // surface its exact reason and re-sync the strip with the real state.
+        toast.error(t('git.switchFailed'), { description: data.error })
+        void refresh()
+        return
+      }
+      setInfo(data)
+      toast.success(t('git.switched', { branch }))
+    } catch {
+      toast.error(t('git.switchFailed'))
+      void refresh()
+    } finally {
+      setSwitching(false)
+    }
+  }, [base, info?.branch, t, refresh])
+
+  const filtered = useMemo(() => {
+    if (!info) return []
+    const q = query.trim().toLowerCase()
+    return q ? info.branches.filter((b) => b.toLowerCase().includes(q)) : info.branches
+  }, [info, query])
+
+  if (!info?.git) return null
+
+  const disabled = switching || isStreaming
+  const currentLabel = info.detached ? t('git.detached') : info.branch ?? t('git.detached')
+  // Branches living in a LINKED worktree (rails create them for parallel
+  // implementation) can't be checked out here — git refuses "already checked
+  // out at <path>". They render grouped with their path and copy it on click.
+  const worktreeByBranch = new Map(
+    (info.worktrees ?? []).filter((w) => !w.isMain && w.branch).map((w) => [w.branch as string, w]),
+  )
+  const switchable = filtered.filter((b) => !worktreeByBranch.has(b))
+  const inWorktrees = filtered.filter((b) => worktreeByBranch.has(b))
+
+  const copyWorktreePath = async (w: GitWorktree) => {
+    setOpen(false)
+    setQuery('')
+    try {
+      await navigator.clipboard.writeText(w.path)
+      toast.success(t('git.worktreePathCopied'), { description: w.path })
+    } catch {
+      // Clipboard unavailable (permissions) — still show WHERE it lives.
+      toast.info?.(w.path)
+    }
+  }
+
+  return (
+    <div ref={rootRef} className="relative mt-1.5 flex min-w-0 items-center gap-2 px-1 text-[11px] text-foreground/50" data-agent-interactive>
+      <button
+        type="button"
+        onClick={() => { if (!disabled) setOpen((o) => !o) }}
+        disabled={disabled}
+        aria-label={t('git.branch')}
+        aria-expanded={open}
+        title={disabled && isStreaming ? t('git.lockedWhileWorking') : t('git.branch')}
+        className="flex max-w-[220px] shrink-0 items-center gap-1.5 rounded-md border border-border/50 bg-surface/60 px-1.5 py-0.5 text-[11px] text-foreground transition-colors hover:bg-surface disabled:opacity-50"
+      >
+        {switching
+          ? <Loader2 className="h-3 w-3 shrink-0 animate-spin text-accent-primary/70" />
+          : <GitBranch className="h-3 w-3 shrink-0 text-accent-primary/70" />}
+        <span className="min-w-0 truncate">{currentLabel}</span>
+        <ChevronDown className="h-3 w-3 shrink-0 text-foreground/40" />
+      </button>
+
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            initial={{ opacity: 0, y: 6, scale: 0.98 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 6, scale: 0.98 }}
+            transition={{ duration: 0.16, ease: 'easeOut' }}
+            // Anchored ABOVE the trigger — the composer hugs the bottom edge.
+            className="absolute bottom-full left-0 z-20 mb-1 w-72 overflow-hidden rounded-xl border border-border/60 bg-card/95 shadow-2xl backdrop-blur-xl"
+          >
+            <div className="flex items-center gap-2 border-b border-border/50 px-3 py-2">
+              <Search className="h-3.5 w-3.5 text-foreground/40" />
+              <input
+                autoFocus
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder={t('git.searchPlaceholder')}
+                aria-label={t('git.searchPlaceholder')}
+                className="w-full bg-transparent text-sm text-foreground outline-none placeholder:text-foreground/40"
+              />
+            </div>
+            <div className="max-h-64 overflow-y-auto py-1" role="listbox" aria-label={t('git.branch')}>
+              {filtered.length === 0 && (
+                <div className="px-3 py-2 text-xs text-foreground/40">{t('git.noMatches')}</div>
+              )}
+              {switchable.map((b, i) => (
+                <motion.button
+                  key={b}
+                  type="button"
+                  role="option"
+                  aria-selected={b === info.branch}
+                  onClick={() => void checkout(b)}
+                  initial={{ opacity: 0, x: -6 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  transition={{ duration: 0.14, delay: Math.min(i * 0.02, 0.16) }}
+                  className="flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-sm text-foreground hover:bg-surface/70"
+                >
+                  <GitBranch className="h-3.5 w-3.5 shrink-0 text-accent-primary/70" />
+                  <span className="min-w-0 flex-1 truncate font-mono text-xs">{b}</span>
+                  {b === info.branch && <Check className="h-3.5 w-3.5 shrink-0 text-accent-primary" />}
+                </motion.button>
+              ))}
+              {inWorktrees.length > 0 && (
+                <>
+                  <div className="mt-1 border-t border-border/50 px-3 pb-0.5 pt-1.5 text-[10px] uppercase tracking-wide text-foreground/40">
+                    {t('git.worktrees')}
+                  </div>
+                  {inWorktrees.map((b, i) => {
+                    const w = worktreeByBranch.get(b)!
+                    return (
+                      <motion.button
+                        key={b}
+                        type="button"
+                        role="option"
+                        aria-selected={false}
+                        onClick={() => void copyWorktreePath(w)}
+                        initial={{ opacity: 0, x: -6 }}
+                        animate={{ opacity: 1, x: 0 }}
+                        transition={{ duration: 0.14, delay: Math.min(i * 0.02, 0.16) }}
+                        title={t('git.copyWorktreePath')}
+                        className="group flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-sm text-foreground hover:bg-surface/70"
+                      >
+                        <FolderGit2 className="h-3.5 w-3.5 shrink-0 text-accent-secondary/80" />
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate font-mono text-xs">{b}</span>
+                          <span className="block truncate text-[10px] text-foreground/40">{w.path}</span>
+                        </span>
+                        <Copy className="h-3 w-3 shrink-0 text-foreground/30 opacity-0 transition-opacity group-hover:opacity-100" />
+                      </motion.button>
+                    )
+                  })}
+                </>
+              )}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {info.dirty && (
+        <span
+          title={t('git.dirty')}
+          aria-label={t('git.dirty')}
+          className="h-1.5 w-1.5 shrink-0 rounded-full bg-accent-warning"
+        />
+      )}
+      {info.lastCommit && (
+        <span className="min-w-0 flex-1 truncate" title={`${info.lastCommit.hash} · ${info.lastCommit.subject}`}>
+          <span className="font-mono text-foreground/40">{info.lastCommit.hash}</span>
+          {' · '}
+          {info.lastCommit.subject}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/client/src/components/agent-chat/AgentMessage.tsx
+++ b/client/src/components/agent-chat/AgentMessage.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { Copy, Check } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '../../lib/utils'
+import { useWebViewModal } from '../../context/WebViewModalContext'
 import { extractAgentOptions } from './agent-options'
 
 // Token-based markdown styling — works across ALL themes (no prose-invert, which
@@ -70,6 +71,30 @@ interface Props {
 /** A single agent chat message: markdown-rendered, with a subtle per-bubble copy. */
 export function AgentMessage({ role, content, streaming, isLast, onPickOption }: Props) {
   const isUser = role === 'user'
+  const { openWebView, canOpenWebView } = useWebViewModal()
+
+  // http(s) links open in the app's embedded browser (same pattern as spec
+  // descriptions) instead of navigating the whole webview away. When the
+  // embedded browser can't open (no project / feature off), keep target=_blank.
+  const markdownComponents = useMemo(() => ({
+    a: ({ href, children }: { href?: string; children?: React.ReactNode }) => (
+      <a
+        href={href}
+        target="_blank"
+        rel="noreferrer"
+        data-agent-interactive
+        onClick={(e) => {
+          if (canOpenWebView && typeof href === 'string' && /^https?:\/\//i.test(href)) {
+            e.preventDefault()
+            e.stopPropagation()
+            openWebView(href)
+          }
+        }}
+      >
+        {children}
+      </a>
+    ),
+  }), [openWebView, canOpenWebView])
 
   if (isUser) {
     return (
@@ -95,7 +120,7 @@ export function AgentMessage({ role, content, streaming, isLast, onPickOption }:
   return (
     <div className="group flex flex-col gap-1">
       <div className={cn('max-w-full', MD)}>
-        <ReactMarkdown remarkPlugins={[remarkGfm]}>{body}</ReactMarkdown>
+        <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>{body}</ReactMarkdown>
       </div>
       {showChips && (
         <div className="flex flex-wrap gap-1.5 pt-1">

--- a/client/src/components/agent-chat/AgentModeCodePane.tsx
+++ b/client/src/components/agent-chat/AgentModeCodePane.tsx
@@ -52,10 +52,14 @@ export function AgentModeCodePane({ projectId, conversationId }: { projectId: st
   }, [width])
 
   return (
+    // Maximized = REALLY maximized: cover the whole Agent-Mode surface
+    // (absolute over the relative surface root), not just grow in the flex row.
     <div
       ref={paneRef}
-      className="flex h-full flex-col overflow-hidden border-l border-border bg-background"
-      style={maximized ? { flex: 1 } : { width, flexShrink: 0 }}
+      className={`flex h-full flex-col overflow-hidden border-l border-border bg-background${
+        maximized ? ' absolute inset-0 z-30 border-l-0' : ''
+      }`}
+      style={maximized ? undefined : { width, flexShrink: 0 }}
       // key by project+conversation so the embedded tree/viewer reset on switch
       // and each conversation restores its own last file (design D15)
       key={selectionKey}

--- a/client/src/components/agent-chat/AgentModeJobsPane.tsx
+++ b/client/src/components/agent-chat/AgentModeJobsPane.tsx
@@ -1,0 +1,185 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { formatDistanceToNow } from 'date-fns'
+import { Maximize2, Minimize2, X, Loader2, Briefcase } from 'lucide-react'
+import { getApiBase } from '../../lib/api'
+import { getDateFnsLocale } from '../../lib/i18n'
+import { cn } from '../../lib/utils'
+import { useAgentWorkspace } from '../../context/AgentWorkspaceContext'
+import { useProjectCache } from '../../hooks/useProjectCache'
+import { useSharedWebSocket } from '../../hooks/useSharedWebSocket'
+import { useDesktop } from '../../hooks/useDesktop'
+import { formatCommandForProvider } from '../../lib/format-command'
+import { Badge } from '../ui/badge'
+import { JobDetailModal } from '../JobDetailModal'
+import type { JobSummary } from '../../types'
+
+const MIN_PANE = 360
+const DEFAULT_PANE = 480
+
+type BadgeVariant = 'success' | 'running' | 'queued' | 'failed' | 'canceled'
+const STATUS_VARIANT: Record<string, BadgeVariant> = {
+  running: 'running',
+  completed: 'success',
+  failed: 'failed',
+  canceled: 'canceled',
+  queued: 'queued',
+}
+
+/**
+ * Agent-Mode inline Jobs pane (same split chrome as `AgentModeCodePane`): the
+ * project's executions listed live beside the conversation. Clicking a job
+ * opens the near-fullscreen `JobDetailModal` with the streaming execution.
+ */
+export function AgentModeJobsPane({ projectId }: { projectId: string }) {
+  const { t } = useTranslation('agent')
+  const { t: tJobs } = useTranslation('jobs')
+  const { closeJobsPane } = useAgentWorkspace()
+  const { projects } = useDesktop()
+  const provider = projects.find((p) => p.id === projectId)?.provider
+  const [width, setWidth] = useState(DEFAULT_PANE)
+  const [maximized, setMaximized] = useState(false)
+  const [detailJobId, setDetailJobId] = useState<string | null>(null)
+
+  const { data: jobs, isFirstLoad, refresh } = useProjectCache<JobSummary[]>({
+    namespace: 'agent-jobs',
+    projectId,
+    initialValue: [],
+    fetcher: async () => {
+      const res = await fetch(`${getApiBase()}/jobs?limit=50`)
+      if (!res.ok) return []
+      const data = await res.json() as { jobs: JobSummary[] }
+      return data.jobs
+    },
+    pollInterval: 5_000,
+  })
+
+  // Live status flips (queued→running→completed) ride the shared queue WS
+  // broadcast — refresh immediately instead of waiting out the poll.
+  const { registerHandler, unregisterHandler } = useSharedWebSocket()
+  const projectIdRef = useRef(projectId)
+  projectIdRef.current = projectId
+  const refreshRef = useRef(refresh)
+  refreshRef.current = refresh
+  useEffect(() => {
+    const handler = (raw: unknown): void => {
+      const msg = raw as { type?: string; projectId?: string }
+      if (msg.type !== 'queue') return
+      if (msg.projectId && msg.projectId !== projectIdRef.current) return
+      refreshRef.current()
+    }
+    registerHandler('agent-jobs-pane', handler)
+    return () => unregisterHandler('agent-jobs-pane')
+  }, [registerHandler, unregisterHandler])
+
+  const beginResize = useCallback((e: React.PointerEvent) => {
+    const startX = e.clientX
+    const startWidth = width
+    const maxWidth = window.innerWidth - MIN_PANE
+    try { (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId) } catch { /* ignore */ }
+    const onMove = (ev: PointerEvent) => {
+      const next = Math.min(Math.max(startWidth + (startX - ev.clientX), MIN_PANE), maxWidth)
+      setWidth(next)
+    }
+    const onUp = () => {
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+      window.removeEventListener('pointercancel', onUp)
+    }
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp)
+    window.addEventListener('pointercancel', onUp)
+  }, [width])
+
+  return (
+    // Maximized = REALLY maximized: cover the whole Agent-Mode surface
+    // (absolute over the relative surface root), not just grow in the flex row.
+    <div
+      className={cn(
+        'flex h-full flex-col overflow-hidden border-l border-border bg-background',
+        maximized && 'absolute inset-0 z-30 border-l-0',
+      )}
+      style={maximized ? undefined : { width, flexShrink: 0 }}
+    >
+      <div className="relative flex items-center">
+        {!maximized && (
+          <div
+            role="separator"
+            aria-orientation="vertical"
+            onPointerDown={beginResize}
+            className="absolute left-0 top-0 h-full w-1.5 -translate-x-full cursor-col-resize select-none touch-none hover:bg-accent-primary/20"
+            title={t('workspace.resizeJobs')}
+          />
+        )}
+      </div>
+      <div className="flex items-center gap-2 border-b border-border/60 bg-surface/40 px-3 py-1.5">
+        <span className="text-xs font-medium text-foreground/70">{t('workspace.jobs')}</span>
+        <div className="ml-auto flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => setMaximized((m) => !m)}
+            aria-label={maximized ? t('restore') : t('maximize')}
+            title={maximized ? t('restore') : t('maximize')}
+            className="rounded-md p-1 text-foreground/60 hover:bg-surface hover:text-foreground"
+          >
+            {maximized ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
+          </button>
+          <button
+            type="button"
+            onClick={closeJobsPane}
+            aria-label={t('workspace.closeJobs')}
+            title={t('workspace.closeJobs')}
+            className="rounded-md p-1 text-foreground/60 hover:bg-surface hover:text-foreground"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-2">
+        {isFirstLoad ? (
+          <div className="flex h-24 items-center justify-center text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+          </div>
+        ) : jobs.length === 0 ? (
+          <div className="flex h-full flex-col items-center justify-center gap-2 text-center text-muted-foreground">
+            <Briefcase className="h-6 w-6 opacity-40" />
+            <p className="text-xs">{t('workspace.noJobs')}</p>
+          </div>
+        ) : (
+          <ul className="space-y-1">
+            {jobs.map((job) => (
+              <li key={job.id}>
+                <button
+                  type="button"
+                  onClick={() => setDetailJobId(job.id)}
+                  className={cn(
+                    'flex w-full flex-col gap-1 rounded-lg border border-border/50 bg-surface/30 px-2.5 py-2 text-left transition-colors',
+                    'hover:border-accent-primary/40 hover:bg-surface/60',
+                  )}
+                >
+                  <div className="flex items-center gap-2">
+                    <Badge variant={STATUS_VARIANT[job.status] ?? 'queued'}>
+                      {tJobs(`statusLabel.${job.status in STATUS_VARIANT ? job.status : 'queued'}`)}
+                    </Badge>
+                    {job.status === 'running' && <Loader2 className="h-3 w-3 animate-spin text-accent-primary" />}
+                    <span className="ml-auto text-[10px] text-muted-foreground">
+                      {formatDistanceToNow(new Date(job.started_at), { addSuffix: true, locale: getDateFnsLocale() })}
+                    </span>
+                  </div>
+                  <code className="truncate font-mono text-xs text-foreground/85">
+                    {formatCommandForProvider(job.command, provider)}
+                  </code>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {detailJobId && (
+        <JobDetailModal jobId={detailJobId} onClose={() => setDetailJobId(null)} />
+      )}
+    </div>
+  )
+}

--- a/client/src/components/agent-chat/AgentModeSurface.tsx
+++ b/client/src/components/agent-chat/AgentModeSurface.tsx
@@ -12,6 +12,9 @@ import { AgentComposer } from './AgentComposer'
 const AgentModeCodePane = lazy(() =>
   import('./AgentModeCodePane').then((m) => ({ default: m.AgentModeCodePane })),
 )
+const AgentModeJobsPane = lazy(() =>
+  import('./AgentModeJobsPane').then((m) => ({ default: m.AgentModeJobsPane })),
+)
 const AgentBrowserCapture = lazy(() =>
   import('./AgentBrowserCapture').then((m) => ({ default: m.AgentBrowserCapture })),
 )
@@ -25,7 +28,7 @@ const AgentBrowserCapture = lazy(() =>
 export function AgentModeSurface() {
   const { t } = useTranslation('agent')
   const { active, refreshConversations } = useAgentChat()
-  const { codePaneOpen, browserOpen } = useAgentWorkspace()
+  const { codePaneOpen, jobsPaneOpen, browserOpen } = useAgentWorkspace()
   const { activeProjectId } = useDesktop()
   // Easter egg: on the Matrix theme, the agent becomes agent Smith.
   const emptyTitle = useActiveTheme().id === 'matrix' ? t('emptyTitleMatrix') : t('emptyTitle')
@@ -39,6 +42,7 @@ export function AgentModeSurface() {
   // thread — it only needs an active project (its own store is per-conversation,
   // falling back to a Home key when no conversation is open yet).
   const showCode = codePaneOpen && !!activeProjectId
+  const showJobs = jobsPaneOpen && !!activeProjectId
 
   return (
     <MotionConfig reducedMotion="user">
@@ -58,7 +62,7 @@ export function AgentModeSurface() {
         {active === null ? (
           // ── EMPTY: centered composer card. The card carries the shared
           // `layoutId`, so the first send morphs it down into the docked
-          // composer of the conversation view (and New Agent morphs it back).
+          // composer of the conversation view (and New Mission morphs it back).
           <div className="relative z-10 flex h-full w-full items-center justify-center px-6">
             <motion.div
               layoutId="agent-composer-dock"
@@ -85,6 +89,12 @@ export function AgentModeSurface() {
           </div>
         )}
       </div>
+
+      {showJobs && (
+        <Suspense fallback={<div className="w-[480px] border-l border-border" />}>
+          <AgentModeJobsPane projectId={activeProjectId!} />
+        </Suspense>
+      )}
 
       {showCode && (
         <Suspense fallback={<div className="w-[520px] border-l border-border" />}>

--- a/client/src/components/agent-chat/AgentWorkspaceSidebar.tsx
+++ b/client/src/components/agent-chat/AgentWorkspaceSidebar.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Globe, TerminalSquare, FileCode2, PanelRight } from 'lucide-react'
+import { Globe, TerminalSquare, FileCode2, PanelRight, Briefcase } from 'lucide-react'
 import { cn } from '../../lib/utils'
 import { useSidebarPin } from '../../context/SidebarPinContext'
 import { useDesktop } from '../../hooks/useDesktop'
@@ -37,6 +37,13 @@ export function AgentWorkspaceSidebar() {
   const noProject = !activeProjectId
 
   const tools = [
+    // Jobs sits ABOVE Browser: the executions the agent launches are the first
+    // thing the user reaches for from Agent Mode.
+    {
+      key: 'jobs', icon: Briefcase, label: t('workspace.jobs'),
+      onClick: () => workspace.toggleJobsPane(),
+      disabled: noProject, disabledTitle: t('workspace.requiresProject'),
+    },
     ...(isBrowserCaptureEnabled()
       ? [{
           key: 'browser', icon: Globe, label: t('workspace.browser'),

--- a/client/src/components/agent-chat/__tests__/AgentGitBar.test.tsx
+++ b/client/src/components/agent-chat/__tests__/AgentGitBar.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+
+const toastError = vi.fn()
+const toastSuccess = vi.fn()
+vi.mock('sonner', () => ({
+  toast: { error: (...a: unknown[]) => toastError(...a), success: (...a: unknown[]) => toastSuccess(...a) },
+}))
+
+vi.mock('../../../lib/origin', () => ({ API_ORIGIN: '' }))
+
+import { AgentGitBar } from '../AgentGitBar'
+
+const INFO = {
+  git: true,
+  branch: 'main',
+  detached: false,
+  dirty: false,
+  branches: ['main', 'feature', 'fix/windows-npm-shell'],
+  lastCommit: { hash: 'abc1234', subject: 'fix: last commit subject', at: '2026-07-02T10:00:00Z' },
+}
+
+function mockFetchSequence(handlers: Array<(url: string, init?: RequestInit) => { status?: number; body: unknown }>) {
+  let call = 0
+  global.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+    const h = handlers[Math.min(call, handlers.length - 1)]
+    call++
+    const { status = 200, body } = h(String(url), init)
+    return Promise.resolve({ ok: status < 400, status, json: async () => body })
+  }) as unknown as typeof fetch
+}
+
+async function openDropdown() {
+  const trigger = await screen.findByLabelText('Branch')
+  fireEvent.click(trigger)
+  return trigger
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('AgentGitBar', () => {
+  it('renders the themed branch trigger and the last commit', async () => {
+    mockFetchSequence([() => ({ body: INFO })])
+    render(<AgentGitBar projectId="p1" />)
+    const trigger = await screen.findByLabelText('Branch')
+    expect(trigger.textContent).toContain('main')
+    expect(screen.getByText('abc1234')).toBeInTheDocument()
+    expect(screen.getByText(/fix: last commit subject/)).toBeInTheDocument()
+    expect(screen.queryByLabelText('Uncommitted changes')).not.toBeInTheDocument()
+    // Never the OS-native select — the dropdown is our own themed listbox.
+    expect(document.querySelector('select')).toBeNull()
+  })
+
+  it('renders nothing when the project is not a git repo', async () => {
+    mockFetchSequence([() => ({ body: { ...INFO, git: false } })])
+    const { container } = render(<AgentGitBar projectId="p1" />)
+    await act(async () => { await Promise.resolve() })
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('shows the dirty dot when there are uncommitted changes', async () => {
+    mockFetchSequence([() => ({ body: { ...INFO, dirty: true } })])
+    render(<AgentGitBar projectId="p1" />)
+    expect(await screen.findByLabelText('Uncommitted changes')).toBeInTheDocument()
+  })
+
+  it('opens the listbox, filters by search, and checks out the picked branch', async () => {
+    mockFetchSequence([
+      () => ({ body: INFO }),
+      (url, init) => {
+        expect(url).toContain('/git/checkout')
+        expect(JSON.parse(String(init?.body))).toEqual({ branch: 'feature' })
+        return { body: { ...INFO, branch: 'feature', lastCommit: { hash: 'def5678', subject: 'feature tip', at: '' } } }
+      },
+    ])
+    render(<AgentGitBar projectId="p1" />)
+    await openDropdown()
+    // All branches listed as options with the current one marked selected.
+    expect(screen.getAllByRole('option')).toHaveLength(3)
+    expect(screen.getByRole('option', { name: /main/ })).toHaveAttribute('aria-selected', 'true')
+    // Search narrows the list.
+    fireEvent.change(screen.getByLabelText('Search branches…'), { target: { value: 'feat' } })
+    expect(screen.getAllByRole('option')).toHaveLength(1)
+    await act(async () => { fireEvent.click(screen.getByRole('option', { name: /feature/ })) })
+    await waitFor(() => expect(screen.getByLabelText('Branch').textContent).toContain('feature'))
+    expect(screen.getByText('def5678')).toBeInTheDocument()
+    expect(toastSuccess).toHaveBeenCalled()
+  })
+
+  it('a REFUSED checkout surfaces the git reason and snaps back to the real branch', async () => {
+    mockFetchSequence([
+      () => ({ body: INFO }),
+      () => ({ status: 409, body: { error: 'Your local changes would be overwritten by checkout' } }),
+      () => ({ body: INFO }), // resync refetch after the failure
+    ])
+    render(<AgentGitBar projectId="p1" />)
+    await openDropdown()
+    await act(async () => { fireEvent.click(screen.getByRole('option', { name: /feature/ })) })
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith('Couldn\'t switch branch', {
+      description: 'Your local changes would be overwritten by checkout',
+    }))
+    // Controlled by server truth — never left showing a branch we are not on.
+    await waitFor(() => expect(screen.getByLabelText('Branch').textContent).toContain('main'))
+    expect(global.fetch).toHaveBeenCalledTimes(3) // info + checkout + resync
+  })
+
+  it('shows the detached label when HEAD is detached', async () => {
+    mockFetchSequence([() => ({ body: { ...INFO, branch: null, detached: true } })])
+    render(<AgentGitBar projectId="p1" />)
+    const trigger = await screen.findByLabelText('Branch')
+    expect(trigger.textContent).toContain('(detached)')
+  })
+
+  it('groups worktree-bound branches: click COPIES the path, never a doomed checkout', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { clipboard: { writeText } })
+    mockFetchSequence([() => ({
+      body: {
+        ...INFO,
+        branches: [...INFO.branches, 'sr/ticket-7'],
+        worktrees: [
+          { path: '/repo', branch: 'main', head: 'a', isMain: true },
+          { path: '/repo/.claude/worktrees/ticket-7', branch: 'sr/ticket-7', head: 'b', isMain: false },
+        ],
+      },
+    })])
+    render(<AgentGitBar projectId="p1" />)
+    await openDropdown()
+    // Worktree group visible with the branch + its path.
+    expect(screen.getByText('Worktrees')).toBeInTheDocument()
+    expect(screen.getByText('/repo/.claude/worktrees/ticket-7')).toBeInTheDocument()
+    await act(async () => { fireEvent.click(screen.getByText('sr/ticket-7')) })
+    expect(writeText).toHaveBeenCalledWith('/repo/.claude/worktrees/ticket-7')
+    expect(toastSuccess).toHaveBeenCalled()
+    // git checkout was NEVER attempted (only the initial info fetch happened).
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    vi.unstubAllGlobals()
+  })
+
+  it('hides the worktrees group when only the main worktree exists', async () => {
+    mockFetchSequence([() => ({
+      body: { ...INFO, worktrees: [{ path: '/repo', branch: 'main', head: 'a', isMain: true }] },
+    })])
+    render(<AgentGitBar projectId="p1" />)
+    await openDropdown()
+    expect(screen.queryByText('Worktrees')).not.toBeInTheDocument()
+    expect(screen.getAllByRole('option')).toHaveLength(3) // all switchable
+  })
+
+  it('shows the empty state when the search matches nothing', async () => {
+    mockFetchSequence([() => ({ body: INFO })])
+    render(<AgentGitBar projectId="p1" />)
+    await openDropdown()
+    fireEvent.change(screen.getByLabelText('Search branches…'), { target: { value: 'zzz' } })
+    expect(screen.queryAllByRole('option')).toHaveLength(0)
+    expect(screen.getByText('No branches match')).toBeInTheDocument()
+  })
+})

--- a/client/src/components/agent-chat/__tests__/AgentModeJobsPane.test.tsx
+++ b/client/src/components/agent-chat/__tests__/AgentModeJobsPane.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import type { JobSummary } from '../../../types'
+
+vi.mock('../../../lib/api', () => ({ getApiBase: () => '/api/projects/p1' }))
+
+vi.mock('../../../hooks/useDesktop', () => ({
+  useDesktop: () => ({
+    projects: [{ id: 'p1', name: 'acme', slug: 'acme', path: '/acme', provider: 'claude' }],
+    activeProjectId: 'p1',
+    setActiveProjectId: vi.fn(),
+  }),
+}))
+
+vi.mock('../../../hooks/useSharedWebSocket', () => ({
+  useSharedWebSocket: () => ({
+    registerHandler: vi.fn(),
+    unregisterHandler: vi.fn(),
+    connectionStatus: 'connected',
+  }),
+}))
+
+let mockJobs: JobSummary[] = []
+let mockFirstLoad = false
+vi.mock('../../../hooks/useProjectCache', () => ({
+  useProjectCache: () => ({ data: mockJobs, isFirstLoad: mockFirstLoad, refresh: vi.fn() }),
+}))
+
+// The real modal has its own test suite — a stub proves the pane wires jobId/onClose.
+vi.mock('../../JobDetailModal', () => ({
+  JobDetailModal: ({ jobId, onClose }: { jobId: string; onClose: () => void }) => (
+    <div data-testid="job-modal">
+      <span>{jobId}</span>
+      <button onClick={onClose}>close-modal</button>
+    </div>
+  ),
+}))
+
+import { AgentModeJobsPane } from '../AgentModeJobsPane'
+import { AgentWorkspaceProvider } from '../../../context/AgentWorkspaceContext'
+
+function job(id: string, status: JobSummary['status'], command: string): JobSummary {
+  return { id, command, status, started_at: new Date().toISOString() }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockJobs = []
+  mockFirstLoad = false
+})
+
+function renderPane() {
+  return render(
+    <AgentWorkspaceProvider>
+      <AgentModeJobsPane projectId="p1" />
+    </AgentWorkspaceProvider>,
+  )
+}
+
+describe('AgentModeJobsPane', () => {
+  it('lists the project jobs with their status', () => {
+    mockJobs = [
+      job('j1', 'running', '/specrails:implement #12'),
+      job('j2', 'completed', '/specrails:implement #9'),
+    ]
+    renderPane()
+    expect(screen.getByText('/specrails:implement #12')).toBeInTheDocument()
+    expect(screen.getByText('/specrails:implement #9')).toBeInTheDocument()
+    expect(screen.getByText('running')).toBeInTheDocument()
+    expect(screen.getByText('completed')).toBeInTheDocument()
+  })
+
+  it('opens the near-fullscreen execution modal on job click and closes it', () => {
+    mockJobs = [job('j-42', 'running', '/specrails:implement #7')]
+    renderPane()
+    expect(screen.queryByTestId('job-modal')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByText('/specrails:implement #7'))
+    expect(screen.getByTestId('job-modal')).toBeInTheDocument()
+    expect(screen.getByText('j-42')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('close-modal'))
+    expect(screen.queryByTestId('job-modal')).not.toBeInTheDocument()
+  })
+
+  it('shows the empty state when the project has no jobs', () => {
+    renderPane()
+    expect(screen.getByText('No jobs yet — ask the agent to launch one')).toBeInTheDocument()
+  })
+
+  it('shows a spinner during the first load', () => {
+    mockFirstLoad = true
+    const { container } = renderPane()
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument()
+  })
+
+  it('maximize covers the whole surface (absolute inset-0), restore returns to the split', () => {
+    const { container } = renderPane()
+    const pane = container.firstElementChild as HTMLElement
+    expect(pane.className).not.toContain('absolute')
+    fireEvent.click(screen.getByLabelText('Maximize'))
+    expect(pane.className).toContain('absolute')
+    expect(pane.className).toContain('inset-0')
+    fireEvent.click(screen.getByLabelText('Restore'))
+    expect(pane.className).not.toContain('absolute')
+    expect(pane.style.width).toBe('480px')
+  })
+})

--- a/client/src/components/agent-chat/__tests__/agent-chat.test.tsx
+++ b/client/src/components/agent-chat/__tests__/agent-chat.test.tsx
@@ -31,7 +31,7 @@ vi.mock('../../../lib/agent-api', async (orig) => {
     getAgentConversation: vi.fn(async () => ({ conversation: api.conv, messages: [] })),
     patchAgentConversation: vi.fn(async (_id: string, patch: Record<string, unknown>) => ({ ...api.conv, ...patch, tier_level: patch.tierLevel ?? api.conv.tier_level })),
     deleteAgentConversation: vi.fn(async () => {}),
-    sendAgentMessage: vi.fn(async () => {}),
+    sendAgentMessage: vi.fn(async () => ({ queued: false })),
     abortAgentTurn: vi.fn(async () => {}),
     getMcpStatus: vi.fn(async () => ({ enabled: true, running: true })),
     enableMcp: vi.fn(async () => {}),
@@ -45,8 +45,14 @@ vi.mock('../../../lib/agent-api', async (orig) => {
   }
 })
 
+const mockOpenWebView = vi.fn()
+vi.mock('../../../context/WebViewModalContext', () => ({
+  useWebViewModal: () => ({ openWebView: mockOpenWebView, canOpenWebView: true }),
+}))
+
 import * as agentApi from '../../../lib/agent-api'
 import { AgentChatProvider, useAgentChat } from '../../../context/AgentChatContext'
+import { __clearComposerDrafts } from '../AgentComposer'
 import { AgentTierChip } from '../AgentTierChip'
 import { AgentProjectSelector } from '../AgentProjectSelector'
 import { AgentActivityChip, toolChipLabel } from '../AgentActivityChip'
@@ -57,6 +63,7 @@ import { AgentModelSelector } from '../AgentModelSelector'
 beforeEach(() => {
   wsHandler = null
   vi.clearAllMocks()
+  __clearComposerDrafts()
   vi.mocked(agentApi.listAgentConversations).mockResolvedValue([])
   vi.mocked(agentApi.createAgentConversation).mockResolvedValue(api.conv)
   vi.mocked(agentApi.getAgentConversation).mockResolvedValue({ conversation: api.conv, messages: [] })
@@ -139,6 +146,14 @@ describe('AgentMessage', () => {
     expect(screen.queryByLabelText('Copy')).not.toBeInTheDocument()
   })
 
+  it('opens http(s) links in the embedded browser instead of navigating the app', () => {
+    render(<AgentMessage role="assistant" content="See [the docs](https://specrails.dev/docs) for more." />)
+    const link = screen.getByRole('link', { name: 'the docs' })
+    expect(link).toHaveAttribute('target', '_blank')
+    fireEvent.click(link)
+    expect(mockOpenWebView).toHaveBeenCalledWith('https://specrails.dev/docs')
+  })
+
   it('copies the content to the clipboard on click', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined)
     vi.stubGlobal('navigator', { clipboard: { writeText } })
@@ -194,6 +209,43 @@ describe('AgentMessage option chips', () => {
     expect(container.querySelector('pre')).toBeInTheDocument()
   })
 
+  it('renders chips for a REAL-WORLD malformed fence: glued to prose, inline JSON, no closing fence', () => {
+    // Regression: the model emitted "…extra?```options [\"A\", \"B\"]" (no
+    // newline before the fence, array on the fence line, unclosed) and the raw
+    // protocol text leaked into the bubble alongside an empty code block.
+    const content = 'sin tocar mayúsculas/espacios extra?```options ["Sí a ambas", "Live lessons también", "Decide tú"]'
+    const { container } = render(
+      <AgentMessage role="assistant" content={content} isLast onPickOption={vi.fn()} />,
+    )
+    expect(screen.getByRole('button', { name: 'Sí a ambas' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Decide tú' })).toBeInTheDocument()
+    expect(container.querySelector('pre')).not.toBeInTheDocument()
+    expect(container.textContent).not.toContain('```options')
+  })
+
+  it('renders chips when the closing fence is present but the array sits on the fence line', () => {
+    const content = 'Pick one:\n\n```options ["A", "B"]\n```'
+    render(<AgentMessage role="assistant" content={content} isLast onPickOption={vi.fn()} />)
+    expect(screen.getByRole('button', { name: 'A' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'B' })).toBeInTheDocument()
+  })
+
+  it('an ```options mention INSIDE a label does not shadow the real block (first-valid wins)', () => {
+    const content = 'Pick one:\n\n```options\n["Use the ```options fence", "Skip it"]\n```'
+    render(<AgentMessage role="assistant" content={content} isLast onPickOption={vi.fn()} />)
+    expect(screen.getByRole('button', { name: 'Use the ```options fence' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Skip it' })).toBeInTheDocument()
+  })
+
+  it('never treats a longer ````options fence as the protocol block', () => {
+    const content = 'The protocol looks like this:\n\n````options\n["A", "B"]'
+    const { container } = render(
+      <AgentMessage role="assistant" content={content} isLast onPickOption={vi.fn()} />,
+    )
+    expect(screen.queryByRole('button', { name: 'A' })).not.toBeInTheDocument()
+    expect(container.textContent).toContain('The protocol looks like this:')
+  })
+
   it('suppresses chips while streaming but still strips a complete block', () => {
     const { container } = render(
       <AgentMessage role="assistant" content={withOptions} isLast streaming onPickOption={vi.fn()} />,
@@ -232,11 +284,17 @@ function Harness() {
       <span data-testid="streaming">{String(a.isStreaming)}</span>
       <span data-testid="stream">{a.streamingText}</span>
       <span data-testid="tools">{a.liveTools.length}</span>
+      <span data-testid="queued">{a.queuedMessages.length}</span>
+      <span data-testid="live-ids">{[...a.streamingConversationIds].sort().join(',')}</span>
       <span data-testid="mcp">{String(a.mcpEnabled)}</span>
       <span data-testid="tier">{a.active?.tier_level ?? -1}</span>
       <span data-testid="msgs">{a.messages.length}</span>
       <button onClick={a.open}>open</button>
       <button onClick={() => void a.send('hi')}>send</button>
+      <button onClick={() => void a.send('extra')}>send-extra</button>
+      <button onClick={() => void a.abort()}>abort</button>
+      <button onClick={() => void a.selectConversation('c2')}>go-c2</button>
+      <button onClick={() => void a.selectConversation('c1')}>go-c1</button>
       <button onClick={() => void a.cycleTier()}>cycle</button>
       <button onClick={a.minimize}>min</button>
       <button onClick={a.close}>close</button>
@@ -331,7 +389,7 @@ describe('AgentChatProvider', () => {
   it('renders the persistent bubble when not open and opens on click', async () => {
     render(<AgentChatProvider><Harness /></AgentChatProvider>)
     // visibility starts hidden → bubble present
-    const bubble = screen.getByLabelText('Agent')
+    const bubble = screen.getByLabelText('Mission Control')
     expect(bubble).toBeInTheDocument()
     await act(async () => { fireEvent.click(bubble) })
     await waitFor(() => expect(agentApi.createAgentConversation).toHaveBeenCalled())
@@ -340,7 +398,7 @@ describe('AgentChatProvider', () => {
   it('restores the bubble at the remembered position', () => {
     localStorage.setItem('specrails-desktop:agent-bubble-pos', JSON.stringify({ left: 123, top: 234 }))
     render(<AgentChatProvider><Harness /></AgentChatProvider>)
-    const bubble = screen.getByLabelText('Agent')
+    const bubble = screen.getByLabelText('Mission Control')
     expect(bubble.style.left).toBe('123px')
     expect(bubble.style.top).toBe('234px')
     localStorage.clear()
@@ -363,11 +421,147 @@ describe('AgentChatProvider', () => {
     expect(agentApi.sendAgentMessage).toHaveBeenCalledWith('c1', 'Launch it', expect.anything())
   })
 
+  it('parks a mid-stream send as a queued chip and promotes it on agent_dequeued', async () => {
+    vi.mocked(agentApi.sendAgentMessage)
+      .mockResolvedValueOnce({ queued: false }) // first turn runs directly
+      .mockResolvedValue({ queued: true })      // mid-stream send parks
+    render(<AgentChatProvider><Harness /></AgentChatProvider>)
+    await act(async () => { fireEvent.click(screen.getByText('open')) })
+    await act(async () => { fireEvent.click(screen.getByText('send')) })
+    await waitFor(() => expect(screen.getByTestId('msgs').textContent).toBe('1'))
+    await act(async () => { wsHandler!({ type: 'agent_stream', conversationId: 'c1', delta: 'Working…' }) })
+
+    await act(async () => { fireEvent.click(screen.getByText('send-extra')) })
+    // Parked, NOT appended to the thread.
+    expect(screen.getByTestId('queued').textContent).toBe('1')
+    expect(screen.getByTestId('msgs').textContent).toBe('1')
+    const opts = vi.mocked(agentApi.sendAgentMessage).mock.calls[1][2] as { queueId?: string }
+    expect(typeof opts.queueId).toBe('string')
+
+    // First turn settles → the chip SURVIVES (its drained turn is about to start).
+    await act(async () => { wsHandler!({ type: 'agent_done', conversationId: 'c1', fullText: 'First reply' }) })
+    expect(screen.getByTestId('queued').textContent).toBe('1')
+    expect(screen.getByTestId('msgs').textContent).toBe('2')
+
+    // Dequeue: chip → real user bubble, streaming resumes for the drained turn.
+    await act(async () => {
+      wsHandler!({ type: 'agent_dequeued', conversationId: 'c1', queueId: opts.queueId, text: 'extra' })
+    })
+    expect(screen.getByTestId('queued').textContent).toBe('0')
+    expect(screen.getByTestId('msgs').textContent).toBe('3')
+    expect(screen.getByTestId('streaming').textContent).toBe('true')
+  })
+
+  it('abort drops the queued chips immediately', async () => {
+    vi.mocked(agentApi.sendAgentMessage)
+      .mockResolvedValueOnce({ queued: false })
+      .mockResolvedValue({ queued: true })
+    render(<AgentChatProvider><Harness /></AgentChatProvider>)
+    await act(async () => { fireEvent.click(screen.getByText('open')) })
+    await act(async () => { fireEvent.click(screen.getByText('send')) })
+    await act(async () => { wsHandler!({ type: 'agent_stream', conversationId: 'c1', delta: 'x' }) })
+    await act(async () => { fireEvent.click(screen.getByText('send-extra')) })
+    expect(screen.getByTestId('queued').textContent).toBe('1')
+    await act(async () => { fireEvent.click(screen.getByText('abort')) })
+    expect(agentApi.abortAgentTurn).toHaveBeenCalledWith('c1')
+    expect(screen.getByTestId('queued').textContent).toBe('0')
+    expect(screen.getByTestId('streaming').textContent).toBe('false')
+  })
+
+  it('keeps a background conversation streaming and restores its text on switch-back', async () => {
+    const conv2 = { ...api.conv, id: 'c2' }
+    vi.mocked(agentApi.getAgentConversation).mockImplementation(async (id: string) => ({
+      conversation: id === 'c2' ? conv2 : api.conv,
+      messages: [],
+    }))
+    render(<AgentChatProvider><Harness /></AgentChatProvider>)
+    await act(async () => { fireEvent.click(screen.getByText('open')) })
+    await waitFor(() => expect(agentApi.createAgentConversation).toHaveBeenCalled())
+    await act(async () => { wsHandler!({ type: 'agent_stream', conversationId: 'c1', delta: 'Hel' }) })
+    expect(screen.getByTestId('stream').textContent).toBe('Hel')
+
+    // Focus another thread mid-stream: the view empties but NOTHING is lost.
+    await act(async () => { fireEvent.click(screen.getByText('go-c2')) })
+    expect(screen.getByTestId('stream').textContent).toBe('')
+    expect(screen.getByTestId('streaming').textContent).toBe('false')
+
+    // Background deltas keep accumulating + the working cue stays exposed.
+    await act(async () => { wsHandler!({ type: 'agent_stream', conversationId: 'c1', delta: 'lo' }) })
+    expect(screen.getByTestId('live-ids').textContent).toBe('c1')
+    expect(screen.getByTestId('stream').textContent).toBe('')
+
+    // Switch back: the FULL accumulated stream re-appears mid-flight.
+    await act(async () => { fireEvent.click(screen.getByText('go-c1')) })
+    expect(screen.getByTestId('stream').textContent).toBe('Hello')
+    expect(screen.getByTestId('streaming').textContent).toBe('true')
+  })
+
+  it('does not duplicate the assistant reply when the refetch already contains it', async () => {
+    vi.mocked(agentApi.getAgentConversation).mockResolvedValue({
+      conversation: api.conv,
+      messages: [{ id: 'a1', conversation_id: 'c1', role: 'assistant', content: 'Same reply', created_at: '' }],
+    })
+    vi.mocked(agentApi.listAgentConversations).mockResolvedValue([api.conv])
+    render(<AgentChatProvider><Harness /></AgentChatProvider>)
+    await act(async () => { fireEvent.click(screen.getByText('open')) })
+    await waitFor(() => expect(screen.getByTestId('msgs').textContent).toBe('1'))
+    await act(async () => { wsHandler!({ type: 'agent_done', conversationId: 'c1', fullText: 'Same reply' }) })
+    expect(screen.getByTestId('msgs').textContent).toBe('1') // deduped
+  })
+
+  it('composer tri-state: red stop only with an empty box; typing flips to queue-send', async () => {
+    render(<AgentChatProvider><Harness /></AgentChatProvider>)
+    await act(async () => { fireEvent.click(screen.getByText('open')) })
+    await waitFor(() => expect(agentApi.createAgentConversation).toHaveBeenCalled())
+    // Start a turn → streaming, box empty → red Stop.
+    await act(async () => { fireEvent.click(screen.getByText('send')) })
+    expect(screen.getByLabelText('Stop')).toBeInTheDocument()
+    const box = screen.getByPlaceholderText('Add more while the agent works — it will queue…') as HTMLTextAreaElement
+    // Typing mid-stream → third state: send-to-queue (Stop hidden).
+    fireEvent.change(box, { target: { value: 'follow-up' } })
+    expect(screen.queryByLabelText('Stop')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('Send to queue')).toBeInTheDocument()
+    // Clearing the box restores the red Stop.
+    fireEvent.change(box, { target: { value: '' } })
+    expect(screen.getByLabelText('Stop')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Send to queue')).not.toBeInTheDocument()
+  })
+
+  it('a typed-but-unsent draft SURVIVES unmounting the composer (Mission⇄Board switch)', async () => {
+    const first = render(<AgentChatProvider><Harness /></AgentChatProvider>)
+    await act(async () => { fireEvent.click(screen.getByText('open')) })
+    const box = await screen.findByPlaceholderText('Ask the agent to do anything…') as HTMLTextAreaElement
+    fireEvent.change(box, { target: { value: 'idea a medio escribir' } })
+    // Switch to Board mode = the whole agent surface unmounts.
+    first.unmount()
+    // Back to Mission Control: the draft is right where it was left.
+    render(<AgentChatProvider><Harness /></AgentChatProvider>)
+    await act(async () => { fireEvent.click(screen.getByText('open')) })
+    const box2 = await screen.findByPlaceholderText('Ask the agent to do anything…') as HTMLTextAreaElement
+    expect(box2.value).toBe('idea a medio escribir')
+    // Sending clears the stored draft — a fresh mount starts empty again.
+    await act(async () => { fireEvent.keyDown(box2, { key: 'Enter' }) })
+    expect(box2.value).toBe('')
+  })
+
   it('Shift+Tab inside the panel cycles the tier', async () => {
     render(<AgentChatProvider><Harness /></AgentChatProvider>)
     await act(async () => { fireEvent.click(screen.getByText('open')) })
     const dialog = await screen.findByRole('dialog')
     await act(async () => { fireEvent.keyDown(dialog, { key: 'Tab', shiftKey: true }) })
     expect(agentApi.patchAgentConversation).toHaveBeenCalledWith('c1', { tierLevel: 1 })
+  })
+
+  it('Shift+Tab inside the TEXTAREA cycles the tier exactly once (no focus jump, no double-cycle)', async () => {
+    render(<AgentChatProvider><Harness /></AgentChatProvider>)
+    await act(async () => { fireEvent.click(screen.getByText('open')) })
+    const box = await screen.findByPlaceholderText('Ask the agent to do anything…')
+    await act(async () => { fireEvent.keyDown(box, { key: 'Tab', shiftKey: true }) })
+    // Once — the textarea handler stops propagation so the view wrapper's
+    // Shift+Tab listener doesn't cycle a second time.
+    const cycleCalls = vi.mocked(agentApi.patchAgentConversation).mock.calls.filter(
+      (c) => (c[1] as { tierLevel?: number }).tierLevel !== undefined,
+    )
+    expect(cycleCalls).toEqual([['c1', { tierLevel: 1 }]])
   })
 })

--- a/client/src/components/agent-chat/agent-options.ts
+++ b/client/src/components/agent-chat/agent-options.ts
@@ -1,17 +1,19 @@
 // ─── Agent reply option chips: protocol parsing ────────────────────────────────
 // The operator agent ends a reply with a fenced ```options code block containing
 // a JSON array of choice labels when (and only when) it asks the user to pick
-// between concrete choices (taught in server/agent-operator-prompt.ts). This
-// module extracts that trailing block STRICTLY — anything malformed is left in
-// the content so it renders as a normal code block instead of chips.
+// between concrete choices (taught in server/agent-operator-prompt.ts). The
+// VALIDATION stays strict (a JSON array of 2-8 short strings, nothing after it),
+// but the fence SHAPE is parsed tolerantly: real models emit the fence glued to
+// the prose ("…extra?```options"), put the array on the fence line itself, or
+// drop the closing ``` entirely — all of those must still become chips instead
+// of leaking raw protocol text into the bubble. Anything that doesn't validate
+// is left untouched in the content.
 
 const MIN_OPTIONS = 2
 const MAX_OPTIONS = 8
 const MAX_OPTION_LENGTH = 80
 
-// A ```options fence starting at a line boundary, closing at the END of the
-// message (trailing whitespace tolerated). Nothing but whitespace may follow.
-const TRAILING_OPTIONS_BLOCK = /(?:^|\n)```options[^\S\n]*\n([\s\S]*?)\n?```\s*$/
+const OPTIONS_FENCE = '```options'
 
 export interface ParsedAgentOptions {
   /** Message body with the options block stripped (unchanged when invalid). */
@@ -20,29 +22,43 @@ export interface ParsedAgentOptions {
   options: string[] | null
 }
 
+/** Parse + validate one candidate tail; null when it is not a valid block. */
+function parseOptionsTail(rawTail: string): string[] | null {
+  // The JSON array may sit on the fence line itself or on following lines,
+  // optionally closed by ``` and trailing whitespace.
+  const tail = rawTail.replace(/^[^\S\n]*\n?/, '').replace(/\s*(?:```)?\s*$/, '')
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(tail)
+  } catch {
+    return null
+  }
+  if (!Array.isArray(parsed) || parsed.length < MIN_OPTIONS || parsed.length > MAX_OPTIONS) return null
+  const options: string[] = []
+  for (const item of parsed) {
+    if (typeof item !== 'string') return null
+    const label = item.trim()
+    if (!label || label.length > MAX_OPTION_LENGTH) return null
+    options.push(label)
+  }
+  return options
+}
+
 /** Extract a trailing ```options block from assistant content.
  *  Valid = JSON array of 2-8 non-empty strings, each ≤80 chars after trimming. */
 export function extractAgentOptions(content: string): ParsedAgentOptions {
-  const match = TRAILING_OPTIONS_BLOCK.exec(content)
-  if (!match) return { body: content, options: null }
-
-  let parsed: unknown
-  try {
-    parsed = JSON.parse(match[1])
-  } catch {
-    return { body: content, options: null }
+  // Scan fence occurrences FIRST-to-last and take the first one whose tail
+  // validates: an occurrence of the literal ```options INSIDE a label of the
+  // real (earlier) block must not shadow it. Occurrences preceded by another
+  // backtick (a ````options long fence — e.g. the model quoting the protocol)
+  // are never candidates.
+  let idx = content.indexOf(OPTIONS_FENCE)
+  while (idx !== -1) {
+    if (idx === 0 || content[idx - 1] !== '`') {
+      const options = parseOptionsTail(content.slice(idx + OPTIONS_FENCE.length))
+      if (options) return { body: content.slice(0, idx).replace(/\s+$/, ''), options }
+    }
+    idx = content.indexOf(OPTIONS_FENCE, idx + 1)
   }
-  if (!Array.isArray(parsed) || parsed.length < MIN_OPTIONS || parsed.length > MAX_OPTIONS) {
-    return { body: content, options: null }
-  }
-
-  const options: string[] = []
-  for (const item of parsed) {
-    if (typeof item !== 'string') return { body: content, options: null }
-    const label = item.trim()
-    if (!label || label.length > MAX_OPTION_LENGTH) return { body: content, options: null }
-    options.push(label)
-  }
-
-  return { body: content.slice(0, match.index).replace(/\s+$/, ''), options }
+  return { body: content, options: null }
 }

--- a/client/src/components/agents/RailProfileSelector.tsx
+++ b/client/src/components/agents/RailProfileSelector.tsx
@@ -26,7 +26,9 @@ export function RailProfileSelector({ value, onChange }: Props) {
     fetch(`${getApiBase()}/profiles`)
       .then((r) => (r.ok ? (r.json() as Promise<{ profiles: ProfileListEntry[] }>) : { profiles: [] }))
       .then((data) => {
-        if (!cancelled) setProfiles(data.profiles)
+        // A malformed/empty payload must degrade to "no profiles", never crash
+        // the rail header render.
+        if (!cancelled) setProfiles(Array.isArray(data.profiles) ? data.profiles : [])
       })
       .catch(() => {
         if (!cancelled) setProfiles([])

--- a/client/src/components/explore-spec/useSmoothStream.ts
+++ b/client/src/components/explore-spec/useSmoothStream.ts
@@ -36,6 +36,17 @@ export function useSmoothStream(target: string, isStreaming: boolean): string {
   useEffect(() => { displayedRef.current = displayed }, [displayed])
 
   useEffect(() => {
+    // Target REPLACED rather than extended — e.g. switching to a DIFFERENT
+    // conversation whose stream is shorter, or a drained queued turn resetting
+    // the stream to ''. The incremental typing model only holds while target
+    // grows in place; on replacement, snap to the new target immediately
+    // (otherwise backlog goes negative and the stale text sticks forever).
+    if (!target.startsWith(displayedRef.current)) {
+      displayedRef.current = target
+      lastTickRef.current = 0
+      if (displayed !== target) setDisplayed(target)
+      return
+    }
     if (!isStreaming && target.length <= displayedRef.current.length) {
       // Idle and nothing pending — make sure we don't have a stale RAF.
       if (rafRef.current != null) {

--- a/client/src/components/settings/ProjectSettingsDialog.tsx
+++ b/client/src/components/settings/ProjectSettingsDialog.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Settings, SlidersHorizontal, Wallet, Activity, TerminalSquare } from 'lucide-react'
+import { cn } from '../../lib/utils'
+import { useDesktop } from '../../hooks/useDesktop'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '../ui/dialog'
+import { TerminalSettingsSection } from './TerminalSettingsSection'
+import {
+  ProjectTelemetrySection,
+  ProjectPrePromptsSection,
+  ProjectBudgetSection,
+} from './ProjectSettingsSections'
+
+const PROJECT_SETTINGS_SECTIONS = [
+  { id: 'general', icon: SlidersHorizontal, labelKey: 'projectDialog.nav.general' },
+  { id: 'budget', icon: Wallet, labelKey: 'projectDialog.nav.budget' },
+  { id: 'telemetry', icon: Activity, labelKey: 'projectDialog.nav.telemetry' },
+  { id: 'terminal', icon: TerminalSquare, labelKey: 'projectDialog.nav.terminal' },
+] as const
+
+type SectionId = (typeof PROJECT_SETTINGS_SECTIONS)[number]['id']
+
+/**
+ * Project settings as a MODAL (Agent Mode — the /settings route belongs to the
+ * Kanban surface). Mirrors the Global Settings / Docs dialogs exactly: same
+ * movable-resizable DialogContent proportions (max-w-5xl · 92vw · 82vh), same
+ * left section nav + scrollable content, all panes mounted and toggled with
+ * `hidden` so switching sections never refetches or resizes.
+ */
+export function ProjectSettingsDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const { t } = useTranslation('settings')
+  const { activeProjectId, projects } = useDesktop()
+  const project = projects.find((p) => p.id === activeProjectId)
+  const [activeSection, setActiveSection] = useState<SectionId>('general')
+  const paneCls = (id: SectionId) => cn('space-y-5', activeSection === id ? '' : 'hidden')
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => { if (!isOpen) onClose() }}>
+      <DialogContent movableResizable className="flex max-w-5xl w-[92vw] h-[82vh] flex-col overflow-hidden">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Settings className="w-4 h-4" />
+            {project ? t('projectDialog.title', { name: project.name }) : t('page.title')}
+          </DialogTitle>
+          <DialogDescription>{t('projectDialog.description')}</DialogDescription>
+        </DialogHeader>
+
+        <div className="flex min-h-0 flex-1 gap-5 py-2">
+          {/* Left section nav — same chrome as the Global Settings dialog */}
+          <nav className="w-40 shrink-0 space-y-0.5 overflow-y-auto border-r border-border pr-2">
+            {PROJECT_SETTINGS_SECTIONS.map((s) => {
+              const Icon = s.icon
+              return (
+                <button
+                  key={s.id}
+                  type="button"
+                  onClick={() => setActiveSection(s.id)}
+                  className={cn(
+                    'flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left text-xs transition-colors',
+                    activeSection === s.id
+                      ? 'bg-accent-primary/15 font-medium text-foreground'
+                      : 'text-muted-foreground hover:bg-muted/40 hover:text-foreground',
+                  )}
+                >
+                  <Icon className="w-3.5 h-3.5 shrink-0" />
+                  <span className="truncate">{t(s.labelKey)}</span>
+                </button>
+              )
+            })}
+          </nav>
+
+          {/* Active section content — fills the fixed-height dialog and scrolls,
+              so switching sections never resizes the modal. */}
+          <div className="min-w-0 flex-1 overflow-y-auto pr-1">
+            <div className={paneCls('general')}>
+              <ProjectPrePromptsSection />
+            </div>
+            <div className={paneCls('budget')}>
+              <ProjectBudgetSection />
+            </div>
+            <div className={paneCls('telemetry')}>
+              <ProjectTelemetrySection />
+            </div>
+            <div className={paneCls('terminal')}>
+              <TerminalSettingsSection mode="project" />
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/client/src/components/settings/ProjectSettingsSections.tsx
+++ b/client/src/components/settings/ProjectSettingsSections.tsx
@@ -1,0 +1,384 @@
+import { useEffect, useRef, useState } from 'react'
+import { toast } from 'sonner'
+import { useTranslation, Trans } from 'react-i18next'
+import { getApiBase } from '../../lib/api'
+import { useDesktop } from '../../hooks/useDesktop'
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../ui/card'
+import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+
+// ─── Project settings sections ────────────────────────────────────────────────
+// Self-contained cards (own fetch + save against the ACTIVE project's API base)
+// shared by the /settings route page and the Agent-Mode ProjectSettingsDialog.
+// Extracted verbatim from SettingsPage — same endpoints, toasts and copy.
+
+interface ProjectSettingsPayload {
+  pipelineTelemetryEnabled?: boolean
+  prePrompt?: string
+  ultraPrePrompt?: string
+}
+
+/** Skeleton shown until a section's GET settles — fields never flash empty and
+ *  a late response can never clobber what the user already typed. */
+function SectionSkeleton() {
+  return <div className="h-32 animate-pulse rounded-lg bg-muted/30" data-testid="section-skeleton" />
+}
+
+/** Pipeline telemetry opt-in toggle (Super mode only — enforced by callers). */
+export function ProjectTelemetrySection() {
+  const { t } = useTranslation('settings')
+  const { activeProjectId } = useDesktop()
+  const [telemetryEnabled, setTelemetryEnabled] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const [loaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    if (!activeProjectId) return
+    let cancelled = false
+    setLoaded(false)
+    fetch(`${getApiBase()}/settings`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: ProjectSettingsPayload | null) => {
+        if (!cancelled && data) setTelemetryEnabled(data.pipelineTelemetryEnabled ?? false)
+      })
+      .catch(() => {})
+      .finally(() => { if (!cancelled) setLoaded(true) })
+    return () => { cancelled = true }
+  }, [activeProjectId])
+
+  if (!loaded) return <SectionSkeleton />
+
+  async function saveToggle(enabled: boolean) {
+    setIsSaving(true)
+    const prev = telemetryEnabled
+    setTelemetryEnabled(enabled)
+    try {
+      const res = await fetch(`${getApiBase()}/settings`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pipelineTelemetryEnabled: enabled }),
+      })
+      if (!res.ok) throw new Error('Failed to save')
+      toast.success(enabled ? t('telemetry.enabled') : t('telemetry.disabled'))
+    } catch (err) {
+      setTelemetryEnabled(prev)
+      toast.error(t('telemetry.saveFailed'), { description: (err as Error).message })
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('telemetry.title')}</CardTitle>
+        <CardDescription>{t('telemetry.description')}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div className="space-y-0.5">
+            <p className="text-xs font-medium">{t('telemetry.toggleLabel')}</p>
+            <p className="text-[10px] text-muted-foreground">
+              <Trans
+                ns="settings"
+                i18nKey="telemetry.toggleDescription"
+                components={{ mono: <span className="font-mono" /> }}
+              />
+            </p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-label={t('telemetry.toggleLabel')}
+            aria-checked={telemetryEnabled}
+            disabled={isSaving}
+            onClick={() => saveToggle(!telemetryEnabled)}
+            className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 ${
+              telemetryEnabled ? 'bg-primary' : 'bg-input'
+            }`}
+          >
+            <span
+              className={`inline-block h-3.5 w-3.5 rounded-full bg-background shadow-sm transition-transform ${
+                telemetryEnabled ? 'translate-x-4' : 'translate-x-0.5'
+              }`}
+            />
+          </button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+/** One pre-prompt editor card (shared shape for the normal + Freestyle prompt). */
+function PrePromptCard({
+  value,
+  onChange,
+  onSave,
+  isSaving,
+  fieldId,
+  i18nRoot,
+}: {
+  value: string
+  onChange: (v: string) => void
+  onSave: () => void
+  isSaving: boolean
+  fieldId: string
+  i18nRoot: 'prePrompt' | 'ultraPrePrompt'
+}) {
+  const { t } = useTranslation('settings')
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t(`${i18nRoot}.title`)}</CardTitle>
+        <CardDescription>{t(`${i18nRoot}.description`)}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="space-y-2">
+          <label htmlFor={fieldId} className="text-xs font-medium">
+            {t(`${i18nRoot}.label`)}
+          </label>
+          <textarea
+            id={fieldId}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder={t(`${i18nRoot}.placeholder`)}
+            className="min-h-32 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/20"
+          />
+          <p className="text-xs text-muted-foreground">{t(`${i18nRoot}.helper`)}</p>
+        </div>
+        <div className="flex justify-end">
+          <Button size="sm" variant="secondary" className="h-7 text-xs" disabled={isSaving} onClick={onSave}>
+            {isSaving ? t('common:states.saving') : t(`${i18nRoot}.saveButton`)}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+/** Pre-prompt + Freestyle pre-prompt cards (loads both from GET /settings). */
+export function ProjectPrePromptsSection() {
+  const { t } = useTranslation('settings')
+  const { activeProjectId } = useDesktop()
+  const [prePrompt, setPrePrompt] = useState('')
+  const [isSavingPrePrompt, setIsSavingPrePrompt] = useState(false)
+  const [ultraPrePrompt, setUltraPrePrompt] = useState('')
+  const [isSavingUltraPrePrompt, setIsSavingUltraPrePrompt] = useState(false)
+  const [loaded, setLoaded] = useState(false)
+  // A late-landing GET must never clobber a field the user already edited.
+  const touchedRef = useRef({ pre: false, ultra: false })
+
+  useEffect(() => {
+    if (!activeProjectId) return
+    let cancelled = false
+    setLoaded(false)
+    touchedRef.current = { pre: false, ultra: false }
+    fetch(`${getApiBase()}/settings`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: ProjectSettingsPayload | null) => {
+        if (cancelled || !data) return
+        if (!touchedRef.current.pre) setPrePrompt(data.prePrompt ?? '')
+        if (!touchedRef.current.ultra) setUltraPrePrompt(data.ultraPrePrompt ?? '')
+      })
+      .catch(() => {})
+      .finally(() => { if (!cancelled) setLoaded(true) })
+    return () => { cancelled = true }
+  }, [activeProjectId])
+
+  async function savePrePrompt() {
+    setIsSavingPrePrompt(true)
+    try {
+      const res = await fetch(`${getApiBase()}/settings`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prePrompt }),
+      })
+      if (!res.ok) throw new Error('Failed to save')
+      const data = await res.json() as { settings?: ProjectSettingsPayload }
+      const savedValue = data.settings?.prePrompt ?? ''
+      setPrePrompt(savedValue)
+      toast.success(savedValue.trim() === '' ? t('prePrompt.cleared') : t('prePrompt.saved'))
+    } catch (err) {
+      toast.error(t('prePrompt.saveFailed'), { description: (err as Error).message })
+    } finally {
+      setIsSavingPrePrompt(false)
+    }
+  }
+
+  async function saveUltraPrePrompt() {
+    setIsSavingUltraPrePrompt(true)
+    try {
+      const res = await fetch(`${getApiBase()}/settings`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ultraPrePrompt }),
+      })
+      if (!res.ok) throw new Error('Failed to save')
+      const data = await res.json() as { settings?: ProjectSettingsPayload }
+      const savedValue = data.settings?.ultraPrePrompt ?? ''
+      setUltraPrePrompt(savedValue)
+      toast.success(savedValue.trim() === '' ? t('ultraPrePrompt.resetToDefault') : t('ultraPrePrompt.saved'))
+    } catch (err) {
+      toast.error(t('ultraPrePrompt.saveFailed'), { description: (err as Error).message })
+    } finally {
+      setIsSavingUltraPrePrompt(false)
+    }
+  }
+
+  if (!loaded) return <SectionSkeleton />
+
+  return (
+    <>
+      <PrePromptCard
+        value={prePrompt}
+        onChange={(v) => { touchedRef.current.pre = true; setPrePrompt(v) }}
+        onSave={savePrePrompt}
+        isSaving={isSavingPrePrompt}
+        fieldId="project-pre-prompt"
+        i18nRoot="prePrompt"
+      />
+      <PrePromptCard
+        value={ultraPrePrompt}
+        onChange={(v) => { touchedRef.current.ultra = true; setUltraPrePrompt(v) }}
+        onSave={saveUltraPrePrompt}
+        isSaving={isSavingUltraPrePrompt}
+        fieldId="project-ultra-pre-prompt"
+        i18nRoot="ultraPrePrompt"
+      />
+    </>
+  )
+}
+
+/** Daily budget + per-job cost alert card (GET/PATCH /budget). */
+export function ProjectBudgetSection() {
+  const { t } = useTranslation('settings')
+  const { activeProjectId } = useDesktop()
+  const [dailyBudget, setDailyBudget] = useState('')
+  const [isSavingBudget, setIsSavingBudget] = useState(false)
+  const [jobCostThreshold, setJobCostThreshold] = useState('')
+  const [isSavingJobThreshold, setIsSavingJobThreshold] = useState(false)
+  const [loaded, setLoaded] = useState(false)
+  // A late-landing GET must never clobber a field the user already edited.
+  const touchedRef = useRef({ daily: false, perJob: false })
+
+  useEffect(() => {
+    if (!activeProjectId) return
+    let cancelled = false
+    setLoaded(false)
+    touchedRef.current = { daily: false, perJob: false }
+    fetch(`${getApiBase()}/budget`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: { dailyBudgetUsd?: number | null; jobCostThresholdUsd?: number | null } | null) => {
+        if (cancelled || !data) return
+        if (!touchedRef.current.daily) setDailyBudget(data.dailyBudgetUsd != null ? String(data.dailyBudgetUsd) : '')
+        if (!touchedRef.current.perJob) setJobCostThreshold(data.jobCostThresholdUsd != null ? String(data.jobCostThresholdUsd) : '')
+      })
+      .catch(() => {})
+      .finally(() => { if (!cancelled) setLoaded(true) })
+    return () => { cancelled = true }
+  }, [activeProjectId])
+
+  async function savePatch(body: Record<string, number | null>, okMsg: string, failKey: string, setSaving: (v: boolean) => void) {
+    setSaving(true)
+    try {
+      const res = await fetch(`${getApiBase()}/budget`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      if (!res.ok) throw new Error('Failed to save')
+      toast.success(okMsg)
+    } catch (err) {
+      toast.error(t(failKey), { description: (err as Error).message })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function parseAmount(raw: string): number | null | undefined {
+    const parsed = raw.trim() === '' ? null : parseFloat(raw)
+    if (parsed !== null && (isNaN(parsed) || parsed <= 0)) {
+      toast.error(t('budget.invalidNumber'))
+      return undefined
+    }
+    return parsed
+  }
+
+  function saveDailyBudget() {
+    const parsed = parseAmount(dailyBudget)
+    if (parsed === undefined) return
+    void savePatch(
+      { dailyBudgetUsd: parsed },
+      parsed == null ? t('budget.dailyRemoved') : t('budget.dailySet', { amount: parsed }),
+      'budget.saveBudgetFailed',
+      setIsSavingBudget,
+    )
+  }
+
+  function saveJobCostThreshold() {
+    const parsed = parseAmount(jobCostThreshold)
+    if (parsed === undefined) return
+    void savePatch(
+      { jobCostThresholdUsd: parsed },
+      parsed == null ? t('budget.perJobAlertDisabled') : t('budget.alertSet', { amount: parsed }),
+      'budget.saveThresholdFailed',
+      setIsSavingJobThreshold,
+    )
+  }
+
+  if (!loaded) return <SectionSkeleton />
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('budget.title')}</CardTitle>
+        <CardDescription>{t('budget.description')}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-2 gap-6">
+          <div className="space-y-2">
+            <div>
+              <label className="text-xs font-medium">{t('budget.dailyLabel')}</label>
+              <p className="text-xs text-muted-foreground">{t('budget.dailyHelper')}</p>
+            </div>
+            <Input
+              type="number"
+              min="0"
+              step="0.01"
+              value={dailyBudget}
+              onChange={(e) => { touchedRef.current.daily = true; setDailyBudget(e.target.value) }}
+              placeholder={t('budget.dailyPlaceholder')}
+              className="h-8 text-xs font-mono"
+            />
+            <div className="flex justify-end">
+              <Button size="sm" variant="secondary" className="h-7 text-xs" disabled={isSavingBudget} onClick={saveDailyBudget}>
+                {isSavingBudget ? t('common:states.saving') : t('common:actions.save')}
+              </Button>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <div>
+              <label className="text-xs font-medium">{t('budget.perJobLabel')}</label>
+              <p className="text-xs text-muted-foreground">{t('budget.perJobHelper')}</p>
+            </div>
+            <Input
+              type="number"
+              min="0"
+              step="0.01"
+              value={jobCostThreshold}
+              onChange={(e) => { touchedRef.current.perJob = true; setJobCostThreshold(e.target.value) }}
+              placeholder={t('budget.perJobPlaceholder')}
+              className="h-8 text-xs font-mono"
+            />
+            <div className="flex justify-end">
+              <Button size="sm" variant="secondary" className="h-7 text-xs" disabled={isSavingJobThreshold} onClick={saveJobCostThreshold}>
+                {isSavingJobThreshold ? t('common:states.saving') : t('common:actions.save')}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/client/src/components/settings/__tests__/ProjectSettingsDialog.test.tsx
+++ b/client/src/components/settings/__tests__/ProjectSettingsDialog.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '../../../test-utils'
+
+vi.mock('../../../lib/api', () => ({ getApiBase: () => '/api/projects/p1' }))
+
+vi.mock('../../../hooks/useDesktop', () => ({
+  useDesktop: () => ({
+    projects: [{ id: 'p1', name: 'acme-api', slug: 'acme-api', path: '/acme', provider: 'claude' }],
+    activeProjectId: 'p1',
+    setActiveProjectId: vi.fn(),
+  }),
+}))
+
+// Heavy self-fetching section — its own suite covers it.
+vi.mock('../TerminalSettingsSection', () => ({
+  TerminalSettingsSection: () => <div data-testid="terminal-section" />,
+}))
+
+import { ProjectSettingsDialog } from '../ProjectSettingsDialog'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) })
+})
+
+describe('ProjectSettingsDialog', () => {
+  it('shows the project name in the title and the four section entries', () => {
+    render(<ProjectSettingsDialog open onClose={vi.fn()} />)
+    expect(screen.getByText('acme-api — Settings')).toBeInTheDocument()
+    for (const label of ['General', 'Budget', 'Telemetry', 'Terminal']) {
+      expect(screen.getByRole('button', { name: label })).toBeInTheDocument()
+    }
+  })
+
+  it('starts on General (pre-prompts visible) and switches panes on nav click', async () => {
+    render(<ProjectSettingsDialog open onClose={vi.fn()} />)
+    // General pane: the pre-prompt editor is visible (after its GET settles),
+    // terminal pane hidden.
+    await waitFor(() => expect(document.getElementById('project-pre-prompt')).toBeTruthy())
+    const generalField = document.getElementById('project-pre-prompt')!
+    expect(generalField.closest('.hidden')).toBeNull()
+    const terminalPane = screen.getByTestId('terminal-section').closest('div.space-y-5')!
+    expect(terminalPane.className).toContain('hidden')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Terminal' }))
+    expect(screen.getByTestId('terminal-section').closest('div.space-y-5')!.className).not.toContain('hidden')
+    expect(generalField.closest('.hidden')).not.toBeNull()
+  })
+
+  it('closes through onOpenChange', () => {
+    const onClose = vi.fn()
+    render(<ProjectSettingsDialog open onClose={onClose} />)
+    fireEvent.keyDown(document.body, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/client/src/context/AgentChatContext.tsx
+++ b/client/src/context/AgentChatContext.tsx
@@ -38,6 +38,24 @@ export interface AgentLiveTool {
   tool: string
 }
 
+/** A message sent while the agent was busy — parked server-side, shown as a
+ *  dimmed chip below the streaming bubble until its turn starts. */
+export interface AgentQueuedItem {
+  queueId: string
+  text: string
+}
+
+/** Live turn state for ONE conversation. Kept per-conversation so background
+ *  agents keep streaming while the user reads another thread. */
+export interface AgentConvLive {
+  streamingText: string
+  isStreaming: boolean
+  liveTools: AgentLiveTool[]
+  queued: AgentQueuedItem[]
+}
+
+const EMPTY_LIVE: AgentConvLive = { streamingText: '', isStreaming: false, liveTools: [], queued: [] }
+
 export interface AgentChatContextValue {
   visibility: AgentVisibility
   open: () => void
@@ -51,6 +69,10 @@ export interface AgentChatContextValue {
   streamingText: string
   isStreaming: boolean
   liveTools: AgentLiveTool[]
+  /** Messages waiting behind the in-flight turn (FIFO, server-drained). */
+  queuedMessages: AgentQueuedItem[]
+  /** Every conversation with a live turn — feeds the sidebar title shimmer. */
+  streamingConversationIds: ReadonlySet<string>
 
   mcpEnabled: boolean
   enablingMcp: boolean
@@ -95,9 +117,12 @@ interface WsAgentMsg {
   fullText?: string
   error?: string
   tool?: string
+  queueId?: string | null
+  text?: string
 }
 
 let _toolSeq = 0
+let _queueSeq = 0
 
 export function AgentChatProvider({ children }: { children: ReactNode }) {
   const { registerHandler, unregisterHandler } = useSharedWebSocket()
@@ -108,9 +133,10 @@ export function AgentChatProvider({ children }: { children: ReactNode }) {
   const [conversations, setConversations] = useState<AgentConversation[]>([])
   const [active, setActive] = useState<AgentConversation | null>(null)
   const [messages, setMessages] = useState<AgentMessage[]>([])
-  const [streamingText, setStreamingText] = useState('')
-  const [isStreaming, setIsStreaming] = useState(false)
-  const [liveTools, setLiveTools] = useState<AgentLiveTool[]>([])
+  // Live turn state is PER CONVERSATION: agents keep working in the background,
+  // so switching threads never drops streamed text, tool chips or queued
+  // messages. The view derives the active conversation's slice below.
+  const [liveByConv, setLiveByConv] = useState<ReadonlyMap<string, AgentConvLive>>(new Map())
   const [mcpEnabled, setMcpEnabled] = useState(true)
   const [enablingMcp, setEnablingMcp] = useState(false)
   const [providersReady, setProvidersReady] = useState<boolean | null>(null)
@@ -132,6 +158,42 @@ export function AgentChatProvider({ children }: { children: ReactNode }) {
 
   const activeIdRef = useRef<string | null>(null)
   activeIdRef.current = active?.id ?? null
+  // send() decides queue-vs-direct from a ref (liveByConv is not among its deps).
+  const liveRef = useRef(liveByConv)
+  liveRef.current = liveByConv
+  // queueIds whose agent_dequeued already ran — send()'s race reconciliation
+  // must never re-add a chip that was consumed while the POST was in flight.
+  const consumedQueueIdsRef = useRef(new Set<string>())
+
+  /** Update one conversation's live slice; a fully-idle slice drops its entry. */
+  const patchLive = useCallback((id: string, fn: (prev: AgentConvLive) => AgentConvLive | null) => {
+    setLiveByConv((m) => {
+      const next = fn(m.get(id) ?? EMPTY_LIVE)
+      const copy = new Map(m)
+      if (
+        next === null ||
+        (!next.isStreaming && !next.streamingText && next.liveTools.length === 0 && next.queued.length === 0)
+      ) {
+        copy.delete(id)
+      } else {
+        copy.set(id, next)
+      }
+      return copy
+    })
+  }, [])
+
+  // The view's slice — everything downstream (panel, composer, Agent Mode
+  // surface) keeps consuming the same flat fields as before.
+  const activeLive = (active ? liveByConv.get(active.id) : undefined) ?? EMPTY_LIVE
+  const streamingText = activeLive.streamingText
+  const isStreaming = activeLive.isStreaming
+  const liveTools = activeLive.liveTools
+  const queuedMessages = activeLive.queued
+  const streamingConversationIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const [id, live] of liveByConv) if (live.isStreaming) ids.add(id)
+    return ids
+  }, [liveByConv])
 
   // Refresh the conversation list + MCP status lazily on first open.
   const refreshConversations = useCallback(async () => {
@@ -174,45 +236,81 @@ export function AgentChatProvider({ children }: { children: ReactNode }) {
         setActive((a) => (a && a.id === msg.conversationId ? { ...a, title } : a))
         return
       }
-      if (!msg.conversationId || msg.conversationId !== activeIdRef.current) return
+      const convId = msg.conversationId
+      if (!convId) return
+      // NO active-conversation filter for live state: background turns keep
+      // accumulating in their own slice so a switch-back shows the full stream.
+      // Only the `messages` list (the active thread) is gated on isActive.
+      const isActive = convId === activeIdRef.current
       if (msg.type === 'agent_stream') {
-        setIsStreaming(true)
-        setStreamingText((t) => t + (msg.delta ?? ''))
+        patchLive(convId, (p) => ({ ...p, isStreaming: true, streamingText: p.streamingText + (msg.delta ?? '') }))
       } else if (msg.type === 'agent_tool') {
-        setLiveTools((tools) => [...tools, { id: `t${_toolSeq++}`, tool: msg.tool ?? 'tool' }])
+        patchLive(convId, (p) => ({ ...p, isStreaming: true, liveTools: [...p.liveTools, { id: `t${_toolSeq++}`, tool: msg.tool ?? 'tool' }] }))
       } else if (msg.type === 'agent_done') {
         const full = msg.fullText ?? ''
-        setMessages((m) => [
-          ...m,
-          { id: `local-${Date.now()}`, conversation_id: msg.conversationId!, role: 'assistant', content: full, created_at: new Date().toISOString() },
-        ])
-        setStreamingText('')
-        setIsStreaming(false)
-        setLiveTools([])
+        if (isActive) {
+          setMessages((m) => {
+            // A switch-back refetch can already contain this reply (it is
+            // persisted before the broadcast) — don't append it twice. Only
+            // server-fetched rows (non-local ids) dedupe: two legitimately
+            // identical consecutive replies both arrive as local appends.
+            const last = m[m.length - 1]
+            if (last && last.role === 'assistant' && last.content === full && !last.id.startsWith('local-')) return m
+            return [
+              ...m,
+              { id: `local-${Date.now()}`, conversation_id: convId, role: 'assistant', content: full, created_at: new Date().toISOString() },
+            ]
+          })
+        }
+        // Keep queued chips: with a non-empty queue the next drained turn is
+        // about to start (agent_dequeued follows).
+        patchLive(convId, (p) => ({ ...EMPTY_LIVE, queued: p.queued }))
       } else if (msg.type === 'agent_error') {
-        setStreamingText('')
-        setIsStreaming(false)
-        setLiveTools([])
+        patchLive(convId, (p) => ({ ...EMPTY_LIVE, queued: p.queued }))
         const err = msg.error || 'The agent turn failed.'
         toast.error(err)
         // Also surface it inline so it's visible in the conversation.
-        setMessages((m) => [
-          ...m,
-          { id: `err-${Date.now()}`, conversation_id: msg.conversationId!, role: 'assistant', content: `⚠️ ${err}`, created_at: new Date().toISOString() },
-        ])
+        if (isActive) {
+          setMessages((m) => [
+            ...m,
+            { id: `err-${Date.now()}`, conversation_id: convId, role: 'assistant', content: `⚠️ ${err}`, created_at: new Date().toISOString() },
+          ])
+        }
+      } else if (msg.type === 'agent_queued') {
+        // Dedupe by queueId: the sending window already parked its own chip.
+        patchLive(convId, (p) => {
+          if (msg.queueId && p.queued.some((q) => q.queueId === msg.queueId)) return p
+          return { ...p, queued: [...p.queued, { queueId: msg.queueId ?? `srv-${_queueSeq++}`, text: msg.text ?? '' }] }
+        })
+      } else if (msg.type === 'agent_dequeued') {
+        // The queued message's turn starts now: chip → real user bubble.
+        if (msg.queueId) consumedQueueIdsRef.current.add(msg.queueId)
+        patchLive(convId, (p) => {
+          const idx = msg.queueId ? p.queued.findIndex((q) => q.queueId === msg.queueId) : 0
+          const drop = idx === -1 ? 0 : idx
+          return { ...p, queued: p.queued.filter((_, i) => i !== drop), isStreaming: true, streamingText: '', liveTools: [] }
+        })
+        if (isActive && msg.text) {
+          setMessages((m) => [
+            ...m,
+            { id: `local-u-${Date.now()}`, conversation_id: convId, role: 'user', content: msg.text!, created_at: new Date().toISOString() },
+          ])
+        }
+      } else if (msg.type === 'agent_queue_cleared') {
+        patchLive(convId, (p) => ({ ...p, queued: [] }))
       }
     }
     registerHandler('agent-chat', handler)
     return () => unregisterHandler('agent-chat')
-  }, [registerHandler, unregisterHandler])
+  }, [registerHandler, unregisterHandler, patchLive])
 
   const loadConversation = useCallback(async (id: string) => {
     const { conversation, messages: msgs } = await getAgentConversation(id)
     setActive(conversation)
     setMessages(msgs)
-    setStreamingText('')
-    setIsStreaming(false)
-    setLiveTools([])
+    // Live state (stream text / tools / queue) is per-conversation and is
+    // deliberately NOT reset here — a background turn keeps its full context
+    // and re-appears mid-stream when the user switches back.
   }, [])
 
   const ensureActive = useCallback(async (): Promise<AgentConversation> => {
@@ -268,30 +366,64 @@ export function AgentChatProvider({ children }: { children: ReactNode }) {
       setActive(conv)
       setMessages([])
     }
-    setMessages((m) => [
-      ...m,
-      { id: `local-u-${Date.now()}`, conversation_id: conv.id, role: 'user', content: trimmed, attachment_ids: opts?.attachmentIds ?? [], created_at: new Date().toISOString() },
-    ])
-    setIsStreaming(true)
-    setStreamingText('')
+    const queueId = `q-${Date.now()}-${_queueSeq++}`
+    const userBubble = {
+      id: `local-u-${Date.now()}`,
+      conversation_id: conv.id,
+      role: 'user' as const,
+      content: trimmed,
+      attachment_ids: opts?.attachmentIds ?? [],
+      created_at: new Date().toISOString(),
+    }
+    // Busy conversation → the message QUEUES (server-side FIFO) and shows as a
+    // parked chip below the streaming bubble instead of a normal bubble.
+    const wasBusy = liveRef.current.get(conv.id)?.isStreaming === true
+    if (wasBusy) {
+      patchLive(conv.id, (p) => ({ ...p, queued: [...p.queued, { queueId, text: trimmed }] }))
+    } else {
+      setMessages((m) => [...m, userBubble])
+      patchLive(conv.id, (p) => ({ ...p, isStreaming: true, streamingText: '', liveTools: [] }))
+    }
     const attachments = opts?.attachmentIds && opts.attachmentIds.length ? { ids: opts.attachmentIds } : undefined
     try {
-      await sendAgentMessage(conv.id, trimmed, { tierLevel: conv.tier_level, attachments })
+      const res = await sendAgentMessage(conv.id, trimmed, { tierLevel: conv.tier_level, attachments, queueId })
+      const queued = res?.queued === true
+      if (queued && !wasBusy) {
+        // Rare race: the server was actually mid-turn — re-home the optimistic
+        // bubble as a queued chip (the agent_queued event dedupes by queueId).
+        // If its agent_dequeued ALREADY ran while this POST was in flight, the
+        // chip is consumed — re-adding it would park a phantom chip forever.
+        setMessages((m) => m.filter((x) => x.id !== userBubble.id))
+        if (!consumedQueueIdsRef.current.has(queueId)) {
+          patchLive(conv.id, (p) =>
+            p.queued.some((q) => q.queueId === queueId) ? p : { ...p, queued: [...p.queued, { queueId, text: trimmed }] },
+          )
+        }
+      } else if (!queued && wasBusy) {
+        // Rare race: the turn had just settled — our chip is running as a direct
+        // turn (no agent_dequeued will ever come for it), promote it now.
+        patchLive(conv.id, (p) => ({ ...p, queued: p.queued.filter((q) => q.queueId !== queueId), isStreaming: true }))
+        setMessages((m) => [...m, userBubble])
+      }
     } catch (e) {
       // No agent_* WS event will arrive (the POST never spawned a turn) — reset
-      // the streaming state here, mirroring the agent_error handler.
-      setStreamingText('')
-      setIsStreaming(false)
-      setLiveTools([])
+      // the optimistic state here, mirroring the agent_error handler.
+      if (wasBusy) {
+        patchLive(conv.id, (p) => ({ ...p, queued: p.queued.filter((q) => q.queueId !== queueId) }))
+      } else {
+        patchLive(conv.id, (p) => ({ ...p, isStreaming: false, streamingText: '', liveTools: [] }))
+      }
       toast.error(e instanceof Error ? e.message : 'Failed to send message.')
     }
-  }, [active])
+  }, [active, patchLive])
 
   const abort = useCallback(async () => {
-    if (active) await abortAgentTurn(active.id)
-    setIsStreaming(false)
-    setStreamingText('')
-  }, [active])
+    if (!active) return
+    // Stop means stop: drop the stream state AND any queued chips immediately
+    // (the server discards its queue too and broadcasts agent_queue_cleared).
+    patchLive(active.id, () => null)
+    await abortAgentTurn(active.id)
+  }, [active, patchLive])
 
   const patchActive = useCallback(async (patch: Parameters<typeof patchAgentConversation>[1]) => {
     if (!active) return
@@ -336,9 +468,6 @@ export function AgentChatProvider({ children }: { children: ReactNode }) {
   const startNewConversation = useCallback((projectId?: string | null) => {
     setActive(null)
     setMessages([])
-    setStreamingText('')
-    setIsStreaming(false)
-    setLiveTools([])
     setDraftPinnedProjectId(projectId ?? null)
     setDraftProvider('claude')
     setDraftModel(null)
@@ -354,8 +483,6 @@ export function AgentChatProvider({ children }: { children: ReactNode }) {
     setConversations((c) => [created, ...c])
     setActive(created)
     setMessages([])
-    setStreamingText('')
-    setIsStreaming(false)
   }, [active])
 
   const selectConversation = useCallback(async (id: string) => { await loadConversation(id) }, [loadConversation])
@@ -363,14 +490,12 @@ export function AgentChatProvider({ children }: { children: ReactNode }) {
   const deleteConversation = useCallback(async (id: string) => {
     await deleteAgentConversation(id)
     setConversations((c) => c.filter((x) => x.id !== id))
+    patchLive(id, () => null)
     if (activeIdRef.current === id) {
       setActive(null)
       setMessages([])
-      setStreamingText('')
-      setIsStreaming(false)
-      setLiveTools([])
     }
-  }, [])
+  }, [patchLive])
 
   const enableMcpServer = useCallback(async () => {
     setEnablingMcp(true)
@@ -385,6 +510,7 @@ export function AgentChatProvider({ children }: { children: ReactNode }) {
   const value = useMemo<AgentChatContextValue>(() => ({
     visibility, open, close, minimize, toggle,
     conversations, active, messages, streamingText, isStreaming, liveTools,
+    queuedMessages, streamingConversationIds,
     mcpEnabled, enablingMcp, enableMcpServer, providersReady,
     send, abort, cycleTier, setTier, setProvider, setModel, setPinnedProject,
     newConversation, startNewConversation, draftPinnedProjectId,
@@ -393,6 +519,7 @@ export function AgentChatProvider({ children }: { children: ReactNode }) {
   }), [
     visibility, open, close, minimize, toggle,
     conversations, active, messages, streamingText, isStreaming, liveTools,
+    queuedMessages, streamingConversationIds,
     mcpEnabled, enablingMcp, enableMcpServer, providersReady,
     send, abort, cycleTier, setTier, setProvider, setModel, setPinnedProject,
     newConversation, startNewConversation, draftPinnedProjectId,
@@ -420,6 +547,7 @@ const NOOP_AGENT_CHAT: AgentChatContextValue = {
   visibility: 'hidden',
   open: () => {}, close: () => {}, minimize: () => {}, toggle: () => {},
   conversations: [], active: null, messages: [], streamingText: '', isStreaming: false, liveTools: [],
+  queuedMessages: [], streamingConversationIds: new Set<string>(),
   mcpEnabled: true, enablingMcp: false, enableMcpServer: async () => {}, providersReady: true,
   send: async () => {}, abort: async () => {}, cycleTier: async () => {}, setTier: async () => {},
   setProvider: async () => {}, setModel: async () => {}, setPinnedProject: async () => {},

--- a/client/src/context/AgentWorkspaceContext.tsx
+++ b/client/src/context/AgentWorkspaceContext.tsx
@@ -12,6 +12,10 @@ interface AgentWorkspaceContextValue {
   openCodePane: () => void
   closeCodePane: () => void
   toggleCodePane: () => void
+  jobsPaneOpen: boolean
+  openJobsPane: () => void
+  closeJobsPane: () => void
+  toggleJobsPane: () => void
   browserOpen: boolean
   openBrowser: () => void
   closeBrowser: () => void
@@ -26,12 +30,16 @@ const AgentWorkspaceContext = createContext<AgentWorkspaceContextValue | null>(n
 
 export function AgentWorkspaceProvider({ children }: { children: ReactNode }) {
   const [codePaneOpen, setCodePaneOpen] = useState(false)
+  const [jobsPaneOpen, setJobsPaneOpen] = useState(false)
   const [browserOpen, setBrowserOpen] = useState(false)
   const [pendingCaptures, setPendingCaptures] = useState<AgentAttachment[]>([])
 
   const openCodePane = useCallback(() => setCodePaneOpen(true), [])
   const closeCodePane = useCallback(() => setCodePaneOpen(false), [])
   const toggleCodePane = useCallback(() => setCodePaneOpen((v) => !v), [])
+  const openJobsPane = useCallback(() => setJobsPaneOpen(true), [])
+  const closeJobsPane = useCallback(() => setJobsPaneOpen(false), [])
+  const toggleJobsPane = useCallback(() => setJobsPaneOpen((v) => !v), [])
   const openBrowser = useCallback(() => setBrowserOpen(true), [])
   const closeBrowser = useCallback(() => setBrowserOpen(false), [])
   const queueCapture = useCallback((att: AgentAttachment) => {
@@ -49,10 +57,11 @@ export function AgentWorkspaceProvider({ children }: { children: ReactNode }) {
   const value = useMemo(
     () => ({
       codePaneOpen, openCodePane, closeCodePane, toggleCodePane,
+      jobsPaneOpen, openJobsPane, closeJobsPane, toggleJobsPane,
       browserOpen, openBrowser, closeBrowser,
       pendingCaptures, queueCapture, consumePendingCaptures,
     }),
-    [codePaneOpen, openCodePane, closeCodePane, toggleCodePane, browserOpen, openBrowser, closeBrowser, pendingCaptures, queueCapture, consumePendingCaptures],
+    [codePaneOpen, openCodePane, closeCodePane, toggleCodePane, jobsPaneOpen, openJobsPane, closeJobsPane, toggleJobsPane, browserOpen, openBrowser, closeBrowser, pendingCaptures, queueCapture, consumePendingCaptures],
   )
   return <AgentWorkspaceContext.Provider value={value}>{children}</AgentWorkspaceContext.Provider>
 }
@@ -62,6 +71,10 @@ const NOOP: AgentWorkspaceContextValue = {
   openCodePane: () => {},
   closeCodePane: () => {},
   toggleCodePane: () => {},
+  jobsPaneOpen: false,
+  openJobsPane: () => {},
+  closeJobsPane: () => {},
+  toggleJobsPane: () => {},
   browserOpen: false,
   openBrowser: () => {},
   closeBrowser: () => {},

--- a/client/src/context/WebViewModalContext.tsx
+++ b/client/src/context/WebViewModalContext.tsx
@@ -7,6 +7,9 @@ interface WebViewModalApi {
   /** Open an http(s) URL in the in-app embedded browser modal (shares the global
    *  browser profile / cookies). */
   openWebView: (url: string) => void
+  /** False when the embedded browser cannot open (feature disabled or no active
+   *  project) — callers keep the link's default target=_blank behaviour then. */
+  canOpenWebView: boolean
 }
 
 const WebViewModalContext = createContext<WebViewModalApi | null>(null)
@@ -18,7 +21,7 @@ export function WebViewModalProvider({ children }: { children: ReactNode }) {
   const enabled = isBrowserCaptureEnabled()
 
   return (
-    <WebViewModalContext.Provider value={{ openWebView }}>
+    <WebViewModalContext.Provider value={{ openWebView, canOpenWebView: enabled && !!activeProjectId }}>
       {children}
       {enabled && url && activeProjectId && (
         <WebViewModal open url={url} projectId={activeProjectId} onClose={() => setUrl(null)} />
@@ -33,5 +36,5 @@ export function WebViewModalProvider({ children }: { children: ReactNode }) {
  * and the link keeps its default behaviour.
  */
 export function useWebViewModal(): WebViewModalApi {
-  return useContext(WebViewModalContext) ?? { openWebView: () => {} }
+  return useContext(WebViewModalContext) ?? { openWebView: () => {}, canOpenWebView: false }
 }

--- a/client/src/lib/__tests__/agent-api.test.ts
+++ b/client/src/lib/__tests__/agent-api.test.ts
@@ -44,8 +44,12 @@ describe('agent-api', () => {
     await api.deleteAgentConversation('c1')
     expect(del).toHaveBeenCalledWith(expect.stringContaining('/c1'), expect.objectContaining({ method: 'DELETE' }))
     const send = mockFetch(undefined)
-    await api.sendAgentMessage('c1', 'hi', { tierLevel: 2 })
+    expect(await api.sendAgentMessage('c1', 'hi', { tierLevel: 2 })).toEqual({ queued: false })
     expect(send).toHaveBeenCalledWith(expect.stringContaining('/c1/send'), expect.objectContaining({ method: 'POST' }))
+    const sendQueued = mockFetch({ accepted: true, queued: true })
+    expect(await api.sendAgentMessage('c1', 'later', { queueId: 'q-1' })).toEqual({ queued: true })
+    const [, init] = sendQueued.mock.calls[0] as [string, RequestInit]
+    expect(JSON.parse(String(init.body))).toMatchObject({ text: 'later', queueId: 'q-1' })
     const ab = mockFetch(undefined)
     await api.abortAgentTurn('c1')
     expect(ab).toHaveBeenCalledWith(expect.stringContaining('/c1/abort'), expect.objectContaining({ method: 'POST' }))

--- a/client/src/lib/agent-api.ts
+++ b/client/src/lib/agent-api.ts
@@ -117,15 +117,16 @@ export async function deleteAgentConversation(id: string): Promise<void> {
 export async function sendAgentMessage(
   id: string,
   text: string,
-  opts: { tierLevel?: AgentTierLevel; model?: string; attachments?: { ids: string[] } } = {},
-): Promise<void> {
+  opts: { tierLevel?: AgentTierLevel; model?: string; attachments?: { ids: string[] }; queueId?: string } = {},
+): Promise<{ queued: boolean }> {
   // Through json() so a non-OK response (400/404) throws — the caller resets its
   // streaming state instead of waiting for WS events that will never arrive.
-  await json(await fetch(`${base}/conversations/${id}/send`, {
+  const body = await json<{ accepted: boolean; queued?: boolean } | null>(await fetch(`${base}/conversations/${id}/send`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ text, ...opts }),
   }))
+  return { queued: body?.queued === true }
 }
 
 export async function uploadAgentAttachment(conversationId: string, file: File): Promise<AgentAttachment> {

--- a/client/src/locales/de/agent.json
+++ b/client/src/locales/de/agent.json
@@ -1,7 +1,7 @@
 {
-  "title": "Agent",
+  "title": "Missionszentrale",
   "subtitle": "Specrails per Chat bedienen",
-  "trigger": "Agent",
+  "trigger": "Missionszentrale",
   "composerPlaceholder": "Bitte den Agenten um alles…",
   "send": "Senden",
   "stop": "Stopp",
@@ -10,8 +10,8 @@
   "restore": "Wiederherstellen",
   "minimize": "Minimieren",
   "close": "Schließen",
-  "newConversation": "Neue Unterhaltung",
-  "emptyTitle": "Was soll der Agent tun?",
+  "newConversation": "Neue Mission",
+  "emptyTitle": "Wie lautet die Mission?",
   "emptyHint": "Wähle ein Projekt und frag dann. Das Board aktualisiert sich live, während der Agent arbeitet.",
   "thinking": "Denkt nach…",
   "connecting": "Verbinden…",
@@ -26,6 +26,25 @@
   },
   "history": {
     "hint": "Verlauf durchsuchen — tippen zum Bearbeiten, ↑↓ zum Navigieren"
+  },
+  "queue": {
+    "queued": "In Warteschlange",
+    "send": "In Warteschlange senden",
+    "sendHint": "Der Agent arbeitet noch — diese Nachricht wird eingereiht und danach ausgeführt",
+    "placeholder": "Mehr hinzufügen, während der Agent arbeitet — wird eingereiht…"
+  },
+  "git": {
+    "branch": "Branch",
+    "detached": "(detached)",
+    "dirty": "Nicht committete Änderungen",
+    "switched": "Zu {{branch}} gewechselt",
+    "switchFailed": "Branch-Wechsel fehlgeschlagen",
+    "lockedWhileWorking": "Branch gesperrt, während der Agent arbeitet",
+    "searchPlaceholder": "Branches durchsuchen…",
+    "noMatches": "Keine passenden Branches",
+    "worktrees": "Worktrees",
+    "worktreePathCopied": "Worktree-Pfad kopiert",
+    "copyWorktreePath": "Worktree-Pfad kopieren"
   },
   "provider": {
     "label": "Anbieter",
@@ -98,11 +117,11 @@
     "busy": "Der Agent ist beschäftigt. Versuch es gleich noch einmal."
   },
   "chip": {
-    "kindAgent": "Agent-Chat"
+    "kindAgent": "Agenten-Mission"
   },
-  "newAgent": "Neuer Agent",
-  "switchToAgent": "Zum Agentenmodus wechseln",
-  "switchToKanban": "Zum Kanban-Modus wechseln",
+  "newAgent": "Neue Mission",
+  "switchToAgent": "Zur Missionszentrale wechseln",
+  "switchToKanban": "Zum Board wechseln",
   "search": "Suchen",
   "home": "Start",
   "untitled": "Ohne Titel",
@@ -117,7 +136,11 @@
     "browserConfirm": "Zum Agenten hinzufügen",
     "browserCaptured": "Aufnahme hinzugefügt",
     "uploadFailed": "Upload fehlgeschlagen",
-    "requiresConversation": "Starte eine Unterhaltung, um dieses Werkzeug zu nutzen"
+    "requiresConversation": "Starte eine Mission, um dieses Werkzeug zu nutzen",
+    "jobs": "Jobs",
+    "closeJobs": "Jobs schließen",
+    "resizeJobs": "Jobs-Bereich anpassen",
+    "noJobs": "Noch keine Jobs — bitte den Agenten, einen zu starten"
   },
   "attachFile": "Datei anhängen",
   "deleteConversation": "„{{title}}“ löschen",
@@ -132,5 +155,5 @@
     "high": "Hoch",
     "xhigh": "Sehr hoch"
   },
-  "emptyTitleMatrix": "Was soll der Agent Smith tun?"
+  "emptyTitleMatrix": "Wie lautet die Mission, Neo?"
 }

--- a/client/src/locales/de/nav.json
+++ b/client/src/locales/de/nav.json
@@ -20,7 +20,8 @@
     "added": "Projekt hinzugefügt: {{name}}",
     "removed": "Projekt entfernt",
     "expand": "{{name}} aufklappen",
-    "collapse": "{{name}} einklappen"
+    "collapse": "{{name}} einklappen",
+    "settings": "Einstellungen für {{name}}"
   },
   "arcSidebar": {
     "desktopTitle": "Desktop",

--- a/client/src/locales/de/settings.json
+++ b/client/src/locales/de/settings.json
@@ -242,5 +242,15 @@
     "unavailable": "App-Updates sind nur in der Desktop-App verfügbar.",
     "toastUpToDate": "Specrails Desktop ist aktuell",
     "toastCheckFailed": "Update-Prüfung fehlgeschlagen: {{message}}"
+  },
+  "projectDialog": {
+    "title": "{{name}} — Einstellungen",
+    "description": "Projektkonfiguration: Prompts, Budget, Telemetrie und Terminal.",
+    "nav": {
+      "general": "Allgemein",
+      "budget": "Budget",
+      "telemetry": "Telemetrie",
+      "terminal": "Terminal"
+    }
   }
 }

--- a/client/src/locales/en/agent.json
+++ b/client/src/locales/en/agent.json
@@ -1,7 +1,7 @@
 {
-  "title": "Agent",
+  "title": "Mission Control",
   "subtitle": "Operate Specrails by chatting",
-  "trigger": "Agent",
+  "trigger": "Mission Control",
   "composerPlaceholder": "Ask the agent to do anything…",
   "send": "Send",
   "stop": "Stop",
@@ -10,8 +10,8 @@
   "restore": "Restore",
   "minimize": "Minimize",
   "close": "Close",
-  "newConversation": "New conversation",
-  "emptyTitle": "What should the agent do?",
+  "newConversation": "New mission",
+  "emptyTitle": "What's the mission?",
   "emptyHint": "Pick a project, then ask. The board updates live as the agent works.",
   "thinking": "Thinking…",
   "connecting": "Connecting…",
@@ -26,6 +26,25 @@
   },
   "history": {
     "hint": "Browsing prompt history — type to edit, ↑↓ to navigate"
+  },
+  "queue": {
+    "queued": "Queued",
+    "send": "Send to queue",
+    "sendHint": "The agent is still working — this message will queue and run next",
+    "placeholder": "Add more while the agent works — it will queue…"
+  },
+  "git": {
+    "branch": "Branch",
+    "detached": "(detached)",
+    "dirty": "Uncommitted changes",
+    "switched": "Switched to {{branch}}",
+    "switchFailed": "Couldn't switch branch",
+    "lockedWhileWorking": "Branch locked while the agent works",
+    "searchPlaceholder": "Search branches…",
+    "noMatches": "No branches match",
+    "worktrees": "Worktrees",
+    "worktreePathCopied": "Worktree path copied",
+    "copyWorktreePath": "Copy worktree path"
   },
   "provider": {
     "label": "Provider",
@@ -98,11 +117,11 @@
     "busy": "The agent is busy. Try again in a moment."
   },
   "chip": {
-    "kindAgent": "Agent chat"
+    "kindAgent": "Agent mission"
   },
-  "newAgent": "New Agent",
-  "switchToAgent": "Switch to Agent Mode",
-  "switchToKanban": "Switch to Kanban mode",
+  "newAgent": "New Mission",
+  "switchToAgent": "Switch to Mission Control",
+  "switchToKanban": "Switch to Board",
   "search": "Search",
   "home": "Home",
   "untitled": "Untitled",
@@ -117,7 +136,11 @@
     "browserConfirm": "Add to agent",
     "browserCaptured": "Capture added",
     "uploadFailed": "Upload failed",
-    "requiresConversation": "Start a conversation to use this tool"
+    "requiresConversation": "Start a mission to use this tool",
+    "jobs": "Jobs",
+    "closeJobs": "Close jobs",
+    "resizeJobs": "Resize jobs pane",
+    "noJobs": "No jobs yet — ask the agent to launch one"
   },
   "attachFile": "Attach file",
   "deleteConversation": "Delete \"{{title}}\"",
@@ -132,5 +155,5 @@
     "high": "High",
     "xhigh": "Extra high"
   },
-  "emptyTitleMatrix": "What should the agent Smith do?"
+  "emptyTitleMatrix": "What's the mission, Neo?"
 }

--- a/client/src/locales/en/nav.json
+++ b/client/src/locales/en/nav.json
@@ -20,7 +20,8 @@
     "added": "Project added: {{name}}",
     "removed": "Project removed",
     "expand": "Expand {{name}}",
-    "collapse": "Collapse {{name}}"
+    "collapse": "Collapse {{name}}",
+    "settings": "Settings for {{name}}"
   },
   "arcSidebar": {
     "desktopTitle": "Desktop",

--- a/client/src/locales/en/settings.json
+++ b/client/src/locales/en/settings.json
@@ -242,5 +242,15 @@
     "unavailable": "App updates are only available in the desktop app.",
     "toastUpToDate": "Specrails Desktop is up to date",
     "toastCheckFailed": "Update check failed: {{message}}"
+  },
+  "projectDialog": {
+    "title": "{{name}} — Settings",
+    "description": "Project-level configuration: prompts, budget, telemetry and terminal.",
+    "nav": {
+      "general": "General",
+      "budget": "Budget",
+      "telemetry": "Telemetry",
+      "terminal": "Terminal"
+    }
   }
 }

--- a/client/src/locales/es/agent.json
+++ b/client/src/locales/es/agent.json
@@ -1,7 +1,7 @@
 {
-  "title": "Agente",
+  "title": "Control de misiones",
   "subtitle": "Maneja Specrails conversando",
-  "trigger": "Agente",
+  "trigger": "Control de misiones",
   "composerPlaceholder": "Pídele al agente lo que necesites…",
   "send": "Enviar",
   "stop": "Detener",
@@ -10,8 +10,8 @@
   "restore": "Restaurar",
   "minimize": "Minimizar",
   "close": "Cerrar",
-  "newConversation": "Nueva conversación",
-  "emptyTitle": "¿Qué debe hacer el agente?",
+  "newConversation": "Nueva misión",
+  "emptyTitle": "¿Cuál es la misión?",
   "emptyHint": "Elige un proyecto y luego pregunta. El tablero se actualiza en vivo mientras el agente trabaja.",
   "thinking": "Pensando…",
   "connecting": "Conectando…",
@@ -26,6 +26,25 @@
   },
   "history": {
     "hint": "Explorando historial de prompts — escribe para editar, ↑↓ para navegar"
+  },
+  "queue": {
+    "queued": "En cola",
+    "send": "Enviar a la cola",
+    "sendHint": "El agente sigue trabajando — este mensaje se pondrá en cola y se ejecutará después",
+    "placeholder": "Añade más mientras el agente trabaja — se pondrá en cola…"
+  },
+  "git": {
+    "branch": "Rama",
+    "detached": "(detached)",
+    "dirty": "Cambios sin commitear",
+    "switched": "Cambiado a {{branch}}",
+    "switchFailed": "No se pudo cambiar de rama",
+    "lockedWhileWorking": "Rama bloqueada mientras el agente trabaja",
+    "searchPlaceholder": "Buscar ramas…",
+    "noMatches": "Ninguna rama coincide",
+    "worktrees": "Worktrees",
+    "worktreePathCopied": "Ruta del worktree copiada",
+    "copyWorktreePath": "Copiar ruta del worktree"
   },
   "provider": {
     "label": "Proveedor",
@@ -98,11 +117,11 @@
     "busy": "El agente está ocupado. Inténtalo de nuevo en un momento."
   },
   "chip": {
-    "kindAgent": "Chat del agente"
+    "kindAgent": "Misión del agente"
   },
-  "newAgent": "Nuevo agente",
-  "switchToAgent": "Cambiar a modo Agente",
-  "switchToKanban": "Cambiar a modo Kanban",
+  "newAgent": "Nueva misión",
+  "switchToAgent": "Cambiar a Control de misiones",
+  "switchToKanban": "Cambiar al tablero",
   "search": "Buscar",
   "home": "Inicio",
   "untitled": "Sin título",
@@ -117,7 +136,11 @@
     "browserConfirm": "Añadir al agente",
     "browserCaptured": "Captura añadida",
     "uploadFailed": "Error al subir",
-    "requiresConversation": "Inicia una conversación para usar esta herramienta"
+    "requiresConversation": "Inicia una misión para usar esta herramienta",
+    "jobs": "Jobs",
+    "closeJobs": "Cerrar jobs",
+    "resizeJobs": "Redimensionar panel de jobs",
+    "noJobs": "Aún no hay jobs — pide al agente que lance uno"
   },
   "attachFile": "Adjuntar archivo",
   "deleteConversation": "Borrar «{{title}}»",
@@ -132,5 +155,5 @@
     "high": "Alto",
     "xhigh": "Extra alto"
   },
-  "emptyTitleMatrix": "¿Qué debería hacer el agente Smith?"
+  "emptyTitleMatrix": "¿Cuál es la misión, Neo?"
 }

--- a/client/src/locales/es/nav.json
+++ b/client/src/locales/es/nav.json
@@ -20,7 +20,8 @@
     "added": "Proyecto añadido: {{name}}",
     "removed": "Proyecto eliminado",
     "expand": "Expandir {{name}}",
-    "collapse": "Contraer {{name}}"
+    "collapse": "Contraer {{name}}",
+    "settings": "Ajustes de {{name}}"
   },
   "arcSidebar": {
     "desktopTitle": "Desktop",

--- a/client/src/locales/es/settings.json
+++ b/client/src/locales/es/settings.json
@@ -242,5 +242,15 @@
     "unavailable": "Las actualizaciones solo están disponibles en la app de escritorio.",
     "toastUpToDate": "Specrails Desktop está actualizado",
     "toastCheckFailed": "Error al buscar actualizaciones: {{message}}"
+  },
+  "projectDialog": {
+    "title": "{{name}} — Ajustes",
+    "description": "Configuración del proyecto: prompts, presupuesto, telemetría y terminal.",
+    "nav": {
+      "general": "General",
+      "budget": "Presupuesto",
+      "telemetry": "Telemetría",
+      "terminal": "Terminal"
+    }
   }
 }

--- a/client/src/locales/fr/agent.json
+++ b/client/src/locales/fr/agent.json
@@ -1,7 +1,7 @@
 {
-  "title": "Agent",
+  "title": "Contrôle des missions",
   "subtitle": "Pilotez Specrails en discutant",
-  "trigger": "Agent",
+  "trigger": "Contrôle des missions",
   "composerPlaceholder": "Demandez à l'agent ce que vous voulez…",
   "send": "Envoyer",
   "stop": "Arrêter",
@@ -10,8 +10,8 @@
   "restore": "Restaurer",
   "minimize": "Réduire",
   "close": "Fermer",
-  "newConversation": "Nouvelle conversation",
-  "emptyTitle": "Que doit faire l'agent ?",
+  "newConversation": "Nouvelle mission",
+  "emptyTitle": "Quelle est la mission ?",
   "emptyHint": "Choisissez un projet, puis demandez. Le tableau se met à jour en direct pendant que l'agent travaille.",
   "thinking": "Réflexion…",
   "connecting": "Connexion…",
@@ -26,6 +26,25 @@
   },
   "history": {
     "hint": "Parcours de l'historique — tapez pour modifier, ↑↓ pour naviguer"
+  },
+  "queue": {
+    "queued": "En file",
+    "send": "Envoyer dans la file",
+    "sendHint": "L'agent travaille encore — ce message sera mis en file puis traité",
+    "placeholder": "Ajoutez-en pendant que l'agent travaille — mis en file…"
+  },
+  "git": {
+    "branch": "Branche",
+    "detached": "(détaché)",
+    "dirty": "Modifications non commitées",
+    "switched": "Basculé sur {{branch}}",
+    "switchFailed": "Impossible de changer de branche",
+    "lockedWhileWorking": "Branche verrouillée pendant que l'agent travaille",
+    "searchPlaceholder": "Rechercher des branches…",
+    "noMatches": "Aucune branche ne correspond",
+    "worktrees": "Worktrees",
+    "worktreePathCopied": "Chemin du worktree copié",
+    "copyWorktreePath": "Copier le chemin du worktree"
   },
   "provider": {
     "label": "Fournisseur",
@@ -98,11 +117,11 @@
     "busy": "L'agent est occupé. Réessayez dans un instant."
   },
   "chip": {
-    "kindAgent": "Chat de l'agent"
+    "kindAgent": "Mission de l'agent"
   },
-  "newAgent": "Nouvel agent",
-  "switchToAgent": "Passer en mode Agent",
-  "switchToKanban": "Passer en mode Kanban",
+  "newAgent": "Nouvelle mission",
+  "switchToAgent": "Passer au Contrôle des missions",
+  "switchToKanban": "Passer au tableau",
   "search": "Rechercher",
   "home": "Accueil",
   "untitled": "Sans titre",
@@ -117,7 +136,11 @@
     "browserConfirm": "Ajouter à l'agent",
     "browserCaptured": "Capture ajoutée",
     "uploadFailed": "Échec du téléversement",
-    "requiresConversation": "Démarrez une conversation pour utiliser cet outil"
+    "requiresConversation": "Lancez une mission pour utiliser cet outil",
+    "jobs": "Jobs",
+    "closeJobs": "Fermer les jobs",
+    "resizeJobs": "Redimensionner le panneau des jobs",
+    "noJobs": "Aucun job pour l'instant — demandez à l'agent d'en lancer un"
   },
   "attachFile": "Joindre un fichier",
   "deleteConversation": "Supprimer « {{title}} »",
@@ -132,5 +155,5 @@
     "high": "Élevé",
     "xhigh": "Très élevé"
   },
-  "emptyTitleMatrix": "Que doit faire l'agent Smith ?"
+  "emptyTitleMatrix": "Quelle est la mission, Neo ?"
 }

--- a/client/src/locales/fr/nav.json
+++ b/client/src/locales/fr/nav.json
@@ -20,7 +20,8 @@
     "added": "Projet ajouté : {{name}}",
     "removed": "Projet supprimé",
     "expand": "Développer {{name}}",
-    "collapse": "Réduire {{name}}"
+    "collapse": "Réduire {{name}}",
+    "settings": "Paramètres de {{name}}"
   },
   "arcSidebar": {
     "desktopTitle": "Desktop",

--- a/client/src/locales/fr/settings.json
+++ b/client/src/locales/fr/settings.json
@@ -242,5 +242,15 @@
     "unavailable": "Les mises à jour ne sont disponibles que dans l'app de bureau.",
     "toastUpToDate": "Specrails Desktop est à jour",
     "toastCheckFailed": "Échec de la recherche de mises à jour : {{message}}"
+  },
+  "projectDialog": {
+    "title": "{{name}} — Paramètres",
+    "description": "Configuration du projet : prompts, budget, télémétrie et terminal.",
+    "nav": {
+      "general": "Général",
+      "budget": "Budget",
+      "telemetry": "Télémétrie",
+      "terminal": "Terminal"
+    }
   }
 }

--- a/client/src/locales/it/agent.json
+++ b/client/src/locales/it/agent.json
@@ -1,7 +1,7 @@
 {
-  "title": "Agente",
+  "title": "Controllo missioni",
   "subtitle": "Gestisci Specrails chattando",
-  "trigger": "Agente",
+  "trigger": "Controllo missioni",
   "composerPlaceholder": "Chiedi all'agente qualsiasi cosa…",
   "send": "Invia",
   "stop": "Ferma",
@@ -10,8 +10,8 @@
   "restore": "Ripristina",
   "minimize": "Riduci a icona",
   "close": "Chiudi",
-  "newConversation": "Nuova conversazione",
-  "emptyTitle": "Cosa deve fare l'agente?",
+  "newConversation": "Nuova missione",
+  "emptyTitle": "Qual è la missione?",
   "emptyHint": "Scegli un progetto, poi chiedi. La board si aggiorna in tempo reale mentre l'agente lavora.",
   "thinking": "Sto pensando…",
   "connecting": "Connessione…",
@@ -26,6 +26,25 @@
   },
   "history": {
     "hint": "Cronologia prompt — scrivi per modificare, ↑↓ per navigare"
+  },
+  "queue": {
+    "queued": "In coda",
+    "send": "Invia in coda",
+    "sendHint": "L'agente sta ancora lavorando — questo messaggio verrà messo in coda ed eseguito dopo",
+    "placeholder": "Aggiungi altro mentre l'agente lavora — verrà messo in coda…"
+  },
+  "git": {
+    "branch": "Branch",
+    "detached": "(detached)",
+    "dirty": "Modifiche non committate",
+    "switched": "Passato a {{branch}}",
+    "switchFailed": "Impossibile cambiare branch",
+    "lockedWhileWorking": "Branch bloccato mentre l'agente lavora",
+    "searchPlaceholder": "Cerca branch…",
+    "noMatches": "Nessun branch corrisponde",
+    "worktrees": "Worktree",
+    "worktreePathCopied": "Percorso del worktree copiato",
+    "copyWorktreePath": "Copia percorso del worktree"
   },
   "provider": {
     "label": "Provider",
@@ -98,11 +117,11 @@
     "busy": "L'agente è occupato. Riprova tra un momento."
   },
   "chip": {
-    "kindAgent": "Chat dell'agente"
+    "kindAgent": "Missione dell'agente"
   },
-  "newAgent": "Nuovo agente",
-  "switchToAgent": "Passa alla modalità Agente",
-  "switchToKanban": "Passa alla modalità Kanban",
+  "newAgent": "Nuova missione",
+  "switchToAgent": "Passa al Controllo missioni",
+  "switchToKanban": "Passa alla board",
   "search": "Cerca",
   "home": "Home",
   "untitled": "Senza titolo",
@@ -117,7 +136,11 @@
     "browserConfirm": "Aggiungi all'agente",
     "browserCaptured": "Cattura aggiunta",
     "uploadFailed": "Caricamento non riuscito",
-    "requiresConversation": "Avvia una conversazione per usare questo strumento"
+    "requiresConversation": "Avvia una missione per usare questo strumento",
+    "jobs": "Jobs",
+    "closeJobs": "Chiudi jobs",
+    "resizeJobs": "Ridimensiona pannello jobs",
+    "noJobs": "Ancora nessun job — chiedi all'agente di lanciarne uno"
   },
   "attachFile": "Allega file",
   "deleteConversation": "Elimina «{{title}}»",
@@ -132,5 +155,5 @@
     "high": "Alto",
     "xhigh": "Extra alto"
   },
-  "emptyTitleMatrix": "Cosa dovrebbe fare l'agente Smith?"
+  "emptyTitleMatrix": "Qual è la missione, Neo?"
 }

--- a/client/src/locales/it/nav.json
+++ b/client/src/locales/it/nav.json
@@ -20,7 +20,8 @@
     "added": "Progetto aggiunto: {{name}}",
     "removed": "Progetto rimosso",
     "expand": "Espandi {{name}}",
-    "collapse": "Comprimi {{name}}"
+    "collapse": "Comprimi {{name}}",
+    "settings": "Impostazioni di {{name}}"
   },
   "arcSidebar": {
     "desktopTitle": "Desktop",

--- a/client/src/locales/it/settings.json
+++ b/client/src/locales/it/settings.json
@@ -242,5 +242,15 @@
     "unavailable": "Gli aggiornamenti sono disponibili solo nell'app desktop.",
     "toastUpToDate": "Specrails Desktop è aggiornato",
     "toastCheckFailed": "Ricerca aggiornamenti non riuscita: {{message}}"
+  },
+  "projectDialog": {
+    "title": "{{name}} — Impostazioni",
+    "description": "Configurazione del progetto: prompt, budget, telemetria e terminale.",
+    "nav": {
+      "general": "Generale",
+      "budget": "Budget",
+      "telemetry": "Telemetria",
+      "terminal": "Terminale"
+    }
   }
 }

--- a/client/src/locales/ja/agent.json
+++ b/client/src/locales/ja/agent.json
@@ -1,7 +1,7 @@
 {
-  "title": "エージェント",
+  "title": "ミッションセンター",
   "subtitle": "チャットで Specrails を操作",
-  "trigger": "エージェント",
+  "trigger": "ミッションセンター",
   "composerPlaceholder": "エージェントに何でも頼んでください…",
   "send": "送信",
   "stop": "停止",
@@ -10,8 +10,8 @@
   "restore": "元に戻す",
   "minimize": "最小化",
   "close": "閉じる",
-  "newConversation": "新しい会話",
-  "emptyTitle": "エージェントに何をさせますか？",
+  "newConversation": "新しいミッション",
+  "emptyTitle": "ミッションは何ですか？",
   "emptyHint": "プロジェクトを選んでから尋ねてください。エージェントの作業中、ボードはリアルタイムで更新されます。",
   "thinking": "考え中…",
   "connecting": "接続中…",
@@ -26,6 +26,25 @@
   },
   "history": {
     "hint": "プロンプト履歴を表示中 — 入力で編集、↑↓ で移動"
+  },
+  "queue": {
+    "queued": "待機中",
+    "send": "キューに送信",
+    "sendHint": "エージェントは作業中です — このメッセージはキューに入り、次に実行されます",
+    "placeholder": "エージェントの作業中に追加できます — キューに入ります…"
+  },
+  "git": {
+    "branch": "ブランチ",
+    "detached": "（detached）",
+    "dirty": "未コミットの変更あり",
+    "switched": "{{branch}} に切り替えました",
+    "switchFailed": "ブランチを切り替えられませんでした",
+    "lockedWhileWorking": "エージェントの作業中はブランチをロックしています",
+    "searchPlaceholder": "ブランチを検索…",
+    "noMatches": "一致するブランチがありません",
+    "worktrees": "ワークツリー",
+    "worktreePathCopied": "ワークツリーのパスをコピーしました",
+    "copyWorktreePath": "ワークツリーのパスをコピー"
   },
   "provider": {
     "label": "プロバイダー",
@@ -98,11 +117,11 @@
     "busy": "エージェントは処理中です。しばらくしてからお試しください。"
   },
   "chip": {
-    "kindAgent": "エージェントチャット"
+    "kindAgent": "エージェントのミッション"
   },
-  "newAgent": "新しいエージェント",
-  "switchToAgent": "エージェントモードに切替",
-  "switchToKanban": "カンバンモードに切替",
+  "newAgent": "新しいミッション",
+  "switchToAgent": "ミッションセンターに切り替え",
+  "switchToKanban": "ボードに切り替え",
   "search": "検索",
   "home": "ホーム",
   "untitled": "無題",
@@ -117,7 +136,11 @@
     "browserConfirm": "エージェントに追加",
     "browserCaptured": "キャプチャを追加しました",
     "uploadFailed": "アップロードに失敗しました",
-    "requiresConversation": "このツールを使うには会話を開始してください"
+    "requiresConversation": "このツールを使うにはミッションを開始してください",
+    "jobs": "ジョブ",
+    "closeJobs": "ジョブを閉じる",
+    "resizeJobs": "ジョブパネルのサイズ変更",
+    "noJobs": "まだジョブがありません — エージェントに実行を頼んでみましょう"
   },
   "attachFile": "ファイルを添付",
   "deleteConversation": "「{{title}}」を削除",
@@ -132,5 +155,5 @@
     "high": "高",
     "xhigh": "最高"
   },
-  "emptyTitleMatrix": "エージェント・スミスに何をさせますか？"
+  "emptyTitleMatrix": "ミッションは何ですか、ネオ？"
 }

--- a/client/src/locales/ja/nav.json
+++ b/client/src/locales/ja/nav.json
@@ -20,7 +20,8 @@
     "added": "プロジェクトを追加しました: {{name}}",
     "removed": "プロジェクトを削除しました",
     "expand": "{{name}} を展開",
-    "collapse": "{{name}} を折りたたむ"
+    "collapse": "{{name}} を折りたたむ",
+    "settings": "{{name}} の設定"
   },
   "arcSidebar": {
     "desktopTitle": "Desktop",

--- a/client/src/locales/ja/settings.json
+++ b/client/src/locales/ja/settings.json
@@ -242,5 +242,15 @@
     "unavailable": "アップデートはデスクトップアプリでのみ利用できます。",
     "toastUpToDate": "Specrails Desktop は最新です",
     "toastCheckFailed": "アップデートの確認に失敗しました: {{message}}"
+  },
+  "projectDialog": {
+    "title": "{{name}} — 設定",
+    "description": "プロジェクト設定：プロンプト、予算、テレメトリ、ターミナル。",
+    "nav": {
+      "general": "一般",
+      "budget": "予算",
+      "telemetry": "テレメトリ",
+      "terminal": "ターミナル"
+    }
   }
 }

--- a/client/src/locales/pt/agent.json
+++ b/client/src/locales/pt/agent.json
@@ -1,7 +1,7 @@
 {
-  "title": "Agente",
+  "title": "Controle de missões",
   "subtitle": "Opere o Specrails conversando",
-  "trigger": "Agente",
+  "trigger": "Controle de missões",
   "composerPlaceholder": "Peça ao agente o que quiser…",
   "send": "Enviar",
   "stop": "Parar",
@@ -10,8 +10,8 @@
   "restore": "Restaurar",
   "minimize": "Minimizar",
   "close": "Fechar",
-  "newConversation": "Nova conversa",
-  "emptyTitle": "O que o agente deve fazer?",
+  "newConversation": "Nova missão",
+  "emptyTitle": "Qual é a missão?",
   "emptyHint": "Escolha um projeto e depois pergunte. O quadro é atualizado ao vivo enquanto o agente trabalha.",
   "thinking": "Pensando…",
   "connecting": "Conectando…",
@@ -26,6 +26,25 @@
   },
   "history": {
     "hint": "Explorando histórico — escreva para editar, ↑↓ para navegar"
+  },
+  "queue": {
+    "queued": "Na fila",
+    "send": "Enviar para a fila",
+    "sendHint": "O agente ainda está trabalhando — esta mensagem entrará na fila e será executada em seguida",
+    "placeholder": "Adicione mais enquanto o agente trabalha — entrará na fila…"
+  },
+  "git": {
+    "branch": "Branch",
+    "detached": "(detached)",
+    "dirty": "Alterações sem commit",
+    "switched": "Mudou para {{branch}}",
+    "switchFailed": "Não foi possível trocar de branch",
+    "lockedWhileWorking": "Branch bloqueada enquanto o agente trabalha",
+    "searchPlaceholder": "Buscar branches…",
+    "noMatches": "Nenhuma branch corresponde",
+    "worktrees": "Worktrees",
+    "worktreePathCopied": "Caminho do worktree copiado",
+    "copyWorktreePath": "Copiar caminho do worktree"
   },
   "provider": {
     "label": "Provedor",
@@ -98,11 +117,11 @@
     "busy": "O agente está ocupado. Tente novamente em um instante."
   },
   "chip": {
-    "kindAgent": "Chat do agente"
+    "kindAgent": "Missão do agente"
   },
-  "newAgent": "Novo agente",
-  "switchToAgent": "Mudar para o modo Agente",
-  "switchToKanban": "Mudar para o modo Kanban",
+  "newAgent": "Nova missão",
+  "switchToAgent": "Mudar para o Controle de missões",
+  "switchToKanban": "Mudar para o quadro",
   "search": "Buscar",
   "home": "Início",
   "untitled": "Sem título",
@@ -117,7 +136,11 @@
     "browserConfirm": "Adicionar ao agente",
     "browserCaptured": "Captura adicionada",
     "uploadFailed": "Falha no upload",
-    "requiresConversation": "Inicie uma conversa para usar esta ferramenta"
+    "requiresConversation": "Inicie uma missão para usar esta ferramenta",
+    "jobs": "Jobs",
+    "closeJobs": "Fechar jobs",
+    "resizeJobs": "Redimensionar painel de jobs",
+    "noJobs": "Ainda não há jobs — peça ao agente para lançar um"
   },
   "attachFile": "Anexar arquivo",
   "deleteConversation": "Excluir \"{{title}}\"",
@@ -132,5 +155,5 @@
     "high": "Alto",
     "xhigh": "Extra alto"
   },
-  "emptyTitleMatrix": "O que o agente Smith deve fazer?"
+  "emptyTitleMatrix": "Qual é a missão, Neo?"
 }

--- a/client/src/locales/pt/nav.json
+++ b/client/src/locales/pt/nav.json
@@ -20,7 +20,8 @@
     "added": "Projeto adicionado: {{name}}",
     "removed": "Projeto removido",
     "expand": "Expandir {{name}}",
-    "collapse": "Recolher {{name}}"
+    "collapse": "Recolher {{name}}",
+    "settings": "Configurações de {{name}}"
   },
   "arcSidebar": {
     "desktopTitle": "Desktop",

--- a/client/src/locales/pt/settings.json
+++ b/client/src/locales/pt/settings.json
@@ -242,5 +242,15 @@
     "unavailable": "Atualizações estão disponíveis apenas no app desktop.",
     "toastUpToDate": "O Specrails Desktop está atualizado",
     "toastCheckFailed": "Falha ao verificar atualizações: {{message}}"
+  },
+  "projectDialog": {
+    "title": "{{name}} — Configurações",
+    "description": "Configuração do projeto: prompts, orçamento, telemetria e terminal.",
+    "nav": {
+      "general": "Geral",
+      "budget": "Orçamento",
+      "telemetry": "Telemetria",
+      "terminal": "Terminal"
+    }
   }
 }

--- a/client/src/locales/zh/agent.json
+++ b/client/src/locales/zh/agent.json
@@ -1,7 +1,7 @@
 {
-  "title": "智能体",
+  "title": "任务中心",
   "subtitle": "通过对话操作 Specrails",
-  "trigger": "智能体",
+  "trigger": "任务中心",
   "composerPlaceholder": "让智能体做任何事…",
   "send": "发送",
   "stop": "停止",
@@ -10,8 +10,8 @@
   "restore": "还原",
   "minimize": "最小化",
   "close": "关闭",
-  "newConversation": "新对话",
-  "emptyTitle": "要让智能体做什么？",
+  "newConversation": "新任务",
+  "emptyTitle": "这次的任务是什么？",
   "emptyHint": "先选择一个项目，然后提问。智能体工作时看板会实时更新。",
   "thinking": "思考中…",
   "connecting": "连接中…",
@@ -26,6 +26,25 @@
   },
   "history": {
     "hint": "浏览提示历史 — 输入以编辑，↑↓ 导航"
+  },
+  "queue": {
+    "queued": "排队中",
+    "send": "发送到队列",
+    "sendHint": "智能体仍在工作——此消息将排队并在之后执行",
+    "placeholder": "智能体工作时可继续输入——消息将排队…"
+  },
+  "git": {
+    "branch": "分支",
+    "detached": "（分离头指针）",
+    "dirty": "有未提交的更改",
+    "switched": "已切换到 {{branch}}",
+    "switchFailed": "无法切换分支",
+    "lockedWhileWorking": "智能体工作时分支已锁定",
+    "searchPlaceholder": "搜索分支…",
+    "noMatches": "没有匹配的分支",
+    "worktrees": "工作树",
+    "worktreePathCopied": "已复制工作树路径",
+    "copyWorktreePath": "复制工作树路径"
   },
   "provider": {
     "label": "提供方",
@@ -98,11 +117,11 @@
     "busy": "智能体正忙。请稍后重试。"
   },
   "chip": {
-    "kindAgent": "智能体聊天"
+    "kindAgent": "智能体任务"
   },
-  "newAgent": "新建智能体",
-  "switchToAgent": "切换到智能体模式",
-  "switchToKanban": "切换到看板模式",
+  "newAgent": "新任务",
+  "switchToAgent": "切换到任务中心",
+  "switchToKanban": "切换到看板",
   "search": "搜索",
   "home": "主页",
   "untitled": "未命名",
@@ -117,7 +136,11 @@
     "browserConfirm": "添加到智能体",
     "browserCaptured": "已添加捕获",
     "uploadFailed": "上传失败",
-    "requiresConversation": "开始一段对话以使用此工具"
+    "requiresConversation": "启动任务后才能使用此工具",
+    "jobs": "作业",
+    "closeJobs": "关闭作业",
+    "resizeJobs": "调整作业面板大小",
+    "noJobs": "还没有作业——让智能体启动一个吧"
   },
   "attachFile": "附加文件",
   "deleteConversation": "删除「{{title}}」",
@@ -132,5 +155,5 @@
     "high": "高",
     "xhigh": "极高"
   },
-  "emptyTitleMatrix": "让史密斯特工做什么？"
+  "emptyTitleMatrix": "这次的任务是什么，Neo？"
 }

--- a/client/src/locales/zh/nav.json
+++ b/client/src/locales/zh/nav.json
@@ -20,7 +20,8 @@
     "added": "已添加项目：{{name}}",
     "removed": "项目已移除",
     "expand": "展开 {{name}}",
-    "collapse": "折叠 {{name}}"
+    "collapse": "折叠 {{name}}",
+    "settings": "{{name}} 的设置"
   },
   "arcSidebar": {
     "desktopTitle": "Desktop",

--- a/client/src/locales/zh/settings.json
+++ b/client/src/locales/zh/settings.json
@@ -242,5 +242,15 @@
     "unavailable": "更新仅在桌面应用中可用。",
     "toastUpToDate": "Specrails Desktop 已是最新",
     "toastCheckFailed": "检查更新失败: {{message}}"
+  },
+  "projectDialog": {
+    "title": "{{name}} — 设置",
+    "description": "项目级配置：提示词、预算、遥测和终端。",
+    "nav": {
+      "general": "常规",
+      "budget": "预算",
+      "telemetry": "遥测",
+      "terminal": "终端"
+    }
   }
 }

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -164,22 +164,31 @@ export default function DashboardPage() {
     saveSpecsViewTier(activeProjectId, tier)
   }, [activeProjectId])
 
-  // ── Reconcile stale 'running' rails on mount / project switch / WS reconnect ─
-  // If the user navigates away while a rail is running, the WS handler is
-  // unregistered and the rail.job_completed event is missed. Also, after a
-  // server restart the WS reconnects but stale 'running' state persists in
-  // localStorage. On re-mount or reconnect, check the server for active rail
-  // jobs and reset any stale 'running' rails.
+  // ── Reconcile rails against the server on mount / project switch / reconnect ─
+  // The Kanban's rail state is a client-local projection (localStorage + live WS
+  // while THIS component is mounted). Launches can happen while it is unmounted
+  // — the global agent via MCP (Agent Mode), the mobile companion, another
+  // window — and after a server restart stale 'running' state persists locally.
+  // So this reconcile is BIDIRECTIONAL and always runs:
+  //   • server-active rail, local idle  → ADOPT (running + activeJobId + the
+  //     server's ticket assignment), so an agent-launched rail lights up here;
+  //   • local running, server inactive  → CLEAR (finished while we were away);
+  //   • both running                    → restore a lost activeJobId only.
   useEffect(() => {
-    if (connectionStatus !== 'connected') return
-    const currentRails = loadRails(activeProjectId) ?? INITIAL_RAILS
-    const hasRunning = currentRails.some((r) => r.status === 'running')
-    if (!hasRunning || !activeProjectId) return
+    if (connectionStatus !== 'connected' || !activeProjectId) return
 
     let cancelled = false
+    // Snapshot BEFORE the fetch: a rail that goes running only AFTER this point
+    // was launched locally while the request was in flight — the (stale)
+    // response must not clear that optimistic state back to idle.
+    const preRails = loadRails(activeProjectId) ?? INITIAL_RAILS
     fetch(`${getApiBase()}/rails`)
       .then((res) => res.ok ? res.json() : null)
-      .then((data: { activeJobs?: Record<string, { jobId: string }>; activeLoopRuns?: Record<string, { loopRunId: string }> } | null) => {
+      .then((data: {
+        rails?: { railIndex: number; ticketIds?: number[]; mode?: string }[]
+        activeJobs?: Record<string, { jobId: string; mode?: string }>
+        activeLoopRuns?: Record<string, { loopRunId: string; loopId?: string }>
+      } | null) => {
         if (cancelled || !data) return
         const activeJobs = data.activeJobs ?? {}
         // Loop-mode rails track an active LOOP run (not a queue job), so a rail
@@ -190,22 +199,79 @@ export default function DashboardPage() {
           ...Object.keys(activeJobs).map(Number),
           ...Object.keys(activeLoopRuns).map(Number),
         ])
+        const serverTicketsByIndex = new Map<number, number[]>()
+        for (const r of data.rails ?? []) {
+          serverTicketsByIndex.set(r.railIndex, Array.isArray(r.ticketIds) ? r.ticketIds : [])
+        }
+        const isRailMode = (m: string | undefined): m is RailMode =>
+          m === 'implement' || m === 'batch-implement' || m === 'ultracode' || m === 'loop'
         setRails((prev) => {
+          let changed = false
+          const adoptedTickets = new Map<number, number[]>()
           const next = prev.map((r, idx) => {
-            if (r.status !== 'running') return r
+            const loopRun = activeLoopRuns[String(idx)]
+            const serverJobId = activeJobs[String(idx)]?.jobId ?? loopRun?.loopRunId
             if (activeIndices.has(idx)) {
-              // Still running — restore the active id (job or loop run) if lost.
-              const serverJobId = activeJobs[String(idx)]?.jobId ?? activeLoopRuns[String(idx)]?.loopRunId
-              if (serverJobId && !r.activeJobId) return { ...r, activeJobId: serverJobId }
-              return r
+              if (r.status === 'running') {
+                // Still running — restore the active id (job or loop run) if lost.
+                if (serverJobId && !r.activeJobId) {
+                  changed = true
+                  return { ...r, activeJobId: serverJobId }
+                }
+                return r
+              }
+              // Was running when the fetch STARTED but idle now: a completion WS
+              // event landed during the round-trip — the response is stale, do
+              // not resurrect the finished run.
+              if (preRails[idx]?.status === 'running') return r
+              // Idle locally but EXECUTING server-side: launched while this board
+              // was unmounted (agent via MCP, mobile, another window). Adopt the
+              // run + the server's ticket assignment. Desktop launches always
+              // register as LOOP runs (factory:implement etc.) — derive the real
+              // mode from the loopId instead of hardcoding 'loop'.
+              const serverTickets = serverTicketsByIndex.get(idx) ?? []
+              const jobMode = activeJobs[String(idx)]?.mode
+              const serverMode = isRailMode(jobMode) ? jobMode : loopRun ? deriveRailMode(loopRun.loopId) : undefined
+              const ticketIds = serverTickets.length ? serverTickets : r.ticketIds
+              adoptedTickets.set(idx, ticketIds)
+              changed = true
+              return {
+                ...r,
+                status: 'running' as const,
+                activeJobId: serverJobId,
+                ticketIds,
+                mode: serverMode ?? r.mode,
+                // A custom loop needs its id selected for the rail header to
+                // label the run; factory loops keep the rail's own selection.
+                ...(loopRun?.loopId && loopRun.loopId.startsWith('custom:')
+                  ? { selectedLoopId: loopRun.loopId }
+                  : {}),
+              }
             }
+            if (r.status !== 'running') return r
+            // Launched locally AFTER the fetch started (optimistic 202 state):
+            // the response predates the launch — leave it alone.
+            if (preRails[idx]?.status !== 'running') return r
             // Rail was running but server has no active job → job finished while
             // we were away. Clear tickets so they reappear in Specs/Done based
             // on their current server-side status (useTickets re-fetches on mount).
+            changed = true
             return { ...r, status: 'idle' as const, activeJobId: undefined, ticketIds: [] }
           })
-          saveRails(activeProjectId, next)
-          return next
+          if (!changed) return prev
+          // An adopted ticket may still sit on ANOTHER rail from a local drag —
+          // strip it there (mirrors handleMoveTicketToRail) so no ticket renders
+          // on two rails at once (duplicate dnd ids / double-launch risk).
+          const adoptedIdSet = new Set([...adoptedTickets.values()].flat())
+          const deduped = adoptedIdSet.size
+            ? next.map((r, idx) => {
+                if (adoptedTickets.has(idx)) return r
+                const filtered = r.ticketIds.filter((id) => !adoptedIdSet.has(id))
+                return filtered.length === r.ticketIds.length ? r : { ...r, ticketIds: filtered }
+              })
+            : next
+          saveRails(activeProjectId, deduped)
+          return deduped
         })
       })
       .catch(() => {})
@@ -263,7 +329,10 @@ export default function DashboardPage() {
       saveRails(activeProjectId, next)
       return next
     })
-  }, [tickets, activeProjectId])
+    // `rails` is a dep so a reconcile ADOPTION that re-introduces a done ticket
+    // is stripped too (the updater returns `prev` identity when nothing changes,
+    // so this cannot loop).
+  }, [tickets, activeProjectId, rails])
 
   // Persist-aware spec order updater
   const updateSpecOrder = useCallback((updater: (prev: number[] | null) => number[] | null) => {

--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -1,21 +1,15 @@
 import { useEffect, useState, useRef } from 'react'
 import { useLocation } from 'react-router-dom'
-import { toast } from 'sonner'
-import { useTranslation, Trans } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 import { getApiBase } from '../lib/api'
 import { useDesktop } from '../hooks/useDesktop'
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../components/ui/card'
-import { Button } from '../components/ui/button'
-import { Input } from '../components/ui/input'
 import type { ProjectConfig } from '../types'
 import { TerminalSettingsSection } from '../components/settings/TerminalSettingsSection'
-
-interface ProjectSettings {
-  pipelineTelemetryEnabled: boolean
-  orchestratorModel?: string
-  prePrompt?: string
-  ultraPrePrompt?: string
-}
+import {
+  ProjectTelemetrySection,
+  ProjectPrePromptsSection,
+  ProjectBudgetSection,
+} from '../components/settings/ProjectSettingsSections'
 
 export default function SettingsPage() {
   const { t } = useTranslation('settings')
@@ -52,19 +46,9 @@ export default function SettingsPage() {
     tryScroll()
     return () => { cancelled = true }
   }, [location.hash, location.key])
+
   const [config, setConfig] = useState<ProjectConfig | null>(null)
   const [isLoading, setIsLoading] = useState(true)
-  const [dailyBudget, setDailyBudget] = useState('')
-  const [isSavingBudget, setIsSavingBudget] = useState(false)
-  const [jobCostThreshold, setJobCostThreshold] = useState('')
-  const [isSavingJobThreshold, setIsSavingJobThreshold] = useState(false)
-  const [telemetryEnabled, setTelemetryEnabled] = useState(false)
-  const [isSavingTelemetry, setIsSavingTelemetry] = useState(false)
-  const [prePrompt, setPrePrompt] = useState('')
-  const [isSavingPrePrompt, setIsSavingPrePrompt] = useState(false)
-  const [ultraPrePrompt, setUltraPrePrompt] = useState('')
-  const [isSavingUltraPrePrompt, setIsSavingUltraPrePrompt] = useState(false)
-
   const cacheRef = useRef<Map<string, ProjectConfig>>(new Map())
 
   useEffect(() => {
@@ -73,7 +57,6 @@ export default function SettingsPage() {
       const cached = cacheRef.current.get(activeProjectId)
       if (cached) {
         setConfig(cached)
-        setDailyBudget(cached.dailyBudgetUsd != null ? String(cached.dailyBudgetUsd) : '')
         setIsLoading(false)
       } else {
         setIsLoading(true)
@@ -85,7 +68,6 @@ export default function SettingsPage() {
         if (!res.ok) return
         const data = await res.json() as ProjectConfig
         setConfig(data)
-        setDailyBudget(data.dailyBudgetUsd != null ? String(data.dailyBudgetUsd) : '')
         if (activeProjectId) cacheRef.current.set(activeProjectId, data)
       } catch {
         // ignore
@@ -95,144 +77,6 @@ export default function SettingsPage() {
     }
     loadConfig()
   }, [activeProjectId])
-
-  useEffect(() => {
-    if (!activeProjectId) return
-    async function loadBudget() {
-      try {
-        const res = await fetch(`${getApiBase()}/budget`)
-        if (!res.ok) return
-        const data = await res.json() as { dailyBudgetUsd?: number | null; jobCostThresholdUsd?: number | null }
-        if (data.dailyBudgetUsd != null) setDailyBudget(String(data.dailyBudgetUsd))
-        if (data.jobCostThresholdUsd != null) setJobCostThreshold(String(data.jobCostThresholdUsd))
-        else setJobCostThreshold('')
-      } catch {
-        // ignore
-      }
-    }
-    void loadBudget()
-  }, [activeProjectId])
-
-  useEffect(() => {
-    if (!activeProjectId || !isSuperMode) return
-    async function loadTelemetrySettings() {
-      try {
-        const res = await fetch(`${getApiBase()}/settings`)
-        if (!res.ok) return
-        const data = await res.json() as ProjectSettings
-        setTelemetryEnabled(data.pipelineTelemetryEnabled ?? false)
-        setPrePrompt(data.prePrompt ?? '')
-        setUltraPrePrompt(data.ultraPrePrompt ?? '')
-      } catch {
-        // ignore
-      }
-    }
-    void loadTelemetrySettings()
-  }, [activeProjectId, isSuperMode])
-
-  async function saveDailyBudget() {
-    setIsSavingBudget(true)
-    try {
-      const parsed = dailyBudget.trim() === '' ? null : parseFloat(dailyBudget)
-      if (parsed !== null && (isNaN(parsed) || parsed <= 0)) {
-        toast.error(t('budget.invalidNumber'))
-        return
-      }
-      const res = await fetch(`${getApiBase()}/budget`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ dailyBudgetUsd: parsed }),
-      })
-      if (!res.ok) throw new Error('Failed to save')
-      toast.success(parsed == null ? t('budget.dailyRemoved') : t('budget.dailySet', { amount: parsed }))
-    } catch (err) {
-      toast.error(t('budget.saveBudgetFailed'), { description: (err as Error).message })
-    } finally {
-      setIsSavingBudget(false)
-    }
-  }
-
-  async function saveJobCostThreshold() {
-    setIsSavingJobThreshold(true)
-    try {
-      const parsed = jobCostThreshold.trim() === '' ? null : parseFloat(jobCostThreshold)
-      if (parsed !== null && (isNaN(parsed) || parsed <= 0)) {
-        toast.error(t('budget.invalidNumber'))
-        return
-      }
-      const res = await fetch(`${getApiBase()}/budget`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ jobCostThresholdUsd: parsed }),
-      })
-      if (!res.ok) throw new Error('Failed to save')
-      toast.success(parsed == null ? t('budget.perJobAlertDisabled') : t('budget.alertSet', { amount: parsed }))
-    } catch (err) {
-      toast.error(t('budget.saveThresholdFailed'), { description: (err as Error).message })
-    } finally {
-      setIsSavingJobThreshold(false)
-    }
-  }
-
-  async function saveTelemetryToggle(enabled: boolean) {
-    setIsSavingTelemetry(true)
-    const prev = telemetryEnabled
-    setTelemetryEnabled(enabled)
-    try {
-      const res = await fetch(`${getApiBase()}/settings`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ pipelineTelemetryEnabled: enabled }),
-      })
-      if (!res.ok) throw new Error('Failed to save')
-      toast.success(enabled ? t('telemetry.enabled') : t('telemetry.disabled'))
-    } catch (err) {
-      setTelemetryEnabled(prev)
-      toast.error(t('telemetry.saveFailed'), { description: (err as Error).message })
-    } finally {
-      setIsSavingTelemetry(false)
-    }
-  }
-
-  async function savePrePrompt() {
-    setIsSavingPrePrompt(true)
-    try {
-      const res = await fetch(`${getApiBase()}/settings`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ prePrompt }),
-      })
-      if (!res.ok) throw new Error('Failed to save')
-      const data = await res.json() as { settings?: ProjectSettings }
-      const savedValue = data.settings?.prePrompt ?? ''
-      setPrePrompt(savedValue)
-      toast.success(savedValue.trim() === '' ? t('prePrompt.cleared') : t('prePrompt.saved'))
-    } catch (err) {
-      toast.error(t('prePrompt.saveFailed'), { description: (err as Error).message })
-    } finally {
-      setIsSavingPrePrompt(false)
-    }
-  }
-
-  async function saveUltraPrePrompt() {
-    setIsSavingUltraPrePrompt(true)
-    try {
-      const res = await fetch(`${getApiBase()}/settings`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ultraPrePrompt }),
-      })
-      if (!res.ok) throw new Error('Failed to save')
-      const data = await res.json() as { settings?: ProjectSettings }
-      const savedValue = data.settings?.ultraPrePrompt ?? ''
-      setUltraPrePrompt(savedValue)
-      toast.success(savedValue.trim() === '' ? t('ultraPrePrompt.resetToDefault') : t('ultraPrePrompt.saved'))
-    } catch (err) {
-      toast.error(t('ultraPrePrompt.saveFailed'), { description: (err as Error).message })
-    } finally {
-      setIsSavingUltraPrePrompt(false)
-    }
-  }
 
   if (isLoading) {
     return (
@@ -257,192 +101,11 @@ export default function SettingsPage() {
       </div>
 
       {/* Pipeline Telemetry Section — Super mode only */}
-      {isSuperMode && (
-        <Card>
-          <CardHeader>
-            <CardTitle>{t('telemetry.title')}</CardTitle>
-            <CardDescription>
-              {t('telemetry.description')}
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="flex items-center justify-between">
-              <div className="space-y-0.5">
-                <p className="text-xs font-medium">{t('telemetry.toggleLabel')}</p>
-                <p className="text-[10px] text-muted-foreground">
-                  <Trans
-                    ns="settings"
-                    i18nKey="telemetry.toggleDescription"
-                    components={{ mono: <span className="font-mono" /> }}
-                  />
-                </p>
-              </div>
-              <button
-                type="button"
-                role="switch"
-                aria-label={t('telemetry.toggleLabel')}
-                aria-checked={telemetryEnabled}
-                disabled={isSavingTelemetry}
-                onClick={() => saveTelemetryToggle(!telemetryEnabled)}
-                className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 ${
-                  telemetryEnabled ? 'bg-primary' : 'bg-input'
-                }`}
-              >
-                <span
-                  className={`inline-block h-3.5 w-3.5 rounded-full bg-background shadow-sm transition-transform ${
-                    telemetryEnabled ? 'translate-x-4' : 'translate-x-0.5'
-                  }`}
-                />
-              </button>
-            </div>
-          </CardContent>
-        </Card>
-      )}
+      {isSuperMode && <ProjectTelemetrySection />}
 
-      <Card>
-        <CardHeader>
-          <CardTitle>{t('prePrompt.title')}</CardTitle>
-          <CardDescription>
-            {t('prePrompt.description')}
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          <div className="space-y-2">
-            <label htmlFor="project-pre-prompt" className="text-xs font-medium">
-              {t('prePrompt.label')}
-            </label>
-            <textarea
-              id="project-pre-prompt"
-              value={prePrompt}
-              onChange={(e) => setPrePrompt(e.target.value)}
-              placeholder={t('prePrompt.placeholder')}
-              className="min-h-32 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/20"
-            />
-            <p className="text-xs text-muted-foreground">
-              {t('prePrompt.helper')}
-            </p>
-          </div>
-          <div className="flex justify-end">
-            <Button
-              size="sm"
-              variant="secondary"
-              className="h-7 text-xs"
-              disabled={isSavingPrePrompt}
-              onClick={savePrePrompt}
-            >
-              {isSavingPrePrompt ? t('common:states.saving') : t('prePrompt.saveButton')}
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
+      <ProjectPrePromptsSection />
 
-      <Card>
-        <CardHeader>
-          <CardTitle>{t('ultraPrePrompt.title')}</CardTitle>
-          <CardDescription>
-            {t('ultraPrePrompt.description')}
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          <div className="space-y-2">
-            <label htmlFor="project-ultra-pre-prompt" className="text-xs font-medium">
-              {t('ultraPrePrompt.label')}
-            </label>
-            <textarea
-              id="project-ultra-pre-prompt"
-              value={ultraPrePrompt}
-              onChange={(e) => setUltraPrePrompt(e.target.value)}
-              placeholder={t('ultraPrePrompt.placeholder')}
-              className="min-h-32 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/20"
-            />
-            <p className="text-xs text-muted-foreground">
-              {t('ultraPrePrompt.helper')}
-            </p>
-          </div>
-          <div className="flex justify-end">
-            <Button
-              size="sm"
-              variant="secondary"
-              className="h-7 text-xs"
-              disabled={isSavingUltraPrePrompt}
-              onClick={saveUltraPrePrompt}
-            >
-              {isSavingUltraPrePrompt ? t('common:states.saving') : t('ultraPrePrompt.saveButton')}
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Budget Section */}
-      <Card>
-        <CardHeader>
-          <CardTitle>{t('budget.title')}</CardTitle>
-          <CardDescription>
-            {t('budget.description')}
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-2 gap-6">
-            <div className="space-y-2">
-              <div>
-                <label className="text-xs font-medium">{t('budget.dailyLabel')}</label>
-                <p className="text-xs text-muted-foreground">
-                  {t('budget.dailyHelper')}
-                </p>
-              </div>
-              <Input
-                type="number"
-                min="0"
-                step="0.01"
-                value={dailyBudget}
-                onChange={(e) => setDailyBudget(e.target.value)}
-                placeholder={t('budget.dailyPlaceholder')}
-                className="h-8 text-xs font-mono"
-              />
-              <div className="flex justify-end">
-                <Button
-                  size="sm"
-                  variant="secondary"
-                  className="h-7 text-xs"
-                  disabled={isSavingBudget}
-                  onClick={saveDailyBudget}
-                >
-                  {isSavingBudget ? t('common:states.saving') : t('common:actions.save')}
-                </Button>
-              </div>
-            </div>
-
-            <div className="space-y-2">
-              <div>
-                <label className="text-xs font-medium">{t('budget.perJobLabel')}</label>
-                <p className="text-xs text-muted-foreground">
-                  {t('budget.perJobHelper')}
-                </p>
-              </div>
-              <Input
-                type="number"
-                min="0"
-                step="0.01"
-                value={jobCostThreshold}
-                onChange={(e) => setJobCostThreshold(e.target.value)}
-                placeholder={t('budget.perJobPlaceholder')}
-                className="h-8 text-xs font-mono"
-              />
-              <div className="flex justify-end">
-                <Button
-                  size="sm"
-                  variant="secondary"
-                  className="h-7 text-xs"
-                  disabled={isSavingJobThreshold}
-                  onClick={saveJobCostThreshold}
-                >
-                  {isSavingJobThreshold ? t('common:states.saving') : t('common:actions.save')}
-                </Button>
-              </div>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+      <ProjectBudgetSection />
 
       <TerminalSettingsSection mode="project" />
 

--- a/client/src/pages/__tests__/DashboardPageRails.test.tsx
+++ b/client/src/pages/__tests__/DashboardPageRails.test.tsx
@@ -111,6 +111,11 @@ describe('DashboardPage — server rail reconcile (adopt agent/MCP launches)', (
       if (typeof url === 'string' && url.endsWith('/rails')) {
         return Promise.resolve({ ok: true, json: () => Promise.resolve(payload) })
       }
+      // Adopted rails go 'running', which mounts RailProfileSelector — it needs
+      // a well-formed profiles payload or its render crashes (CI 'Errors: 5').
+      if (typeof url === 'string' && url.includes('/profiles')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ profiles: [] }) })
+      }
       return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
     })
 

--- a/client/src/pages/__tests__/DashboardPageRails.test.tsx
+++ b/client/src/pages/__tests__/DashboardPageRails.test.tsx
@@ -105,6 +105,109 @@ describe('DashboardPage — rail interactions', () => {
   })
 })
 
+describe('DashboardPage — server rail reconcile (adopt agent/MCP launches)', () => {
+  const railsResponse = (payload: unknown) =>
+    vi.fn().mockImplementation((url: unknown) => {
+      if (typeof url === 'string' && url.endsWith('/rails')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(payload) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+
+  it('adopts a server-active job into an idle local rail (running + tickets + jobId)', async () => {
+    // A launch made while this board was UNMOUNTED (global agent via MCP in
+    // Agent Mode, mobile companion, another window): localStorage knows nothing,
+    // but GET /rails reports the active job + the rail's ticket assignment.
+    mockActiveProjectId = 'proj-1'
+    global.fetch = railsResponse({
+      rails: [{ railIndex: 0, ticketIds: [7], mode: 'implement' }],
+      activeJobs: { '0': { jobId: 'job-9', mode: 'implement' } },
+      activeLoopRuns: {},
+    })
+    render(<DashboardPage />)
+    await waitFor(() => {
+      const raw = localStorage.getItem('specrails-desktop:rails:proj-1')
+      expect(raw).toBeTruthy()
+      const rails = JSON.parse(raw!)
+      expect(rails[0].status).toBe('running')
+      expect(rails[0].activeJobId).toBe('job-9')
+      expect(rails[0].ticketIds).toEqual([7])
+      expect(rails[1].status).toBe('idle')
+    })
+  })
+
+  it('still clears a locally-running rail the server no longer reports active', async () => {
+    mockActiveProjectId = 'proj-1'
+    localStorage.setItem('specrails-desktop:rails:proj-1', JSON.stringify([
+      { id: 'rail-1', label: 'Rail 1', ticketIds: [3], mode: 'implement', status: 'running', activeJobId: 'gone' },
+      { id: 'rail-2', label: 'Rail 2', ticketIds: [], mode: 'implement', status: 'idle' },
+      { id: 'rail-3', label: 'Rail 3', ticketIds: [], mode: 'implement', status: 'idle' },
+    ]))
+    global.fetch = railsResponse({ rails: [], activeJobs: {}, activeLoopRuns: {} })
+    render(<DashboardPage />)
+    await waitFor(() => {
+      const rails = JSON.parse(localStorage.getItem('specrails-desktop:rails:proj-1')!)
+      expect(rails[0].status).toBe('idle')
+      expect(rails[0].ticketIds).toEqual([])
+      expect(rails[0].activeJobId).toBeUndefined()
+    })
+  })
+
+  it('adopts an active LOOP run with mode loop and no ticket clobber', async () => {
+    mockActiveProjectId = 'proj-1'
+    global.fetch = railsResponse({
+      rails: [{ railIndex: 1, ticketIds: [] }],
+      activeJobs: {},
+      activeLoopRuns: { '1': { loopRunId: 'run-4', loopId: 'custom:my-loop' } },
+    })
+    render(<DashboardPage />)
+    await waitFor(() => {
+      const rails = JSON.parse(localStorage.getItem('specrails-desktop:rails:proj-1')!)
+      expect(rails[1].status).toBe('running')
+      expect(rails[1].activeJobId).toBe('run-4')
+      expect(rails[1].mode).toBe('loop')
+      expect(rails[1].selectedLoopId).toBe('custom:my-loop')
+    })
+  })
+
+  it('derives the REAL mode from a factory loopId (desktop launches register as loop runs)', async () => {
+    mockActiveProjectId = 'proj-1'
+    global.fetch = railsResponse({
+      rails: [{ railIndex: 0, ticketIds: [4] }],
+      activeJobs: {},
+      activeLoopRuns: { '0': { loopRunId: 'run-7', loopId: 'factory:implement' } },
+    })
+    render(<DashboardPage />)
+    await waitFor(() => {
+      const rails = JSON.parse(localStorage.getItem('specrails-desktop:rails:proj-1')!)
+      expect(rails[0].status).toBe('running')
+      expect(rails[0].mode).toBe('implement') // NOT hardcoded 'loop'
+      expect(rails[0].ticketIds).toEqual([4])
+    })
+  })
+
+  it('strips adopted tickets from OTHER rails (no ticket on two rails at once)', async () => {
+    mockActiveProjectId = 'proj-1'
+    // Ticket 7 was locally dragged onto rail-2, but the server launched it on slot 0.
+    localStorage.setItem('specrails-desktop:rails:proj-1', JSON.stringify([
+      { id: 'rail-1', label: 'Rail 1', ticketIds: [], mode: 'implement', status: 'idle' },
+      { id: 'rail-2', label: 'Rail 2', ticketIds: [7], mode: 'implement', status: 'idle' },
+      { id: 'rail-3', label: 'Rail 3', ticketIds: [], mode: 'implement', status: 'idle' },
+    ]))
+    global.fetch = railsResponse({
+      rails: [{ railIndex: 0, ticketIds: [7] }],
+      activeJobs: { '0': { jobId: 'job-1', mode: 'implement' } },
+      activeLoopRuns: {},
+    })
+    render(<DashboardPage />)
+    await waitFor(() => {
+      const rails = JSON.parse(localStorage.getItem('specrails-desktop:rails:proj-1')!)
+      expect(rails[0].ticketIds).toEqual([7])
+      expect(rails[1].ticketIds).toEqual([]) // stripped from the local drag target
+    })
+  })
+})
+
 describe('DashboardPage — loop model picker wiring', () => {
   it('model picker change updates loopModel and subsequent launch includes the new model', async () => {
     mockActiveProjectId = 'proj-1'

--- a/server/agent-chat-manager.ts
+++ b/server/agent-chat-manager.ts
@@ -30,6 +30,14 @@ export interface AgentTurnOptions {
   tierLevel?: AgentTierLevel
   model?: string
   attachmentIds?: string[]
+  /** Client-generated correlation id echoed on agent_queued / agent_dequeued. */
+  queueId?: string | null
+}
+
+interface QueuedTurn {
+  queueId: string | null
+  text: string
+  options: AgentTurnOptions
 }
 
 export class AgentChatManager {
@@ -41,6 +49,12 @@ export class AgentChatManager {
    *  window the attachment-extraction await opens between the busy guard and
    *  `_active.set` in onSpawn (mirrors ChatManager's reservation pattern). */
   private readonly _reserved = new Set<string>()
+  /** Messages sent while a turn was in flight — drained FIFO after it settles. */
+  private readonly _queue = new Map<string, QueuedTurn[]>()
+  /** Conversations whose in-flight turn the user deliberately stopped. Consulted
+   *  at settle so an abort is never mistaken for a stale session (auto-heal
+   *  would resurrect the aborted prompt) nor surfaced as an error. */
+  private readonly _abortedTurns = new Set<string>()
 
   constructor(broadcast: (msg: WsMessage) => void, db: DbInstance, port: number) {
     this._broadcast = broadcast
@@ -53,10 +67,20 @@ export class AgentChatManager {
     return this._active.has(conversationId)
   }
 
+  /** True while a turn is in flight (spawned or reserved) — a send now queues. */
+  isBusy(conversationId: string): boolean {
+    return this._active.has(conversationId) || this._reserved.has(conversationId)
+  }
+
   /**
    * Runs one agent turn: persists the user message, spawns the AI CLI pointed at
    * the Specrails MCP, streams deltas + tool-use as `agent_*` events, then
    * persists the assistant reply and the session id. Settles once.
+   *
+   * A send while a turn is in flight is QUEUED (never rejected): the busy check
+   * and the enqueue are synchronous (before any await), so the router's isBusy
+   * read in the same event-loop frame is consistent with what happens here.
+   * Queued turns drain FIFO after the current turn settles; abort discards them.
    */
   async sendMessage(conversationId: string, userText: string, options: AgentTurnOptions = {}): Promise<void> {
     const conversation = getAgentConversation(this._db, conversationId)
@@ -64,15 +88,60 @@ export class AgentChatManager {
       this._emitError(conversationId, 'Unknown conversation')
       return
     }
-    if (this._active.has(conversationId) || this._reserved.has(conversationId)) {
-      this._emitError(conversationId, 'The agent is busy. Try again in a moment.')
+    if (this.isBusy(conversationId)) {
+      const pending = this._queue.get(conversationId) ?? []
+      const queueId = options.queueId ?? null
+      pending.push({ queueId, text: userText, options })
+      this._queue.set(conversationId, pending)
+      this._broadcast({
+        type: 'agent_queued',
+        conversationId,
+        queueId,
+        text: userText,
+        position: pending.length,
+        timestamp: new Date().toISOString(),
+      })
       return
     }
     this._reserved.add(conversationId)
     try {
-      await this._runTurn(conversation, userText, options)
+      await this._runTurnSafely(conversation, userText, options)
+      // Drain messages queued while we were running. Each drained turn re-reads
+      // the conversation row so a mid-flight tier/provider/model change applies.
+      for (;;) {
+        const pending = this._queue.get(conversationId)
+        const next = pending?.shift()
+        if (!next) break
+        if (pending && pending.length === 0) this._queue.delete(conversationId)
+        const conv = getAgentConversation(this._db, conversationId)
+        if (!conv) break // deleted mid-drain (abort() already cleared the queue)
+        this._broadcast({
+          type: 'agent_dequeued',
+          conversationId,
+          queueId: next.queueId,
+          text: next.text,
+          timestamp: new Date().toISOString(),
+        })
+        await this._runTurnSafely(conv, next.text, next.options)
+      }
     } finally {
       this._reserved.delete(conversationId)
+      this._abortedTurns.delete(conversationId)
+    }
+  }
+
+  /** One turn that can never break the drain loop (or leave the client hung
+   *  streaming): an unexpected throw surfaces as agent_error instead. */
+  private async _runTurnSafely(
+    conversation: NonNullable<ReturnType<typeof getAgentConversation>>,
+    userText: string,
+    options: AgentTurnOptions,
+  ): Promise<void> {
+    try {
+      await this._runTurn(conversation, userText, options)
+    } catch (err) {
+      console.error(`[agent-chat] turn failed (${conversation.id}):`, err)
+      this._emitError(conversation.id, err instanceof Error ? err.message : 'The agent turn failed.')
     }
   }
 
@@ -213,10 +282,17 @@ export class AgentChatManager {
           switch (ev.kind) {
             case 'text-delta':
               streamed += ev.text
-              this._broadcast({ type: 'agent_stream', conversationId, delta: ev.text, timestamp: timestamp() })
+              // A killed child (abort / conversation DELETE) keeps flushing its
+              // buffered stdout — suppress the broadcasts once it left _active
+              // so stragglers can't resurrect client-side streaming state.
+              if (this._active.has(conversationId)) {
+                this._broadcast({ type: 'agent_stream', conversationId, delta: ev.text, timestamp: timestamp() })
+              }
               break
             case 'tool-use':
-              this._broadcast({ type: 'agent_tool', conversationId, tool: ev.name, timestamp: timestamp() })
+              if (this._active.has(conversationId)) {
+                this._broadcast({ type: 'agent_tool', conversationId, tool: ev.name, timestamp: timestamp() })
+              }
               break
             case 'session-started':
               if (ev.sessionId) capturedSessionId = ev.sessionId
@@ -247,12 +323,38 @@ export class AgentChatManager {
       return { text, sessionId: capturedSessionId, error: capturedError, code: result.code, spawnFailed: result.spawnFailed, stderrTail: result.stderrTail }
     }
 
+    // Conversation CONFIG (provider/model/tier) is owned by the PATCH route —
+    // never write turn-START snapshots back at settle, or a mid-turn provider
+    // switch would be silently reverted and a queued turn drained onto the old
+    // provider. Only the session id persists, and only while the row's provider
+    // is still the one this turn actually ran on (a foreign session id must not
+    // pollute the new provider's freshly-reset state).
+    const persistSession = (sessionId: string | null): void => {
+      const fresh = getAgentConversation(this._db, conversationId)
+      if (fresh && fresh.provider === conversation.provider) {
+        updateAgentConversation(this._db, conversationId, { session_id: sessionId })
+      }
+    }
+    const settleAborted = (r: { text: string; sessionId: string | null }): void => {
+      // Deliberate user Stop: keep any partial text (it was already streamed to
+      // the client), never auto-heal, never surface an error.
+      if (r.text && getAgentConversation(this._db, conversationId)) {
+        addAgentMessage(this._db, { conversationId, role: 'assistant', content: r.text })
+        persistSession(r.sessionId)
+        this._broadcast({ type: 'agent_done', conversationId, fullText: r.text, timestamp: timestamp() })
+      }
+    }
+
     const canResume = !!conversation.session_id && adapter.capabilities.nativeResume
     let r = await invoke(canResume)
 
     // Deleted mid-turn (DELETE aborts the child and drops the row): stop here —
     // no auto-heal respawn, no FK-violating assistant INSERT.
     if (!getAgentConversation(this._db, conversationId)) return
+    if (this._abortedTurns.delete(conversationId)) {
+      settleAborted(r)
+      return
+    }
 
     // Auto-heal a stale/foreign session: a resume that produced no text (e.g. a
     // provider switch leaving another provider's session id, or codex
@@ -262,6 +364,10 @@ export class AgentChatManager {
       updateAgentConversation(this._db, conversationId, { session_id: null })
       r = await invoke(false)
       if (!getAgentConversation(this._db, conversationId)) return
+      if (this._abortedTurns.delete(conversationId)) {
+        settleAborted(r)
+        return
+      }
     }
 
     if (r.spawnFailed) {
@@ -271,19 +377,14 @@ export class AgentChatManager {
 
     if (r.text) {
       addAgentMessage(this._db, { conversationId, role: 'assistant', content: r.text })
-      updateAgentConversation(this._db, conversationId, {
-        session_id: r.sessionId,
-        provider: conversation.provider,
-        model,
-        tier_level: tierLevel,
-      })
+      persistSession(r.sessionId)
       this._broadcast({ type: 'agent_done', conversationId, fullText: r.text, timestamp: timestamp() })
       return
     }
 
     // Failure: reset the session so the NEXT turn starts fresh, and surface the
     // real reason instead of silently doing nothing.
-    updateAgentConversation(this._db, conversationId, { session_id: null, provider: conversation.provider, model, tier_level: tierLevel })
+    persistSession(null)
     const reason =
       r.error ||
       (r.stderrTail ? r.stderrTail.split('\n').filter(Boolean).slice(-3).join(' ').slice(0, 300) : '') ||
@@ -315,8 +416,13 @@ export class AgentChatManager {
     }
   }
 
-  /** Aborts the active turn for a conversation, if any. */
+  /** Aborts the active turn for a conversation, if any. Stop means stop: any
+   *  queued messages are discarded too (broadcast so the client drops chips),
+   *  and the settling turn is marked aborted so the stale-session auto-heal
+   *  can never resurrect the stopped prompt as a fresh spawn. */
   abort(conversationId: string): boolean {
+    this._clearQueue(conversationId)
+    if (this.isBusy(conversationId)) this._abortedTurns.add(conversationId)
     const child = this._active.get(conversationId)
     if (!child) return false
     try {
@@ -328,8 +434,16 @@ export class AgentChatManager {
     return true
   }
 
+  private _clearQueue(conversationId: string): void {
+    const pending = this._queue.get(conversationId)
+    if (!pending || pending.length === 0) return
+    this._queue.delete(conversationId)
+    this._broadcast({ type: 'agent_queue_cleared', conversationId, timestamp: new Date().toISOString() })
+  }
+
   /** Kills all active turns (graceful shutdown). */
   async shutdown(): Promise<void> {
+    this._queue.clear()
     for (const [, child] of this._active) {
       try {
         child.kill('SIGTERM')

--- a/server/agent-chat-router.ts
+++ b/server/agent-chat-router.ts
@@ -318,13 +318,18 @@ export function createAgentChatRouter(deps: AgentRouterDeps): Router {
     if (rawAtt && typeof rawAtt === 'object' && Array.isArray((rawAtt as { ids?: unknown }).ids)) {
       attachmentIds = ((rawAtt as { ids: unknown[] }).ids).filter((x): x is string => typeof x === 'string')
     }
+    const queueId = typeof body.queueId === 'string' ? body.queueId : null
     // Fire-and-forget: the turn streams over WS. Persist the chosen tier first so
     // a refresh mid-turn restores the right level.
     if (tierLevel !== undefined) updateAgentConversation(desktopDb, conversation.id, { tier_level: tierLevel })
-    void manager.sendMessage(conversation.id, text, { tierLevel, model, attachmentIds }).catch((e) =>
+    // isBusy here and sendMessage's own busy/enqueue branch run in the same
+    // synchronous frame (the enqueue happens before sendMessage's first await),
+    // so the flag the client gets always matches what actually happened.
+    const queued = manager.isBusy(conversation.id)
+    void manager.sendMessage(conversation.id, text, { tierLevel, model, attachmentIds, queueId }).catch((e) =>
       console.error('[agent-chat] send failed:', e),
     )
-    res.status(202).json({ accepted: true })
+    res.status(202).json({ accepted: true, queued })
   })
 
   router.post('/conversations/:id/abort', (req: Request, res: Response) => {

--- a/server/agent-chat.test.ts
+++ b/server/agent-chat.test.ts
@@ -331,6 +331,7 @@ describe('agent-chat-router', () => {
         sent.push({ id, text })
       },
       abort: () => true,
+      isBusy: () => false,
     }
     app = makeApp(db, manager)
   })
@@ -352,6 +353,7 @@ describe('agent-chat-router', () => {
 
     const send = await req(app, 'POST', `/api/agent/conversations/${id}/send`, { text: 'do it', tierLevel: 3 })
     expect(send.status).toBe(202)
+    expect(send.body.queued).toBe(false)
     expect(sent).toEqual([{ id, text: 'do it' }])
     // tier persisted before dispatch
     expect((await req(app, 'GET', `/api/agent/conversations/${id}`)).body.conversation.tier_level).toBe(3)
@@ -416,6 +418,26 @@ describe('agent-chat-router', () => {
     const c = await req(app, 'POST', '/api/agent/conversations', {})
     expect((await req(app, 'POST', `/api/agent/conversations/${c.body.conversation.id}/send`, { text: '  ' })).status).toBe(400)
     expect((await req(app, 'POST', '/api/agent/conversations/missing/send', { text: 'x' })).status).toBe(404)
+  })
+
+  it('reports queued=true when a turn is in flight and forwards the queueId', async () => {
+    const captured: unknown[] = []
+    const busyManager: Partial<AgentChatManager> = {
+      sendMessage: async (_id, _text, options) => {
+        captured.push(options)
+      },
+      abort: () => true,
+      isBusy: () => true,
+    }
+    const busyApp = makeApp(db, busyManager)
+    const c = await req(busyApp, 'POST', '/api/agent/conversations', {})
+    const send = await req(busyApp, 'POST', `/api/agent/conversations/${c.body.conversation.id}/send`, {
+      text: 'later please',
+      queueId: 'q-front-1',
+    })
+    expect(send.status).toBe(202)
+    expect(send.body.queued).toBe(true)
+    expect((captured[0] as { queueId?: string }).queueId).toBe('q-front-1')
   })
 
   it('404s the whole surface when SPECRAILS_AGENT_CHAT=false', async () => {
@@ -486,27 +508,116 @@ describe('AgentChatManager', () => {
     expect(events.some((e) => e.type === 'agent_error')).toBe(true)
   })
 
-  it('refuses a second concurrent turn as busy', async () => {
+  it('queues a second concurrent turn and drains it FIFO after the first settles', async () => {
     const c = createAgentConversation(db, { provider: 'claude' })
     let release: () => void = () => {}
-    vi.mocked(runAiCliInvocation).mockImplementation(
-      (hooks) =>
-        new Promise<InvocationResult>((resolve) => {
-          hooks.onSpawn?.({ kill: () => true } as never)
+    let calls = 0
+    vi.mocked(runAiCliInvocation).mockImplementation((hooks) => {
+      calls++
+      hooks.onSpawn?.({ kill: () => true } as never)
+      if (calls === 1) {
+        hooks.onEvent?.({ kind: 'text-delta', text: 'first reply' })
+        return new Promise<InvocationResult>((resolve) => {
           release = () =>
             resolve({ code: 0, timedOut: false, spawnFailed: false, events: [], lastResultEvent: null, sessionId: null, stderrTail: '', child: null } as InvocationResult)
-        }),
-    )
+        })
+      }
+      hooks.onEvent?.({ kind: 'text-delta', text: 'second reply' })
+      return Promise.resolve({ code: 0, timedOut: false, spawnFailed: false, events: [], lastResultEvent: null, sessionId: null, stderrTail: '', child: null } as InvocationResult)
+    })
     const first = manager.sendMessage(c.id, 'one')
-    await manager.sendMessage(c.id, 'two') // rejected as busy while first is mid-flight
-    expect(events.some((e) => e.type === 'agent_error')).toBe(true)
+    // Mid-flight send: never rejected, parked on the queue with its queueId.
+    await manager.sendMessage(c.id, 'two', { queueId: 'q-77' })
+    expect(events.some((e) => e.type === 'agent_error')).toBe(false)
+    const queuedEv = events.find((e) => e.type === 'agent_queued') as { queueId?: string; position?: number } | undefined
+    expect(queuedEv?.queueId).toBe('q-77')
+    expect(queuedEv?.position).toBe(1)
+
     release()
     await first
+    // Drained: dequeued event + BOTH turns persisted in FIFO order.
+    const dequeuedEv = events.find((e) => e.type === 'agent_dequeued') as { queueId?: string } | undefined
+    expect(dequeuedEv?.queueId).toBe('q-77')
+    expect(calls).toBe(2)
+    const msgs = listAgentMessages(db, c.id).map((m) => `${m.role}:${m.content}`)
+    expect(msgs).toEqual(['user:one', 'assistant:first reply', 'user:two', 'assistant:second reply'])
+  })
+
+  it('abort discards the queue (agent_queue_cleared) and the queued turn never runs', async () => {
+    const c = createAgentConversation(db, { provider: 'claude' })
+    let release: () => void = () => {}
+    let calls = 0
+    vi.mocked(runAiCliInvocation).mockImplementation((hooks) => {
+      calls++
+      hooks.onSpawn?.({ kill: () => true } as never)
+      return new Promise<InvocationResult>((resolve) => {
+        release = () =>
+          resolve({ code: 0, timedOut: false, spawnFailed: false, events: [], lastResultEvent: null, sessionId: null, stderrTail: '', child: null } as InvocationResult)
+      })
+    })
+    const first = manager.sendMessage(c.id, 'one')
+    await manager.sendMessage(c.id, 'two', { queueId: 'q-88' })
+    expect(manager.isBusy(c.id)).toBe(true)
+    manager.abort(c.id)
+    expect(events.some((e) => e.type === 'agent_queue_cleared')).toBe(true)
+    release()
+    await first
+    expect(calls).toBe(1) // the queued turn was discarded, never spawned
+    expect(events.some((e) => e.type === 'agent_dequeued')).toBe(false)
+    expect(listAgentMessages(db, c.id).some((m) => m.content === 'two')).toBe(false)
   })
 
   it('errors on unknown conversation', async () => {
     await manager.sendMessage('nope', 'hi')
     expect(events[0]?.type).toBe('agent_error')
+  })
+
+  it('abort never resurrects the stopped prompt via the stale-session auto-heal', async () => {
+    const c = createAgentConversation(db, { provider: 'claude' })
+    updateAgentConversation(db, c.id, { session_id: 'live-session' }) // → canResume
+    let release: () => void = () => {}
+    let calls = 0
+    vi.mocked(runAiCliInvocation).mockImplementation((hooks) => {
+      calls++
+      hooks.onSpawn?.({ kill: () => true } as never)
+      // Pre-first-delta window: the child is killed before emitting anything.
+      return new Promise<InvocationResult>((resolve) => {
+        release = () =>
+          resolve({ code: null, timedOut: false, spawnFailed: false, events: [], lastResultEvent: null, sessionId: null, stderrTail: '', child: null } as InvocationResult)
+      })
+    })
+    const turn = manager.sendMessage(c.id, 'stop me')
+    manager.abort(c.id) // user presses Stop before any text streamed
+    release()
+    await turn
+    expect(calls).toBe(1) // NO fresh respawn of the aborted prompt
+    expect(events.some((e) => e.type === 'agent_error')).toBe(false) // a stop is not an error
+    expect(events.some((e) => e.type === 'agent_done')).toBe(false) // nothing streamed → nothing persisted
+    expect(listAgentMessages(db, c.id).some((m) => m.role === 'assistant')).toBe(false)
+  })
+
+  it('settle never clobbers a mid-turn provider switch (config is PATCH-owned)', async () => {
+    const c = createAgentConversation(db, { provider: 'claude' })
+    let release: () => void = () => {}
+    vi.mocked(runAiCliInvocation).mockImplementation((hooks) => {
+      hooks.onSpawn?.({ kill: () => true } as never)
+      hooks.onEvent?.({ kind: 'text-delta', text: 'claude reply' })
+      hooks.onEvent?.({ kind: 'session-started', sessionId: 'claude-sess' })
+      return new Promise<InvocationResult>((resolve) => {
+        release = () =>
+          resolve({ code: 0, timedOut: false, spawnFailed: false, events: [], lastResultEvent: null, sessionId: null, stderrTail: '', child: null } as InvocationResult)
+      })
+    })
+    const turn = manager.sendMessage(c.id, 'hola')
+    // Mid-turn the user switches provider — PATCH semantics: session/model reset.
+    updateAgentConversation(db, c.id, { provider: 'codex', session_id: null, model: null })
+    release()
+    await turn
+    const row = getAgentConversation(db, c.id)
+    expect(row?.provider).toBe('codex') // NOT reverted to claude
+    expect(row?.session_id).toBeNull() // claude session never pollutes codex state
+    expect(row?.model).toBeNull()
+    expect(events.some((e) => e.type === 'agent_done')).toBe(true) // reply still lands
   })
 
   it('auto-heals a stale/foreign session: a resume with no text retries fresh', async () => {

--- a/server/agent-operator-prompt.ts
+++ b/server/agent-operator-prompt.ts
@@ -72,8 +72,10 @@ coding pipelines over them.
   block with language \`options\` at the very END of the reply, containing only a
   JSON array of the choice labels (2-6 short strings, e.g.
   \`["Option A", "Option B"]\`) — the app renders them as clickable chips the
-  user can tap to answer. Never emit this block when you are not asking the
-  user to choose.
+  user can tap to answer. The opening \`\`\`options fence MUST start on its own
+  line (a blank line after your prose), the array on the next line, and the
+  block MUST close with \`\`\`. Never emit this block when you are not asking
+  the user to choose.
 
 ## Permission ladder & confirmation rules
 

--- a/server/file-provenance.ts
+++ b/server/file-provenance.ts
@@ -38,7 +38,9 @@ const GIT_MAX_BUFFER = 16 * 1024 * 1024
 // the on-demand diff patches beyond this cap are skipped (the UI shows "diff
 // unavailable" for them). Mirrors the existing large-job warn threshold (50).
 const MAX_PATCH_FILES = 50
-const GIT_EXEC_ENV = (() => {
+// Exported: project-git.ts (the Agent-Mode git bar) runs the same cwd-scoped
+// git calls and needs the identical hostile-repo hardening.
+export const GIT_EXEC_ENV = (() => {
   // Inherit the parent env but STRIP git-location vars. If the app process (or a
   // parent) ever exports GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE, every cwd-scoped
   // git call below would silently operate on that repo instead of the project —

--- a/server/project-git.test.ts
+++ b/server/project-git.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import express, { Router, type Request } from 'express'
+import { execFileSync } from 'child_process'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { getProjectGitInfo, checkoutProjectBranch, parseWorktreePorcelain, compactCheckoutError } from './project-git'
+import { registerGitRoutes } from './project-router-git'
+import type { ProjectRoutesDeps } from './project-router-helpers'
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: 'test',
+  GIT_AUTHOR_EMAIL: 'test@test.local',
+  GIT_COMMITTER_NAME: 'test',
+  GIT_COMMITTER_EMAIL: 'test@test.local',
+  GIT_CONFIG_NOSYSTEM: '1',
+}
+
+function run(cwd: string, ...args: string[]): void {
+  execFileSync('git', args, { cwd, env: GIT_ENV, stdio: 'pipe' })
+}
+
+let repo: string
+let plainDir: string
+
+beforeAll(() => {
+  repo = fs.mkdtempSync(path.join(os.tmpdir(), 'sr-git-'))
+  plainDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sr-plain-'))
+  run(repo, 'init', '--initial-branch=main')
+  fs.writeFileSync(path.join(repo, 'file.txt'), 'a\n')
+  run(repo, 'add', '.')
+  run(repo, 'commit', '-m', 'first commit')
+  run(repo, 'checkout', '-b', 'feature')
+  fs.writeFileSync(path.join(repo, 'file.txt'), 'b\n')
+  run(repo, 'commit', '-am', 'feature commit')
+  run(repo, 'checkout', 'main')
+})
+
+afterAll(() => {
+  fs.rmSync(repo, { recursive: true, force: true })
+  fs.rmSync(plainDir, { recursive: true, force: true })
+})
+
+describe('project-git', () => {
+  it('reports git:false outside a work tree', async () => {
+    const info = await getProjectGitInfo(plainDir)
+    expect(info.git).toBe(false)
+    expect(info.branches).toEqual([])
+  })
+
+  it('reads branch, local branches and last commit', async () => {
+    const info = await getProjectGitInfo(repo)
+    expect(info.git).toBe(true)
+    expect(info.branch).toBe('main')
+    expect(info.detached).toBe(false)
+    expect(info.dirty).toBe(false)
+    expect(info.branches.sort()).toEqual(['feature', 'main'])
+    expect(info.lastCommit?.subject).toBe('first commit')
+    expect(info.lastCommit?.hash).toMatch(/^[0-9a-f]{7,}$/)
+  })
+
+  it('flags a dirty working tree', async () => {
+    fs.writeFileSync(path.join(repo, 'file.txt'), 'dirty\n')
+    expect((await getProjectGitInfo(repo)).dirty).toBe(true)
+    run(repo, 'checkout', '--', 'file.txt')
+    expect((await getProjectGitInfo(repo)).dirty).toBe(false)
+  })
+
+  it('checks out an existing local branch', async () => {
+    const r = await checkoutProjectBranch(repo, 'feature')
+    expect(r).toEqual({ ok: true })
+    const info = await getProjectGitInfo(repo)
+    expect(info.branch).toBe('feature')
+    expect(info.lastCommit?.subject).toBe('feature commit')
+    run(repo, 'checkout', 'main')
+  })
+
+  it('rejects a branch not in the local list (no flag smuggling)', async () => {
+    for (const bad of ['nope', '--force', '-b evil', 'origin/main']) {
+      const r = await checkoutProjectBranch(repo, bad)
+      expect(r.ok).toBe(false)
+      if (!r.ok) expect(r.error).toContain('Unknown local branch')
+    }
+    expect((await getProjectGitInfo(repo)).branch).toBe('main')
+  })
+
+  it('REFUSES a checkout that would overwrite uncommitted changes — repo untouched', async () => {
+    fs.writeFileSync(path.join(repo, 'file.txt'), 'precious uncommitted work\n')
+    const r = await checkoutProjectBranch(repo, 'feature')
+    expect(r.ok).toBe(false)
+    // Still on main, the uncommitted content survived.
+    const info = await getProjectGitInfo(repo)
+    expect(info.branch).toBe('main')
+    expect(fs.readFileSync(path.join(repo, 'file.txt'), 'utf-8')).toContain('precious')
+    run(repo, 'checkout', '--', 'file.txt')
+  })
+
+  it('reports an unborn fresh repo as git:true with no commits', async () => {
+    const fresh = fs.mkdtempSync(path.join(os.tmpdir(), 'sr-fresh-'))
+    try {
+      run(fresh, 'init', '--initial-branch=main')
+      const info = await getProjectGitInfo(fresh)
+      expect(info.git).toBe(true)
+      expect(info.branch).toBe('main')
+      expect(info.lastCommit).toBeNull()
+    } finally {
+      fs.rmSync(fresh, { recursive: true, force: true })
+    }
+  })
+
+  it('compacts the many-files checkout refusal into a toast-sized message', () => {
+    const raw = [
+      'error: Your local changes to the following files would be overwritten by checkout:',
+      ...Array.from({ length: 44 }, (_, i) => `\tclient/src/file-${i}.tsx`),
+      'Please commit your changes or stash them before you switch branches.',
+      'Aborting',
+    ].join('\n')
+    const compact = compactCheckoutError(raw)
+    expect(compact).toContain('44 files')
+    expect(compact).toContain('file-0.tsx')
+    expect(compact).toContain('+41 more')
+    expect(compact.length).toBeLessThan(300)
+    // Unrelated errors pass through (capped).
+    expect(compactCheckoutError('fatal: reference is not a tree')).toBe('fatal: reference is not a tree')
+  })
+
+  it('parses `git worktree list --porcelain` blocks', () => {
+    const out = [
+      'worktree /repo',
+      'HEAD aaaa111',
+      'branch refs/heads/main',
+      '',
+      'worktree /repo/.claude/worktrees/ticket-7',
+      'HEAD bbbb222',
+      'branch refs/heads/sr/ticket-7',
+      '',
+      'worktree /repo/.claude/worktrees/probe',
+      'HEAD cccc333',
+      'detached',
+    ].join('\n')
+    expect(parseWorktreePorcelain(out)).toEqual([
+      { path: '/repo', branch: 'main', head: 'aaaa111', isMain: true },
+      { path: '/repo/.claude/worktrees/ticket-7', branch: 'sr/ticket-7', head: 'bbbb222', isMain: false },
+      { path: '/repo/.claude/worktrees/probe', branch: null, head: 'cccc333', isMain: false },
+    ])
+  })
+
+  it('surfaces linked worktrees in the info payload', async () => {
+    const wtPath = path.join(os.tmpdir(), `sr-wt-${process.pid}`)
+    run(repo, 'worktree', 'add', wtPath, 'feature')
+    try {
+      const info = await getProjectGitInfo(repo)
+      expect(info.worktrees.length).toBe(2)
+      expect(info.worktrees[0].isMain).toBe(true)
+      const linked = info.worktrees[1]
+      expect(linked.branch).toBe('feature')
+      expect(fs.realpathSync(linked.path)).toBe(fs.realpathSync(wtPath))
+    } finally {
+      run(repo, 'worktree', 'remove', '--force', wtPath)
+    }
+  })
+
+  it('reports a detached HEAD', async () => {
+    const hash = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, env: GIT_ENV }).toString().trim()
+    run(repo, 'checkout', hash)
+    const info = await getProjectGitInfo(repo)
+    expect(info.detached).toBe(true)
+    expect(info.branch).toBeNull()
+    run(repo, 'checkout', 'main')
+  })
+})
+
+describe('git routes', () => {
+  function makeApp(repoDir: string) {
+    const app = express()
+    app.use(express.json())
+    const router = Router()
+    registerGitRoutes({
+      router,
+      ctx: () => ({ project: { path: repoDir } }),
+      registry: {},
+      ticketPath: () => '',
+    } as unknown as ProjectRoutesDeps)
+    // Same mount shape as index.ts: the ROUTER paths carry the :projectId
+    // prefix (this exact mismatch once shipped /api/projects/git by accident).
+    app.use('/api/projects', router)
+    return app
+  }
+
+  async function req(app: express.Express, method: string, p: string, body?: unknown) {
+    const server = app.listen(0)
+    const addr = server.address()
+    const port = typeof addr === 'object' && addr ? addr.port : 0
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}${p}`, {
+        method,
+        headers: body !== undefined ? { 'content-type': 'application/json' } : {},
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+      })
+      return { status: res.status, body: await res.json() }
+    } finally {
+      server.close()
+    }
+  }
+
+  it('GET /git returns the info payload', async () => {
+    const r = await req(makeApp(repo), 'GET', '/api/projects/p1/git')
+    expect(r.status).toBe(200)
+    expect(r.body.git).toBe(true)
+    expect(r.body.branch).toBe('main')
+  })
+
+  it('POST /git/checkout: 400 without branch, 409 unknown branch, 200 switching', async () => {
+    const app = makeApp(repo)
+    expect((await req(app, 'POST', '/api/projects/p1/git/checkout', {})).status).toBe(400)
+    const unknown = await req(app, 'POST', '/api/projects/p1/git/checkout', { branch: 'ghost' })
+    expect(unknown.status).toBe(409)
+    expect(unknown.body.error).toContain('Unknown local branch')
+    const ok = await req(app, 'POST', '/api/projects/p1/git/checkout', { branch: 'feature' })
+    expect(ok.status).toBe(200)
+    expect(ok.body.branch).toBe('feature')
+    await req(app, 'POST', '/api/projects/p1/git/checkout', { branch: 'main' })
+  })
+})

--- a/server/project-git.ts
+++ b/server/project-git.ts
@@ -1,0 +1,168 @@
+import { execFile } from 'child_process'
+import { GIT_EXEC_ENV } from './file-provenance'
+
+// ─── Project git info + branch switch (Agent-Mode git bar) ────────────────────
+//
+// Read the repo's current branch / last commit / local branches, and check out
+// another LOCAL branch on user request. Always spawns the `git` CLI with the
+// hardened env from file-provenance (hostile-repo config stripped, prompts
+// disabled) and argv arrays (no shell). The checkout target is validated
+// against `git branch` output, so no user string can smuggle flags or refs.
+
+const GIT_TIMEOUT_MS = 10_000
+const GIT_MAX_BUFFER = 4 * 1024 * 1024
+
+function git(repoDir: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      'git',
+      args,
+      { cwd: repoDir, env: GIT_EXEC_ENV, timeout: GIT_TIMEOUT_MS, maxBuffer: GIT_MAX_BUFFER, windowsHide: true },
+      (err, stdout, stderr) => {
+        if (err) {
+          const detail = String(stderr || err.message).trim()
+          reject(new Error(detail))
+          return
+        }
+        resolve(String(stdout).trim())
+      },
+    )
+  })
+}
+
+export interface ProjectWorktree {
+  path: string
+  /** Branch checked out there; null when detached. */
+  branch: string | null
+  head: string
+  /** True for the repo's main working tree (the project path itself). */
+  isMain: boolean
+}
+
+export interface ProjectGitInfo {
+  /** False when the project path is not inside a git work tree. */
+  git: boolean
+  /** Current branch name; null while detached or on an unborn/empty repo state. */
+  branch: string | null
+  detached: boolean
+  /** Uncommitted changes present (staged or not). */
+  dirty: boolean
+  /** Local branch names. */
+  branches: string[]
+  lastCommit: { hash: string; subject: string; at: string } | null
+  /** All working trees (main first) — rails create linked worktrees for
+   *  parallel implementation, surfaced by the Mission Control git bar. */
+  worktrees: ProjectWorktree[]
+}
+
+const NOT_A_REPO: ProjectGitInfo = { git: false, branch: null, detached: false, dirty: false, branches: [], lastCommit: null, worktrees: [] }
+
+/** Parse `git worktree list --porcelain` blocks (blank-line separated). */
+export function parseWorktreePorcelain(out: string): ProjectWorktree[] {
+  const worktrees: ProjectWorktree[] = []
+  for (const block of out.split(/\n\n+/)) {
+    const lines = block.split('\n').map((l) => l.trim()).filter(Boolean)
+    if (lines.length === 0) continue
+    let wtPath: string | null = null
+    let head = ''
+    let branch: string | null = null
+    for (const line of lines) {
+      if (line.startsWith('worktree ')) wtPath = line.slice('worktree '.length)
+      else if (line.startsWith('HEAD ')) head = line.slice('HEAD '.length)
+      else if (line.startsWith('branch refs/heads/')) branch = line.slice('branch refs/heads/'.length)
+    }
+    if (wtPath) worktrees.push({ path: wtPath, branch, head, isMain: worktrees.length === 0 })
+  }
+  return worktrees
+}
+
+async function listLocalBranches(repoDir: string): Promise<string[]> {
+  const out = await git(repoDir, ['branch', '--format=%(refname:short)'])
+  return out.split('\n').map((b) => b.trim()).filter(Boolean)
+}
+
+export async function getProjectGitInfo(repoDir: string): Promise<ProjectGitInfo> {
+  try {
+    await git(repoDir, ['rev-parse', '--is-inside-work-tree'])
+  } catch {
+    return NOT_A_REPO
+  }
+  // symbolic-ref works on an unborn branch too (fresh `git init`); it fails
+  // when HEAD is detached.
+  let branch: string | null = null
+  let detached = false
+  try {
+    branch = await git(repoDir, ['symbolic-ref', '--short', 'HEAD'])
+  } catch {
+    detached = true
+  }
+  let lastCommit: ProjectGitInfo['lastCommit'] = null
+  try {
+    const raw = await git(repoDir, ['log', '-1', '--format=%h%s%cI'])
+    const [hash, subject, at] = raw.split('')
+    if (hash) lastCommit = { hash, subject: subject ?? '', at: at ?? '' }
+  } catch {
+    /* empty repo — no commits yet */
+  }
+  let branches: string[] = []
+  try {
+    branches = await listLocalBranches(repoDir)
+  } catch {
+    /* keep [] */
+  }
+  let dirty = false
+  try {
+    dirty = (await git(repoDir, ['status', '--porcelain'])) !== ''
+  } catch {
+    /* keep false */
+  }
+  let worktrees: ProjectWorktree[] = []
+  try {
+    worktrees = parseWorktreePorcelain(await git(repoDir, ['worktree', 'list', '--porcelain']))
+  } catch {
+    /* keep [] */
+  }
+  return { git: true, branch, detached, dirty, branches, lastCommit, worktrees }
+}
+
+export type CheckoutResult = { ok: true } | { ok: false; error: string }
+
+/** Compact git's overwrite refusal: the raw message lists EVERY dirty file
+ *  (dozens on a busy tree) — unreadable in a toast. Keep the count + a taste. */
+export function compactCheckoutError(msg: string): string {
+  const lines = msg.split('\n').map((l) => l.trim()).filter(Boolean)
+  const idx = lines.findIndex((l) => l.includes('Your local changes to the following files would be overwritten'))
+  if (idx === -1) return msg.slice(0, 400)
+  const files = lines
+    .slice(idx + 1)
+    .filter((l) => !l.startsWith('Please ') && !l.startsWith('Aborting') && !l.startsWith('error:') && !l.startsWith('hint:'))
+  if (files.length === 0) return msg.slice(0, 400)
+  const shown = files.slice(0, 3).join(', ')
+  const more = files.length - Math.min(files.length, 3)
+  return (
+    `Your local changes to ${files.length} file${files.length === 1 ? '' : 's'} would be overwritten by checkout` +
+    ` (${shown}${more > 0 ? ` … +${more} more` : ''}). Commit or stash them first.`
+  )
+}
+
+/** Check out an existing LOCAL branch. The name must match one reported by
+ *  `git branch`, so arbitrary flags/refs can never reach the argv. */
+export async function checkoutProjectBranch(repoDir: string, branch: string): Promise<CheckoutResult> {
+  let branches: string[]
+  try {
+    branches = await listLocalBranches(repoDir)
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : 'git failed' }
+  }
+  if (!branches.includes(branch)) {
+    return { ok: false, error: `Unknown local branch: ${branch}` }
+  }
+  try {
+    await git(repoDir, ['checkout', branch])
+    return { ok: true }
+  } catch (err) {
+    // Typical: uncommitted changes that would be overwritten — surface git's own
+    // reason (compacted: the raw refusal lists every dirty file).
+    return { ok: false, error: compactCheckoutError(err instanceof Error ? err.message : 'git checkout failed') }
+  }
+}

--- a/server/project-router-git.ts
+++ b/server/project-router-git.ts
@@ -1,0 +1,44 @@
+import type { Request, Response } from 'express'
+import type { ProjectRoutesDeps } from './project-router-helpers'
+import { getProjectGitInfo, checkoutProjectBranch } from './project-git'
+
+// ─── Git domain routes (/api/projects/:projectId/git) ─────────────────────────
+//
+// Backs the Agent-Mode git bar: current branch + last commit + local branches,
+// and a user-initiated branch switch. Git always runs against project.path (the
+// REAL repo — under artifact relocation the workspace never holds the code).
+
+export function registerGitRoutes(deps: ProjectRoutesDeps): void {
+  const { router, ctx } = deps
+
+  router.get('/:projectId/git', async (req: Request, res: Response) => {
+    try {
+      res.json(await getProjectGitInfo(ctx(req).project.path))
+    } catch (err) {
+      console.error('[project-git] info failed:', err)
+      res.status(500).json({ error: 'Failed to read git info' })
+    }
+  })
+
+  router.post('/:projectId/git/checkout', async (req: Request, res: Response) => {
+    const body = (req.body ?? {}) as Record<string, unknown>
+    const branch = typeof body.branch === 'string' ? body.branch.trim() : ''
+    if (!branch) {
+      res.status(400).json({ error: 'branch is required' })
+      return
+    }
+    const repoDir = ctx(req).project.path
+    try {
+      const result = await checkoutProjectBranch(repoDir, branch)
+      if (!result.ok) {
+        // 409: the working tree state (or an unknown branch) refused the switch.
+        res.status(409).json({ error: result.error })
+        return
+      }
+      res.json(await getProjectGitInfo(repoDir))
+    } catch (err) {
+      console.error('[project-git] checkout failed:', err)
+      res.status(500).json({ error: 'Checkout failed' })
+    }
+  })
+}

--- a/server/project-router.ts
+++ b/server/project-router.ts
@@ -16,6 +16,7 @@ import { registerTicketsRoutes } from './project-router-tickets'
 import { registerTerminalsRoutes } from './project-router-terminals'
 import { registerSettingsRoutes } from './project-router-settings'
 import { registerLoopRunRoutes } from './project-router-loop-runs'
+import { registerGitRoutes } from './project-router-git'
 import type { ProjectRoutesDeps } from './project-router-helpers'
 
 // Re-export the spec helpers from their new home so existing importers
@@ -139,6 +140,7 @@ export function createProjectRouter(registry: ProjectRegistry): Router {
   registerTerminalsRoutes(deps)
   registerSettingsRoutes(deps)
   registerLoopRunRoutes(deps)
+  registerGitRoutes(deps)
 
   return router
 }

--- a/server/types.ts
+++ b/server/types.ts
@@ -1092,6 +1092,7 @@ export type WsMessage =
   | JiraOutboxChangedMessage | JiraDegradedMessage
   | AgentStreamMessage | AgentDoneMessage | AgentErrorMessage | AgentToolMessage
   | AgentTitleMessage
+  | AgentQueuedMessage | AgentDequeuedMessage | AgentQueueClearedMessage
 
 // ─── App-global agent chat (no projectId — fans to all subscribers) ───────────
 
@@ -1132,6 +1133,33 @@ export interface AgentToolMessage {
   type: 'agent_tool'
   conversationId: string
   tool: string
+  timestamp: string
+}
+
+/** A message sent mid-turn was queued; it runs after the current turn settles. */
+export interface AgentQueuedMessage {
+  type: 'agent_queued'
+  conversationId: string
+  /** Client-generated correlation id (null when the sender didn't provide one). */
+  queueId: string | null
+  text: string
+  position: number
+  timestamp: string
+}
+
+/** A queued message left the queue and its turn is starting now. */
+export interface AgentDequeuedMessage {
+  type: 'agent_dequeued'
+  conversationId: string
+  queueId: string | null
+  text: string
+  timestamp: string
+}
+
+/** The pending queue was discarded (abort or conversation deletion). */
+export interface AgentQueueClearedMessage {
+  type: 'agent_queue_cleared'
+  conversationId: string
   timestamp: string
 }
 


### PR DESCRIPTION
## Summary

One coherent batch turning the in-app agent into **Mission Control**:

### Mission Control (agent chat)
- **Message queue**: sends mid-turn are queued server-side (FIFO per conversation, `agent_queued`/`agent_dequeued`/`agent_queue_cleared` WS events) and rendered as parked chips below the stream — no more "agent is busy" rejections. Tri-state composer button: send / red stop (empty box) / send-to-queue (typing mid-turn).
- **Background missions**: live streaming state is per-conversation — switching threads never drops streamed text/tools/queue, and the sidebar title shimmer stays lit for every working mission, not just the focused one.
- **Correctness** (13-finding adversarial review applied): abort can no longer be resurrected by the stale-session auto-heal; the settle write-back persists the session id only (mid-turn provider switches survive); `agent_done` dedupe never swallows legitimately identical replies; `useSmoothStream` snaps on target replacement.
- Tolerant ```` ```options ```` fence parsing (glued to prose / inline JSON / missing close) + operator-prompt hardening; agent links open in the embedded browser; Shift+Tab cycles the tier from the textarea everywhere (macOS focus-jump fixed); composer drafts survive the Mission⇄Board switch.

### Mission vocabulary
`+ New Mission`, bubble/panel **Mission Control**, mode toggle (Mission Control / Board), "What's the mission?" (Matrix easter egg: *", Neo?"*) — ×8 locales; zh disambiguation (jobs → 作业, 任务 = mission); wider left sidebar so localized labels never clip.

### Agent-Mode workspace
- **Jobs pane** (above Browser): live job list; clicking opens the near-fullscreen `JobDetailModal` (now carries its own `TooltipProvider` — opening it from Agent Mode used to blank the app). Panes maximize to cover the whole surface.
- **Project settings modal**: hover gear on project folders → dialog cloning the Global Settings shell (same proportions, left nav). Sections extracted to shared components with loading skeletons + touched-field guards (late GETs can never clobber typed values).
- **Git bar** under the composer: themed branch dropdown (search, opens upward, semantic tokens per theme), real `git checkout` with local-branch allow-list + hardened git env + 10s timeout; refusals surface git's exact reason (compacted) and the UI resyncs — never a forced checkout, never a lying selector. Worktree-bound branches group with their path and copy it on click (git refuses checking them out).

### Kanban
Rail reconcile now **adopts** server-active jobs/loop-runs on mount (rails launched by the agent via MCP / mobile / another window light up with their tickets), derives the real mode from `loopId`, dedupes adopted tickets across rails, and guards both stale-clear and stale-adopt races.

## Test plan
- `npm run typecheck` ✅ (server, cli, mcp-bridge, client)
- `npm test` ✅ (~4670 server tests, includes real-git-repo suites for the new git module)
- `cd client && npx vitest run` ✅ (3062 tests)
- Coverage gates ✅ server 80%+ / client 80%+ / global 70%+
- Locale parity ×8 ✅
- Manually verified live: queue chips + tri-state button, background streaming + shimmer, jobs pane + execution modal, project settings modal, git bar (branch switch, refused-checkout protection with the real dirty tree, worktree grouping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R982uLJYJxAepBa3EQzvw9