### PR TITLE
feat: integration-branch REST API + branch-name arg-injection guard

### DIFF
--- a/openspec/changes/safe-pr-workflow/tasks.md
+++ b/openspec/changes/safe-pr-workflow/tasks.md
@@ -4,7 +4,7 @@
 - [x] 1.1 Add a per-project `integrationBranch` setting (`ProjectSettings`, stored as a `queue_state` KV `config.integration_branch` — no migration needed as-built); default resolver = `git symbolic-ref refs/remotes/origin/HEAD` → else current `HEAD`.
 - [x] 1.2 Pure resolution module (`server/integration-branch.ts` + tests) — precedence explicit → project setting → repo default → head-fallback, returning `{branch, source}`.
 - [x] 1.3 Make `CreateWorktreeInput.baseRef` live: `rail-isolated-launch.ts` resolves the integration branch once and passes it as `baseRef` to every `createWorktree` (was implicit `HEAD`).
-- [ ] 1.4 Client: integration-branch picker in project settings; resolved base shown before every launch (no git vocabulary in the builder path).
+- [~] 1.4 Server half DONE: `PATCH /:projectId/settings` accepts+validates `integrationBranch` (arg-injection guard `isValidBranchName`), `GET /:projectId/integration-branch` resolves `{configured, branch, source}` for pre-launch display. **Pending (own PR):** client picker in project settings + resolved base shown before launch + i18n ×8.
 
 ## 2. App-owned git/PR primitive (`safe-pr-workflow` / `core-git-agnostic-contract`)
 - [x] 2.1 New desktop primitive (`server/pr-publisher.ts` + tests): `git push -u origin <branch>` → `gh pr create --draft --base <baseBranch> --head <branch>`; parses + returns the PR URL.

--- a/server/integration-branch.test.ts
+++ b/server/integration-branch.test.ts
@@ -3,6 +3,7 @@ import {
   resolveIntegrationBranch,
   repoDefaultBranch,
   currentBranch,
+  isValidBranchName,
 } from './integration-branch'
 import type { GitRunner, GitResult } from './worktree-manager'
 
@@ -40,6 +41,19 @@ describe('currentBranch', () => {
   })
   it('returns null when detached (HEAD)', async () => {
     expect(await currentBranch(fakeGit({ abbrevHead: null }), '/r')).toBeNull()
+  })
+})
+
+describe('isValidBranchName (input-boundary guard)', () => {
+  it('accepts normal branch names', () => {
+    for (const ok of ['main', 'develop', 'release/1.2', 'feature/foo-bar', 'v2.20.1', 'a_b.c']) {
+      expect(isValidBranchName(ok)).toBe(true)
+    }
+  })
+  it('rejects argument-injection and malformed refs', () => {
+    for (const bad of ['--upload-pack=x', '-x', 'a b', 'foo..bar', 'a//b', 'ends/', '/starts', 'x.lock', 'tab\tname', '', '   ', 'na$me', 'a;rm -rf']) {
+      expect(isValidBranchName(bad)).toBe(false)
+    }
   })
 })
 

--- a/server/integration-branch.ts
+++ b/server/integration-branch.ts
@@ -52,6 +52,23 @@ export async function currentBranch(git: GitRunner, repoDir: string): Promise<st
   return null
 }
 
+/**
+ * Conservative git branch-name validator. The integration branch flows into
+ * `git worktree add -b <branch> <path> <base>` as `<base>`, so a value starting
+ * with `-` or containing whitespace/control chars would be an argument-injection
+ * vector. We allow only a safe subset (letters, digits, `._/-`), reject a leading
+ * `-`, `..`, a trailing `/` or `.lock`, and cap the length. This is stricter than
+ * git's own rules on purpose — it is an input-boundary guard, not a git parser.
+ */
+export function isValidBranchName(name: string): boolean {
+  if (typeof name !== 'string') return false
+  const n = name.trim()
+  if (!n || n.length > 255) return false
+  if (n.startsWith('-') || n.startsWith('/') || n.endsWith('/')) return false
+  if (n.includes('..') || n.includes('//') || n.endsWith('.lock')) return false
+  return /^[A-Za-z0-9._/-]+$/.test(n)
+}
+
 export async function resolveIntegrationBranch(
   git: GitRunner,
   input: ResolveIntegrationBranchInput,

--- a/server/project-router-settings.ts
+++ b/server/project-router-settings.ts
@@ -17,6 +17,8 @@ import {
   getTelemetryBlob, getTelemetrySummaries, getJobsWithTelemetry, hasJobTelemetry,
 } from './db'
 import { createDiagnosticZip } from './telemetry-export'
+import { resolveIntegrationBranch, isValidBranchName } from './integration-branch'
+import { defaultGitRunner } from './worktree-manager'
 import { getProjectSetupSession } from './desktop-db'
 import { ClaudeNotFoundError, JobNotFoundError, JobAlreadyTerminalError, DEFAULT_ZOMBIE_TIMEOUT_MS } from './queue-manager'
 import type { JobPriority } from './types'
@@ -199,12 +201,43 @@ export function registerSettingsRoutes(deps: ProjectRoutesDeps): void {
       }
       patch.ultraPrePrompt = ultraPrePrompt
     }
+    if (req.body?.integrationBranch !== undefined) {
+      const ib = req.body.integrationBranch
+      if (typeof ib !== 'string') {
+        res.status(400).json({ error: 'integrationBranch must be a string' })
+        return
+      }
+      // Empty = clear (auto-resolve). A non-empty value flows into `git worktree
+      // add … <base>`, so it must be a safe branch name (no arg-injection).
+      if (ib.trim() !== '' && !isValidBranchName(ib)) {
+        res.status(400).json({ error: 'integrationBranch is not a valid branch name' })
+        return
+      }
+      patch.integrationBranch = ib
+    }
     try {
       updateProjectSettings(ctx(req).db, patch)
       res.json({ ok: true, settings: getProjectSettings(ctx(req).db) })
     } catch (err) {
       console.error('[project-router] settings patch error:', err)
       res.status(500).json({ error: 'Failed to update settings' })
+    }
+  })
+
+  // Resolve the effective integration branch (configured value + what it resolves
+  // to right now + provenance) so the client can show the base before launch.
+  router.get('/:projectId/integration-branch', async (req: Request, res: Response) => {
+    const { project, db } = ctx(req)
+    const configured = getProjectSettings(db).integrationBranch
+    try {
+      const resolved = await resolveIntegrationBranch(defaultGitRunner, {
+        repoDir: project.path,
+        projectSetting: configured,
+      })
+      res.json({ configured, branch: resolved.branch, source: resolved.source })
+    } catch (err) {
+      console.error('[project-router] integration-branch resolve failed:', err)
+      res.status(500).json({ error: 'failed to resolve integration branch' })
     }
   })
 

--- a/server/project-router.test.ts
+++ b/server/project-router.test.ts
@@ -185,6 +185,40 @@ describe('project-router', () => {
     })
   })
 
+  // ─── Project settings: integration branch ──────────────────────────────────
+
+  describe('project settings — integration branch', () => {
+    function appWithProject() {
+      const contexts = new Map<string, ProjectContext>()
+      contexts.set('proj-1', makeContext(db))
+      return createApp(contexts)
+    }
+
+    it('rejects an invalid integrationBranch (arg-injection guard)', async () => {
+      const { app } = appWithProject()
+      const res = await request(app).patch('/api/projects/proj-1/settings').send({ integrationBranch: '--upload-pack=x' })
+      expect(res.status).toBe(400)
+      expect(res.body.error).toMatch(/integrationBranch/)
+    })
+
+    it('persists a valid integrationBranch and clears it with empty string', async () => {
+      const { app } = appWithProject()
+      let res = await request(app).patch('/api/projects/proj-1/settings').send({ integrationBranch: 'develop' })
+      expect(res.status).toBe(200)
+      expect(res.body.settings.integrationBranch).toBe('develop')
+      res = await request(app).patch('/api/projects/proj-1/settings').send({ integrationBranch: '' })
+      expect(res.body.settings.integrationBranch).toBe('')
+    })
+
+    it('resolve endpoint echoes the configured setting (project-setting short-circuits git)', async () => {
+      const { app } = appWithProject()
+      await request(app).patch('/api/projects/proj-1/settings').send({ integrationBranch: 'develop' })
+      const res = await request(app).get('/api/projects/proj-1/integration-branch')
+      expect(res.status).toBe(200)
+      expect(res.body).toEqual({ configured: 'develop', branch: 'develop', source: 'project-setting' })
+    })
+  })
+
   // ─── Hooks mount (H18: memoized per ProjectContext) ─────────────────────────
 
   describe('hooks sub-router mount', () => {


### PR DESCRIPTION
## What & why

Second slice of the `safe-pr-workflow` change — the **server half of task 1.4**, additive and non-destructive. Builds on #486 (the resolver + setting).

## Changes

- **`PATCH /:projectId/settings`** now accepts `integrationBranch`. Empty string clears it (auto-resolve); a non-empty value is validated by **`isValidBranchName`** before it can ever reach `git worktree add … <base>`.
- **Security:** closes an **argument-injection** vector — the integration branch flows into a git arg, so values like `--upload-pack=…`, whitespace, `..`, `//`, leading `-`, or `.lock` are rejected with 400.
- **`GET /:projectId/integration-branch`** returns `{configured, branch, source}` via `resolveIntegrationBranch`, so the client can display the resolved base **before launch** (the certainty the design calls for). A configured setting short-circuits git, so the endpoint is deterministic for that case.

## Deferred

The client picker in project settings, the pre-launch display, and i18n ×8 are their own PR.

## Tests

Full suite **4813 pass**; server coverage **85.5 / 76.8 / 88.4 / 87.6** (above the 80/70/80/80 gate). Includes an arg-injection rejection test, persist/clear, and a deterministic resolve-endpoint test.

## Note

Draft on purpose — dogfooding the methodology (specrails produces the PR, the engineer merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R982uLJYJxAepBa3EQzvw9