### PR TITLE
feat: flag-gated draft-PR delivery for isolated rails (combined batch PR)

### DIFF
--- a/openspec/changes/safe-pr-workflow/tasks.md
+++ b/openspec/changes/safe-pr-workflow/tasks.md
@@ -8,8 +8,8 @@
 
 ## 2. App-owned git/PR primitive (`safe-pr-workflow` / `core-git-agnostic-contract`)
 - [x] 2.1 New desktop primitive (`server/pr-publisher.ts` + tests): `git push -u origin <branch>` → `gh pr create --draft --base <baseBranch> --head <branch>`; parses + returns the PR URL.
-- [~] 2.2 Degradation ladder IMPLEMENTED in the primitive (`pr-created` / `pushed` / `local-only`, never throws). **Pending:** wiring the degraded outcome to a WS broadcast — done at integration time (with 2.3).
-- [ ] 2.3 Retire local merge-back on the mutating path (`merge-manager.ts` `git merge --no-ff` into HEAD removed from this flow).
+- [x] 2.2 Degradation ladder in the primitive + WS surfacing DONE — `rail.pr_delivered` broadcast carries `{delivery, prState, prUrl, branch}` (`server/types.ts` + `rail-isolated-launch.ts`).
+- [~] 2.3 Flag-gated draft-PR delivery path added (`SPECRAILS_RAIL_DELIVER_PR`, default OFF): when on, a settled isolated rail delivers a draft PR instead of merging back (`server/rail-pr-delivery.ts`, wired in `rail-isolated-launch.ts`). **Full retirement of the local merge-back is deferred** — the default path is still merge-back until the PR path is validated in the field.
 - [ ] 2.4 Hard git guardrails: block force-push and direct commits to the integration branch (technical block, not prompt text).
 
 ## 3. Platform-law enforcement (`safe-pr-workflow`)
@@ -25,9 +25,9 @@
 - [ ] 4.5 Interim stopgap: write `git_auto:false` for all projects + ensure present inside the worktree (until 4.1 ships).
 
 ## 5. Combined batch PR (`combined-batch-pr`)
-- [ ] 5.1 Repurpose the AI merge-resolver to assemble N ticket branches onto `sr/<slug>/batch-<id>` (off the designated base), kept clean.
-- [ ] 5.2 One draft PR per batch; body = per-ticket checklist + per-ticket verification; preserve per-ticket commit history (no squash).
-- [ ] 5.3 Safe failure mode: cannot combine → fall back to N PRs or flag "needs a human to combine"; never touch the base.
+- [x] 5.1 `server/rail-pr-delivery.ts` `deliverRailAsPr` assembles N ticket branches onto `sr/<slug>/batch-<railKey>` off the designated integration branch (transient worktree, `git merge --no-ff`), kept clean.
+- [x] 5.2 One draft PR per batch; body = per-ticket checklist (`buildBatchPrBody`); per-ticket commit history preserved (`--no-ff`, no squash). (AI-resolver-assisted conflict resolution during assembly = follow-up; v1 uses plain merge.)
+- [x] 5.3 Safe failure mode: conflict → `merge --abort` + teardown of the batch branch/worktree → `assembly-failed` (ticket branches left for a human); the base is never touched.
 
 ## 6. Relocation overlay blocker (D7)
 - [ ] 6.1 Implement the per-run workspace overlay so a relocated project under isolation has `.specrails/` (agents, `.mcp.json`, `/specrails:*`) inside the worktree.

--- a/server/rail-isolated-launch.ts
+++ b/server/rail-isolated-launch.ts
@@ -24,6 +24,9 @@ import { createRailWorktree, updateRailWorktreeState, listNonTerminalRailWorktre
 import type { DbInstance } from './db'
 import { getProjectSettings } from './db'
 import { resolveIntegrationBranch } from './integration-branch'
+import { isRailPrDeliveryEnabled } from './rail-isolation'
+import { deliverRailAsPr, buildBatchPrBody } from './rail-pr-delivery'
+import { defaultExec } from './pr-publisher'
 import { runMergeBack } from './rail-merge-orchestrator'
 import { createLoopExecutors } from './loop-executors'
 import type { BranchToMerge } from './merge-manager'
@@ -138,13 +141,43 @@ export async function launchIsolatedRail(input: IsolatedLaunchInput, io: Isolate
     try { ctx.jiraSyncManager.onRailLaunch([a.ticketId], a.runId) } catch { /* non-fatal */ }
   }
 
-  // 3. When ALL runs settle → merge-back on the base repo (background; the HTTP
-  //    response has already returned the run ids).
+  // 3. When ALL runs settle → integrate on the base repo (background; the HTTP
+  //    response has already returned the run ids). Two mutually-exclusive paths:
+  //     • DEFAULT (flag off): legacy local merge-back into the checked-out branch.
+  //     • SPECRAILS_RAIL_DELIVER_PR on: assemble the ticket branches into a batch
+  //       branch off the designated integration branch and open ONE draft PR —
+  //       specrails never merges into base (safe-pr-workflow).
   void Promise.allSettled(runPromises).then(async (settled) => {
     const results = settled.flatMap((s) => (s.status === 'fulfilled' ? [s.value] : []))
     const branches: BranchToMerge[] = results.map((r) => ({
       ticketId: r.run.ticketId, branch: r.run.handle.branch, succeeded: r.succeeded,
     }))
+
+    if (isRailPrDeliveryEnabled()) {
+      try {
+        const succeededTickets = results.filter((r) => r.succeeded).map((r) => ({
+          ticketId: r.run.ticketId, title: ctx.getTicketSpec(r.run.ticketId)?.title,
+        }))
+        const delivery = await deliverRailAsPr(git, defaultExec, {
+          baseRepo, integrationBranch: integration.branch, slug,
+          railKey: `${railIndex}-${loopId}`, batchWorktreeRoot: worktreesRoot,
+          branches,
+          title: `${loopName}: ${succeededTickets.length} ticket(s)`,
+          body: buildBatchPrBody(loopName, succeededTickets),
+        })
+        ctx.broadcast({
+          type: 'rail.pr_delivered', projectId: ctx.project.id, railIndex,
+          delivery: delivery.state,
+          ...(delivery.state === 'delivered'
+            ? { prState: delivery.pr.state, prUrl: delivery.pr.prUrl, branch: delivery.branch }
+            : {}),
+        })
+      } catch (err) {
+        console.error('[rail-isolated] pr-delivery failed:', err)
+      }
+      return
+    }
+
     try {
       const outcomes = await runMergeBack({
         git, executor: createLoopExecutors(), baseDir: baseRepo,

--- a/server/rail-isolation.test.ts
+++ b/server/rail-isolation.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mutatesRepo, isRailWorktreesEnabled, isolationApplies } from './rail-isolation'
+import { mutatesRepo, isRailWorktreesEnabled, isRailPrDeliveryEnabled, isolationApplies } from './rail-isolation'
 
 const ORIG = process.env.SPECRAILS_RAIL_WORKTREES
+const ORIG_PR = process.env.SPECRAILS_RAIL_DELIVER_PR
 afterEach(() => {
   if (ORIG === undefined) delete process.env.SPECRAILS_RAIL_WORKTREES
   else process.env.SPECRAILS_RAIL_WORKTREES = ORIG
+  if (ORIG_PR === undefined) delete process.env.SPECRAILS_RAIL_DELIVER_PR
+  else process.env.SPECRAILS_RAIL_DELIVER_PR = ORIG_PR
 })
 
 describe('mutatesRepo', () => {
@@ -32,6 +35,25 @@ describe('isRailWorktreesEnabled (default-on kill-switch)', () => {
     for (const v of ['1', 'true', 'on', 'yes', '']) {
       process.env.SPECRAILS_RAIL_WORKTREES = v
       expect(isRailWorktreesEnabled()).toBe(true)
+    }
+  })
+})
+
+describe('isRailPrDeliveryEnabled (default-off opt-in)', () => {
+  it('is OFF when unset (default-off)', () => {
+    delete process.env.SPECRAILS_RAIL_DELIVER_PR
+    expect(isRailPrDeliveryEnabled()).toBe(false)
+  })
+  it('ON only for 1/true/on (case-insensitive)', () => {
+    for (const v of ['1', 'true', 'on', 'ON', 'True']) {
+      process.env.SPECRAILS_RAIL_DELIVER_PR = v
+      expect(isRailPrDeliveryEnabled()).toBe(true)
+    }
+  })
+  it('OFF for any other value', () => {
+    for (const v of ['0', 'false', 'off', 'yes', '']) {
+      process.env.SPECRAILS_RAIL_DELIVER_PR = v
+      expect(isRailPrDeliveryEnabled()).toBe(false)
     }
   })
 })

--- a/server/rail-isolation.ts
+++ b/server/rail-isolation.ts
@@ -38,6 +38,19 @@ export function isRailWorktreesEnabled(): boolean {
   return v !== '0' && v !== 'false' && v !== 'off'
 }
 
+/**
+ * Flag for the NEW draft-PR delivery path (safe-pr-workflow). **Default OFF** — an
+ * opt-in switch: only `1`/`true`/`on` enables it. When off, a settled isolated rail
+ * uses the legacy local merge-back (byte-identical to before). When on, the rail's
+ * ticket branches are assembled onto a batch branch and delivered as ONE draft PR
+ * (specrails never merges into the base). Kept separate from the isolation gate so
+ * the two roll out independently.
+ */
+export function isRailPrDeliveryEnabled(): boolean {
+  const v = (process.env.SPECRAILS_RAIL_DELIVER_PR ?? '').trim().toLowerCase()
+  return v === '1' || v === 'true' || v === 'on'
+}
+
 export interface IsolationDecisionInput {
   /** Loops feature enabled for the server. */
   loopsEnabled: boolean

--- a/server/rail-pr-delivery.test.ts
+++ b/server/rail-pr-delivery.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+import { deliverRailAsPr, batchBranchName, buildBatchPrBody, type DeliverBranch } from './rail-pr-delivery'
+import type { GitRunner, GitResult } from './worktree-manager'
+import type { Exec, ExecResult } from './pr-publisher'
+
+function fakeGit(opts: { addFails?: boolean; conflictOn?: string } = {}): { git: GitRunner; calls: string[][] } {
+  const calls: string[][] = []
+  const git: GitRunner = {
+    async run(args): Promise<GitResult> {
+      calls.push(args)
+      if (args[0] === 'worktree' && args[1] === 'add') {
+        return opts.addFails ? { code: 1, stdout: '', stderr: 'fatal: add boom' } : { code: 0, stdout: '', stderr: '' }
+      }
+      if (args[0] === 'merge' && args[1] === '--no-ff') {
+        return opts.conflictOn && args.includes(opts.conflictOn) ? { code: 1, stdout: '', stderr: 'CONFLICT' } : { code: 0, stdout: '', stderr: '' }
+      }
+      return { code: 0, stdout: '', stderr: '' }
+    },
+  }
+  return { git, calls }
+}
+
+function fakeExec(pr: ExecResult = { code: 0, stdout: 'https://github.com/o/r/pull/5\n', stderr: '' }): { exec: Exec; calls: Array<{ cmd: string; args: string[] }> } {
+  const calls: Array<{ cmd: string; args: string[] }> = []
+  const exec: Exec = {
+    async run(cmd, args) {
+      calls.push({ cmd, args })
+      if (cmd === 'gh') return pr
+      return { code: 0, stdout: '', stderr: '' }
+    },
+  }
+  return { exec, calls }
+}
+
+const base = {
+  baseRepo: '/repo',
+  integrationBranch: 'main',
+  slug: 'p',
+  railKey: '0-impl',
+  batchWorktreeRoot: '/wt',
+  title: 'Batch',
+  body: 'B',
+}
+const br = (ticketId: number, succeeded: boolean): DeliverBranch => ({ ticketId, branch: `sr/p/ticket-${ticketId}`, succeeded })
+
+describe('helpers', () => {
+  it('batchBranchName', () => {
+    expect(batchBranchName('p', '0-impl')).toBe('sr/p/batch-0-impl')
+  })
+  it('buildBatchPrBody lists every ticket', () => {
+    const body = buildBatchPrBody('Implement', [{ ticketId: 1, title: 'A' }, { ticketId: 2 }])
+    expect(body).toContain('- [x] #1 — A')
+    expect(body).toContain('- [x] #2')
+    expect(body).toContain('Implement')
+  })
+})
+
+describe('deliverRailAsPr', () => {
+  it('no-op when nothing succeeded', async () => {
+    const { git } = fakeGit()
+    const { exec } = fakeExec()
+    const r = await deliverRailAsPr(git, exec, { ...base, branches: [br(1, false), br(2, false)] })
+    expect(r).toEqual({ state: 'no-op', reason: 'no-succeeded-branches' })
+  })
+
+  it('single ticket → PR straight from its branch (no batch worktree)', async () => {
+    const { git, calls } = fakeGit()
+    const { exec } = fakeExec()
+    const r = await deliverRailAsPr(git, exec, { ...base, branches: [br(1, true), br(2, false)] })
+    expect(r.state).toBe('delivered')
+    if (r.state === 'delivered') {
+      expect(r.branch).toBe('sr/p/ticket-1')
+      expect(r.pr.state).toBe('pr-created')
+      expect(r.ticketIds).toEqual([1])
+    }
+    // no batch worktree was created
+    expect(calls.some((c) => c[0] === 'worktree' && c[1] === 'add')).toBe(false)
+  })
+
+  it('multiple tickets clean → batch branch off integration, merges, one PR, worktree removed', async () => {
+    const { git, calls } = fakeGit()
+    const { exec, calls: execCalls } = fakeExec()
+    const r = await deliverRailAsPr(git, exec, { ...base, branches: [br(1, true), br(2, true)] })
+    expect(r.state).toBe('delivered')
+    if (r.state === 'delivered') {
+      expect(r.branch).toBe('sr/p/batch-0-impl')
+      expect(r.ticketIds).toEqual([1, 2])
+    }
+    // batch branch created off the integration branch
+    expect(calls).toContainEqual(['worktree', 'add', '-b', 'sr/p/batch-0-impl', '/wt/batch-0-impl', 'main'])
+    // both ticket branches merged
+    expect(calls.filter((c) => c[0] === 'merge' && c[1] === '--no-ff')).toHaveLength(2)
+    // PR opened against integration base from the batch branch
+    expect(execCalls.find((c) => c.cmd === 'gh')?.args).toContain('main')
+    // transient worktree cleaned up
+    expect(calls).toContainEqual(['worktree', 'remove', '--force', '/wt/batch-0-impl'])
+  })
+
+  it('multiple tickets conflict → abort + teardown + assembly-failed (base untouched)', async () => {
+    const { git, calls } = fakeGit({ conflictOn: 'sr/p/ticket-2' })
+    const { exec, calls: execCalls } = fakeExec()
+    const r = await deliverRailAsPr(git, exec, { ...base, branches: [br(1, true), br(2, true)] })
+    expect(r).toEqual({ state: 'assembly-failed', reason: 'merge-conflict:sr/p/ticket-2', ticketIds: [1, 2] })
+    expect(calls).toContainEqual(['merge', '--abort'])
+    expect(calls).toContainEqual(['branch', '-D', 'sr/p/batch-0-impl'])
+    // never pushed / opened a PR
+    expect(execCalls.some((c) => c.cmd === 'gh')).toBe(false)
+  })
+
+  it('assembly-failed when the batch worktree cannot be created', async () => {
+    const { git } = fakeGit({ addFails: true })
+    const { exec } = fakeExec()
+    const r = await deliverRailAsPr(git, exec, { ...base, branches: [br(1, true), br(2, true)] })
+    expect(r.state).toBe('assembly-failed')
+    if (r.state === 'assembly-failed') expect(r.reason).toContain('add boom')
+  })
+})

--- a/server/rail-pr-delivery.ts
+++ b/server/rail-pr-delivery.ts
@@ -1,0 +1,126 @@
+/**
+ * Deliver a parallel rail's isolated ticket branches as ONE draft pull request,
+ * WITHOUT ever touching the base repo's HEAD.
+ *
+ * This is the flag-gated alternative to the legacy local merge-back
+ * (`rail-merge-orchestrator`): instead of `git merge --no-ff` into whatever is
+ * checked out, we assemble the successful ticket branches onto a fresh batch
+ * integration branch (branched from the DESIGNATED integration branch) and open a
+ * single draft PR from it. The engineer owns the merge — specrails is a PR
+ * producer, never a merge authority.
+ *
+ *   0 succeeded          → no-op.
+ *   1 succeeded          → draft PR straight from that ticket branch.
+ *   N succeeded (clean)  → batch branch `sr/<slug>/batch-<key>` off the integration
+ *                          branch, merge each ticket branch in, one combined draft PR
+ *                          whose body lists every ticket.
+ *   N succeeded (conflict) → SAFE failure: abort, tear down the batch branch/worktree,
+ *                          leave the ticket branches for a human. Never touch base.
+ *
+ * Pure over injectable `GitRunner` + `Exec` so it is unit-tested without git/gh/net.
+ */
+import type { GitRunner } from './worktree-manager'
+import { publishDraftPr, type Exec, type PrPublishResult } from './pr-publisher'
+
+export interface DeliverBranch {
+  ticketId: number
+  branch: string
+  succeeded: boolean
+}
+
+export interface DeliverRailInput {
+  /** The base repo (shares the object-store with every ticket worktree). */
+  baseRepo: string
+  /** The designated integration branch the draft PR targets and batches off. */
+  integrationBranch: string
+  slug: string
+  /** A key unique to this rail run (used in the batch branch + worktree path). */
+  railKey: string
+  /** Where to create the transient batch worktree (removed after the PR is opened). */
+  batchWorktreeRoot: string
+  branches: DeliverBranch[]
+  title: string
+  body: string
+}
+
+export type DeliverResult =
+  | { state: 'no-op'; reason: string }
+  | { state: 'delivered'; branch: string; pr: PrPublishResult; ticketIds: number[] }
+  | { state: 'assembly-failed'; reason: string; ticketIds: number[] }
+
+export function batchBranchName(slug: string, railKey: string): string {
+  return `sr/${slug}/batch-${railKey}`
+}
+
+export async function deliverRailAsPr(git: GitRunner, exec: Exec, input: DeliverRailInput): Promise<DeliverResult> {
+  const succeeded = input.branches.filter((b) => b.succeeded)
+  if (succeeded.length === 0) return { state: 'no-op', reason: 'no-succeeded-branches' }
+
+  // Single ticket → PR straight from its branch; no batch assembly needed.
+  if (succeeded.length === 1) {
+    const b = succeeded[0]
+    const pr = await publishDraftPr(exec, {
+      repoDir: input.baseRepo,
+      branch: b.branch,
+      baseBranch: input.integrationBranch,
+      title: input.title,
+      body: input.body,
+    })
+    return { state: 'delivered', branch: b.branch, pr, ticketIds: [b.ticketId] }
+  }
+
+  // Multiple tickets → assemble onto ONE batch branch off the integration base.
+  const batch = batchBranchName(input.slug, input.railKey)
+  const wt = `${input.batchWorktreeRoot.replace(/\/$/, '')}/batch-${input.railKey}`
+  const ticketIds = succeeded.map((b) => b.ticketId)
+
+  const add = await git.run(['worktree', 'add', '-b', batch, wt, input.integrationBranch], input.baseRepo)
+  if (add.code !== 0) {
+    return { state: 'assembly-failed', reason: firstLine(add) || 'worktree-add-failed', ticketIds }
+  }
+
+  for (const b of succeeded) {
+    const merge = await git.run(['merge', '--no-ff', '--no-edit', b.branch], wt)
+    if (merge.code !== 0) {
+      // Conflict/failure → abort and tear the batch down cleanly. Ticket branches
+      // stay intact for a human. Never leave a half-merged batch.
+      await git.run(['merge', '--abort'], wt).catch(() => {})
+      await teardownBatch(git, input.baseRepo, wt, batch)
+      return { state: 'assembly-failed', reason: `merge-conflict:${b.branch}`, ticketIds }
+    }
+  }
+
+  const pr = await publishDraftPr(exec, {
+    repoDir: wt,
+    branch: batch,
+    baseBranch: input.integrationBranch,
+    title: input.title,
+    body: input.body,
+  })
+
+  // Remove the transient worktree but KEEP the batch branch (the PR references it).
+  await git.run(['worktree', 'remove', '--force', wt], input.baseRepo).catch(() => {})
+
+  return { state: 'delivered', branch: batch, pr, ticketIds }
+}
+
+async function teardownBatch(git: GitRunner, baseRepo: string, wt: string, batch: string): Promise<void> {
+  await git.run(['worktree', 'remove', '--force', wt], baseRepo).catch(() => {})
+  await git.run(['branch', '-D', batch], baseRepo).catch(() => {})
+}
+
+/** Build a combined-PR body listing every ticket delivered by the rail. */
+export function buildBatchPrBody(loopName: string, tickets: Array<{ ticketId: number; title?: string }>): string {
+  const lines = [
+    `Implemented by the **${loopName}** rail as one batch:`,
+    '',
+    ...tickets.map((t) => `- [x] #${t.ticketId}${t.title ? ` — ${t.title}` : ''}`),
+    '',
+    '_Draft PR produced by specrails — the engineer owns the merge._',
+  ]
+  return lines.join('\n')
+}
+
+function firstLine(r: { stderr: string; stdout: string }): string {
+  return (r.stderr.trim() || r.stdout.trim()).split('\n')[0]
+}

--- a/server/types.ts
+++ b/server/types.ts
@@ -749,6 +749,22 @@ export interface RailWorktreeProgressMessage {
   state: 'building' | 'built' | 'merging' | 'merged' | 'needs-review' | 'failed'
 }
 
+/**
+ * A parallel rail's isolated ticket branches were delivered as a draft PR
+ * (safe-pr-workflow, behind `SPECRAILS_RAIL_DELIVER_PR`). `delivery` is the
+ * outcome; when `delivered`, `prState`/`prUrl` carry the degradation-ladder
+ * result and (if opened) the PR URL.
+ */
+export interface RailPrDeliveredMessage {
+  type: 'rail.pr_delivered'
+  projectId: string
+  railIndex: number
+  delivery: 'delivered' | 'assembly-failed' | 'no-op'
+  prState?: 'pr-created' | 'pushed' | 'local-only'
+  prUrl?: string
+  branch?: string
+}
+
 export interface RailUpdatedMessage {
   type: 'rail.updated'
   projectId: string
@@ -1071,7 +1087,7 @@ export type WsMessage =
   | TicketCreatedMessage | TicketUpdatedMessage | TicketDeletedMessage
   | TicketAiEditStreamMessage | TicketAiEditDoneMessage | TicketAiEditErrorMessage
   | SpecGenStreamMessage | SpecGenDoneMessage | SpecGenErrorMessage
-  | RailJobStartedMessage | RailJobStoppedMessage | RailJobCompletedMessage | RailUpdatedMessage | RailWorktreeProgressMessage
+  | RailJobStartedMessage | RailJobStoppedMessage | RailJobCompletedMessage | RailUpdatedMessage | RailWorktreeProgressMessage | RailPrDeliveredMessage
   | LoopRunStartedMessage | LoopRunProgressMessage | LoopRunStoppedMessage | LoopRunCompletedMessage
   | AgentRefineStreamMessage | AgentRefinePhaseMessage | AgentRefineReadyMessage
   | AgentRefineTestMessage | AgentRefineErrorMessage | AgentRefineCancelledMessage


### PR DESCRIPTION
## What & why

The slice that makes `safe-pr-workflow` **real**: a settled parallel rail can now deliver its isolated ticket branches as **one draft PR** instead of merging into the local base. Behind **`SPECRAILS_RAIL_DELIVER_PR` (default OFF)** so `main` is byte-identical by default (safe rollout).

## Changes

- **`server/rail-pr-delivery.ts` `deliverRailAsPr`:**
  - 0 succeeded → no-op
  - 1 succeeded → draft PR straight from the ticket branch
  - N succeeded → assemble a batch branch `sr/<slug>/batch-<key>` off the **designated integration branch** (transient worktree, `git merge --no-ff`, per-ticket history preserved) → **one combined draft PR** whose body lists every ticket (`buildBatchPrBody`)
  - conflict → `merge --abort` + teardown → `assembly-failed`, ticket branches left for a human, **base never touched**
- `isRailPrDeliveryEnabled()` (default-off opt-in) gates the path in `rail-isolated-launch.ts`; flag off → legacy merge-back unchanged.
- New `rail.pr_delivered` WS message surfaces `{delivery, prState, prUrl, branch}`.

## Philosophy

specrails is a **PR producer, never a merge authority** — the engineer owns the merge. Full retirement of the local merge-back is deferred until this path is field-validated.

## Tests

Full suite **4823 pass**; server coverage **85.5/76.8/88.3/87.6** (above the gate). The delivery module is fully unit-tested (no-op / single / clean-batch / conflict-abort / worktree-add-failure) with injectable git + exec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R982uLJYJxAepBa3EQzvw9