### PR TITLE
feat: integration-branch picker in project Settings (client, i18n x8)

### DIFF
--- a/client/src/components/__tests__/ProjectIntegrationBranchSection.test.tsx
+++ b/client/src/components/__tests__/ProjectIntegrationBranchSection.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { ProjectIntegrationBranchSection } from '../settings/ProjectSettingsSections'
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+vi.mock('../../hooks/useDesktop', () => ({ useDesktop: () => ({ activeProjectId: 'proj-1' }) }))
+vi.mock('../../lib/api', () => ({ getApiBase: () => '/api/projects/proj-1' }))
+
+function jsonRes(body: unknown, ok = true) {
+  return { ok, json: async () => body } as Response
+}
+
+describe('ProjectIntegrationBranchSection', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      const method = init?.method ?? 'GET'
+      if (url.endsWith('/integration-branch')) {
+        return jsonRes({ configured: '', branch: 'main', source: 'repo-default' })
+      }
+      if (url.endsWith('/settings') && method === 'PATCH') {
+        return jsonRes({ ok: true })
+      }
+      return jsonRes({})
+    }) as unknown as typeof fetch
+  })
+
+  it('shows the resolved base branch after loading', async () => {
+    render(<ProjectIntegrationBranchSection />)
+    const resolved = await screen.findByTestId('integration-branch-resolved')
+    expect(resolved.textContent).toContain('main')
+  })
+
+  it('saves a typed integration branch via PATCH /settings', async () => {
+    render(<ProjectIntegrationBranchSection />)
+    const input = await screen.findByTestId('integration-branch-input')
+    fireEvent.change(input, { target: { value: 'develop' } })
+    fireEvent.click(screen.getByTestId('integration-branch-save'))
+
+    await waitFor(() => {
+      const calls = (global.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls
+      const patch = calls.find((c) => String(c[0]).endsWith('/settings') && c[1]?.method === 'PATCH')
+      expect(patch).toBeTruthy()
+      expect(JSON.parse(patch![1]!.body as string)).toEqual({ integrationBranch: 'develop' })
+    })
+  })
+})

--- a/client/src/components/settings/ProjectSettingsSections.tsx
+++ b/client/src/components/settings/ProjectSettingsSections.tsx
@@ -16,6 +16,7 @@ interface ProjectSettingsPayload {
   pipelineTelemetryEnabled?: boolean
   prePrompt?: string
   ultraPrePrompt?: string
+  integrationBranch?: string
 }
 
 /** Skeleton shown until a section's GET settles — fields never flash empty and
@@ -104,6 +105,90 @@ export function ProjectTelemetrySection() {
             />
           </button>
         </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+/** Designated integration branch: the base parallel rails branch from and target
+ *  their draft PRs at. Empty = auto-resolve to the repo default. Shows the
+ *  resolved base so it is a certainty, not an implicit surprise. */
+export function ProjectIntegrationBranchSection() {
+  const { t } = useTranslation('settings')
+  const { activeProjectId } = useDesktop()
+  const [configured, setConfigured] = useState('')
+  const [resolved, setResolved] = useState<{ branch: string; source: string } | null>(null)
+  const [isSaving, setIsSaving] = useState(false)
+  const [loaded, setLoaded] = useState(false)
+
+  async function reload(cancelledRef?: { current: boolean }) {
+    const r = await fetch(`${getApiBase()}/integration-branch`)
+      .then((res) => (res.ok ? res.json() : null))
+      .catch(() => null) as { configured?: string; branch?: string; source?: string } | null
+    if (cancelledRef?.current) return
+    if (r) {
+      setConfigured(r.configured ?? '')
+      if (r.branch) setResolved({ branch: r.branch, source: r.source ?? '' })
+    }
+  }
+
+  useEffect(() => {
+    if (!activeProjectId) return
+    const cancelled = { current: false }
+    setLoaded(false)
+    reload(cancelled).finally(() => { if (!cancelled.current) setLoaded(true) })
+    return () => { cancelled.current = true }
+  }, [activeProjectId])
+
+  if (!loaded) return <SectionSkeleton />
+
+  async function save() {
+    setIsSaving(true)
+    try {
+      const res = await fetch(`${getApiBase()}/settings`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ integrationBranch: configured.trim() }),
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({} as { error?: string }))
+        throw new Error(body.error || 'Failed to save')
+      }
+      toast.success(t('integrationBranch.saved'))
+      await reload()
+    } catch (err) {
+      toast.error(t('integrationBranch.saveFailed'), { description: (err as Error).message })
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('integrationBranch.title')}</CardTitle>
+        <CardDescription>{t('integrationBranch.description')}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <Input
+          value={configured}
+          onChange={(e) => setConfigured(e.target.value)}
+          placeholder={t('integrationBranch.placeholder')}
+          data-testid="integration-branch-input"
+        />
+        {resolved && (
+          <p className="text-[10px] text-muted-foreground" data-testid="integration-branch-resolved">
+            <Trans
+              ns="settings"
+              i18nKey="integrationBranch.resolved"
+              values={{ branch: resolved.branch }}
+              components={{ mono: <span className="font-mono" /> }}
+            />
+          </p>
+        )}
+        <Button size="sm" onClick={save} disabled={isSaving} data-testid="integration-branch-save">
+          {t('integrationBranch.save')}
+        </Button>
       </CardContent>
     </Card>
   )

--- a/client/src/locales/de/settings.json
+++ b/client/src/locales/de/settings.json
@@ -252,5 +252,14 @@
       "telemetry": "Telemetrie",
       "terminal": "Terminal"
     }
+  },
+  "integrationBranch": {
+    "title": "Integrationszweig",
+    "description": "Der Branch, von dem parallele Rails abzweigen und auf den ihre Entwurfs-PRs zielen. Leer lassen, um automatisch den Standard-Branch des Repositorys zu verwenden.",
+    "placeholder": "automatisch (Standard-Branch)",
+    "resolved": "Rails zweigen von <mono>{{branch}}</mono> ab",
+    "save": "Branch speichern",
+    "saved": "Integrationszweig gespeichert",
+    "saveFailed": "Integrationszweig konnte nicht gespeichert werden"
   }
 }

--- a/client/src/locales/en/settings.json
+++ b/client/src/locales/en/settings.json
@@ -252,5 +252,14 @@
       "telemetry": "Telemetry",
       "terminal": "Terminal"
     }
+  },
+  "integrationBranch": {
+    "title": "Integration branch",
+    "description": "The branch parallel rails branch from and target their draft PRs at. Leave empty to auto-resolve to the repository's default branch.",
+    "placeholder": "auto (repository default)",
+    "resolved": "Rails branch off <mono>{{branch}}</mono>",
+    "save": "Save branch",
+    "saved": "Integration branch saved",
+    "saveFailed": "Could not save the integration branch"
   }
 }

--- a/client/src/locales/es/settings.json
+++ b/client/src/locales/es/settings.json
@@ -252,5 +252,14 @@
       "telemetry": "Telemetría",
       "terminal": "Terminal"
     }
+  },
+  "integrationBranch": {
+    "title": "Rama de integración",
+    "description": "La rama desde la que parten los rails paralelos y a la que apuntan sus PRs en borrador. Déjalo vacío para resolver automáticamente a la rama por defecto del repositorio.",
+    "placeholder": "automático (rama por defecto)",
+    "resolved": "Los rails parten de <mono>{{branch}}</mono>",
+    "save": "Guardar rama",
+    "saved": "Rama de integración guardada",
+    "saveFailed": "No se pudo guardar la rama de integración"
   }
 }

--- a/client/src/locales/fr/settings.json
+++ b/client/src/locales/fr/settings.json
@@ -252,5 +252,14 @@
       "telemetry": "Télémétrie",
       "terminal": "Terminal"
     }
+  },
+  "integrationBranch": {
+    "title": "Branche d'intégration",
+    "description": "La branche depuis laquelle les rails parallèles se ramifient et que ciblent leurs PR en brouillon. Laissez vide pour résoudre automatiquement vers la branche par défaut du dépôt.",
+    "placeholder": "automatique (branche par défaut)",
+    "resolved": "Les rails partent de <mono>{{branch}}</mono>",
+    "save": "Enregistrer la branche",
+    "saved": "Branche d'intégration enregistrée",
+    "saveFailed": "Impossible d'enregistrer la branche d'intégration"
   }
 }

--- a/client/src/locales/it/settings.json
+++ b/client/src/locales/it/settings.json
@@ -252,5 +252,14 @@
       "telemetry": "Telemetria",
       "terminal": "Terminale"
     }
+  },
+  "integrationBranch": {
+    "title": "Ramo di integrazione",
+    "description": "Il ramo da cui i rail paralleli si diramano e a cui puntano le loro PR in bozza. Lascia vuoto per risolvere automaticamente al ramo predefinito del repository.",
+    "placeholder": "automatico (ramo predefinito)",
+    "resolved": "I rail si diramano da <mono>{{branch}}</mono>",
+    "save": "Salva ramo",
+    "saved": "Ramo di integrazione salvato",
+    "saveFailed": "Impossibile salvare il ramo di integrazione"
   }
 }

--- a/client/src/locales/ja/settings.json
+++ b/client/src/locales/ja/settings.json
@@ -252,5 +252,14 @@
       "telemetry": "テレメトリ",
       "terminal": "ターミナル"
     }
+  },
+  "integrationBranch": {
+    "title": "統合ブランチ",
+    "description": "並列レールが分岐し、ドラフト PR の対象となるブランチです。空欄にするとリポジトリのデフォルトブランチに自動解決されます。",
+    "placeholder": "自動（リポジトリのデフォルト）",
+    "resolved": "レールは <mono>{{branch}}</mono> から分岐します",
+    "save": "ブランチを保存",
+    "saved": "統合ブランチを保存しました",
+    "saveFailed": "統合ブランチを保存できませんでした"
   }
 }

--- a/client/src/locales/pt/settings.json
+++ b/client/src/locales/pt/settings.json
@@ -252,5 +252,14 @@
       "telemetry": "Telemetria",
       "terminal": "Terminal"
     }
+  },
+  "integrationBranch": {
+    "title": "Ramo de integração",
+    "description": "O ramo a partir do qual os rails paralelos derivam e para o qual apontam os seus PRs em rascunho. Deixe vazio para resolver automaticamente para o ramo padrão do repositório.",
+    "placeholder": "automático (ramo padrão)",
+    "resolved": "Os rails derivam de <mono>{{branch}}</mono>",
+    "save": "Guardar ramo",
+    "saved": "Ramo de integração guardado",
+    "saveFailed": "Não foi possível guardar o ramo de integração"
   }
 }

--- a/client/src/locales/zh/settings.json
+++ b/client/src/locales/zh/settings.json
@@ -252,5 +252,14 @@
       "telemetry": "遥测",
       "terminal": "终端"
     }
+  },
+  "integrationBranch": {
+    "title": "集成分支",
+    "description": "并行 rail 从此分支创建，其草稿 PR 也以此为目标。留空则自动解析为仓库的默认分支。",
+    "placeholder": "自动（仓库默认分支）",
+    "resolved": "Rail 从 <mono>{{branch}}</mono> 创建分支",
+    "save": "保存分支",
+    "saved": "集成分支已保存",
+    "saveFailed": "无法保存集成分支"
   }
 }

--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -9,6 +9,7 @@ import {
   ProjectTelemetrySection,
   ProjectPrePromptsSection,
   ProjectBudgetSection,
+  ProjectIntegrationBranchSection,
 } from '../components/settings/ProjectSettingsSections'
 
 export default function SettingsPage() {
@@ -104,6 +105,8 @@ export default function SettingsPage() {
       {isSuperMode && <ProjectTelemetrySection />}
 
       <ProjectPrePromptsSection />
+
+      <ProjectIntegrationBranchSection />
 
       <ProjectBudgetSection />
 

--- a/openspec/changes/safe-pr-workflow/tasks.md
+++ b/openspec/changes/safe-pr-workflow/tasks.md
@@ -4,7 +4,7 @@
 - [x] 1.1 Add a per-project `integrationBranch` setting (`ProjectSettings`, stored as a `queue_state` KV `config.integration_branch` — no migration needed as-built); default resolver = `git symbolic-ref refs/remotes/origin/HEAD` → else current `HEAD`.
 - [x] 1.2 Pure resolution module (`server/integration-branch.ts` + tests) — precedence explicit → project setting → repo default → head-fallback, returning `{branch, source}`.
 - [x] 1.3 Make `CreateWorktreeInput.baseRef` live: `rail-isolated-launch.ts` resolves the integration branch once and passes it as `baseRef` to every `createWorktree` (was implicit `HEAD`).
-- [~] 1.4 Server half DONE: `PATCH /:projectId/settings` accepts+validates `integrationBranch` (arg-injection guard `isValidBranchName`), `GET /:projectId/integration-branch` resolves `{configured, branch, source}` for pre-launch display. **Pending (own PR):** client picker in project settings + resolved base shown before launch + i18n ×8.
+- [x] 1.4 Server API + client picker DONE: `PATCH /settings` accepts+validates `integrationBranch` (`isValidBranchName`), `GET /:projectId/integration-branch` resolves `{configured, branch, source}`; `ProjectIntegrationBranchSection` in project Settings lets the user set it and shows the resolved base (`Rails branch off <branch>`), i18n ×8 (parity green). **Deferred:** surfacing the resolved base in the rail-launch header (Settings surfaces it today).
 
 ## 2. App-owned git/PR primitive (`safe-pr-workflow` / `core-git-agnostic-contract`)
 - [x] 2.1 New desktop primitive (`server/pr-publisher.ts` + tests): `git push -u origin <branch>` → `gh pr create --draft --base <baseBranch> --head <branch>`; parses + returns the PR URL.


### PR DESCRIPTION
## What & why

Completes **task 1.4** — the product builder can now **set** the designated integration branch and **see** the resolved base, with no git vocabulary. Builds on #486 / #488.

## Changes

- **`ProjectIntegrationBranchSection`** in project Settings: a text input (empty = auto), reads `GET /integration-branch` to show `Rails branch off <branch>`, saves via `PATCH /settings`, and surfaces the server's 400 on an invalid branch name.
- Wired into `SettingsPage` between the pre-prompt and budget sections.
- i18n `integrationBranch.*` across all **8 locales** (locale-parity test green).
- Save button labelled **"Save branch"** (not bare "Save") — clearer UX and avoids colliding with the budget section's generic Save in tests.

## Deferred

Surfacing the resolved base in the rail-launch header (Settings surfaces it today).

## Tests

Client suite **3081 pass**; client coverage **85.96 lines/stmts, 81.17 branch, 71.54 func** (above the 80/80/70 gate). New component test covers load + save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R982uLJYJxAepBa3EQzvw9