### PR TITLE
feat: surface rail.pr_delivered in the dashboard (draft-PR toast + link)

### DIFF
--- a/client/src/locales/de/dashboard.json
+++ b/client/src/locales/de/dashboard.json
@@ -21,7 +21,12 @@
     "launchDescription_other": "{{mode}} mit {{count}} Specs",
     "railWorktreeNeedsReview": "Rail {{n}}: Spec #{{ticket}} muss nach dem Merge geprüft werden",
     "railWorktreesNoGit": "Worktree-Isolation nicht verfügbar: Dieses Projekt ist kein Git-Repository — Ausführung im gemeinsamen Modus.",
-    "railWorktreesNoCommits": "Worktree-Isolation nicht verfügbar: Das Repository hat noch keine Commits — erstelle einen ersten Commit und starte neu."
+    "railWorktreesNoCommits": "Worktree-Isolation nicht verfügbar: Das Repository hat noch keine Commits — erstelle einen ersten Commit und starte neu.",
+    "railPrDelivered": "Entwurfs-PR bereit für Rail {{n}}",
+    "railPrOpen": "PR öffnen",
+    "railPrPushed": "Rail {{n}}: Branch gepusht — öffne die PR bei Bedarf",
+    "railPrLocal": "Rail {{n}}: Änderungen in einem lokalen Branch gespeichert",
+    "railPrAssemblyFailed": "Rail {{n}}: Branches konnten nicht kombiniert werden — manueller Eingriff nötig"
   },
   "railsBoard": {
     "title": "Rails",

--- a/client/src/locales/en/dashboard.json
+++ b/client/src/locales/en/dashboard.json
@@ -21,7 +21,12 @@
     "launchDescription_other": "{{mode}} with {{count}} specs",
     "railWorktreeNeedsReview": "Rail {{n}}: spec #{{ticket}} needs review after merge",
     "railWorktreesNoGit": "Worktree isolation unavailable: this project isn't a git repository — running in shared mode.",
-    "railWorktreesNoCommits": "Worktree isolation unavailable: the repository has no commits yet — make an initial commit, then relaunch."
+    "railWorktreesNoCommits": "Worktree isolation unavailable: the repository has no commits yet — make an initial commit, then relaunch.",
+    "railPrDelivered": "Draft PR ready for rail {{n}}",
+    "railPrOpen": "Open PR",
+    "railPrPushed": "Rail {{n}}: branch pushed — open the PR when ready",
+    "railPrLocal": "Rail {{n}}: changes saved to a local branch",
+    "railPrAssemblyFailed": "Rail {{n}}: couldn't combine branches — needs a human"
   },
   "railsBoard": {
     "title": "Rails",

--- a/client/src/locales/es/dashboard.json
+++ b/client/src/locales/es/dashboard.json
@@ -21,7 +21,12 @@
     "launchDescription_other": "{{mode}} con {{count}} specs",
     "railWorktreeNeedsReview": "Rail {{n}}: la spec #{{ticket}} necesita revisión tras el merge",
     "railWorktreesNoGit": "Aislamiento por worktrees no disponible: el proyecto no es un repositorio git — ejecutando en modo compartido.",
-    "railWorktreesNoCommits": "Aislamiento por worktrees no disponible: el repositorio aún no tiene commits — haz un commit inicial y relanza."
+    "railWorktreesNoCommits": "Aislamiento por worktrees no disponible: el repositorio aún no tiene commits — haz un commit inicial y relanza.",
+    "railPrDelivered": "PR en borrador lista para el rail {{n}}",
+    "railPrOpen": "Abrir PR",
+    "railPrPushed": "Rail {{n}}: rama subida — abre la PR cuando quieras",
+    "railPrLocal": "Rail {{n}}: cambios guardados en una rama local",
+    "railPrAssemblyFailed": "Rail {{n}}: no se pudieron combinar las ramas — requiere un humano"
   },
   "railsBoard": {
     "title": "Rails",

--- a/client/src/locales/fr/dashboard.json
+++ b/client/src/locales/fr/dashboard.json
@@ -21,7 +21,12 @@
     "launchDescription_other": "{{mode}} avec {{count}} specs",
     "railWorktreeNeedsReview": "Rail {{n}} : la spec #{{ticket}} nécessite une revue après le merge",
     "railWorktreesNoGit": "Isolation par worktree indisponible : ce projet n'est pas un dépôt git — exécution en mode partagé.",
-    "railWorktreesNoCommits": "Isolation par worktree indisponible : le dépôt n'a pas encore de commit — faites un commit initial puis relancez."
+    "railWorktreesNoCommits": "Isolation par worktree indisponible : le dépôt n'a pas encore de commit — faites un commit initial puis relancez.",
+    "railPrDelivered": "PR en brouillon prête pour le rail {{n}}",
+    "railPrOpen": "Ouvrir la PR",
+    "railPrPushed": "Rail {{n}} : branche poussée — ouvrez la PR quand vous voulez",
+    "railPrLocal": "Rail {{n}} : modifications enregistrées dans une branche locale",
+    "railPrAssemblyFailed": "Rail {{n}} : impossible de combiner les branches — intervention humaine requise"
   },
   "railsBoard": {
     "title": "Rails",

--- a/client/src/locales/it/dashboard.json
+++ b/client/src/locales/it/dashboard.json
@@ -21,7 +21,12 @@
     "launchDescription_other": "{{mode}} con {{count}} spec",
     "railWorktreeNeedsReview": "Rail {{n}}: la spec #{{ticket}} richiede revisione dopo il merge",
     "railWorktreesNoGit": "Isolamento con worktree non disponibile: il progetto non è un repository git — esecuzione in modalità condivisa.",
-    "railWorktreesNoCommits": "Isolamento con worktree non disponibile: il repository non ha ancora commit — crea un commit iniziale e rilancia."
+    "railWorktreesNoCommits": "Isolamento con worktree non disponibile: il repository non ha ancora commit — crea un commit iniziale e rilancia.",
+    "railPrDelivered": "PR in bozza pronta per il rail {{n}}",
+    "railPrOpen": "Apri PR",
+    "railPrPushed": "Rail {{n}}: ramo inviato — apri la PR quando vuoi",
+    "railPrLocal": "Rail {{n}}: modifiche salvate in un ramo locale",
+    "railPrAssemblyFailed": "Rail {{n}}: impossibile combinare i rami — serve un intervento umano"
   },
   "railsBoard": {
     "title": "Rails",

--- a/client/src/locales/ja/dashboard.json
+++ b/client/src/locales/ja/dashboard.json
@@ -21,7 +21,12 @@
     "launchDescription_other": "{{mode}} · スペック {{count}} 件",
     "railWorktreeNeedsReview": "Rail {{n}}：マージ後、spec #{{ticket}} は要確認です",
     "railWorktreesNoGit": "worktree 分離は利用できません：このプロジェクトは git リポジトリではありません — 共有モードで実行します。",
-    "railWorktreesNoCommits": "worktree 分離は利用できません：リポジトリにまだコミットがありません — 初回コミットを作成してから再実行してください。"
+    "railWorktreesNoCommits": "worktree 分離は利用できません：リポジトリにまだコミットがありません — 初回コミットを作成してから再実行してください。",
+    "railPrDelivered": "レール {{n}} のドラフト PR が準備できました",
+    "railPrOpen": "PR を開く",
+    "railPrPushed": "レール {{n}}：ブランチをプッシュしました — 必要に応じて PR を開いてください",
+    "railPrLocal": "レール {{n}}：変更をローカルブランチに保存しました",
+    "railPrAssemblyFailed": "レール {{n}}：ブランチを結合できませんでした — 手動対応が必要です"
   },
   "railsBoard": {
     "title": "レール",

--- a/client/src/locales/pt/dashboard.json
+++ b/client/src/locales/pt/dashboard.json
@@ -21,7 +21,12 @@
     "launchDescription_other": "{{mode}} com {{count}} specs",
     "railWorktreeNeedsReview": "Rail {{n}}: a spec #{{ticket}} precisa de revisão após o merge",
     "railWorktreesNoGit": "Isolamento por worktree indisponível: este projeto não é um repositório git — executando em modo compartilhado.",
-    "railWorktreesNoCommits": "Isolamento por worktree indisponível: o repositório ainda não tem commits — faça um commit inicial e relance."
+    "railWorktreesNoCommits": "Isolamento por worktree indisponível: o repositório ainda não tem commits — faça um commit inicial e relance.",
+    "railPrDelivered": "PR em rascunho pronta para o rail {{n}}",
+    "railPrOpen": "Abrir PR",
+    "railPrPushed": "Rail {{n}}: ramo enviado — abre a PR quando quiseres",
+    "railPrLocal": "Rail {{n}}: alterações guardadas num ramo local",
+    "railPrAssemblyFailed": "Rail {{n}}: não foi possível combinar os ramos — requer um humano"
   },
   "railsBoard": {
     "title": "Rails",

--- a/client/src/locales/zh/dashboard.json
+++ b/client/src/locales/zh/dashboard.json
@@ -21,7 +21,12 @@
     "launchDescription_other": "{{mode}}，共 {{count}} 个 Spec",
     "railWorktreeNeedsReview": "Rail {{n}}：合并后 spec #{{ticket}} 需要复查",
     "railWorktreesNoGit": "worktree 隔离不可用：该项目不是 git 仓库 — 以共享模式运行。",
-    "railWorktreesNoCommits": "worktree 隔离不可用：仓库还没有任何提交 — 先做一次初始提交再重新启动。"
+    "railWorktreesNoCommits": "worktree 隔离不可用：仓库还没有任何提交 — 先做一次初始提交再重新启动。",
+    "railPrDelivered": "rail {{n}} 的草稿 PR 已就绪",
+    "railPrOpen": "打开 PR",
+    "railPrPushed": "Rail {{n}}：分支已推送 — 可随时打开 PR",
+    "railPrLocal": "Rail {{n}}：更改已保存到本地分支",
+    "railPrAssemblyFailed": "Rail {{n}}：无法合并分支 — 需要人工处理"
   },
   "railsBoard": {
     "title": "Rails",

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -465,6 +465,27 @@ export default function DashboardPage() {
       return
     }
 
+    if (m.type === 'rail.pr_delivered') {
+      const n = (m.railIndex ?? 0) + 1
+      const d = m as { delivery?: string; prState?: string; prUrl?: string }
+      if (d.delivery === 'delivered') {
+        if (d.prState === 'pr-created' && d.prUrl) {
+          const url = d.prUrl
+          toast.success(t('toasts.railPrDelivered', { n }), {
+            description: url,
+            action: { label: t('toasts.railPrOpen'), onClick: () => window.open(url, '_blank') },
+          })
+        } else if (d.prState === 'pushed') {
+          toast.info(t('toasts.railPrPushed', { n }))
+        } else {
+          toast.info(t('toasts.railPrLocal', { n }))
+        }
+      } else if (d.delivery === 'assembly-failed') {
+        toast.error(t('toasts.railPrAssemblyFailed', { n }))
+      }
+      return
+    }
+
     if (m.type === 'rail.job_completed') {
       const targetIndex = m.railIndex ?? 0
       // Strip this job's tickets from the rail on every terminal outcome so they

--- a/openspec/changes/safe-pr-workflow/tasks.md
+++ b/openspec/changes/safe-pr-workflow/tasks.md
@@ -34,9 +34,9 @@
 - [ ] 6.2 Verify `{{cmd:implement}}` runs correctly in an isolated worktree on a relocated project.
 
 ## 7. Product-builder "Review & Approve" surface (`safe-pr-workflow`)
-- [ ] 7.1 Plain-language "what changed + proof" review bundle per loop result (diff summarized, verification/tests/screenshots).
-- [ ] 7.2 Approve → draft PR promoted to ready + reviewer notified/assigned; Discard → close PR + drop branch/worktree.
-- [ ] 7.3 i18n for all new builder-facing strings across the 8 locales (parity test passes).
+- [~] 7.1 Delivery is now SURFACED to the user: `DashboardPage` handles the `rail.pr_delivered` WS event → toast with the draft-PR link (`Open PR`) / pushed / local-only / assembly-failed, i18n ×8 (parity green). **Deferred:** the full plain-language "what changed + proof" review bundle (needs a product/UX decision).
+- [ ] 7.2 Approve → draft PR promoted to ready + reviewer notified/assigned; Discard → close PR + drop branch/worktree. (Deferred with 7.1's bundle.)
+- [x] 7.3 i18n for the delivery toasts across all 8 locales (parity test passes). (Remaining builder-facing strings ship with 7.1/7.2.)
 
 ## 8. Coverage & docs
 - [ ] 8.1 Unit tests: integration-branch resolution, mutating/read-only classifier, git-agnostic-signal propagation, combined-PR assembly (server ≥80%, client ≥80%).


### PR DESCRIPTION
## What & why

Closes the loop on the flag-gated PR delivery (#489): when an isolated rail delivers a draft PR, the user now **sees** it.

## Changes

- `DashboardPage` handles the `rail.pr_delivered` WS event:
  - **delivered + pr-created** → success toast with an **"Open PR"** action opening the URL
  - **delivered + pushed** → info toast ("branch pushed — open the PR when ready")
  - **delivered + local-only** → info toast ("changes saved to a local branch")
  - **assembly-failed** → error toast ("couldn't combine branches — needs a human")
- i18n `toasts.railPr*` across all **8 locales** (locale-parity green).

## Deferred

The full **Review & Approve** bundle (plain-language what-changed + proof, Approve/Discard) — needs a product/UX decision.

## Tests

Client suite **3081 pass**; client coverage **85.91 / 81.16 / 71.51** (above 80/80/70). The delivery logic is unit-tested server-side (`rail-pr-delivery`); this handler is a thin toast dispatcher mirroring the existing `rail.worktree_progress` handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R982uLJYJxAepBa3EQzvw9