### PR TITLE
feat: derive rail isolation from a loop-effect classifier (mutating vs read-only)

### DIFF
--- a/openspec/changes/safe-pr-workflow/tasks.md
+++ b/openspec/changes/safe-pr-workflow/tasks.md
@@ -13,9 +13,9 @@
 - [ ] 2.4 Hard git guardrails: block force-push and direct commits to the integration branch (technical block, not prompt text).
 
 ## 3. Platform-law enforcement (`safe-pr-workflow`)
-- [ ] 3.1 Server-authoritative `mutating` vs `read-only` classifier derived from loop node content; unit-tested.
-- [ ] 3.2 Enforce at launch: mutating loop ⇒ isolated worktree + draft PR; read-only ⇒ no branch/PR. Custom loops cannot opt out.
-- [ ] 3.3 Client mirror of the classifier (advisory), server remains authoritative.
+- [x] 3.1 `server/loop-effect.ts` `classifyLoopEffect` — server-authoritative, derived from node content (read-only iff no `ai-step`/`shell` node), unit-tested.
+- [x] 3.2 Wired into `rails-router.ts` (replaces the hardcoded `readOnly:false`): the isolation gate now derives read-only from content, so a custom loop cannot declare itself read-only to escape isolation (there is no user flag to lie with — it's derived).
+- [~] 3.3 Client mirror deferred — there is no user-facing read-only flag to mirror (the classifier is purely server-derived), so an advisory client mirror is moot until a UI exposes the effect.
 
 ## 4. Cross-repo git-agnostic contract (`core-git-agnostic-contract`)
 - [ ] 4.1 **specrails-core**: parse `--no-ship` (and read `SPECRAILS_GIT_AUTO`) in `implement.md` Phase 0; short-circuit Phase 4c/4d like `GIT_AUTO=false`.

--- a/server/loop-effect.test.ts
+++ b/server/loop-effect.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { classifyLoopEffect, loopIsMutating } from './loop-effect'
+import type { LoopGraph, LoopNodeType } from './loop-graph'
+
+function graph(types: LoopNodeType[]): LoopGraph {
+  return {
+    nodes: types.map((type, i) => ({ id: `n${i}`, type, position: { x: 0, y: 0 } })),
+    edges: [],
+    config: { maxIterations: 10, timeoutMinutes: 30 },
+  }
+}
+
+describe('classifyLoopEffect', () => {
+  it('is mutating when any ai-step is present', () => {
+    expect(classifyLoopEffect(graph(['start', 'ai-step', 'decider', 'end']))).toBe('mutating')
+    expect(loopIsMutating(graph(['start', 'ai-step', 'end']))).toBe(true)
+  })
+
+  it('is mutating when any shell node is present', () => {
+    expect(classifyLoopEffect(graph(['start', 'shell', 'end']))).toBe('mutating')
+  })
+
+  it('is read-only when no ai-step and no shell node', () => {
+    expect(classifyLoopEffect(graph(['start', 'decider', 'condition', 'end']))).toBe('read-only')
+    expect(loopIsMutating(graph(['start', 'end']))).toBe(false)
+  })
+
+  it('is read-only for an empty node list', () => {
+    expect(classifyLoopEffect(graph([]))).toBe('read-only')
+  })
+})

--- a/server/loop-effect.ts
+++ b/server/loop-effect.ts
@@ -1,0 +1,23 @@
+/**
+ * Classify a loop by whether it can WRITE to the repo, DERIVED from node content
+ * (not a user toggle). Used by the isolation gate so a repo-mutating loop is
+ * isolated and a genuinely read-only loop is not.
+ *
+ * A loop is `read-only` only when it contains NO node that can mutate the working
+ * tree — no `shell` node (arbitrary command) and no `ai-step` node (the AI can
+ * edit files). Any of those makes it `mutating`. Deliberately conservative: a
+ * false `read-only` would let a repo-mutating loop skip isolation (dangerous),
+ * whereas a false `mutating` only costs a cleaned-up empty worktree (harmless).
+ * `start` / `end` / `decider` / `condition` never write.
+ */
+import type { LoopGraph } from './loop-graph'
+
+export function classifyLoopEffect(graph: LoopGraph): 'mutating' | 'read-only' {
+  const writes = graph.nodes.some((n) => n.type === 'ai-step' || n.type === 'shell')
+  return writes ? 'mutating' : 'read-only'
+}
+
+/** Convenience: true when the loop mutates the repo (derived from its nodes). */
+export function loopIsMutating(graph: LoopGraph): boolean {
+  return classifyLoopEffect(graph) === 'mutating'
+}

--- a/server/rails-router.ts
+++ b/server/rails-router.ts
@@ -14,6 +14,7 @@ import { loadConstantMap } from './loop-constants'
 import { dominantTicketScope, referencesClaudeOnlyCommand } from './loop-command-catalog'
 import { loopNeedsTicket, type LoopGraph } from './loop-graph'
 import { isolationApplies } from './rail-isolation'
+import { classifyLoopEffect } from './loop-effect'
 import { launchIsolatedRail } from './rail-isolated-launch'
 import { repoIsolationStatus, defaultGitRunner } from './worktree-manager'
 import { newId } from './ids'
@@ -368,7 +369,11 @@ export function createRailsRouter(): Router {
         // repo, an unborn HEAD, or a worktree-allocation failure all fall through to
         // the shared-cwd path below. See rail-isolation.ts.
         let isolationUnavailable: string | undefined
-        if (isolationApplies({ loopsEnabled: isLoopsEnabled(), scope, ticketCount: rail.ticketIds.length, readOnly: false })) {
+        // Read-only vs mutating is DERIVED from the loop's nodes (see loop-effect),
+        // not a user flag — a content-read-only loop (no ai-step/shell) never writes,
+        // so it is not isolated; anything that can write is.
+        const loopReadOnly = classifyLoopEffect(loopGraph) === 'read-only'
+        if (isolationApplies({ loopsEnabled: isLoopsEnabled(), scope, ticketCount: rail.ticketIds.length, readOnly: loopReadOnly })) {
           // Worktree isolation needs a git repo WITH at least one commit (an
           // unborn HEAD can't be branched). Fall back (with a message) otherwise.
           const status = await repoIsolationStatus(defaultGitRunner, c.project.path)


### PR DESCRIPTION
## What & why

Replaces the hardcoded `readOnly:false` in the parallel-rail isolation gate with a **content-derived** classification (tasks 3.1/3.2). Part of `safe-pr-workflow`.

## Changes

- **`server/loop-effect.ts` `classifyLoopEffect(graph)`**: read-only iff the loop has **no `ai-step` and no `shell`** node (nothing that can write); anything that can write is `mutating`. Conservative by design — a false read-only would skip isolation (dangerous); a false mutating only costs a cleaned-up empty worktree.
- **`rails-router.ts`** now passes `readOnly: classifyLoopEffect(loopGraph) === 'read-only'` to `isolationApplies`, so a genuinely read-only loop is not isolated and a repo-mutating one always is — and a custom loop **cannot declare itself read-only to escape isolation** (it is derived, not a flag).

## Impact

Behaviour-preserving for every real loop (they contain ai-steps → mutating → isolate exactly as before). Only a nodes-only-read loop changes (correctly skips isolation).

## Tests

Full suite **4827 pass**; server coverage **85.5/76.8/88.3/87.6** (above the gate). `classifyLoopEffect` is unit-tested (ai-step / shell / read-only / empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R982uLJYJxAepBa3EQzvw9