### PR TITLE
feat: git guardrails on the app push path (no force-push, no push to integration)

### DIFF
--- a/openspec/changes/safe-pr-workflow/tasks.md
+++ b/openspec/changes/safe-pr-workflow/tasks.md
@@ -10,7 +10,7 @@
 - [x] 2.1 New desktop primitive (`server/pr-publisher.ts` + tests): `git push -u origin <branch>` → `gh pr create --draft --base <baseBranch> --head <branch>`; parses + returns the PR URL.
 - [x] 2.2 Degradation ladder in the primitive + WS surfacing DONE — `rail.pr_delivered` broadcast carries `{delivery, prState, prUrl, branch}` (`server/types.ts` + `rail-isolated-launch.ts`).
 - [~] 2.3 Flag-gated draft-PR delivery path added (`SPECRAILS_RAIL_DELIVER_PR`, default OFF): when on, a settled isolated rail delivers a draft PR instead of merging back (`server/rail-pr-delivery.ts`, wired in `rail-isolated-launch.ts`). **Full retirement of the local merge-back is deferred** — the default path is still merge-back until the PR path is validated in the field.
-- [ ] 2.4 Hard git guardrails: block force-push and direct commits to the integration branch (technical block, not prompt text).
+- [~] 2.4 `server/git-guardrails.ts` `assertGitAllowed` blocks force-push and direct push to the integration branch, wired into `pr-publisher` (the app's sanctioned push path) as defense-in-depth. **Deferred:** blocking git issued by the AI agent *inside* a loop turn needs a per-worktree pre-push hook (documented follow-up).
 
 ## 3. Platform-law enforcement (`safe-pr-workflow`)
 - [x] 3.1 `server/loop-effect.ts` `classifyLoopEffect` — server-authoritative, derived from node content (read-only iff no `ai-step`/`shell` node), unit-tested.

--- a/server/git-guardrails.test.ts
+++ b/server/git-guardrails.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { assertGitAllowed, isForcePush, pushesToBranch, GitGuardrailError } from './git-guardrails'
+
+describe('isForcePush', () => {
+  it('detects force flags', () => {
+    expect(isForcePush(['push', '--force', 'origin', 'b'])).toBe(true)
+    expect(isForcePush(['push', '-f', 'origin', 'b'])).toBe(true)
+    expect(isForcePush(['push', '--force-with-lease', 'origin', 'b'])).toBe(true)
+    expect(isForcePush(['push', '--force-with-lease=b:sha', 'origin', 'b'])).toBe(true)
+  })
+  it('is false for a normal push', () => {
+    expect(isForcePush(['push', '-u', 'origin', 'b'])).toBe(false)
+  })
+})
+
+describe('pushesToBranch', () => {
+  it('detects implicit + explicit refspecs targeting the branch', () => {
+    expect(pushesToBranch(['push', 'origin', 'main'], 'main')).toBe(true)
+    expect(pushesToBranch(['push', 'origin', 'HEAD:main'], 'main')).toBe(true)
+    expect(pushesToBranch(['push', 'origin', 'sr/p/ticket-1:main'], 'main')).toBe(true)
+    expect(pushesToBranch(['push', 'origin', 'refs/heads/main'], 'main')).toBe(true)
+  })
+  it('is false when pushing a different branch', () => {
+    expect(pushesToBranch(['push', '-u', 'origin', 'sr/p/ticket-1'], 'main')).toBe(false)
+  })
+})
+
+describe('assertGitAllowed', () => {
+  it('allows a normal ticket-branch push', () => {
+    expect(() => assertGitAllowed('git', ['push', '-u', 'origin', 'sr/p/ticket-1'], { protectedBranch: 'main' })).not.toThrow()
+  })
+  it('refuses a force-push', () => {
+    expect(() => assertGitAllowed('git', ['push', '--force', 'origin', 'sr/p/ticket-1'])).toThrow(GitGuardrailError)
+  })
+  it('refuses a direct push to the integration branch', () => {
+    expect(() => assertGitAllowed('git', ['push', 'origin', 'main'], { protectedBranch: 'main' })).toThrow(/integration branch/)
+  })
+  it('ignores non-push git commands and non-git commands', () => {
+    expect(() => assertGitAllowed('git', ['merge', '--no-ff', 'b'], { protectedBranch: 'main' })).not.toThrow()
+    expect(() => assertGitAllowed('gh', ['pr', 'create'], { protectedBranch: 'main' })).not.toThrow()
+  })
+})

--- a/server/git-guardrails.ts
+++ b/server/git-guardrails.ts
@@ -1,0 +1,56 @@
+/**
+ * Git safety guardrails for the app-owned push/PR path (safe-pr-workflow).
+ *
+ * specrails must NEVER force-push and NEVER push directly to a project's
+ * integration branch — work always lands on a ticket/batch branch and reaches the
+ * integration branch only through a human-merged PR. This is a pure policy check
+ * wired into the sanctioned git/PR path (`pr-publisher`) as defense-in-depth: even
+ * a future bug that constructed a bad push is refused loudly.
+ *
+ * NOTE: this guards the APP's own git invocations. Blocking git issued by the AI
+ * agent *inside* a loop turn (e.g. a rogue `git push --force`) requires a
+ * per-worktree pre-push hook and is a documented follow-up.
+ */
+export class GitGuardrailError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'GitGuardrailError'
+  }
+}
+
+const FORCE_FLAGS = new Set(['--force', '-f', '--force-with-lease'])
+
+/** True when a `git push` arg list carries a force flag (incl. `--force-with-lease=…`). */
+export function isForcePush(args: string[]): boolean {
+  return args[0] === 'push' && args.some((a) => FORCE_FLAGS.has(a) || a.startsWith('--force-with-lease='))
+}
+
+/**
+ * Does a `git push` arg list target the protected branch? Catches
+ *   push <remote> <protected>        (implicit same-name)
+ *   push <remote> HEAD:<protected>   (explicit dst refspec)
+ *   push <remote> <src>:<protected>
+ * We only ever push the ticket/batch branch, so any of these is a bug.
+ */
+export function pushesToBranch(args: string[], branch: string): boolean {
+  if (args[0] !== 'push' || !branch) return false
+  return args.slice(1).some((a) => {
+    if (a.startsWith('-')) return false // a flag, not a refspec
+    const dst = a.includes(':') ? a.slice(a.indexOf(':') + 1) : a
+    return dst === branch || dst === `refs/heads/${branch}`
+  })
+}
+
+/**
+ * Throw if a git command violates the guardrails. Only `push` is policed today;
+ * every other command is allowed through unchanged.
+ */
+export function assertGitAllowed(cmd: string, args: string[], opts: { protectedBranch?: string } = {}): void {
+  if (cmd !== 'git' || args[0] !== 'push') return
+  if (isForcePush(args)) {
+    throw new GitGuardrailError('force-push is not allowed on the safe-PR path')
+  }
+  if (opts.protectedBranch && pushesToBranch(args, opts.protectedBranch)) {
+    throw new GitGuardrailError(`direct push to the integration branch "${opts.protectedBranch}" is not allowed`)
+  }
+}

--- a/server/pr-publisher.ts
+++ b/server/pr-publisher.ts
@@ -17,6 +17,7 @@
  * Pure over an injectable `Exec` so it is unit-tested without git/gh or a network.
  */
 import { execFile } from 'child_process'
+import { assertGitAllowed } from './git-guardrails'
 
 export interface ExecResult {
   code: number
@@ -75,7 +76,10 @@ export async function publishDraftPr(exec: Exec, input: PublishDraftPrInput): Pr
   const { repoDir, branch, baseBranch } = input
 
   // 1. Push the branch (set upstream). Failure → local-only, never throw.
-  const push = await exec.run('git', ['push', '-u', remote, branch], repoDir)
+  //    Guardrail: never force-push, never push the integration branch itself.
+  const pushArgs = ['push', '-u', remote, branch]
+  assertGitAllowed('git', pushArgs, { protectedBranch: baseBranch })
+  const push = await exec.run('git', pushArgs, repoDir)
   if (push.code !== 0) {
     return { state: 'local-only', branch, reason: reasonFrom(push) }
   }


### PR DESCRIPTION
## What & why

Task **2.4** at a clean, testable level: the app's sanctioned push/PR path can **never force-push** and **never push directly to a project's integration branch**. Part of `safe-pr-workflow`.

## Changes

- **`server/git-guardrails.ts` `assertGitAllowed(cmd, args, {protectedBranch})`**: refuses force-push (`--force` / `-f` / `--force-with-lease[=…]`) and a push whose target ref is the protected branch (implicit, `HEAD:<b>`, `<src>:<b>`, `refs/heads/<b>`).
- Wired into **`pr-publisher.publishDraftPr`** before the push (`protectedBranch` = the integration base). Work always lands on a ticket/batch branch and reaches the integration branch only through a human-merged PR.

## Scope

Defense-in-depth on the **app's own** git. Blocking git issued by the AI agent *inside* a loop turn (a rogue `git push --force`) needs a per-worktree pre-push hook — a documented follow-up.

## Tests

Full suite **4835 pass**; server coverage **85.5/76.8/88.4/87.6** (above the gate). `assertGitAllowed`, `isForcePush`, `pushesToBranch` fully unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R982uLJYJxAepBa3EQzvw9