### PR TITLE
feat: inject SPECRAILS_GIT_AUTO=false into rail spawns under the safe-PR flag (4.3)

### DIFF
--- a/openspec/changes/safe-pr-workflow/tasks.md
+++ b/openspec/changes/safe-pr-workflow/tasks.md
@@ -20,9 +20,9 @@
 ## 4. Cross-repo git-agnostic contract (`core-git-agnostic-contract`)
 - [ ] 4.1 **specrails-core**: parse `--no-ship` (and read `SPECRAILS_GIT_AUTO`) in `implement.md` Phase 0; short-circuit Phase 4c/4d like `GIT_AUTO=false`.
 - [ ] 4.2 **specrails-core**: reconcile `backend-developer.md`/`frontend-developer.md` self-commit behavior under git-agnostic mode; document the signal in the desktop↔core integration contract.
-- [ ] 4.3 **desktop**: pass the git-agnostic signal on every rail invocation (all 3 providers, both `all`-scoped and per-ticket paths).
-- [ ] 4.4 **desktop**: run `{{cmd:implement}}` per-ticket isolated (change from `ticketScope:'all'`); verify dependency ordering.
-- [ ] 4.5 Interim stopgap: write `git_auto:false` for all projects + ensure present inside the worktree (until 4.1 ships).
+- [x] 4.3 **desktop**: injects `SPECRAILS_GIT_AUTO=false` into every rail spawn when `SPECRAILS_RAIL_DELIVER_PR` is on — both the loop-engine path (`loop-executors.ts`) and the legacy QueueManager path (`queue-manager.ts`, covers implement/batch/ultracode). The signal travels with the invocation (survives into a worktree), superseding the fragile backlog-config stopgap. Gated OFF ⇒ no change.
+- [ ] 4.4 **desktop**: run `{{cmd:implement}}` per-ticket isolated (change from `ticketScope:'all'`); verify dependency ordering. (Deferred — orthogonal to the git-agnostic signal.)
+- [x] 4.5 Superseded by 4.3: a travelling env signal (`SPECRAILS_GIT_AUTO=false`) is more robust than writing `git_auto:false` into a gitignored backlog-config that is absent in a fresh worktree.
 
 ## 5. Combined batch PR (`combined-batch-pr`)
 - [x] 5.1 `server/rail-pr-delivery.ts` `deliverRailAsPr` assembles N ticket branches onto `sr/<slug>/batch-<railKey>` off the designated integration branch (transient worktree, `git merge --no-ff`), kept clean.

--- a/server/loop-executors.test.ts
+++ b/server/loop-executors.test.ts
@@ -7,7 +7,7 @@
 //
 // All real spawn machinery is mocked; we assert only the `buildOpts.extraArgs`
 // (and `action`) handed to `runAiCliInvocation`.
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 const { runAiCliInvocation, getAdapter, ensureFrameworkAgents } = vi.hoisted(() => ({
   runAiCliInvocation: vi.fn(),
@@ -50,6 +50,7 @@ async function callStep(
   return runAiCliInvocation.mock.calls[0][0] as {
     action: string
     buildOpts: { extraArgs?: string[] }
+    env: Record<string, string | undefined>
   }
 }
 
@@ -108,5 +109,25 @@ describe('loop-executors runAiStep — relocated-repo sandbox grant', () => {
     expect(
       (await callStep('codex', { repoDir: '/repo', cwd: '/ws', sessionId: 's' })).action
     ).toBe('chat-resume')
+  })
+
+  describe('git-agnostic signal (SPECRAILS_GIT_AUTO)', () => {
+    const ORIG = process.env.SPECRAILS_RAIL_DELIVER_PR
+    afterEach(() => {
+      if (ORIG === undefined) delete process.env.SPECRAILS_RAIL_DELIVER_PR
+      else process.env.SPECRAILS_RAIL_DELIVER_PR = ORIG
+    })
+
+    it('injects SPECRAILS_GIT_AUTO=false when the delivery flag is ON', async () => {
+      process.env.SPECRAILS_RAIL_DELIVER_PR = '1'
+      const inv = await callStep('claude', { repoDir: '/repo', cwd: '/ws' })
+      expect(inv.env.SPECRAILS_GIT_AUTO).toBe('false')
+    })
+
+    it('does NOT inject the signal when the flag is OFF (default)', async () => {
+      delete process.env.SPECRAILS_RAIL_DELIVER_PR
+      const inv = await callStep('claude', { repoDir: '/repo', cwd: '/ws' })
+      expect(inv.env.SPECRAILS_GIT_AUTO).toBeUndefined()
+    })
   })
 })

--- a/server/loop-executors.ts
+++ b/server/loop-executors.ts
@@ -13,6 +13,7 @@ import { ensureFrameworkAgents } from './workspace-manager'
 import { runAiCliInvocation } from './spawn-lifecycle'
 import { finaliseInvocationResult } from './result-event'
 import { parseDeciderDecision } from './loop-decider'
+import { isRailPrDeliveryEnabled } from './rail-isolation'
 import type { LoopExecutors, ShellResult } from './loop-run-manager'
 
 // Per-step wall-clock caps so a single hung step can't block the engine's
@@ -87,7 +88,13 @@ export function createLoopExecutors(opts: { env?: NodeJS.ProcessEnv } = {}): Loo
       // live, so native `/specrails:*` slash commands resolve). Surface the repo
       // for the pipeline's I/O exactly like QueueManager: SPECRAILS_REPO_DIR +
       // claude `--add-dir <repoDir>`. Best-effort agent self-heal on Windows.
-      const stepEnv = repoDir ? { ...env, SPECRAILS_REPO_DIR: repoDir } : env
+      // When the safe-PR flow is active (SPECRAILS_RAIL_DELIVER_PR on), desktop
+      // owns version control — tell specrails-core's implement to be git-agnostic
+      // (skip its Ship phase) so it never opens an uncoordinated PR alongside the
+      // app's own draft-PR delivery. Default off ⇒ no change. See rail-isolation +
+      // the specrails-core `SPECRAILS_GIT_AUTO` contract.
+      const base = repoDir ? { ...env, SPECRAILS_REPO_DIR: repoDir } : env
+      const stepEnv = isRailPrDeliveryEnabled() ? { ...base, SPECRAILS_GIT_AUTO: 'false' } : base
       // Relocated cwd is the workspace; the source repo is reached via the
       // `./project` symlink + SPECRAILS_REPO_DIR. Each provider must be told the
       // repo is an allowed working dir or it can READ but not WRITE source files:

--- a/server/queue-manager.ts
+++ b/server/queue-manager.ts
@@ -7,6 +7,7 @@ import { treeKillSafe } from './util/win-spawn'
 import type { WsMessage, LogMessage, Job, PhaseDefinition, JobPriority } from './types'
 import { PRIORITY_WEIGHT, VALID_PRIORITIES } from './types'
 import { resolveCommand } from './command-resolver'
+import { isRailPrDeliveryEnabled } from './rail-isolation'
 import { spawnAiCli } from './util/cli-prompt'
 import { extractDisplayText } from './util/stream-display'
 import { resetPhases, setActivePhases } from './hooks'
@@ -1798,6 +1799,14 @@ export class QueueManager {
           spawnEnv = { ...spawnEnv, PATH: prependShimToPath(spawnEnv.PATH, shimDir) }
         }
       }
+    }
+
+    // Safe-PR flow: when active (SPECRAILS_RAIL_DELIVER_PR on), desktop owns version
+    // control — tell specrails-core's implement to be git-agnostic (skip its Ship
+    // phase) via SPECRAILS_GIT_AUTO=false so it never opens an uncoordinated PR
+    // alongside the app's own draft-PR delivery. Default off ⇒ no change.
+    if (isRailPrDeliveryEnabled()) {
+      spawnEnv = { ...spawnEnv, SPECRAILS_GIT_AUTO: 'false' }
     }
 
     // ─── Interactive ultracode branch ──────────────────────────────────────


### PR DESCRIPTION
## What & why

Desktop side of the **core git-agnostic contract**: when the safe-PR flow is active (`SPECRAILS_RAIL_DELIVER_PR` on), desktop owns version control and tells specrails-core's `implement` to skip its Ship phase — so it never opens an **uncoordinated PR** alongside the app's own draft-PR delivery.

## Changes

- `loop-executors.ts`: adds `SPECRAILS_GIT_AUTO=false` to the ai-step spawn env (loop-engine path).
- `queue-manager.ts`: same for the legacy rail path (implement / batch / ultracode).
- The signal **travels with the invocation** (survives into a fresh worktree, where a gitignored `.specrails/backlog-config.json` does not) — superseding the fragile backlog-config stopgap (4.5).
- **Default OFF ⇒ byte-identical** (no env change).

## Dependency

Requires the matching **specrails-core** change (`implement.md` reads `SPECRAILS_GIT_AUTO`) to take effect — ships as its own core-repo PR (4.1/4.2). Inert until then.

## Tests

Full suite passes; server coverage 85.5/76.8/88.4/87.6 (above the gate). The loop-executors test asserts the signal is present iff the flag is on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R982uLJYJxAepBa3EQzvw9