### PR TITLE
chore: bump bundled specrails-core 4.10.0 → 4.11.0 (ships SPECRAILS_GIT_AUTO)

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -24,7 +24,7 @@ env:
   # reproducibility — BUG-CI-02). This MUST equal the version the vendored
   # scripts/assemble-bundled-core.lock.json pins (assemble-bundled-core.mjs fails
   # fast on mismatch). Bump both together via PR. See server/bundled-core.ts.
-  CORE_BUNDLE_VERSION: "4.10.0"
+  CORE_BUNDLE_VERSION: "4.11.0"
   # Bundle @fission-ai/openspec into the app so the LAST network step of
   # project-add (openspec init) runs OFFLINE from the bundle instead of
   # `npx @fission-ai/openspec`. Pinned to match specrails-core's

--- a/scripts/assemble-bundled-core.lock.json
+++ b/scripts/assemble-bundled-core.lock.json
@@ -8,7 +8,7 @@
       "name": "bundled-core-stage",
       "version": "0.0.0",
       "dependencies": {
-        "specrails-core": "4.10.0"
+        "specrails-core": "4.11.0"
       }
     },
     "node_modules/@inquirer/ansi": {
@@ -437,9 +437,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",
@@ -478,9 +478,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -548,9 +548,9 @@
       }
     },
     "node_modules/specrails-core": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/specrails-core/-/specrails-core-4.10.0.tgz",
-      "integrity": "sha512-SfToQM3gz/AOxjeBYqO5guMENaAVsDCwaxxVbwch8kr0AnvmPDZBvvHds4fPoGgvhA+tFPnJjaZIXtHhTsQ9lA==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/specrails-core/-/specrails-core-4.11.0.tgz",
+      "integrity": "sha512-YpR8U8pmQluBR1nfcROXsj0pXrMYdRUcpORSkXsjTmbL7o+JCy2vHxcvn2tY56eEvDR8EhCM6B5Oqzf12e8gew==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",


### PR DESCRIPTION
## Why

The desktop app must **bundle the core release that honours `SPECRAILS_GIT_AUTO`** (specrails-core#320, published as **4.11.0**). Otherwise the app sends the signal (#496) but the bundled core (4.10.0) still self-ships → `implement` rails **double-ship**.

## Changes

- `scripts/assemble-bundled-core.lock.json`: regenerated (vendored npm v3 lock, full closure + integrity) to pin `specrails-core@4.11.0`.
- `.github/workflows/desktop-release.yml`: `CORE_BUNDLE_VERSION` 4.10.0 → 4.11.0 (the consistency assertion the assemble script cross-checks against the lock).

## Verified locally

`node scripts/assemble-bundled-core.mjs 4.11.0` runs `npm ci` against the new lock, stages the package, and the smoke test (`cli.js --help`) passes. The staged `implement.md` reads `SPECRAILS_GIT_AUTO` (✓ #320 is in the bundle).

## ⚠️ Follow-up

A desktop **re-release** is required to ship binaries bundling 4.11.0 — the current release bundles 4.10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R982uLJYJxAepBa3EQzvw9