### PR TITLE
fix(rails): continue explicitly referenced PRs

### DIFF
--- a/client/src/components/agent-chat/AgentPrDecisionCard.tsx
+++ b/client/src/components/agent-chat/AgentPrDecisionCard.tsx
@@ -141,6 +141,8 @@ export function AgentPrDecisionCard({ envelope }: { envelope: AgentPrDecisionEnv
   const { decision, prUrl, prState } = envelope
   const projectName = projects.find((p) => p.id === envelope.projectId)?.name ?? envelope.projectId
   const degradedDraft = decision === 'pr_draft' && !prUrl
+  const existingPrContinuation = decision === 'building' && prState === 'pr-created' && Boolean(envelope.branch)
+  const displayedPrNumber = envelope.prNumber ? `#${envelope.prNumber}` : prUrl ? prNumberFromUrl(prUrl) : null
   const terminal = decision === 'merged' || decision === 'discarded'
 
   // A broadcast moved the envelope on (this surface or the other one answered):
@@ -264,14 +266,51 @@ export function AgentPrDecisionCard({ envelope }: { envelope: AgentPrDecisionEnv
         className="rounded-xl border border-border/60 bg-card/80 px-3.5 py-2.5 text-xs text-foreground/60 shadow-lg backdrop-blur-xl"
       >
         <div className="flex items-center gap-2">
-          <Loader2 className="h-3.5 w-3.5 animate-spin text-accent-primary/70" />
-          <span className="animate-pulse">{t('prCard.title.building')}</span>
+          {existingPrContinuation
+            ? <GitPullRequest className="h-3.5 w-3.5 text-accent-info" />
+            : <Loader2 className="h-3.5 w-3.5 animate-spin text-accent-primary/70" />}
+          <span className={cn(!existingPrContinuation && 'animate-pulse')}>
+            {existingPrContinuation ? t('prCard.title.buildingExistingPr') : t('prCard.title.building')}
+          </span>
         </div>
         {ticketChips && (
           <div className="mt-1.5 flex flex-wrap items-center gap-1.5 pl-[22px]">{ticketChips}</div>
         )}
+        {existingPrContinuation && (
+          <div className="mt-1.5 flex flex-wrap items-center gap-1.5 pl-[22px]">
+            {prUrl ? (
+              <a
+                href={prUrl}
+                target="_blank"
+                rel="noreferrer"
+                onClick={(e) => openPr(e, prUrl)}
+                title={prUrl}
+                data-agent-interactive
+                className="inline-flex items-center gap-1 rounded-full border border-accent-info/40 bg-accent-info/10 px-2 py-0.5 font-mono text-[11px] text-accent-info transition-colors hover:border-accent-info/60 hover:bg-accent-info/15"
+              >
+                <GitPullRequest className="h-3 w-3" />
+                {displayedPrNumber ?? t('prCard.openPr')}
+                <ExternalLink className="h-2.5 w-2.5 opacity-60" />
+              </a>
+            ) : (
+              <span className="inline-flex items-center gap-1 rounded-full border border-accent-info/40 bg-accent-info/10 px-2 py-0.5 font-mono text-[11px] text-accent-info">
+                <GitPullRequest className="h-3 w-3" />
+                {displayedPrNumber ?? t('prCard.existingPr')}
+              </span>
+            )}
+            <span
+              title={t('git.branch')}
+              className="inline-flex min-w-0 max-w-full items-center gap-1 rounded-full border border-border/60 bg-surface/60 px-2 py-0.5 font-mono text-[11px] text-foreground/70"
+            >
+              <GitBranch className="h-3 w-3 shrink-0 text-accent-primary/70" />
+              <span className="truncate">{envelope.branch}</span>
+            </span>
+          </div>
+        )}
         {runChips && <div className="pl-[22px]">{runChips}</div>}
-        <p className="mt-1 pl-[22px] text-[11px] leading-4 text-foreground/40">{t('prCard.buildingHint')}</p>
+        <p className="mt-1 pl-[22px] text-[11px] leading-4 text-foreground/40">
+          {existingPrContinuation ? t('prCard.buildingExistingPrHint') : t('prCard.buildingHint')}
+        </p>
         {logModal}
       </div>
     )
@@ -333,7 +372,7 @@ export function AgentPrDecisionCard({ envelope }: { envelope: AgentPrDecisionEnv
       className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-surface/60 px-2 py-0.5 font-mono text-[11px] text-accent-info transition-colors hover:border-accent-info/50 hover:bg-accent-info/10"
     >
       <GitPullRequest className="h-3 w-3" />
-      {prNumberFromUrl(prUrl) ?? t('prCard.openPr')}
+      {displayedPrNumber ?? t('prCard.openPr')}
       <ExternalLink className="h-2.5 w-2.5 opacity-60" />
     </a>
   )

--- a/client/src/components/agent-chat/AgentRefChip.tsx
+++ b/client/src/components/agent-chat/AgentRefChip.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { Ticket, Briefcase, Repeat } from 'lucide-react'
+import { Ticket, Briefcase, Repeat, GitPullRequest } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '../../lib/utils'
 import type { AgentRefTarget } from '../../lib/agent-refs'
@@ -24,11 +24,19 @@ export function AgentRefChip({ refTarget, onOpen, children }: Props) {
   const label =
     refTarget.kind === 'ticket'
       ? t('refs.openTicket', { id: refTarget.ticketId })
+      : refTarget.kind === 'pull-request'
+        ? t('refs.openPullRequest', { id: refTarget.prNumber })
       : refTarget.kind === 'loop'
         ? t('refs.openLoop', { id: refTarget.loopId })
         : t('refs.openJob', { id: refTarget.jobId.slice(0, 8) })
   const Icon =
-    refTarget.kind === 'ticket' ? Ticket : refTarget.kind === 'loop' ? Repeat : Briefcase
+    refTarget.kind === 'ticket'
+      ? Ticket
+      : refTarget.kind === 'pull-request'
+        ? GitPullRequest
+        : refTarget.kind === 'loop'
+          ? Repeat
+          : Briefcase
   return (
     <button
       type="button"
@@ -46,6 +54,8 @@ export function AgentRefChip({ refTarget, onOpen, children }: Props) {
         'hover:-translate-y-px hover:shadow-sm',
         refTarget.kind === 'ticket'
           ? 'border-accent-primary/35 bg-accent-primary/10 text-accent-primary hover:border-accent-primary/60 hover:bg-accent-primary/15'
+          : refTarget.kind === 'pull-request'
+            ? 'border-accent-success/35 bg-accent-success/10 text-accent-success hover:border-accent-success/60 hover:bg-accent-success/15'
           : refTarget.kind === 'loop'
             ? 'border-accent-highlight/35 bg-accent-highlight/10 text-accent-highlight hover:border-accent-highlight/60 hover:bg-accent-highlight/15'
             : 'border-accent-info/35 bg-accent-info/10 text-accent-info hover:border-accent-info/60 hover:bg-accent-info/15',

--- a/client/src/components/agent-chat/__tests__/agent-pr-decision.test.tsx
+++ b/client/src/components/agent-chat/__tests__/agent-pr-decision.test.tsx
@@ -69,6 +69,7 @@ const env = (over: Partial<AgentPrDecisionEnvelope> = {}): AgentPrDecisionEnvelo
   ticketIds: [4, 7],
   decision: 'on_review',
   prUrl: null,
+  prNumber: null,
   prState: 'none',
   branch: null,
   runIds: [],
@@ -111,7 +112,7 @@ describe('AgentPrDecisionCard states', () => {
   })
 
   it('pr_draft with a PR: Publish + Discard + #number link, no Create PR', () => {
-    render(<AgentPrDecisionCard envelope={env({ decision: 'pr_draft', prUrl: 'https://github.com/o/r/pull/7', prState: 'pr-created', branch: 'sr/acme/batch-x' })} />)
+    render(<AgentPrDecisionCard envelope={env({ decision: 'pr_draft', prUrl: 'https://github.com/o/r/pull/7', prNumber: 7, prState: 'pr-created', branch: 'sr/acme/batch-x' })} />)
     expect(screen.getByText('Draft PR created')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Publish' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Discard' })).toBeInTheDocument()
@@ -170,6 +171,21 @@ describe('AgentPrDecisionCard states', () => {
     render(<AgentPrDecisionCard envelope={env({ decision: 'building' })} />)
     expect(screen.getByText('Implementing in an isolated worktree…')).toBeInTheDocument()
     expect(screen.getByText("You'll be asked to create the PR when it settles.")).toBeInTheDocument()
+    expect(nonChipButtons()).toHaveLength(0)
+  })
+
+  it('building on an existing PR: calls out the PR and head branch immediately', () => {
+    render(<AgentPrDecisionCard envelope={env({
+      decision: 'building',
+      prUrl: 'https://github.com/o/r/pull/2147',
+      prNumber: 2147,
+      prState: 'pr-created',
+      branch: 'feat/SKILLS-19-key-terms-activity',
+    })} />)
+    expect(screen.getByText('Applying changes to an existing PR…')).toBeInTheDocument()
+    expect(screen.getByRole('link')).toHaveTextContent('#2147')
+    expect(screen.getByText('feat/SKILLS-19-key-terms-activity')).toBeInTheDocument()
+    expect(screen.getByText(/push the review changes back to that PR/)).toBeInTheDocument()
     expect(nonChipButtons()).toHaveLength(0)
   })
 })

--- a/client/src/components/agent-chat/__tests__/agent-pr-pinned-dock.test.tsx
+++ b/client/src/components/agent-chat/__tests__/agent-pr-pinned-dock.test.tsx
@@ -74,6 +74,7 @@ const env = (over: Partial<AgentPrDecisionEnvelope> = {}): AgentPrDecisionEnvelo
   ticketIds: [4, 7],
   decision: 'on_review',
   prUrl: null,
+  prNumber: null,
   prState: 'none',
   branch: null,
   runIds: [],

--- a/client/src/components/agent-chat/__tests__/agent-pr-run-chips.test.tsx
+++ b/client/src/components/agent-chat/__tests__/agent-pr-run-chips.test.tsx
@@ -52,6 +52,7 @@ const env = (over: Partial<AgentPrDecisionEnvelope> = {}): AgentPrDecisionEnvelo
   ticketIds: [4, 7],
   decision: 'building',
   prUrl: null,
+  prNumber: null,
   prState: 'none',
   branch: null,
   runIds: ['run-a', 'run-b'],

--- a/client/src/components/agent-chat/__tests__/agent-refs-chips.test.tsx
+++ b/client/src/components/agent-chat/__tests__/agent-refs-chips.test.tsx
@@ -77,6 +77,27 @@ describe('AgentMessage ref chips (settled, pinned project)', () => {
     expect(onOpenRef).toHaveBeenCalledWith({ kind: 'ticket', ticketId: 3 })
   })
 
+  it('renders PR #N as a pull-request chip, not a ticket chip', () => {
+    renderMsg('Review follow-ups from PR #2147')
+    const chip = screen.getByTestId('agent-ref-chip')
+    expect(chip).toHaveAttribute('data-ref-kind', 'pull-request')
+    expect(chip.textContent).toContain('PR #2147')
+    fireEvent.click(chip)
+    expect(onOpenRef).toHaveBeenCalledWith({ kind: 'pull-request', prNumber: 2147 })
+  })
+
+  it('renders GitHub pull URLs as pull-request chips carrying the URL', () => {
+    renderMsg('Opened https://github.com/org/repo/pull/2147')
+    const chip = screen.getByTestId('agent-ref-chip')
+    expect(chip).toHaveAttribute('data-ref-kind', 'pull-request')
+    fireEvent.click(chip)
+    expect(onOpenRef).toHaveBeenCalledWith({
+      kind: 'pull-request',
+      prNumber: 2147,
+      prUrl: 'https://github.com/org/repo/pull/2147',
+    })
+  })
+
   it('renders a context-gated job uuid as a job chip', () => {
     renderMsg(`Job lanzado: ${UUID}`)
     const chip = screen.getByTestId('agent-ref-chip')
@@ -133,6 +154,7 @@ const envelope = (over: Partial<AgentPrDecisionEnvelope> = {}): AgentPrDecisionE
   ticketIds: [4, 7],
   decision: 'on_review',
   prUrl: null,
+  prNumber: null,
   prState: 'none',
   branch: null,
   runIds: [],

--- a/client/src/components/log-ticket-refs.tsx
+++ b/client/src/components/log-ticket-refs.tsx
@@ -19,7 +19,7 @@ import { Fragment, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { agentRefHref, splitAgentRefs, type AgentRefSegment } from '../lib/agent-refs'
 
-/** Empty job-context set ⇒ `splitAgentRefs` can only ever yield ticket refs. */
+/** Empty job-context set ⇒ job/loop-run UUIDs never linkify in log lines. */
 export const NO_JOB_UUIDS: ReadonlySet<string> = new Set()
 
 // ── Quiet inline affordance ───────────────────────────────────────────────────
@@ -83,7 +83,7 @@ export function renderLogLineWithTicketRefs(
         {segment.label}
       </LogTicketRef>
     ) : (
-      <Fragment key={i}>{segment.kind === 'text' ? segment.text : null}</Fragment>
+      <Fragment key={i}>{segment.kind === 'text' ? segment.text : segment.label}</Fragment>
     ),
   )
 }
@@ -119,7 +119,7 @@ function ticketSegmentToNode(segment: AgentRefSegment): MdNode {
       children: [{ type: 'text', value: segment.label }],
     }
   }
-  return { type: 'text', value: segment.kind === 'text' ? segment.text : '' }
+  return { type: 'text', value: segment.kind === 'text' ? segment.text : segment.label }
 }
 
 function walkTicketRefs(node: MdNode): void {

--- a/client/src/hooks/__tests__/useAgentRefActions.test.tsx
+++ b/client/src/hooks/__tests__/useAgentRefActions.test.tsx
@@ -19,7 +19,10 @@ vi.mock('../../context/TicketDetailModalContext', () => ({
   }),
 }))
 
+vi.mock('../../lib/tauri-shell', () => ({ openExternalUrl: vi.fn() }))
+
 import { toast } from 'sonner'
+import { openExternalUrl } from '../../lib/tauri-shell'
 import { useAgentRefActions } from '../useAgentRefActions'
 import type { AgentRefTarget } from '../../lib/agent-refs'
 
@@ -56,6 +59,26 @@ describe('useAgentRefActions', () => {
     render(<Harness projectId="p2" target={{ kind: 'ticket', ticketId: 5 }} />)
     fireEvent.click(screen.getByText('go'))
     await waitFor(() => expect(toast.info).toHaveBeenCalled())
+    expect(openTicketDetailInProject).not.toHaveBeenCalled()
+  })
+
+  it('pull request ref with URL opens externally and does not query specs', async () => {
+    const fetchMock = vi.fn(async () => res(200))
+    vi.stubGlobal('fetch', fetchMock)
+    render(<Harness projectId="p2" target={{ kind: 'pull-request', prNumber: 2147, prUrl: 'https://github.com/org/repo/pull/2147' }} />)
+    fireEvent.click(screen.getByText('go'))
+    await waitFor(() => expect(openExternalUrl).toHaveBeenCalledWith('https://github.com/org/repo/pull/2147'))
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(openTicketDetailInProject).not.toHaveBeenCalled()
+  })
+
+  it('bare pull request ref shows a missing-url toast and does not open a spec', async () => {
+    const fetchMock = vi.fn(async () => res(200))
+    vi.stubGlobal('fetch', fetchMock)
+    render(<Harness projectId="p2" target={{ kind: 'pull-request', prNumber: 2147 }} />)
+    fireEvent.click(screen.getByText('go'))
+    await waitFor(() => expect(toast.info).toHaveBeenCalled())
+    expect(fetchMock).not.toHaveBeenCalled()
     expect(openTicketDetailInProject).not.toHaveBeenCalled()
   })
 

--- a/client/src/hooks/__tests__/useAgentRefActions.test.tsx
+++ b/client/src/hooks/__tests__/useAgentRefActions.test.tsx
@@ -39,7 +39,12 @@ function Harness({ projectId, target }: { projectId: string; target: AgentRefTar
   )
 }
 
-const res = (status: number) => ({ ok: status < 300, status, json: async () => ({}), text: async () => '{}' })
+const res = (status: number, body: Record<string, unknown> = {}) => ({
+  ok: status < 300,
+  status,
+  json: async () => body,
+  text: async () => JSON.stringify(body),
+})
 
 beforeEach(() => vi.clearAllMocks())
 afterEach(() => vi.unstubAllGlobals())
@@ -72,13 +77,23 @@ describe('useAgentRefActions', () => {
     expect(openTicketDetailInProject).not.toHaveBeenCalled()
   })
 
-  it('bare pull request ref shows a missing-url toast and does not open a spec', async () => {
-    const fetchMock = vi.fn(async () => res(200))
+  it('bare pull request ref resolves the PR URL from the owning project before opening', async () => {
+    const fetchMock = vi.fn(async () => res(200, { url: 'https://github.com/org/repo/pull/2147' }))
+    vi.stubGlobal('fetch', fetchMock)
+    render(<Harness projectId="p2" target={{ kind: 'pull-request', prNumber: 2147 }} />)
+    fireEvent.click(screen.getByText('go'))
+    await waitFor(() => expect(openExternalUrl).toHaveBeenCalledWith('https://github.com/org/repo/pull/2147'))
+    expect(fetchMock).toHaveBeenCalledWith('/api/projects/p2/git/pull-requests/2147')
+    expect(openTicketDetailInProject).not.toHaveBeenCalled()
+  })
+
+  it('bare pull request ref not found shows a PR not-found toast and does not open a spec', async () => {
+    const fetchMock = vi.fn(async () => res(404))
     vi.stubGlobal('fetch', fetchMock)
     render(<Harness projectId="p2" target={{ kind: 'pull-request', prNumber: 2147 }} />)
     fireEvent.click(screen.getByText('go'))
     await waitFor(() => expect(toast.info).toHaveBeenCalled())
-    expect(fetchMock).not.toHaveBeenCalled()
+    expect(openExternalUrl).not.toHaveBeenCalled()
     expect(openTicketDetailInProject).not.toHaveBeenCalled()
   })
 

--- a/client/src/hooks/useAgentRefActions.ts
+++ b/client/src/hooks/useAgentRefActions.ts
@@ -41,6 +41,13 @@ async function fetchLoopRef(loopId: string): Promise<AgentLoopRef | null> {
   return loop ? { id: loop.id, name: loop.name, description: loop.description, status: loop.status, graph: loop.graph, locked: false } : null
 }
 
+async function fetchPullRequestUrl(projectId: string, prNumber: number): Promise<string | null> {
+  const res = await fetch(`${API_ORIGIN}/api/projects/${projectId}/git/pull-requests/${prNumber}`)
+  if (!res.ok) return null
+  const body = (await res.json()) as { url?: unknown }
+  return typeof body.url === 'string' && body.url ? body.url : null
+}
+
 /**
  * Click layer for agent-chat reference chips. Lazy verification on click
  * (linkify is pattern-only — no per-message fetches): the ref is fetched from
@@ -50,9 +57,8 @@ async function fetchLoopRef(loopId: string): Promise<AgentLoopRef | null> {
  *
  * - Tickets → `openTicketDetailInProject` (board TicketDetailModal; switches
  *   the active project first when the pin differs — see the provider).
- * - Pull requests → open their captured URL externally. A bare `PR #N` chip
- *   without a URL is intentionally still a PR chip, but reports that no URL is
- *   available instead of falling through to a spec lookup.
+ * - Pull requests → open their captured URL externally, or resolve a bare
+ *   `PR #N` against the owning project's GitHub repo before opening it.
  * - Jobs/loop-runs (loop-run ids ARE job row ids) → `jobRef` state; the caller
  *   mounts the mission-mode `JobDetailModal` with the explicit `projectId`.
  *   A uuid that is NOT a job row falls back to the app-global loops API — a
@@ -81,11 +87,12 @@ export function useAgentRefActions() {
           }
           openTicketDetailInProject(projectId, ref.ticketId)
         } else if (ref.kind === 'pull-request') {
-          if (!ref.prUrl) {
-            toast.info(t('refs.pullRequestUrlMissing', { id: ref.prNumber }))
+          const prUrl = ref.prUrl ?? await fetchPullRequestUrl(projectId, ref.prNumber)
+          if (!prUrl) {
+            toast.info(t('refs.pullRequestNotFound', { id: ref.prNumber }))
             return
           }
-          await openExternalUrl(ref.prUrl)
+          await openExternalUrl(prUrl)
         } else if (ref.kind === 'loop') {
           const loop = await fetchLoopRef(ref.loopId)
           if (!loop) {

--- a/client/src/hooks/useAgentRefActions.ts
+++ b/client/src/hooks/useAgentRefActions.ts
@@ -5,6 +5,7 @@ import { API_ORIGIN } from '../lib/origin'
 import { useTicketDetailModal } from '../context/TicketDetailModalContext'
 import type { AgentRefTarget } from '../lib/agent-refs'
 import type { LoopGraph } from '../lib/loops-api'
+import { openExternalUrl } from '../lib/tauri-shell'
 
 export interface AgentJobRef {
   projectId: string
@@ -49,6 +50,9 @@ async function fetchLoopRef(loopId: string): Promise<AgentLoopRef | null> {
  *
  * - Tickets → `openTicketDetailInProject` (board TicketDetailModal; switches
  *   the active project first when the pin differs — see the provider).
+ * - Pull requests → open their captured URL externally. A bare `PR #N` chip
+ *   without a URL is intentionally still a PR chip, but reports that no URL is
+ *   available instead of falling through to a spec lookup.
  * - Jobs/loop-runs (loop-run ids ARE job row ids) → `jobRef` state; the caller
  *   mounts the mission-mode `JobDetailModal` with the explicit `projectId`.
  *   A uuid that is NOT a job row falls back to the app-global loops API — a
@@ -76,6 +80,12 @@ export function useAgentRefActions() {
             return
           }
           openTicketDetailInProject(projectId, ref.ticketId)
+        } else if (ref.kind === 'pull-request') {
+          if (!ref.prUrl) {
+            toast.info(t('refs.pullRequestUrlMissing', { id: ref.prNumber }))
+            return
+          }
+          await openExternalUrl(ref.prUrl)
         } else if (ref.kind === 'loop') {
           const loop = await fetchLoopRef(ref.loopId)
           if (!loop) {

--- a/client/src/lib/__tests__/agent-refs.test.ts
+++ b/client/src/lib/__tests__/agent-refs.test.ts
@@ -25,6 +25,18 @@ describe('agentRefHref / parseAgentRefHref codec', () => {
     expect(parseAgentRefHref(href)).toEqual({ kind: 'ticket', ticketId: 42 })
   })
 
+  it('round-trips a pull request ref with and without URL', () => {
+    expect(parseAgentRefHref(agentRefHref({ kind: 'pull-request', prNumber: 2147 }))).toEqual({
+      kind: 'pull-request',
+      prNumber: 2147,
+    })
+    expect(parseAgentRefHref(agentRefHref({ kind: 'pull-request', prNumber: 2147, prUrl: 'https://github.com/org/repo/pull/2147' }))).toEqual({
+      kind: 'pull-request',
+      prNumber: 2147,
+      prUrl: 'https://github.com/org/repo/pull/2147',
+    })
+  })
+
   it('round-trips a job ref', () => {
     const href = agentRefHref({ kind: 'job', jobId: UUID })
     expect(parseAgentRefHref(href)).toEqual({ kind: 'job', jobId: UUID })
@@ -37,6 +49,8 @@ describe('agentRefHref / parseAgentRefHref codec', () => {
     expect(parseAgentRefHref(null)).toBeNull()
     expect(parseAgentRefHref('#agentref:ticket:abc')).toBeNull()
     expect(parseAgentRefHref('#agentref:ticket:0')).toBeNull()
+    expect(parseAgentRefHref('#agentref:pr:abc')).toBeNull()
+    expect(parseAgentRefHref('#agentref:pr:0')).toBeNull()
     expect(parseAgentRefHref('#agentref:job:not-a-uuid')).toBeNull()
     expect(parseAgentRefHref('#agentref:other:1')).toBeNull()
   })
@@ -127,6 +141,38 @@ describe('splitAgentRefs — ticket pattern matrix', () => {
   })
 })
 
+describe('splitAgentRefs — pull request refs', () => {
+  it('treats PR #N as a pull-request chip, not a ticket chip', () => {
+    expect(refs(splitAgentRefs('review follow-ups from PR #2147', noCtx))).toEqual([
+      { kind: 'pull-request', prNumber: 2147, label: 'PR #2147' },
+    ])
+  })
+
+  it('treats pull request #N as a pull-request chip', () => {
+    expect(refs(splitAgentRefs('see pull request #2147 before changing code', noCtx))).toEqual([
+      { kind: 'pull-request', prNumber: 2147, label: 'PR #2147' },
+    ])
+  })
+
+  it('keeps a ticket ref and PR ref distinct in the same sentence', () => {
+    expect(refs(splitAgentRefs('ticket #98 follows up PR #2147', noCtx))).toEqual([
+      { kind: 'ticket', ticketId: 98, label: '#98' },
+      { kind: 'pull-request', prNumber: 2147, label: 'PR #2147' },
+    ])
+  })
+
+  it('captures GitHub pull request URLs as pull-request refs with URL metadata', () => {
+    expect(refs(splitAgentRefs('opened https://github.com/org/repo/pull/2147.', noCtx))).toEqual([
+      {
+        kind: 'pull-request',
+        prNumber: 2147,
+        prUrl: 'https://github.com/org/repo/pull/2147',
+        label: 'PR #2147',
+      },
+    ])
+  })
+})
+
 describe('splitAgentRefs — job uuid gating', () => {
   it('linkifies a uuid only when it is in the context set', () => {
     expect(splitAgentRefs(`Job lanzado: ${UUID}`, ctx(UUID))).toEqual([
@@ -183,6 +229,14 @@ describe('remarkAgentRefs plugin', () => {
     expect(children.map((c) => c.type)).toEqual(['text', 'link', 'text'])
     expect(children[1].url).toBe('#agentref:ticket:3')
     expect(children[1].children![0].value).toBe('#3')
+  })
+
+  it('renders PR #N as a pull-request #agentref link instead of a ticket link', () => {
+    const tree = root(para(text('Review follow-ups from PR #2147')))
+    remarkAgentRefs()(tree as never, vfile('Review follow-ups from PR #2147'))
+    const link = tree.children![0].children!.find((c) => c.type === 'link')
+    expect(link?.url).toBe('#agentref:pr:2147')
+    expect(link?.children![0].value).toBe('PR #2147')
   })
 
   it('uses the raw source for job context even when split across siblings', () => {

--- a/client/src/lib/agent-api.ts
+++ b/client/src/lib/agent-api.ts
@@ -190,6 +190,7 @@ export interface AgentPrDecisionEnvelope {
   ticketIds: number[]
   decision: AgentPrDecisionValue
   prUrl: string | null
+  prNumber: number | null
   prState: AgentPrDeliveryState
   branch: string | null
   /** The launch's loop-run ids, in ticket order ([] until allocation lands, and
@@ -222,6 +223,9 @@ export function coercePrDecisionEnvelope(v: unknown): AgentPrDecisionEnvelope | 
       : [],
     decision: o.decision as AgentPrDecisionValue,
     prUrl: typeof o.prUrl === 'string' && o.prUrl ? o.prUrl : null,
+    prNumber: typeof o.prNumber === 'number' && Number.isInteger(o.prNumber) && o.prNumber > 0
+      ? o.prNumber
+      : null,
     prState: typeof o.prState === 'string' && PR_DELIVERY_STATES.includes(o.prState)
       ? (o.prState as AgentPrDeliveryState)
       : 'none',

--- a/client/src/lib/agent-refs.ts
+++ b/client/src/lib/agent-refs.ts
@@ -5,13 +5,15 @@
  * clickable chips that open the same detail modals the board uses:
  *   1. Ticket refs  — `#N` (word-bounded, 1-6 digits), optionally carrying a
  *      title tail (`#3 — Add dark mode`), → the board's TicketDetailModal.
- *   2. Job/loop-run ids — v4-ish UUIDs, but ONLY when the same source line
+ *   2. Pull request refs — `PR #N`, `pull request #N`, or GitHub `/pull/N`
+ *      URLs, → an external PR link when a URL is present.
+ *   3. Job/loop-run ids — v4-ish UUIDs, but ONLY when the same source line
  *      carries a job/run/loop context word (EN + ES) so conversation ids in
  *      debug output never linkify, → the mission-mode JobDetailModal. A uuid
  *      that turns out to be a LOOP DEFINITION id (not a job row) is resolved
  *      at click time (the click layer falls back to the loops API) and opens
  *      the read-only LoopPreviewModal instead — detection stays pattern-only.
- *   3. Factory loop ids — the literal `factory:implement|batch|ultracode`
+ *   4. Factory loop ids — the literal `factory:implement|batch|ultracode`
  *      tokens, → the same LoopPreviewModal (built-in, locked).
  *
  * Implemented as a remark plugin (`remarkAgentRefs`) so code blocks and inline
@@ -24,12 +26,14 @@
 
 export type AgentRefTarget =
   | { kind: 'ticket'; ticketId: number }
+  | { kind: 'pull-request'; prNumber: number; prUrl?: string }
   | { kind: 'job'; jobId: string }
   | { kind: 'loop'; loopId: string }
 
 export type AgentRefSegment =
   | { kind: 'text'; text: string }
   | { kind: 'ticket'; ticketId: number; label: string }
+  | { kind: 'pull-request'; prNumber: number; prUrl?: string; label: string }
   | { kind: 'job'; jobId: string; label: string }
   | { kind: 'loop'; loopId: string; label: string }
 
@@ -39,6 +43,9 @@ const HREF_PREFIX = '#agentref:'
 
 export function agentRefHref(ref: AgentRefTarget): string {
   if (ref.kind === 'ticket') return `${HREF_PREFIX}ticket:${ref.ticketId}`
+  if (ref.kind === 'pull-request') {
+    return `${HREF_PREFIX}pr:${ref.prNumber}${ref.prUrl ? `:${encodeURIComponent(ref.prUrl)}` : ''}`
+  }
   if (ref.kind === 'loop') return `${HREF_PREFIX}loop:${ref.loopId}`
   return `${HREF_PREFIX}job:${ref.jobId}`
 }
@@ -49,6 +56,13 @@ export function parseAgentRefHref(href: string | null | undefined): AgentRefTarg
   if (rest.startsWith('ticket:')) {
     const id = Number.parseInt(rest.slice('ticket:'.length), 10)
     return Number.isInteger(id) && id > 0 ? { kind: 'ticket', ticketId: id } : null
+  }
+  if (rest.startsWith('pr:')) {
+    const [, rawNumber, rawUrl] = /^pr:(\d+)(?::(.+))?$/.exec(rest) ?? []
+    const prNumber = Number.parseInt(rawNumber ?? '', 10)
+    if (!Number.isInteger(prNumber) || prNumber <= 0) return null
+    const prUrl = rawUrl ? decodeURIComponent(rawUrl) : undefined
+    return prUrl ? { kind: 'pull-request', prNumber, prUrl } : { kind: 'pull-request', prNumber }
   }
   if (rest.startsWith('job:')) {
     const jobId = rest.slice('job:'.length)
@@ -103,6 +117,46 @@ interface RawMatch {
 const BAD_BEFORE_RE = /[\w#&$-]/
 /** Chars that must NOT immediately follow a ref (mid-token). */
 const BAD_AFTER_RE = /[\w-]/
+
+function scanPullRequests(text: string, out: RawMatch[]): void {
+  const phraseRe = /\b(?:PR|pull request)\s*#?(\d{1,10})\b/gi
+  let phrase: RegExpExecArray | null
+  while ((phrase = phraseRe.exec(text)) !== null) {
+    const before = text[phrase.index - 1]
+    const after = text[phrase.index + phrase[0].length]
+    if (before !== undefined && BAD_BEFORE_RE.test(before)) continue
+    if (after !== undefined && BAD_AFTER_RE.test(after)) continue
+    const prNumber = Number.parseInt(phrase[1], 10)
+    if (!Number.isInteger(prNumber) || prNumber <= 0) continue
+    out.push({
+      start: phrase.index,
+      end: phrase.index + phrase[0].length,
+      segment: { kind: 'pull-request', prNumber, label: `PR #${prNumber}` },
+    })
+  }
+
+  const urlRe = /https?:\/\/[^\s<>)]+\/pull\/(\d{1,10})(?:[/?#][^\s<>)]*)?/gi
+  let url: RegExpExecArray | null
+  while ((url = urlRe.exec(text)) !== null) {
+    const prNumber = Number.parseInt(url[1], 10)
+    if (!Number.isInteger(prNumber) || prNumber <= 0) continue
+    const prUrl = url[0].replace(/[.,;:!?…]+$/u, '')
+    out.push({
+      start: url.index,
+      end: url.index + prUrl.length,
+      segment: { kind: 'pull-request', prNumber, prUrl, label: `PR #${prNumber}` },
+    })
+  }
+}
+
+function parsePullRequestUrl(url: string | null | undefined): { prNumber: number; prUrl: string } | null {
+  if (!url) return null
+  const match = /^https?:\/\/[^\s<>)]+\/pull\/(\d{1,10})(?:[/?#][^\s<>)]*)?$/i.exec(url)
+  if (!match) return null
+  const prNumber = Number.parseInt(match[1], 10)
+  if (!Number.isInteger(prNumber) || prNumber <= 0) return null
+  return { prNumber, prUrl: url }
+}
 
 function scanTickets(text: string, out: RawMatch[]): void {
   const re = /#(\d{1,6})/g
@@ -176,6 +230,7 @@ export function splitAgentRefs(
   jobContextUuids: ReadonlySet<string>,
 ): AgentRefSegment[] {
   const matches: RawMatch[] = []
+  scanPullRequests(text, matches)
   scanTickets(text, matches)
   scanJobs(text, jobContextUuids, matches)
   scanFactoryLoops(text, matches)
@@ -225,6 +280,8 @@ function segmentToNode(segment: AgentRefSegment): MdNode {
   const ref: AgentRefTarget =
     segment.kind === 'ticket'
       ? { kind: 'ticket', ticketId: segment.ticketId }
+      : segment.kind === 'pull-request'
+        ? { kind: 'pull-request', prNumber: segment.prNumber, prUrl: segment.prUrl }
       : segment.kind === 'loop'
         ? { kind: 'loop', loopId: segment.loopId }
         : { kind: 'job', jobId: segment.jobId }
@@ -251,6 +308,22 @@ function walk(node: MdNode, jobContextUuids: ReadonlySet<string>): void {
       } else if (FACTORY_LOOP_EXACT_RE.test(value)) {
         // Backticked factory ids (`factory:implement`) are loop refs, not code.
         children.splice(i, 1, segmentToNode({ kind: 'loop', loopId: value, label: value }))
+      }
+      continue
+    }
+    if (child.type === 'link' && typeof child.url === 'string') {
+      const pullRequest = parsePullRequestUrl(child.url)
+      if (pullRequest) {
+        children.splice(
+          i,
+          1,
+          segmentToNode({
+            kind: 'pull-request',
+            prNumber: pullRequest.prNumber,
+            prUrl: pullRequest.prUrl,
+            label: `PR #${pullRequest.prNumber}`,
+          }),
+        )
       }
       continue
     }

--- a/client/src/locales/de/agent.json
+++ b/client/src/locales/de/agent.json
@@ -258,6 +258,7 @@
     "openLoop": "Loop {{id}} öffnen",
     "ticketNotFound": "Spec #{{id}} nicht gefunden — möglicherweise gelöscht",
     "pullRequestUrlMissing": "PR #{{id}} wurde ohne URL erwähnt",
+    "pullRequestNotFound": "PR #{{id}} wurde in diesem Projekt nicht gefunden",
     "jobNotFound": "Job nicht gefunden — möglicherweise gelöscht",
     "loopNotFound": "Loop nicht gefunden — er wurde möglicherweise gelöscht",
     "lookupFailed": "Referenz konnte nicht geprüft werden — bitte erneut versuchen"

--- a/client/src/locales/de/agent.json
+++ b/client/src/locales/de/agent.json
@@ -185,8 +185,10 @@
     "specCount_other": "{{count}} Specs",
     "base": "Basis-Branch",
     "openPr": "PR öffnen",
+    "existingPr": "Bestehender PR",
     "title": {
       "building": "Implementierung in einem isolierten Worktree…",
+      "buildingExistingPr": "Änderungen werden auf einen bestehenden PR angewendet…",
       "on_review": "Implementierung bereit zur Prüfung",
       "pr_draft": "Entwurfs-PR erstellt",
       "pr_draft_degraded": "PR-Auslieferung unvollständig",
@@ -196,6 +198,7 @@
       "discarded": "Verworfen"
     },
     "buildingHint": "Nach Abschluss wirst du gefragt, ob der PR erstellt werden soll.",
+    "buildingExistingPrHint": "Specrails arbeitet auf dem Branch des bestehenden PRs und pusht die Review-Änderungen zurück in denselben PR.",
     "createPr": "PR erstellen",
     "publish": "Veröffentlichen",
     "retry": "Erneut versuchen",
@@ -250,9 +253,11 @@
   },
   "refs": {
     "openTicket": "Spec #{{id}} öffnen",
+    "openPullRequest": "PR #{{id}} öffnen",
     "openJob": "Job {{id}} öffnen",
     "openLoop": "Loop {{id}} öffnen",
     "ticketNotFound": "Spec #{{id}} nicht gefunden — möglicherweise gelöscht",
+    "pullRequestUrlMissing": "PR #{{id}} wurde ohne URL erwähnt",
     "jobNotFound": "Job nicht gefunden — möglicherweise gelöscht",
     "loopNotFound": "Loop nicht gefunden — er wurde möglicherweise gelöscht",
     "lookupFailed": "Referenz konnte nicht geprüft werden — bitte erneut versuchen"

--- a/client/src/locales/en/agent.json
+++ b/client/src/locales/en/agent.json
@@ -185,8 +185,10 @@
     "specCount_other": "{{count}} specs",
     "base": "Base branch",
     "openPr": "Open PR",
+    "existingPr": "Existing PR",
     "title": {
       "building": "Implementing in an isolated worktree…",
+      "buildingExistingPr": "Applying changes to an existing PR…",
       "on_review": "Implementation ready for review",
       "pr_draft": "Draft PR created",
       "pr_draft_degraded": "PR delivery incomplete",
@@ -196,6 +198,7 @@
       "discarded": "Discarded"
     },
     "buildingHint": "You'll be asked to create the PR when it settles.",
+    "buildingExistingPrHint": "Specrails is working on the existing PR branch and will push the review changes back to that PR.",
     "createPr": "Create PR",
     "publish": "Publish",
     "retry": "Retry",
@@ -250,9 +253,11 @@
   },
   "refs": {
     "openTicket": "Open spec #{{id}}",
+    "openPullRequest": "Open PR #{{id}}",
     "openJob": "Open job {{id}}",
     "openLoop": "Open loop {{id}}",
     "ticketNotFound": "Spec #{{id}} not found — it may have been deleted",
+    "pullRequestUrlMissing": "PR #{{id}} was referenced without a URL",
     "jobNotFound": "Job not found — it may have been deleted",
     "loopNotFound": "Loop not found — it may have been deleted",
     "lookupFailed": "Couldn't verify the reference — try again"

--- a/client/src/locales/en/agent.json
+++ b/client/src/locales/en/agent.json
@@ -258,6 +258,7 @@
     "openLoop": "Open loop {{id}}",
     "ticketNotFound": "Spec #{{id}} not found — it may have been deleted",
     "pullRequestUrlMissing": "PR #{{id}} was referenced without a URL",
+    "pullRequestNotFound": "PR #{{id}} could not be found in this project",
     "jobNotFound": "Job not found — it may have been deleted",
     "loopNotFound": "Loop not found — it may have been deleted",
     "lookupFailed": "Couldn't verify the reference — try again"

--- a/client/src/locales/es/agent.json
+++ b/client/src/locales/es/agent.json
@@ -258,6 +258,7 @@
     "openLoop": "Abrir loop {{id}}",
     "ticketNotFound": "Spec #{{id}} no encontrada — puede haber sido eliminada",
     "pullRequestUrlMissing": "La PR #{{id}} se mencionó sin URL",
+    "pullRequestNotFound": "No se pudo encontrar la PR #{{id}} en este proyecto",
     "jobNotFound": "Job no encontrado — puede haber sido eliminado",
     "loopNotFound": "Loop no encontrado — puede haber sido eliminado",
     "lookupFailed": "No se pudo verificar la referencia — inténtalo de nuevo"

--- a/client/src/locales/es/agent.json
+++ b/client/src/locales/es/agent.json
@@ -185,8 +185,10 @@
     "specCount_other": "{{count}} specs",
     "base": "Rama base",
     "openPr": "Abrir PR",
+    "existingPr": "PR existente",
     "title": {
       "building": "Implementando en un worktree aislado…",
+      "buildingExistingPr": "Aplicando cambios sobre una PR existente…",
       "on_review": "Implementación lista para revisar",
       "pr_draft": "PR en borrador creada",
       "pr_draft_degraded": "Entrega de la PR incompleta",
@@ -196,6 +198,7 @@
       "discarded": "Descartada"
     },
     "buildingHint": "Cuando termine, se te preguntará si crear la PR.",
+    "buildingExistingPrHint": "Specrails está trabajando sobre la rama de la PR existente y subirá los cambios de revisión a esa misma PR.",
     "createPr": "Crear PR",
     "publish": "Publicar",
     "retry": "Reintentar",
@@ -250,9 +253,11 @@
   },
   "refs": {
     "openTicket": "Abrir spec #{{id}}",
+    "openPullRequest": "Abrir PR #{{id}}",
     "openJob": "Abrir job {{id}}",
     "openLoop": "Abrir loop {{id}}",
     "ticketNotFound": "Spec #{{id}} no encontrada — puede haber sido eliminada",
+    "pullRequestUrlMissing": "La PR #{{id}} se mencionó sin URL",
     "jobNotFound": "Job no encontrado — puede haber sido eliminado",
     "loopNotFound": "Loop no encontrado — puede haber sido eliminado",
     "lookupFailed": "No se pudo verificar la referencia — inténtalo de nuevo"

--- a/client/src/locales/fr/agent.json
+++ b/client/src/locales/fr/agent.json
@@ -185,8 +185,10 @@
     "specCount_other": "{{count}} specs",
     "base": "Branche de base",
     "openPr": "Ouvrir la PR",
+    "existingPr": "PR existante",
     "title": {
       "building": "Implémentation dans un worktree isolé…",
+      "buildingExistingPr": "Application des changements sur une PR existante…",
       "on_review": "Implémentation prête pour la revue",
       "pr_draft": "PR en brouillon créée",
       "pr_draft_degraded": "Livraison de la PR incomplète",
@@ -196,6 +198,7 @@
       "discarded": "Abandonnée"
     },
     "buildingHint": "À la fin, il vous sera proposé de créer la PR.",
+    "buildingExistingPrHint": "Specrails travaille sur la branche de la PR existante et poussera les changements de revue vers cette même PR.",
     "createPr": "Créer la PR",
     "publish": "Publier",
     "retry": "Réessayer",
@@ -250,9 +253,11 @@
   },
   "refs": {
     "openTicket": "Ouvrir la spec #{{id}}",
+    "openPullRequest": "Ouvrir la PR #{{id}}",
     "openJob": "Ouvrir le job {{id}}",
     "openLoop": "Ouvrir la boucle {{id}}",
     "ticketNotFound": "Spec #{{id}} introuvable — elle a peut-être été supprimée",
+    "pullRequestUrlMissing": "La PR #{{id}} est mentionnée sans URL",
     "jobNotFound": "Job introuvable — il a peut-être été supprimé",
     "loopNotFound": "Boucle introuvable — elle a peut-être été supprimée",
     "lookupFailed": "Impossible de vérifier la référence — réessayez"

--- a/client/src/locales/fr/agent.json
+++ b/client/src/locales/fr/agent.json
@@ -258,6 +258,7 @@
     "openLoop": "Ouvrir la boucle {{id}}",
     "ticketNotFound": "Spec #{{id}} introuvable — elle a peut-être été supprimée",
     "pullRequestUrlMissing": "La PR #{{id}} est mentionnée sans URL",
+    "pullRequestNotFound": "PR #{{id}} introuvable dans ce projet",
     "jobNotFound": "Job introuvable — il a peut-être été supprimé",
     "loopNotFound": "Boucle introuvable — elle a peut-être été supprimée",
     "lookupFailed": "Impossible de vérifier la référence — réessayez"

--- a/client/src/locales/it/agent.json
+++ b/client/src/locales/it/agent.json
@@ -258,6 +258,7 @@
     "openLoop": "Apri loop {{id}}",
     "ticketNotFound": "Spec #{{id}} non trovata — potrebbe essere stata eliminata",
     "pullRequestUrlMissing": "La PR #{{id}} è stata citata senza URL",
+    "pullRequestNotFound": "La PR #{{id}} non è stata trovata in questo progetto",
     "jobNotFound": "Job non trovato — potrebbe essere stato eliminato",
     "loopNotFound": "Loop non trovato — potrebbe essere stato eliminato",
     "lookupFailed": "Impossibile verificare il riferimento — riprova"

--- a/client/src/locales/it/agent.json
+++ b/client/src/locales/it/agent.json
@@ -185,8 +185,10 @@
     "specCount_other": "{{count}} spec",
     "base": "Ramo base",
     "openPr": "Apri PR",
+    "existingPr": "PR esistente",
     "title": {
       "building": "Implementazione in un worktree isolato…",
+      "buildingExistingPr": "Applicazione delle modifiche su una PR esistente…",
       "on_review": "Implementazione pronta per la revisione",
       "pr_draft": "PR in bozza creata",
       "pr_draft_degraded": "Consegna della PR incompleta",
@@ -196,6 +198,7 @@
       "discarded": "Scartata"
     },
     "buildingHint": "Al termine ti verrà chiesto se creare la PR.",
+    "buildingExistingPrHint": "Specrails sta lavorando sul branch della PR esistente e invierà le modifiche di review a quella stessa PR.",
     "createPr": "Crea PR",
     "publish": "Pubblica",
     "retry": "Riprova",
@@ -250,9 +253,11 @@
   },
   "refs": {
     "openTicket": "Apri la spec #{{id}}",
+    "openPullRequest": "Apri PR #{{id}}",
     "openJob": "Apri il job {{id}}",
     "openLoop": "Apri loop {{id}}",
     "ticketNotFound": "Spec #{{id}} non trovata — potrebbe essere stata eliminata",
+    "pullRequestUrlMissing": "La PR #{{id}} è stata citata senza URL",
     "jobNotFound": "Job non trovato — potrebbe essere stato eliminato",
     "loopNotFound": "Loop non trovato — potrebbe essere stato eliminato",
     "lookupFailed": "Impossibile verificare il riferimento — riprova"

--- a/client/src/locales/ja/agent.json
+++ b/client/src/locales/ja/agent.json
@@ -258,6 +258,7 @@
     "openLoop": "ループ {{id}} を開く",
     "ticketNotFound": "スペック #{{id}} が見つかりません — 削除された可能性があります",
     "pullRequestUrlMissing": "PR #{{id}} は URL なしで参照されました",
+    "pullRequestNotFound": "このプロジェクトで PR #{{id}} が見つかりません",
     "jobNotFound": "ジョブが見つかりません — 削除された可能性があります",
     "loopNotFound": "ループが見つかりません — 削除された可能性があります",
     "lookupFailed": "参照を確認できませんでした — もう一度お試しください"

--- a/client/src/locales/ja/agent.json
+++ b/client/src/locales/ja/agent.json
@@ -185,8 +185,10 @@
     "specCount_other": "スペック {{count}} 件",
     "base": "ベースブランチ",
     "openPr": "PR を開く",
+    "existingPr": "既存の PR",
     "title": {
       "building": "分離されたワークツリーで実装中…",
+      "buildingExistingPr": "既存の PR に変更を適用中…",
       "on_review": "実装のレビュー準備完了",
       "pr_draft": "ドラフト PR を作成しました",
       "pr_draft_degraded": "PR の公開が未完了",
@@ -196,6 +198,7 @@
       "discarded": "破棄済み"
     },
     "buildingHint": "完了すると PR を作成するか確認します。",
+    "buildingExistingPrHint": "Specrails は既存 PR のブランチで作業しており、レビュー変更を同じ PR に push します。",
     "createPr": "PR を作成",
     "publish": "公開",
     "retry": "再試行",
@@ -250,9 +253,11 @@
   },
   "refs": {
     "openTicket": "スペック #{{id}} を開く",
+    "openPullRequest": "PR #{{id}} を開く",
     "openJob": "ジョブ {{id}} を開く",
     "openLoop": "ループ {{id}} を開く",
     "ticketNotFound": "スペック #{{id}} が見つかりません — 削除された可能性があります",
+    "pullRequestUrlMissing": "PR #{{id}} は URL なしで参照されました",
     "jobNotFound": "ジョブが見つかりません — 削除された可能性があります",
     "loopNotFound": "ループが見つかりません — 削除された可能性があります",
     "lookupFailed": "参照を確認できませんでした — もう一度お試しください"

--- a/client/src/locales/pt/agent.json
+++ b/client/src/locales/pt/agent.json
@@ -185,8 +185,10 @@
     "specCount_other": "{{count}} specs",
     "base": "Ramo base",
     "openPr": "Abrir PR",
+    "existingPr": "PR existente",
     "title": {
       "building": "A implementar num worktree isolado…",
+      "buildingExistingPr": "A aplicar alterações numa PR existente…",
       "on_review": "Implementação pronta para revisão",
       "pr_draft": "PR em rascunho criada",
       "pr_draft_degraded": "Entrega da PR incompleta",
@@ -196,6 +198,7 @@
       "discarded": "Descartada"
     },
     "buildingHint": "Quando terminar, ser-lhe-á perguntado se quer criar a PR.",
+    "buildingExistingPrHint": "O Specrails está a trabalhar no ramo da PR existente e irá enviar as alterações de revisão para essa mesma PR.",
     "createPr": "Criar PR",
     "publish": "Publicar",
     "retry": "Tentar novamente",
@@ -250,9 +253,11 @@
   },
   "refs": {
     "openTicket": "Abrir spec #{{id}}",
+    "openPullRequest": "Abrir PR #{{id}}",
     "openJob": "Abrir job {{id}}",
     "openLoop": "Abrir loop {{id}}",
     "ticketNotFound": "Spec #{{id}} não encontrada — pode ter sido excluída",
+    "pullRequestUrlMissing": "A PR #{{id}} foi mencionada sem URL",
     "jobNotFound": "Job não encontrado — pode ter sido excluído",
     "loopNotFound": "Loop não encontrado — pode ter sido excluído",
     "lookupFailed": "Não foi possível verificar a referência — tente novamente"

--- a/client/src/locales/pt/agent.json
+++ b/client/src/locales/pt/agent.json
@@ -258,6 +258,7 @@
     "openLoop": "Abrir loop {{id}}",
     "ticketNotFound": "Spec #{{id}} não encontrada — pode ter sido excluída",
     "pullRequestUrlMissing": "A PR #{{id}} foi mencionada sem URL",
+    "pullRequestNotFound": "A PR #{{id}} não foi encontrada neste projeto",
     "jobNotFound": "Job não encontrado — pode ter sido excluído",
     "loopNotFound": "Loop não encontrado — pode ter sido excluído",
     "lookupFailed": "Não foi possível verificar a referência — tente novamente"

--- a/client/src/locales/zh/agent.json
+++ b/client/src/locales/zh/agent.json
@@ -185,8 +185,10 @@
     "specCount_other": "{{count}} 个 Spec",
     "base": "基础分支",
     "openPr": "打开 PR",
+    "existingPr": "现有 PR",
     "title": {
       "building": "正在隔离的 worktree 中实现…",
+      "buildingExistingPr": "正在向现有 PR 应用更改…",
       "on_review": "实现已完成，待评审",
       "pr_draft": "已创建草稿 PR",
       "pr_draft_degraded": "PR 交付未完成",
@@ -196,6 +198,7 @@
       "discarded": "已丢弃"
     },
     "buildingHint": "完成后会询问你是否创建 PR。",
+    "buildingExistingPrHint": "Specrails 正在现有 PR 的分支上工作，并会把 review 更改推送回同一个 PR。",
     "createPr": "创建 PR",
     "publish": "发布",
     "retry": "重试",
@@ -250,9 +253,11 @@
   },
   "refs": {
     "openTicket": "打开 Spec #{{id}}",
+    "openPullRequest": "打开 PR #{{id}}",
     "openJob": "打开任务 {{id}}",
     "openLoop": "打开循环 {{id}}",
     "ticketNotFound": "未找到 Spec #{{id}} — 可能已被删除",
+    "pullRequestUrlMissing": "PR #{{id}} 被引用但没有 URL",
     "jobNotFound": "未找到任务 — 可能已被删除",
     "loopNotFound": "未找到循环 — 可能已被删除",
     "lookupFailed": "无法验证该引用 — 请重试"

--- a/client/src/locales/zh/agent.json
+++ b/client/src/locales/zh/agent.json
@@ -258,6 +258,7 @@
     "openLoop": "打开循环 {{id}}",
     "ticketNotFound": "未找到 Spec #{{id}} — 可能已被删除",
     "pullRequestUrlMissing": "PR #{{id}} 被引用但没有 URL",
+    "pullRequestNotFound": "在此项目中找不到 PR #{{id}}",
     "jobNotFound": "未找到任务 — 可能已被删除",
     "loopNotFound": "未找到循环 — 可能已被删除",
     "lookupFailed": "无法验证该引用 — 请重试"

--- a/server/active-pr-continuation.ts
+++ b/server/active-pr-continuation.ts
@@ -44,6 +44,14 @@ interface OpenPr {
   baseRefName?: string
   url?: string
   isDraft?: boolean
+  state?: string
+}
+
+type PrMatchKind = 'pr-number' | 'ticket-ref' | 'title-similarity'
+const PR_MATCH_RANK: Record<PrMatchKind, number> = {
+  'title-similarity': 1,
+  'ticket-ref': 2,
+  'pr-number': 3,
 }
 
 function parsePrNumber(prUrl: string | null | undefined): number | null {
@@ -76,6 +84,18 @@ function ticketRefs(db: DbInstance, ticketId: number, spec: ContinuationTicketSp
   return [...refs]
 }
 
+function mentionedPrNumbers(spec: ContinuationTicketSpec | undefined): Set<number> {
+  const text = `${spec?.title ?? ''}\n${spec?.description ?? ''}`
+  const out = new Set<number>()
+  for (const match of text.matchAll(/\b(?:pr|pull request)\s*#?\s*(\d{1,10})\b/gi)) {
+    out.add(parseInt(match[1], 10))
+  }
+  for (const match of text.matchAll(/\/pull\/(\d{1,10})(?:\b|[/?#])/gi)) {
+    out.add(parseInt(match[1], 10))
+  }
+  return out
+}
+
 function hasJiraRef(db: DbInstance, ticketId: number, spec: ContinuationTicketSpec | undefined): boolean {
   if (spec?.jira_key?.trim()) return true
   try {
@@ -91,14 +111,18 @@ function prMatchKind(
   ticketId: number,
   spec: ContinuationTicketSpec | undefined,
   pr: OpenPr,
-): 'explicit-ref' | 'title-similarity' | null {
+): PrMatchKind | null {
+  const mentionedPrs = mentionedPrNumbers(spec)
+  const prNumber = typeof pr.number === 'number' ? pr.number : parsePrNumber(pr.url)
+  if (prNumber !== null && mentionedPrs.has(prNumber)) return 'pr-number'
+
   const haystack = `${pr.title ?? ''}\n${pr.body ?? ''}\n${pr.headRefName ?? ''}`.toLowerCase()
   for (const ref of ticketRefs(db, ticketId, spec)) {
     const needle = ref.toLowerCase()
     if (needle.startsWith('#') || needle.startsWith('[')) {
-      if (haystack.includes(needle)) return 'explicit-ref'
+      if (haystack.includes(needle)) return 'ticket-ref'
     } else if (new RegExp(`(^|[^a-z0-9])${needle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}([^a-z0-9]|$)`, 'i').test(haystack)) {
-      return 'explicit-ref'
+      return 'ticket-ref'
     }
   }
 
@@ -123,10 +147,10 @@ function canProbeGithubForContinuation(
 
 function matchAllowedForTicket(
   spec: ContinuationTicketSpec | undefined,
-  kind: 'explicit-ref' | 'title-similarity',
+  kind: PrMatchKind,
 ): boolean {
   if (spec?.status === 'on_review') return true
-  return kind === 'explicit-ref'
+  return kind !== 'title-similarity'
 }
 
 async function localBranchExists(git: GitRunner, repoDir: string, branch: string): Promise<boolean> {
@@ -187,8 +211,10 @@ function internalDeliveryTargets(db: DbInstance, ticketIds: number[]): Map<numbe
   return out
 }
 
+const PR_JSON_FIELDS = 'number,title,body,headRefName,baseRefName,url,isDraft,state'
+
 async function listOpenPrs(exec: Exec, repoDir: string): Promise<OpenPr[]> {
-  const r = await exec.run('gh', ['pr', 'list', '--state', 'open', '--json', 'number,title,body,headRefName,baseRefName,url,isDraft'], repoDir)
+  const r = await exec.run('gh', ['pr', 'list', '--state', 'open', '--limit', '200', '--json', PR_JSON_FIELDS], repoDir)
   if (r.code !== 0) return []
   try {
     const parsed = JSON.parse(r.stdout) as unknown
@@ -196,6 +222,40 @@ async function listOpenPrs(exec: Exec, repoDir: string): Promise<OpenPr[]> {
   } catch {
     return []
   }
+}
+
+async function viewOpenPr(exec: Exec, repoDir: string, prNumber: number): Promise<OpenPr | null> {
+  const r = await exec.run('gh', ['pr', 'view', String(prNumber), '--json', PR_JSON_FIELDS], repoDir)
+  if (r.code !== 0) return null
+  try {
+    const parsed = JSON.parse(r.stdout) as OpenPr
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null
+    if (typeof parsed.state === 'string' && parsed.state.toUpperCase() !== 'OPEN') return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+async function mentionedOpenPrs(exec: Exec, repoDir: string, prNumbers: Set<number>): Promise<OpenPr[]> {
+  const out: OpenPr[] = []
+  for (const prNumber of prNumbers) {
+    const pr = await viewOpenPr(exec, repoDir, prNumber)
+    if (pr) out.push(pr)
+  }
+  return out
+}
+
+function mergeOpenPrs(prs: OpenPr[]): OpenPr[] {
+  const out: OpenPr[] = []
+  const seen = new Set<string>()
+  for (const pr of prs) {
+    const key = typeof pr.number === 'number' ? `n:${pr.number}` : pr.url ? `u:${pr.url}` : null
+    if (key && seen.has(key)) continue
+    if (key) seen.add(key)
+    out.push(pr)
+  }
+  return out
 }
 
 /**
@@ -229,15 +289,25 @@ export async function resolveActivePrContinuationTargets(
   const candidateIds = remaining.filter((id) => canProbeGithubForContinuation(input.db, id, input.getTicketSpec(id)))
   if (candidateIds.length === 0) return out
 
-  const openPrs = await listOpenPrs(input.exec, input.repoDir)
+  const mentionedPrs = new Set<number>()
+  for (const ticketId of candidateIds) {
+    for (const prNumber of mentionedPrNumbers(input.getTicketSpec(ticketId))) mentionedPrs.add(prNumber)
+  }
+  const openPrs = mergeOpenPrs([
+    ...await listOpenPrs(input.exec, input.repoDir),
+    ...await mentionedOpenPrs(input.exec, input.repoDir, mentionedPrs),
+  ])
   for (const ticketId of candidateIds) {
     const spec = input.getTicketSpec(ticketId)
-    const matches = openPrs.filter((pr) => {
+    const matches = openPrs.flatMap((pr) => {
       const kind = prMatchKind(input.db, ticketId, spec, pr)
-      return kind ? matchAllowedForTicket(spec, kind) : false
+      return kind && matchAllowedForTicket(spec, kind) ? [{ pr, kind }] : []
     })
-    if (matches.length !== 1) continue
-    const pr = matches[0]
+    if (matches.length === 0) continue
+    const bestRank = Math.max(...matches.map((m) => PR_MATCH_RANK[m.kind]))
+    const best = matches.filter((m) => PR_MATCH_RANK[m.kind] === bestRank)
+    if (best.length !== 1) continue
+    const pr = best[0].pr
     const materialized = await materializeTarget(
       input.git,
       input.repoDir,

--- a/server/active-pr-continuation.ts
+++ b/server/active-pr-continuation.ts
@@ -17,7 +17,7 @@ export interface ActivePrContinuationTarget {
   ticketId: number
   branch: string
   baseBranch: string
-  /** Present when the local branch does not exist but origin/<branch> does. */
+  /** Present when origin/<branch> exists; used to create or safely refresh the PR branch. */
   baseRef?: string
   prUrl: string | null
   prNumber: number | null
@@ -180,12 +180,11 @@ async function materializeTarget(
   if (!head || !base || head === base) return null
   if (!isValidBranchName(head) || !isValidBranchName(base)) return null
 
+  const remoteRef = fetchOk && await remoteBranchExists(git, repoDir, head) ? `origin/${head}` : undefined
   if (await localBranchExists(git, repoDir, head)) {
-    return { ticketId, branch: head, baseBranch: base, prUrl, prNumber, isDraft, source }
+    return { ticketId, branch: head, baseBranch: base, baseRef: remoteRef, prUrl, prNumber, isDraft, source }
   }
-  if (fetchOk && await remoteBranchExists(git, repoDir, head)) {
-    return { ticketId, branch: head, baseBranch: base, baseRef: `origin/${head}`, prUrl, prNumber, isDraft, source }
-  }
+  if (remoteRef) return { ticketId, branch: head, baseBranch: base, baseRef: remoteRef, prUrl, prNumber, isDraft, source }
   return null
 }
 

--- a/server/agent-chat-pr-card.test.ts
+++ b/server/agent-chat-pr-card.test.ts
@@ -35,6 +35,7 @@ function envelope(overrides: Partial<PrDecisionCardEnvelope> = {}): PrDecisionCa
     ticketIds: [1, 2],
     decision: 'on_review',
     prUrl: null,
+    prNumber: null,
     prState: 'none',
     branch: null,
     ...overrides,

--- a/server/jira/jira-adf.test.ts
+++ b/server/jira/jira-adf.test.ts
@@ -33,16 +33,18 @@ describe('textToAdf', () => {
     ])
   })
 
-  it('produces one paragraph per newline-delimited line for multi-line text', () => {
+  it('preserves single newlines inside a paragraph as hardBreaks', () => {
     const doc = textToAdf('line1\nline2\nline3') as any
-    expect(doc.content).toHaveLength(3)
+    expect(doc.content).toHaveLength(1)
     expect(doc.content[0]).toEqual({
       type: 'paragraph',
-      content: [{ type: 'text', text: 'line1' }],
-    })
-    expect(doc.content[2]).toEqual({
-      type: 'paragraph',
-      content: [{ type: 'text', text: 'line3' }],
+      content: [
+        { type: 'text', text: 'line1' },
+        { type: 'hardBreak' },
+        { type: 'text', text: 'line2' },
+        { type: 'hardBreak' },
+        { type: 'text', text: 'line3' },
+      ],
     })
   })
 
@@ -52,6 +54,28 @@ describe('textToAdf', () => {
       { type: 'paragraph', content: [{ type: 'text', text: 'x' }] },
       { type: 'paragraph' },
     ])
+  })
+
+  it('renders common Specrails markdown as structured ADF', () => {
+    const doc = textToAdf([
+      '## Acceptance Criteria',
+      '',
+      '- Render **bold** labels',
+      '- Link to [Jira](https://jira.example/browse/PROJ-1)',
+      '',
+      '1. First',
+      '2. Second',
+      '',
+      '```ts',
+      'const ok = true',
+      '```',
+    ].join('\n')) as any
+    expect(doc.content[0]).toMatchObject({ type: 'heading', attrs: { level: 2 } })
+    expect(doc.content[2]).toMatchObject({ type: 'bulletList' })
+    expect(doc.content[2].content[0].content[0].content).toContainEqual({ type: 'text', text: 'bold', marks: [{ type: 'strong' }] })
+    expect(doc.content[2].content[1].content[0].content).toContainEqual({ type: 'text', text: 'Jira', marks: [{ type: 'link', attrs: { href: 'https://jira.example/browse/PROJ-1' } }] })
+    expect(doc.content[4]).toMatchObject({ type: 'orderedList', attrs: { order: 1 } })
+    expect(doc.content[6]).toMatchObject({ type: 'codeBlock', attrs: { language: 'ts' } })
   })
 })
 
@@ -192,11 +216,11 @@ describe('adfToText', () => {
     const adf = {
       type: 'doc',
       content: [
-        { type: 'heading', content: [{ type: 'text', text: 'Title' }] },
+        { type: 'heading', attrs: { level: 2 }, content: [{ type: 'text', text: 'Title' }] },
         { type: 'paragraph', content: [{ type: 'text', text: 'Body' }] },
       ],
     }
-    expect(adfToText(adf)).toBe('Title\nBody')
+    expect(adfToText(adf)).toBe('## Title\n\nBody')
   })
 
   it('collapses runs of 3+ newlines to a double newline', () => {
@@ -220,11 +244,9 @@ describe('adfToText', () => {
     expect(adfToText(adf)).toBe('a\n\nb')
   })
 
-  it('emits only one newline per empty paragraph (no content array → no separator)', () => {
-    // Documents the actual behavior: textToAdf empty paragraphs push nothing,
-    // so non-empty lines are joined by a single newline.
+  it('keeps an empty paragraph as a markdown blank line', () => {
     const adf = textToAdf('a\n\n\nb')
-    expect(adfToText(adf)).toBe('a\nb')
+    expect(adfToText(adf)).toBe('a\n\nb')
   })
 
   it('ignores non-text leaf nodes and unknown node types', () => {
@@ -266,7 +288,23 @@ describe('adfToText', () => {
         },
       ],
     }
-    expect(adfToText(adf)).toBe('item one')
+    expect(adfToText(adf)).toBe('- item one')
+  })
+
+  it('round-trips common Specrails markdown through ADF', () => {
+    const markdown = [
+      '## Scope',
+      '',
+      'Build **matching** with `motion` and [docs](https://example.com).',
+      '',
+      '- One',
+      '- Two',
+      '',
+      '```tsx',
+      '<KeyTerms />',
+      '```',
+    ].join('\n')
+    expect(adfToText(textToAdf(markdown))).toBe(markdown)
   })
 
   it('returns empty string for a doc with no extractable text', () => {
@@ -293,8 +331,7 @@ describe('adfToText', () => {
         { type: 'paragraph', content: [{ type: 'text', text: 'after' }] },
       ],
     }
-    // Without the fix the codeBlock text ran onto 'after': 'beforeconst x = 1after'.
-    expect(adfToText(adf)).toBe('before\nconst x = 1\nafter')
+    expect(adfToText(adf)).toBe('before\n\n```\nconst x = 1\n```\n\nafter')
   })
 
   it('does not run a codeBlock onto a following heading', () => {
@@ -302,10 +339,10 @@ describe('adfToText', () => {
       type: 'doc',
       content: [
         { type: 'codeBlock', content: [{ type: 'text', text: 'npm test' }] },
-        { type: 'heading', content: [{ type: 'text', text: 'Next' }] },
+        { type: 'heading', attrs: { level: 2 }, content: [{ type: 'text', text: 'Next' }] },
       ],
     }
-    expect(adfToText(adf)).toBe('npm test\nNext')
+    expect(adfToText(adf)).toBe('```\nnpm test\n```\n\n## Next')
   })
 
   it('emits a newline after a blockquote container', () => {
@@ -319,9 +356,7 @@ describe('adfToText', () => {
         { type: 'paragraph', content: [{ type: 'text', text: 'plain' }] },
       ],
     }
-    // The inner paragraph already breaks once; the blockquote boundary adds a
-    // second, so the quote is separated from the next block (was run-on before).
-    expect(adfToText(adf)).toBe('quoted\n\nplain')
+    expect(adfToText(adf)).toBe('> quoted\n\nplain')
   })
 
   it('emits a newline after a panel container', () => {

--- a/server/jira/jira-adf.test.ts
+++ b/server/jira/jira-adf.test.ts
@@ -307,6 +307,51 @@ describe('adfToText', () => {
     expect(adfToText(textToAdf(markdown))).toBe(markdown)
   })
 
+  it('preserves legacy Specrails raw markdown stored as plain ADF paragraphs', () => {
+    const legacyAdf = {
+      type: 'doc',
+      version: 1,
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: '## Scope' }] },
+        { type: 'paragraph' },
+        { type: 'paragraph', content: [{ type: 'text', text: '- One' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: '- Two' }] },
+      ],
+    }
+
+    expect(adfToText(legacyAdf)).toBe('## Scope\n\n- One\n- Two')
+  })
+
+  it('upgrades legacy raw markdown to rich ADF without duplicating markdown syntax', () => {
+    const legacyAdf = {
+      type: 'doc',
+      version: 1,
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: '## Scope' }] },
+        { type: 'paragraph' },
+        { type: 'paragraph', content: [{ type: 'text', text: '- One' }] },
+      ],
+    }
+
+    const upgraded = textToAdf(adfToText(legacyAdf)) as any
+
+    expect(upgraded.content[0]).toMatchObject({
+      type: 'heading',
+      attrs: { level: 2 },
+      content: [{ type: 'text', text: 'Scope' }],
+    })
+    expect(upgraded.content[2]).toMatchObject({
+      type: 'bulletList',
+      content: [
+        {
+          type: 'listItem',
+          content: [{ type: 'paragraph', content: [{ type: 'text', text: 'One' }] }],
+        },
+      ],
+    })
+    expect(adfToText(upgraded)).toBe('## Scope\n\n- One')
+  })
+
   it('returns empty string for a doc with no extractable text', () => {
     const adf = { type: 'doc', content: [{ type: 'paragraph' }] }
     expect(adfToText(adf)).toBe('')

--- a/server/jira/jira-adf.ts
+++ b/server/jira/jira-adf.ts
@@ -298,6 +298,31 @@ export function adfToText(body: unknown): string {
   if (body == null) return ''
   if (typeof body === 'string') return body
 
+  const plainParagraphLines = (nodes: unknown): string[] | null => {
+    if (!Array.isArray(nodes)) return null
+    const lines: string[] = []
+    for (const raw of nodes) {
+      if (!raw || typeof raw !== 'object') return null
+      const node = raw as { type?: unknown; content?: unknown }
+      if (node.type !== 'paragraph') return null
+      if (node.content === undefined) {
+        lines.push('')
+        continue
+      }
+      if (!Array.isArray(node.content)) return null
+      let line = ''
+      for (const child of node.content) {
+        if (!child || typeof child !== 'object') return null
+        const inline = child as { type?: unknown; text?: unknown; marks?: unknown }
+        if (inline.type !== 'text' || typeof inline.text !== 'string') return null
+        if (Array.isArray(inline.marks) && inline.marks.length > 0) return null
+        line += inline.text
+      }
+      lines.push(line)
+    }
+    return lines
+  }
+
   const inlineText = (nodes: unknown): string => {
     if (!Array.isArray(nodes)) return ''
     return nodes.map((node) => {
@@ -372,5 +397,9 @@ export function adfToText(body: unknown): string {
   }
 
   const root = body as { content?: unknown }
+  const legacyLines = plainParagraphLines(root.content)
+  if (legacyLines) {
+    return legacyLines.join('\n').replace(/[ \t]+\n/g, '\n').replace(/\n{3,}/g, '\n\n').trim()
+  }
   return renderBlocks(root.content).join('\n\n').replace(/[ \t]+\n/g, '\n').replace(/\n{3,}/g, '\n\n').trim()
 }

--- a/server/jira/jira-adf.ts
+++ b/server/jira/jira-adf.ts
@@ -7,17 +7,209 @@
 
 import type { JiraDeployment } from './types'
 
-/** Build a minimal ADF document from plain text (newlines → paragraphs). */
+type AdfMark = { type: string; attrs?: Record<string, unknown> }
+
+type AdfInline = {
+  type: 'text'
+  text: string
+  marks?: AdfMark[]
+} | { type: 'hardBreak' }
+
+type AdfBlock = Record<string, unknown>
+
+function textNode(text: string, marks?: AdfMark[]): AdfInline[] {
+  if (!text) return []
+  return marks && Array.isArray(marks) && marks.length > 0
+    ? [{ type: 'text', text, marks }]
+    : [{ type: 'text', text }]
+}
+
+function parseInline(input: string): AdfInline[] {
+  const out: AdfInline[] = []
+  let i = 0
+  const pushPlainUntil = (next: number) => {
+    if (next > i) out.push(...textNode(input.slice(i, next)))
+    i = next
+  }
+  while (i < input.length) {
+    const starts = [
+      input.indexOf('`', i),
+      input.indexOf('**', i),
+      input.indexOf('*', i),
+      input.indexOf('[', i),
+    ].filter((n) => n >= 0)
+    const next = starts.length > 0 ? Math.min(...starts) : -1
+    if (next < 0) {
+      out.push(...textNode(input.slice(i)))
+      break
+    }
+    pushPlainUntil(next)
+    if (input.startsWith('`', i)) {
+      const end = input.indexOf('`', i + 1)
+      if (end > i + 1) {
+        out.push(...textNode(input.slice(i + 1, end), [{ type: 'code' }]))
+        i = end + 1
+        continue
+      }
+    }
+    if (input.startsWith('**', i)) {
+      const end = input.indexOf('**', i + 2)
+      if (end > i + 2) {
+        out.push(...textNode(input.slice(i + 2, end), [{ type: 'strong' }]))
+        i = end + 2
+        continue
+      }
+    }
+    if (input.startsWith('[', i)) {
+      const close = input.indexOf('](', i + 1)
+      const end = close >= 0 ? input.indexOf(')', close + 2) : -1
+      if (close > i + 1 && end > close + 2) {
+        const label = input.slice(i + 1, close)
+        const href = input.slice(close + 2, end)
+        out.push(...textNode(label, [{ type: 'link', attrs: { href } }]))
+        i = end + 1
+        continue
+      }
+    }
+    if (input.startsWith('*', i) && !input.startsWith('**', i)) {
+      const end = input.indexOf('*', i + 1)
+      if (end > i + 1) {
+        out.push(...textNode(input.slice(i + 1, end), [{ type: 'em' }]))
+        i = end + 1
+        continue
+      }
+    }
+    out.push(...textNode(input[i]))
+    i += 1
+  }
+  return out
+}
+
+function paragraphFromLines(lines: string[]): AdfBlock {
+  if (lines.length === 0 || lines.every((line) => line.length === 0)) return { type: 'paragraph' }
+  const content: AdfInline[] = []
+  lines.forEach((line, index) => {
+    if (index > 0) content.push({ type: 'hardBreak' })
+    content.push(...parseInline(line))
+  })
+  return content.length > 0 ? { type: 'paragraph', content } : { type: 'paragraph' }
+}
+
+function isSpecialMarkdownLine(line: string): boolean {
+  return /^```/.test(line) ||
+    /^(#{1,6})\s+\S/.test(line) ||
+    /^\s*[-*+]\s+\S/.test(line) ||
+    /^\s*\d+[.)]\s+\S/.test(line) ||
+    /^>\s?/.test(line) ||
+    /^\s*---+\s*$/.test(line)
+}
+
+function listItem(text: string): AdfBlock {
+  return { type: 'listItem', content: [paragraphFromLines([text])] }
+}
+
+/** Build an ADF document from Specrails Markdown. */
 export function textToAdf(text: string): unknown {
-  const paragraphs = text.split('\n')
+  const lines = text.split('\n')
+  const content: AdfBlock[] = []
+  let i = 0
+  const pushParagraph = (paragraphLines: string[]) => {
+    content.push(paragraphFromLines(paragraphLines))
+  }
+  while (i < lines.length) {
+    const line = lines[i]
+    if (line.length === 0) {
+      content.push({ type: 'paragraph' })
+      i += 1
+      continue
+    }
+
+    const fence = /^```([A-Za-z0-9_-]+)?\s*$/.exec(line)
+    if (fence) {
+      const codeLines: string[] = []
+      i += 1
+      while (i < lines.length && !/^```\s*$/.test(lines[i])) {
+        codeLines.push(lines[i])
+        i += 1
+      }
+      if (i < lines.length) i += 1
+      content.push({
+        type: 'codeBlock',
+        ...(fence[1] ? { attrs: { language: fence[1] } } : {}),
+        content: codeLines.length > 0 ? [{ type: 'text', text: codeLines.join('\n') }] : [],
+      })
+      continue
+    }
+
+    const heading = /^(#{1,6})\s+(.+?)\s*$/.exec(line)
+    if (heading) {
+      content.push({
+        type: 'heading',
+        attrs: { level: heading[1].length },
+        content: parseInline(heading[2]),
+      })
+      i += 1
+      continue
+    }
+
+    const bullet = /^\s*[-*+]\s+(.+)$/.exec(line)
+    if (bullet) {
+      const items: AdfBlock[] = []
+      while (i < lines.length) {
+        const m = /^\s*[-*+]\s+(.+)$/.exec(lines[i])
+        if (!m) break
+        items.push(listItem(m[1]))
+        i += 1
+      }
+      content.push({ type: 'bulletList', content: items })
+      continue
+    }
+
+    const ordered = /^\s*(\d+)[.)]\s+(.+)$/.exec(line)
+    if (ordered) {
+      const items: AdfBlock[] = []
+      const order = parseInt(ordered[1], 10)
+      while (i < lines.length) {
+        const m = /^\s*\d+[.)]\s+(.+)$/.exec(lines[i])
+        if (!m) break
+        items.push(listItem(m[1]))
+        i += 1
+      }
+      content.push({ type: 'orderedList', attrs: { order }, content: items })
+      continue
+    }
+
+    const quote = /^>\s?(.*)$/.exec(line)
+    if (quote) {
+      const quoteLines: string[] = []
+      while (i < lines.length) {
+        const m = /^>\s?(.*)$/.exec(lines[i])
+        if (!m) break
+        quoteLines.push(m[1])
+        i += 1
+      }
+      content.push({ type: 'blockquote', content: [paragraphFromLines(quoteLines)] })
+      continue
+    }
+
+    if (/^\s*---+\s*$/.test(line)) {
+      content.push({ type: 'rule' })
+      i += 1
+      continue
+    }
+
+    const paragraphLines = [line]
+    i += 1
+    while (i < lines.length && lines[i].length > 0 && !isSpecialMarkdownLine(lines[i])) {
+      paragraphLines.push(lines[i])
+      i += 1
+    }
+    pushParagraph(paragraphLines)
+  }
   return {
     type: 'doc',
     version: 1,
-    content: paragraphs.map((line) =>
-      line.length === 0
-        ? { type: 'paragraph' }
-        : { type: 'paragraph', content: [{ type: 'text', text: line }] }
-    ),
+    content: content.length > 0 ? content : [{ type: 'paragraph' }],
   }
 }
 
@@ -73,6 +265,7 @@ export function railReviewCommentMarker(refId: string, ticketId: number): string
 /** True when an ADF doc or wiki string already contains the given marker. */
 export function bodyContainsMarker(body: unknown, marker: string): boolean {
   if (typeof body === 'string') return body.includes(marker)
+  if (adfToText(body).includes(marker)) return true
   try {
     return JSON.stringify(body).includes(marker)
   } catch {
@@ -101,36 +294,83 @@ export function commentHasMarker(
   return bodyContainsMarker(comment.body, marker)
 }
 
-/**
- * Flatten an ADF document (or plain string) back to text — used to read inbound
- * Jira descriptions/comments into the local cache.
- */
-const BLOCK_SEPARATOR_TYPES = new Set<string>([
-  'paragraph',
-  'heading',
-  'codeBlock',
-  'blockquote',
-  'panel',
-  'tableRow',
-])
-
 export function adfToText(body: unknown): string {
   if (body == null) return ''
   if (typeof body === 'string') return body
-  const out: string[] = []
-  const walk = (node: any): void => {
-    if (!node || typeof node !== 'object') return
-    if (node.type === 'text' && typeof node.text === 'string') out.push(node.text)
-    if (node.type === 'hardBreak') out.push('\n')
-    if (Array.isArray(node.content)) {
-      for (const child of node.content) walk(child)
-      // Block separators. `paragraph`/`heading` carry inline children directly;
-      // `codeBlock` holds direct text children (no inner paragraph), and
-      // `blockquote`/`panel`/`tableRow` are containers whose trailing newline
-      // would otherwise be dropped, running their text onto the next block.
-      if (BLOCK_SEPARATOR_TYPES.has(node.type)) out.push('\n')
-    }
+
+  const inlineText = (nodes: unknown): string => {
+    if (!Array.isArray(nodes)) return ''
+    return nodes.map((node) => {
+      if (!node || typeof node !== 'object') return ''
+      const n = node as { type?: unknown; text?: unknown; marks?: unknown; attrs?: Record<string, unknown> }
+      if (n.type === 'hardBreak') return '\n'
+      if (n.type === 'mention' && typeof n.attrs?.text === 'string') return n.attrs.text
+      if (n.type !== 'text' || typeof n.text !== 'string') return ''
+      let text = n.text
+      const marks = Array.isArray(n.marks) ? n.marks as Array<{ type?: unknown; attrs?: Record<string, unknown> }> : []
+      for (const mark of marks) {
+        if (mark.type === 'code') text = `\`${text}\``
+        else if (mark.type === 'strong') text = `**${text}**`
+        else if (mark.type === 'em') text = `*${text}*`
+        else if (mark.type === 'strike') text = `~~${text}~~`
+      }
+      const link = marks.find((mark) => mark.type === 'link' && typeof mark.attrs?.href === 'string')
+      if (link?.attrs?.href) text = `[${text}](${link.attrs.href})`
+      return text
+    }).join('')
   }
-  walk(body)
-  return out.join('').replace(/\n{3,}/g, '\n\n').trim()
+
+  const renderBlocks = (nodes: unknown): string[] => {
+    if (!Array.isArray(nodes)) return []
+    const blocks: string[] = []
+    const renderListItem = (node: any, prefix: string): string => {
+      const rendered = renderBlocks(node?.content)
+      const body = rendered.length > 0 ? rendered.join('\n\n') : ''
+      const lines = body.split('\n')
+      return lines.map((line, index) => index === 0 ? `${prefix}${line}` : `  ${line}`).join('\n')
+    }
+    for (const raw of nodes) {
+      if (!raw || typeof raw !== 'object') continue
+      const node = raw as { type?: string; content?: unknown; attrs?: Record<string, unknown> }
+      if (node.type === 'paragraph') {
+        blocks.push(inlineText(node.content))
+      } else if (node.type === 'heading') {
+        const level = Math.min(6, Math.max(1, Number(node.attrs?.level) || 2))
+        blocks.push(`${'#'.repeat(level)} ${inlineText(node.content)}`.trim())
+      } else if (node.type === 'bulletList') {
+        const items = Array.isArray(node.content) ? node.content.map((item) => renderListItem(item, '- ')) : []
+        blocks.push(items.join('\n'))
+      } else if (node.type === 'orderedList') {
+        const start = Number(node.attrs?.order) || 1
+        const items = Array.isArray(node.content)
+          ? node.content.map((item, index) => renderListItem(item, `${start + index}. `))
+          : []
+        blocks.push(items.join('\n'))
+      } else if (node.type === 'listItem') {
+        blocks.push(...renderBlocks(node.content))
+      } else if (node.type === 'codeBlock') {
+        const lang = typeof node.attrs?.language === 'string' ? node.attrs.language : ''
+        blocks.push(`\`\`\`${lang}\n${inlineText(node.content)}\n\`\`\``)
+      } else if (node.type === 'blockquote') {
+        const quote = renderBlocks(node.content).join('\n\n')
+        blocks.push(quote.split('\n').map((line) => line ? `> ${line}` : '>').join('\n'))
+      } else if (node.type === 'rule') {
+        blocks.push('---')
+      } else if (node.type === 'panel') {
+        blocks.push(renderBlocks(node.content).join('\n\n'))
+      } else if (node.type === 'table') {
+        blocks.push(renderBlocks(node.content).join('\n\n'))
+      } else if (node.type === 'tableRow') {
+        blocks.push(renderBlocks(node.content).join('\n'))
+      } else if (node.type === 'tableCell' || node.type === 'tableHeader') {
+        blocks.push(renderBlocks(node.content).join(' '))
+      } else {
+        blocks.push(...renderBlocks(node.content))
+      }
+    }
+    return blocks
+  }
+
+  const root = body as { content?: unknown }
+  return renderBlocks(root.content).join('\n\n').replace(/[ \t]+\n/g, '\n').replace(/\n{3,}/g, '\n\n').trim()
 }

--- a/server/jira/jira-client.test.ts
+++ b/server/jira/jira-client.test.ts
@@ -887,9 +887,33 @@ describe('createIssue', () => {
       type: 'doc',
       version: 1,
       content: [
-        { type: 'paragraph', content: [{ type: 'text', text: 'line one' }] },
-        { type: 'paragraph', content: [{ type: 'text', text: 'line two' }] },
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'line one' },
+            { type: 'hardBreak' },
+            { type: 'text', text: 'line two' },
+          ],
+        },
       ],
+    })
+  })
+
+  it('renders markdown descriptions as rich ADF on cloud', async () => {
+    const { fetchImpl, requests } = makeFetch({ body: { id: '1', key: 'P-1' } })
+    await new JiraClient(cloudCfg()).createIssue({
+      projectKey: 'P',
+      issueType: 'Task',
+      summary: 's',
+      description: '## Scope\n\n- First\n- **Second**',
+    })
+    const desc = requests[0].body.fields.description
+    expect(desc.content[0]).toMatchObject({ type: 'heading', attrs: { level: 2 } })
+    expect(desc.content[2]).toMatchObject({ type: 'bulletList' })
+    expect(desc.content[2].content[1].content[0].content).toContainEqual({
+      type: 'text',
+      text: 'Second',
+      marks: [{ type: 'strong' }],
     })
   })
 
@@ -989,8 +1013,14 @@ describe('addComment', () => {
       type: 'doc',
       version: 1,
       content: [
-        { type: 'paragraph', content: [{ type: 'text', text: 'hello' }] },
-        { type: 'paragraph', content: [{ type: 'text', text: 'world' }] },
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'hello' },
+            { type: 'hardBreak' },
+            { type: 'text', text: 'world' },
+          ],
+        },
       ],
     })
     if (res.ok) expect(res.data).toEqual({ id: 'c1' })

--- a/server/loop-factory.test.ts
+++ b/server/loop-factory.test.ts
@@ -42,6 +42,15 @@ describe('factory loops', () => {
     }
   })
 
+  it('legacy factory goals describe an exit condition, not a claimed verification result', () => {
+    for (const f of FACTORY_LOOPS.filter((loop) => loop.mode !== 'loop')) {
+      const decider = f.graph.nodes.find((n) => n.type === 'decider')!
+      const goal = String(decider.data?.goal ?? '')
+      expect(goal, f.id).toContain('Stop only when')
+      expect(goal, f.id).not.toMatch(/^The verification step reported/)
+    }
+  })
+
   it('the implement factory loop is an autonomous implement → verify → fix loop', () => {
     const prompts = getFactoryLoop('factory:implement')!.graph.nodes
       .filter((n) => n.type === 'ai-step')

--- a/server/loop-factory.ts
+++ b/server/loop-factory.ts
@@ -30,7 +30,7 @@ export interface FactoryLoop {
   graph: LoopGraph
 }
 
-const GREEN_GOAL = 'The verification step reported {{const:VERIFICATION_PASS}} — the spec is implemented and all tests pass.'
+const GREEN_GOAL = 'Stop only when the latest verification step reports {{const:VERIFICATION_PASS}} and the history proves the spec is implemented with all required tests/build checks passing.'
 
 // Factory loops run the WHOLE architect→developer→reviewer pipeline inside a
 // single AI step (`/specrails:implement` etc.), so they need far more headroom

--- a/server/loop-run-manager.test.ts
+++ b/server/loop-run-manager.test.ts
@@ -529,6 +529,93 @@ describe('LoopRunManager', () => {
     expect(prompt).not.toContain('Specrails rail continuation context')
   })
 
+  it('adds unattended continuation context for literal on_review implement commands', async () => {
+    const graph: LoopGraph = {
+      nodes: [
+        { id: 's', type: 'start', position: { x: 0, y: 0 } },
+        { id: 'ai', type: 'ai-step', position: { x: 0, y: 1 }, data: { prompt: '/specrails:implement #98 --yes' } },
+        { id: 'e', type: 'end', position: { x: 0, y: 2 } },
+      ],
+      edges: [
+        { id: 'e1', source: 's', target: 'ai' },
+        { id: 'e2', source: 'ai', target: 'e' },
+      ],
+      config: { maxIterations: 5, timeoutMinutes: 30 },
+    }
+
+    const ex = makeExecutors()
+    await manager(ex).run({
+      ...baseReq(),
+      graph,
+      spec: { ...baseReq().spec, status: 'on_review' },
+    })
+
+    const prompt = (ex.runAiStep as ReturnType<typeof vi.fn>).mock.calls[0][0].prompt
+    expect(prompt).toContain('/specrails:implement #98 --yes')
+    expect(prompt).toContain('Specrails rail continuation context')
+  })
+
+  it('halts immediately when an unattended AI step asks the human how to proceed', async () => {
+    const graph: LoopGraph = {
+      nodes: [
+        { id: 's', type: 'start', position: { x: 0, y: 0 } },
+        { id: 'implement', type: 'ai-step', position: { x: 0, y: 1 }, data: { prompt: '{{cmd:implement}}' } },
+        { id: 'verify', type: 'ai-step', position: { x: 0, y: 2 }, data: { prompt: '{{cmd:verify}}' } },
+        { id: 'e', type: 'end', position: { x: 0, y: 3 } },
+      ],
+      edges: [
+        { id: 'e1', source: 's', target: 'implement' },
+        { id: 'e2', source: 'implement', target: 'verify' },
+        { id: 'e3', source: 'verify', target: 'e' },
+      ],
+      config: { maxIterations: 5, timeoutMinutes: 30 },
+    }
+    const runAiStep = vi.fn(async () => ({
+      text: [
+        'Before running the full pipeline, this is not a fresh feature to build.',
+        '**How would you like to proceed?**',
+        '1. Treat this as review follow-ups.',
+        '2. Sync first.',
+        "I haven't launched any agents yet, so no code has changed.",
+        'openspec/changes/key-terms-matching-review-followups/',
+      ].join('\n'),
+      provider: 'claude',
+      model: 'sonnet',
+    }))
+
+    const res = await manager(makeExecutors({ runAiStep })).run({ ...baseReq(), graph })
+
+    expect(res.outcome).toBe('blocked')
+    expect(runAiStep).toHaveBeenCalledTimes(1)
+    expect(getLoopRun(db, res.runId)!.final_outcome).toBe('blocked')
+    expect(broadcasts.some((m) => m.type === 'log' && ((m as { line?: string }).line ?? '').includes('Loop blocked'))).toBe(true)
+    expect(broadcasts.some((m) => m.type === 'log' && ((m as { line?: string }).line ?? '').includes('Captured OpenSpec change id'))).toBe(false)
+  })
+
+  it('halts immediately when an AI step emits LOOP_BLOCKED', async () => {
+    const graph: LoopGraph = {
+      nodes: [
+        { id: 's', type: 'start', position: { x: 0, y: 0 } },
+        { id: 'ai', type: 'ai-step', position: { x: 0, y: 1 }, data: { prompt: '{{cmd:fix}}' } },
+        { id: 'verify', type: 'ai-step', position: { x: 0, y: 2 }, data: { prompt: '{{cmd:verify}}' } },
+        { id: 'e', type: 'end', position: { x: 0, y: 3 } },
+      ],
+      edges: [
+        { id: 'e1', source: 's', target: 'ai' },
+        { id: 'e2', source: 'ai', target: 'verify' },
+        { id: 'e3', source: 'verify', target: 'e' },
+      ],
+      config: { maxIterations: 5, timeoutMinutes: 30 },
+    }
+    const runAiStep = vi.fn(async () => ({ text: 'LOOP_BLOCKED: Which review feedback should be applied?', provider: 'claude', model: 'sonnet' }))
+
+    const res = await manager(makeExecutors({ runAiStep })).run({ ...baseReq(), graph })
+
+    expect(res.outcome).toBe('blocked')
+    expect(runAiStep).toHaveBeenCalledTimes(1)
+    expect(broadcasts.some((m) => m.type === 'log' && ((m as { line?: string }).line ?? '').includes('Which review feedback should be applied?'))).toBe(true)
+  })
+
   it('stops at maxIterations when the Decider never stops', async () => {
     const ex = makeExecutors({
       runDecider: vi.fn(async () => ({ continue: true, reasoning: 'keep going', parsed: true })),

--- a/server/loop-run-manager.test.ts
+++ b/server/loop-run-manager.test.ts
@@ -463,6 +463,72 @@ describe('LoopRunManager', () => {
     expect(firstCall.prompt).toContain('Implement Feature X')
   })
 
+  it('adds unattended continuation context for on_review implement commands', async () => {
+    const graph: LoopGraph = {
+      nodes: [
+        { id: 's', type: 'start', position: { x: 0, y: 0 } },
+        { id: 'ai', type: 'ai-step', position: { x: 0, y: 1 }, data: { prompt: '{{cmd:implement}}' } },
+        { id: 'e', type: 'end', position: { x: 0, y: 2 } },
+      ],
+      edges: [
+        { id: 'e1', source: 's', target: 'ai' },
+        { id: 'e2', source: 'ai', target: 'e' },
+      ],
+      config: { maxIterations: 5, timeoutMinutes: 30 },
+    }
+
+    const ex = makeExecutors()
+    await manager(ex).run({
+      ...baseReq(),
+      graph,
+      spec: { ...baseReq().spec, id: 98, status: 'on_review' },
+    })
+
+    const prompt = (ex.runAiStep as ReturnType<typeof vi.fn>).mock.calls[0][0].prompt
+    expect(prompt).toContain('/specrails:implement #98 --yes')
+    expect(prompt).toContain('Specrails rail continuation context')
+    expect(prompt).toContain('do NOT pause')
+    expect(prompt).toContain('review follow-ups on the current PR/worktree')
+  })
+
+  it('does not add review continuation context to new implement work', async () => {
+    const graph: LoopGraph = {
+      nodes: [
+        { id: 's', type: 'start', position: { x: 0, y: 0 } },
+        { id: 'ai', type: 'ai-step', position: { x: 0, y: 1 }, data: { prompt: '{{cmd:implement}}' } },
+        { id: 'e', type: 'end', position: { x: 0, y: 2 } },
+      ],
+      edges: [
+        { id: 'e1', source: 's', target: 'ai' },
+        { id: 'e2', source: 'ai', target: 'e' },
+      ],
+      config: { maxIterations: 5, timeoutMinutes: 30 },
+    }
+
+    const ex = makeExecutors()
+    await manager(ex).run({
+      ...baseReq(),
+      graph,
+      spec: { ...baseReq().spec, id: 98, status: 'todo' },
+    })
+
+    const prompt = (ex.runAiStep as ReturnType<typeof vi.fn>).mock.calls[0][0].prompt
+    expect(prompt).toContain('/specrails:implement #98 --yes')
+    expect(prompt).not.toContain('Specrails rail continuation context')
+  })
+
+  it('does not add review continuation context to ordinary on_review prompts', async () => {
+    const ex = makeExecutors()
+    await manager(ex).run({
+      ...baseReq(),
+      spec: { ...baseReq().spec, id: 98, status: 'on_review' },
+    })
+
+    const prompt = (ex.runAiStep as ReturnType<typeof vi.fn>).mock.calls[0][0].prompt
+    expect(prompt).toContain('Implement Feature X')
+    expect(prompt).not.toContain('Specrails rail continuation context')
+  })
+
   it('stops at maxIterations when the Decider never stops', async () => {
     const ex = makeExecutors({
       runDecider: vi.fn(async () => ({ continue: true, reasoning: 'keep going', parsed: true })),

--- a/server/loop-run-manager.ts
+++ b/server/loop-run-manager.ts
@@ -215,6 +215,24 @@ export interface LoopRunRequest {
   isolation?: { branch: string; worktreePath: string }
 }
 
+const IMPLEMENT_CMD_TOKEN_RE = /\{\{\s*cmd:(?:implement|batch)\s*\}\}/
+
+function withReviewContinuationContext(base: string, rawTemplate: string, spec?: LoopSpec): string {
+  if (spec?.status !== 'on_review') return base
+  if (!IMPLEMENT_CMD_TOKEN_RE.test(rawTemplate)) return base
+  return [
+    base,
+    '',
+    '---',
+    'Specrails rail continuation context:',
+    '- This ticket is already on_review and this run is fully unattended; the user has already chosen to continue implementation work.',
+    '- If the current branch has an existing open PR, or the feature appears already implemented, do NOT pause to ask whether to proceed and do NOT restart from scratch.',
+    '- Treat the run as review follow-ups on the current PR/worktree: inspect the ticket description, PR context, current branch, and working diff; implement only the missing requested deltas.',
+    '- If the local branch is ahead/behind its remote, do not stop for confirmation. Continue safely on the current worktree; only pull/rebase when it is clearly safe and necessary.',
+    '- If truly no code change is needed, state that clearly and leave the tree unchanged; otherwise make the smallest correct change and let the following verify step prove it.',
+  ].join('\n')
+}
+
 export interface LoopRunResult {
   runId: string
   outcome: LoopRunOutcome
@@ -756,7 +774,7 @@ export class LoopRunManager {
             // --yes`, codex `$implement #<id> --yes`) — then resolve `{{spec.*}}`
             // data tokens and finally `{{const:*}}` library constants.
             const rawTemplate = String(node.data?.prompt ?? '')
-            const base = resolveConstants(
+            const expanded = resolveConstants(
               resolveRunVars(
                 interpolateSpec(
                   expandCommands(rawTemplate, { provider: nodeProvider, ticketIds: req.spec?.ticketIds, specId: req.spec?.id }),
@@ -766,6 +784,7 @@ export class LoopRunManager {
               ),
               constMap
             )
+            const base = withReviewContinuationContext(expanded, rawTemplate, req.spec)
             // Inject the cross-iteration history only when there's no live session
             // to carry it (a fresh pass) OR right after a Decider 'continue' (so the
             // step sees the verdict). A mid-body resumed step already has it.

--- a/server/loop-run-manager.ts
+++ b/server/loop-run-manager.ts
@@ -347,9 +347,10 @@ export function truncate(s: string, max = 600): string {
 // — `changeId`, the OpenSpec change id — written so the family can generalize.
 
 const RUN_TOKEN_RE = /\{\{\s*run\.(\w+)\s*\}\}/g
-/** First `openspec/changes/<id>` path mentioned in a step's output (the same
- *  detection SpecLauncherManager uses). The id stops at the first `/`. */
-const CHANGE_ID_RE = /openspec\/changes\/([A-Za-z0-9._-]+)/
+/** First ACTIVE `openspec/changes/<id>` path mentioned in a step's output.
+ *  Archive paths (`openspec/changes/archive/...`) are historical destinations,
+ *  not runnable change ids for later `{{run.changeId}}` commands. */
+const CHANGE_ID_RE = /openspec\/changes\/(?!archive(?:\/|$))([A-Za-z0-9._-]+)(?=\/|\s|$)/g
 
 /** Replace `{{run.<name>}}` with the captured value; uncaptured → '' (never a
  *  leaked literal token). Applied AFTER `{{cmd:*}}` and `{{spec.*}}`. */
@@ -360,6 +361,7 @@ export function resolveRunVars(text: string, vars: Record<string, string>): stri
 /** Extract the OpenSpec change id from a step's output (first match wins), or
  *  undefined when none is present. */
 export function extractChangeId(text: string): string | undefined {
+  CHANGE_ID_RE.lastIndex = 0
   const m = CHANGE_ID_RE.exec(text)
   return m ? m[1] : undefined
 }

--- a/server/loop-run-manager.ts
+++ b/server/loop-run-manager.ts
@@ -216,10 +216,14 @@ export interface LoopRunRequest {
 }
 
 const IMPLEMENT_CMD_TOKEN_RE = /\{\{\s*cmd:(?:implement|batch)\s*\}\}/
+const IMPLEMENT_CMD_TEXT_RE = /(?:^|\s)(?:\/(?:specrails:|sr:)?(?:implement|batch-implement)|\$(?:implement|batch-implement))\b/
+const LOOP_BLOCKED_LINE_RE = /(?:^|\n)\s*LOOP_BLOCKED:\s*(.+?)(?:\n|$)/i
+const HUMAN_PROCEED_QUESTION_RE = /(?:^|\n)\s*(?:\*\*)?How would you like to proceed\??/i
+const HUMAN_PROCEED_NO_WORK_RE = /\b(?:no code has changed|I haven't launched any agents|I have not launched any agents|not a fresh feature to build|would duplicate work|sync first|treat this as)\b/i
 
 function withReviewContinuationContext(base: string, rawTemplate: string, spec?: LoopSpec): string {
   if (spec?.status !== 'on_review') return base
-  if (!IMPLEMENT_CMD_TOKEN_RE.test(rawTemplate)) return base
+  if (!IMPLEMENT_CMD_TOKEN_RE.test(rawTemplate) && !IMPLEMENT_CMD_TEXT_RE.test(rawTemplate) && !IMPLEMENT_CMD_TEXT_RE.test(base)) return base
   return [
     base,
     '',
@@ -231,6 +235,15 @@ function withReviewContinuationContext(base: string, rawTemplate: string, spec?:
     '- If the local branch is ahead/behind its remote, do not stop for confirmation. Continue safely on the current worktree; only pull/rebase when it is clearly safe and necessary.',
     '- If truly no code change is needed, state that clearly and leave the tree unchanged; otherwise make the smallest correct change and let the following verify step prove it.',
   ].join('\n')
+}
+
+function aiStepBlockedReason(text: string): string | null {
+  const explicit = LOOP_BLOCKED_LINE_RE.exec(text)
+  if (explicit?.[1]?.trim()) return explicit[1].trim()
+  if (HUMAN_PROCEED_QUESTION_RE.test(text) && HUMAN_PROCEED_NO_WORK_RE.test(text)) {
+    return 'The AI step asked how to proceed instead of performing unattended work.'
+  }
+  return null
 }
 
 export interface LoopRunResult {
@@ -848,9 +861,12 @@ export class LoopRunManager {
               resultText: res.text.trim() ? res.text : null,
             })
             const zeroWork = res.zeroWork === true || oneShotZeroWork
-            const stepFailed = res.failed === true || zeroWork
+            const blockedReason = aiStepBlockedReason(res.text)
+            const stepFailed = res.failed === true || zeroWork || blockedReason !== null
             const stepErrorText = res.errorText ?? (zeroWork
               ? `zero work performed — the command never ran${res.text.trim() ? `: ${res.text.trim()}` : ''}`
+              : blockedReason
+                ? `blocked — ${blockedReason}`
               : undefined)
             // Make the failure reason land visibly INSIDE the step's log
             // segment (the interactive session already surfaced its own note at
@@ -873,6 +889,12 @@ export class LoopRunManager {
             if (res.sessionId && !stepFailed) aiSessionId = res.sessionId
             history.push(`AI Step: ${truncate(res.text)}`)
             record(`loop:${runId}`, { ...res, failed: stepFailed }, aiStepStart)
+            if (blockedReason) {
+              logLine(`\n■ Loop blocked — needs a human decision: ${blockedReason}`, 'stderr')
+              outcome = 'blocked'
+              settled = true
+              break
+            }
             // Capture the OpenSpec change id from a step's output the FIRST time it
             // appears (first-match-wins, kept stable across loop-back iterations so
             // the re-pass amends the same change). Used by `{{run.changeId}}` in the

--- a/server/opsx-lifecycle-loop.test.ts
+++ b/server/opsx-lifecycle-loop.test.ts
@@ -61,6 +61,14 @@ describe('extractChangeId', () => {
   it('captures the FIRST id when several are mentioned', () => {
     expect(extractChangeId('openspec/changes/aaa and openspec/changes/bbb')).toBe('aaa')
   })
+  it('ignores archived change paths because archive is not a runnable change id', () => {
+    expect(extractChangeId('Archived to apps/web/openspec/changes/archive/2026-07-06-my-change/')).toBeUndefined()
+  })
+  it('skips archived paths and captures the first active change path', () => {
+    expect(extractChangeId(
+      'Archived apps/web/openspec/changes/archive/2026-07-06-old/ then continued openspec/changes/my-change/',
+    )).toBe('my-change')
+  })
   it('returns undefined when no change path is present', () => {
     expect(extractChangeId('nothing to see here')).toBeUndefined()
   })

--- a/server/project-git.test.ts
+++ b/server/project-git.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
 import express, { Router, type Request } from 'express'
 import { execFileSync } from 'child_process'
 import fs from 'fs'
@@ -172,13 +172,14 @@ describe('project-git', () => {
 })
 
 describe('git routes', () => {
-  function makeApp(repoDir: string) {
+  function makeApp(repoDir: string, exec?: ProjectRoutesDeps['exec']) {
     const app = express()
     app.use(express.json())
     const router = Router()
     registerGitRoutes({
       router,
       ctx: () => ({ project: { path: repoDir } }),
+      exec,
       registry: {},
       ticketPath: () => '',
     } as unknown as ProjectRoutesDeps)
@@ -221,5 +222,26 @@ describe('git routes', () => {
     expect(ok.status).toBe(200)
     expect(ok.body.branch).toBe('feature')
     await req(app, 'POST', '/api/projects/p1/git/checkout', { branch: 'main' })
+  })
+
+  it('GET /git/pull-requests/:number resolves a bare PR number through gh', async () => {
+    const exec = {
+      run: vi.fn(async () => ({
+        code: 0,
+        stdout: JSON.stringify({ url: 'https://github.com/o/r/pull/515' }),
+        stderr: '',
+      })),
+    }
+    const r = await req(makeApp(repo, exec), 'GET', '/api/projects/p1/git/pull-requests/515')
+    expect(r.status).toBe(200)
+    expect(r.body).toEqual({ prNumber: 515, url: 'https://github.com/o/r/pull/515' })
+    expect(exec.run).toHaveBeenCalledWith('gh', ['pr', 'view', '515', '--json', 'url'], repo)
+  })
+
+  it('GET /git/pull-requests/:number returns 404 when gh cannot resolve it', async () => {
+    const exec = { run: vi.fn(async () => ({ code: 1, stdout: '', stderr: 'not found' })) }
+    const r = await req(makeApp(repo, exec), 'GET', '/api/projects/p1/git/pull-requests/999')
+    expect(r.status).toBe(404)
+    expect(r.body.error).toBe('pull_request_not_found')
   })
 })

--- a/server/project-router-git.ts
+++ b/server/project-router-git.ts
@@ -2,6 +2,7 @@ import type { Request, Response } from 'express'
 import type { ProjectRoutesDeps } from './project-router-helpers'
 import { getProjectGitInfo, checkoutProjectBranch } from './project-git'
 import { runGitDiagnostic, isGitDiagnosticAction, GIT_DIAGNOSTIC_ACTIONS } from './git-diagnostics'
+import { defaultExec } from './pr-publisher'
 
 // ─── Git domain routes (/api/projects/:projectId/git) ─────────────────────────
 //
@@ -11,6 +12,7 @@ import { runGitDiagnostic, isGitDiagnosticAction, GIT_DIAGNOSTIC_ACTIONS } from 
 
 export function registerGitRoutes(deps: ProjectRoutesDeps): void {
   const { router, ctx } = deps
+  const exec = deps.exec ?? defaultExec
 
   router.get('/:projectId/git', async (req: Request, res: Response) => {
     try {
@@ -18,6 +20,31 @@ export function registerGitRoutes(deps: ProjectRoutesDeps): void {
     } catch (err) {
       console.error('[project-git] info failed:', err)
       res.status(500).json({ error: 'Failed to read git info' })
+    }
+  })
+
+  router.get('/:projectId/git/pull-requests/:number', async (req: Request, res: Response) => {
+    const prNumber = Number.parseInt(String(req.params.number ?? ''), 10)
+    if (!Number.isInteger(prNumber) || prNumber <= 0) {
+      res.status(400).json({ error: 'invalid_pull_request_number' })
+      return
+    }
+
+    try {
+      const r = await exec.run('gh', ['pr', 'view', String(prNumber), '--json', 'url'], ctx(req).project.path)
+      if (r.code !== 0) {
+        res.status(404).json({ error: 'pull_request_not_found' })
+        return
+      }
+      const parsed = JSON.parse(r.stdout) as { url?: unknown }
+      if (typeof parsed.url !== 'string' || !parsed.url) {
+        res.status(404).json({ error: 'pull_request_not_found' })
+        return
+      }
+      res.json({ prNumber, url: parsed.url })
+    } catch (err) {
+      console.error('[project-git] pull request lookup failed:', err)
+      res.status(500).json({ error: 'pull_request_lookup_failed' })
     }
   })
 

--- a/server/project-router-helpers.ts
+++ b/server/project-router-helpers.ts
@@ -15,12 +15,15 @@ import {
 import { clampShortSummary } from './ticket-store'
 import { installConfigPath } from './install-config-path'
 import { resolveProjectExecution } from './workspace-resolution'
+import type { Exec } from './pr-publisher'
 
 /** Shared dependencies handed to every domain register function. */
 export interface ProjectRoutesDeps {
   router: Router
   registry: ProjectRegistry
   ctx: (req: Request) => ProjectContext
+  /** Injectable command runner for git/gh route helpers; production uses defaults. */
+  exec?: Exec
   /** Resolve the per-project ticket-store path for a request (cross-domain). */
   ticketPath: (req: Request) => string
 }

--- a/server/rail-isolated-launch.test.ts
+++ b/server/rail-isolated-launch.test.ts
@@ -369,6 +369,7 @@ describe('launchIsolatedRail — ask-first PR delivery (rail_pr_deliveries lifec
         ticketIds: [1, 2],
         decision: 'on_review',
         prUrl: null,
+        prNumber: null,
         prState: 'none',
         branch: null,
         runIds: ids,
@@ -553,6 +554,7 @@ describe('launchIsolatedRail — conventional branch naming (pr-naming threading
 
 describe('launchIsolatedRail — active PR continuation', () => {
   beforeEach(() => { delete process.env.SPECRAILS_RAIL_DELIVER_PR }) // PR mode default-on
+  afterEach(() => setAgentChatManager(null))
 
   const continuationCtx = (status = 'on_review') => {
     const ctxs = fakeCtx(settlingRun('success'))
@@ -681,12 +683,28 @@ describe('launchIsolatedRail — active PR continuation', () => {
         return { code: 1, stdout: '', stderr: 'unexpected gh call' }
       }),
     }
+    const postPrDecisionCard = vi.fn()
+    const updatePrDecisionCard = vi.fn()
+    setAgentChatManager({ postPrDecisionCard, updatePrDecisionCard } as unknown as AgentChatManager)
 
-    await launchIsolatedRail(input([98], ctx), { git, exec, create, remove: vi.fn(async () => {}) })
+    await launchIsolatedRail(
+      { ...input([98], ctx), originSurface: 'agent-chat', originConversationId: 'conv-pr-2147' },
+      { git, exec, create, remove: vi.fn(async () => {}) },
+    )
 
     expect(create).toHaveBeenCalledWith(git, expect.objectContaining({
       ticketId: 98,
       branch: 'feat/SKILLS-19-key-terms-activity',
+      baseRef: 'origin/feat/SKILLS-19-key-terms-activity',
+      refreshFromBaseRef: true,
+    }))
+    expect(postPrDecisionCard).toHaveBeenCalledWith('conv-pr-2147', expect.objectContaining({
+      kind: 'pr_decision',
+      decision: 'building',
+      branch: 'feat/SKILLS-19-key-terms-activity',
+      prUrl: 'https://github.com/org/repo/pull/2147',
+      prNumber: 2147,
+      prState: 'pr-created',
     }))
     await vi.waitFor(() => expect(getActivePrDeliveryByRail(db, 0)!.decision).toBe('pr_ready'))
     expect(getActivePrDeliveryByRail(db, 0)).toMatchObject({

--- a/server/rail-isolated-launch.test.ts
+++ b/server/rail-isolated-launch.test.ts
@@ -595,7 +595,7 @@ describe('launchIsolatedRail — active PR continuation', () => {
               body: 'Implements ticket #98.',
               headRefName: 'feat/SKILLS-19-key-terms-activity',
               baseRefName: 'main',
-              url: 'https://github.com/Busuu/busuu-web/pull/2147',
+              url: 'https://github.com/org/repo/pull/2147',
               isDraft: false,
             }]),
             stderr: '',
@@ -620,9 +620,80 @@ describe('launchIsolatedRail — active PR continuation', () => {
     expect(getActivePrDeliveryByRail(db, 0)).toMatchObject({
       base_branch: 'main',
       branch: 'feat/SKILLS-19-key-terms-activity',
-      pr_url: 'https://github.com/Busuu/busuu-web/pull/2147',
+      pr_url: 'https://github.com/org/repo/pull/2147',
       pr_number: 2147,
       pr_state: 'pr-created',
+    })
+  })
+
+  it('continues the explicitly mentioned PR number even when the PR branch uses an older Jira key', async () => {
+    const { ctx, db } = continuationCtx()
+    ;(ctx as unknown as { getTicketSpec: (id: number) => unknown }).getTicketSpec = (id: number) => ({
+      id,
+      title: 'Add key-terms activity to Skills v2 lesson player',
+      description: 'Review follow-ups (Adversarial Review - PR #2147, HEAD 5964efb8). Scope: F-001 and F-002 only.',
+      status: 'on_review',
+      labels: ['feature'],
+      jira_key: 'SKILLS-70',
+      ticketIds: [id],
+    })
+    const create = vi.fn(async (_g: unknown, input: { branch?: string; ticketId: number }) => ({
+      branch: input.branch ?? `sr/p/ticket-${input.ticketId}`,
+      worktreePath: `/wt/ticket-${input.ticketId}`,
+    }))
+    const git = {
+      run: async (args: string[]) => {
+        if (args[0] === 'rev-parse' && args.at(-1) === 'refs/heads/feat/SKILLS-19-key-terms-activity') {
+          return { code: 0, stdout: '', stderr: '' }
+        }
+        return { code: 0, stdout: '', stderr: '' }
+      },
+    }
+    const exec = {
+      run: vi.fn(async (_cmd: string, args: string[]) => {
+        if (args[0] === 'pr' && args[1] === 'list') return {
+          code: 0,
+          stdout: JSON.stringify([{
+            number: 3000,
+            title: 'SKILLS-70 unrelated Jira follow-up',
+            body: 'This also mentions SKILLS-70 but is not the PR named by the review.',
+            headRefName: 'feat/SKILLS-70-unrelated-followup',
+            baseRefName: 'main',
+            url: 'https://github.com/org/repo/pull/3000',
+            isDraft: false,
+          }]),
+          stderr: '',
+        }
+        if (args[0] === 'pr' && args[1] === 'view' && args[2] === '2147') return {
+          code: 0,
+          stdout: JSON.stringify({
+            number: 2147,
+            title: '[SKILLS-19] Key terms activity',
+            body: 'Original implementation for the key-terms activity.',
+            headRefName: 'feat/SKILLS-19-key-terms-activity',
+            baseRefName: 'main',
+            url: 'https://github.com/org/repo/pull/2147',
+            isDraft: false,
+            state: 'OPEN',
+          }),
+          stderr: '',
+        }
+        return { code: 1, stdout: '', stderr: 'unexpected gh call' }
+      }),
+    }
+
+    await launchIsolatedRail(input([98], ctx), { git, exec, create, remove: vi.fn(async () => {}) })
+
+    expect(create).toHaveBeenCalledWith(git, expect.objectContaining({
+      ticketId: 98,
+      branch: 'feat/SKILLS-19-key-terms-activity',
+    }))
+    await vi.waitFor(() => expect(getActivePrDeliveryByRail(db, 0)!.decision).toBe('pr_ready'))
+    expect(getActivePrDeliveryByRail(db, 0)).toMatchObject({
+      base_branch: 'main',
+      branch: 'feat/SKILLS-19-key-terms-activity',
+      pr_url: 'https://github.com/org/repo/pull/2147',
+      pr_number: 2147,
     })
   })
 

--- a/server/rail-isolated-launch.ts
+++ b/server/rail-isolated-launch.ts
@@ -326,6 +326,14 @@ export async function launchIsolatedRail(input: IsolatedLaunchInput, io: Isolate
       originSurface: input.originSurface ?? 'dashboard',
       originConversationId: input.originConversationId ?? null,
     }).id
+    if (launchContinuation) {
+      transitionDecision(ctx.db, prDeliveryId, 'building', 'building', {
+        branch: launchContinuation.branch,
+        prUrl: launchContinuation.prUrl,
+        prNumber: launchContinuation.prNumber,
+        prState: 'pr-created',
+      })
+    }
     broadcastPrState()
     syncOriginCard('post')
   }
@@ -363,6 +371,7 @@ export async function launchIsolatedRail(input: IsolatedLaunchInput, io: Isolate
         ticketId: unit.ticketId,
         baseRef: continuationTarget?.baseRef ?? worktreeBaseRef.baseRef,
         branch: unitBranchName(unit.ticketId),
+        refreshFromBaseRef: Boolean(continuationTarget?.baseRef),
       })
       // Per-run overlay: merge-link the framework surface the checkout didn't
       // bring into the worktree (idempotent; resume-safe via its manifest).

--- a/server/rail-pr-store.test.ts
+++ b/server/rail-pr-store.test.ts
@@ -313,6 +313,7 @@ describe('JSON round-trips + snapshot mapper', () => {
       ticketIds: [9],
       decision: 'building',
       prUrl: null,
+      prNumber: null,
       prState: 'none',
       branch: null,
       runIds: ['run-9'],

--- a/server/rail-pr-store.ts
+++ b/server/rail-pr-store.ts
@@ -311,6 +311,7 @@ export function toPrDecisionCardEnvelope(projectId: string, snap: PrDeliverySnap
     ticketIds: snap.ticketIds,
     decision: snap.decision,
     prUrl: snap.prUrl,
+    prNumber: snap.prNumber,
     prState: snap.prState,
     branch: snap.branch,
     runIds: snap.runIds,

--- a/server/types.ts
+++ b/server/types.ts
@@ -1268,6 +1268,7 @@ export interface PrDecisionCardEnvelope {
   ticketIds: number[]
   decision: 'building' | 'on_review' | 'pr_draft' | 'pr_ready' | 'merged' | 'discarded' | 'pr_failed'
   prUrl: string | null
+  prNumber: number | null
   prState: 'none' | 'local-only' | 'pushed' | 'pr-created'
   branch: string | null
   /** The launch's loop-run ids, in ticket order ([] until allocation lands) —
@@ -1519,4 +1520,3 @@ export interface SmashUndoneMessage {
   childrenIds: number[]
   timestamp: string
 }
-

--- a/server/worktree-manager.test.ts
+++ b/server/worktree-manager.test.ts
@@ -13,7 +13,7 @@ import {
   type GitResult,
 } from './worktree-manager'
 
-function fakeGit(opts: { worktrees?: string[]; branchExists?: boolean; addFails?: boolean; insideWorktree?: boolean; hasCommits?: boolean; mountedBranch?: string; headFails?: boolean } = {}) {
+function fakeGit(opts: { worktrees?: string[]; branchExists?: boolean; addFails?: boolean; insideWorktree?: boolean; hasCommits?: boolean; mountedBranch?: string; headFails?: boolean; ancestor?: boolean } = {}) {
   const calls: string[][] = []
   const git: GitRunner = {
     async run(args): Promise<GitResult> {
@@ -35,6 +35,12 @@ function fakeGit(opts: { worktrees?: string[]; branchExists?: boolean; addFails?
       }
       if (args[0] === 'rev-parse' && args.includes('--verify')) {
         return opts.branchExists ? { code: 0, stdout: 'sha\n', stderr: '' } : { code: 1, stdout: '', stderr: '' }
+      }
+      if (args[0] === 'merge-base' && args[1] === '--is-ancestor') {
+        return opts.ancestor === false ? { code: 1, stdout: '', stderr: '' } : { code: 0, stdout: '', stderr: '' }
+      }
+      if (args[0] === 'update-ref' || args[0] === 'merge') {
+        return { code: 0, stdout: '', stderr: '' }
       }
       if (args[0] === 'worktree' && args[1] === 'add') {
         return opts.addFails ? { code: 1, stdout: '', stderr: 'fatal: boom' } : { code: 0, stdout: '', stderr: '' }
@@ -121,6 +127,31 @@ describe('createWorktree (resume-aware)', () => {
     const { git, addCalls } = fakeGit({ branchExists: true })
     await createWorktree(git, { ...base, branch: 'feat/3-x' })
     expect(addCalls()[0]).toEqual(['worktree', 'add', '/wt/ticket-3', 'feat/3-x'])
+  })
+
+  it('active-PR continuation fast-forwards an existing local branch from the remote PR head when safe', async () => {
+    const { git, calls, addCalls } = fakeGit({ branchExists: true })
+    await createWorktree(git, {
+      ...base,
+      branch: 'feat/3-x',
+      baseRef: 'origin/feat/3-x',
+      refreshFromBaseRef: true,
+    })
+    expect(calls).toContainEqual(['merge-base', '--is-ancestor', 'refs/heads/feat/3-x', 'origin/feat/3-x'])
+    expect(calls).toContainEqual(['update-ref', 'refs/heads/feat/3-x', 'origin/feat/3-x'])
+    expect(addCalls()[0]).toEqual(['worktree', 'add', '/wt/ticket-3', 'feat/3-x'])
+  })
+
+  it('active-PR continuation never rewrites a diverged or locally-ahead branch', async () => {
+    const { git, calls } = fakeGit({ branchExists: true, ancestor: false })
+    await createWorktree(git, {
+      ...base,
+      branch: 'feat/3-x',
+      baseRef: 'origin/feat/3-x',
+      refreshFromBaseRef: true,
+    })
+    expect(calls).toContainEqual(['merge-base', '--is-ancestor', 'refs/heads/feat/3-x', 'origin/feat/3-x'])
+    expect(calls.some((c) => c[0] === 'update-ref')).toBe(false)
   })
 })
 

--- a/server/worktree-manager.ts
+++ b/server/worktree-manager.ts
@@ -84,11 +84,36 @@ export interface CreateWorktreeInput {
    *  pr-naming). Absent → legacy `sr/<slug>/ticket-<id>` fallback, so other
    *  callers keep their byte-identical behaviour. */
   branch?: string
+  /** For active-PR continuation only: safely fast-forward an existing local
+   *  branch/worktree from `baseRef` before the run starts. Never rewrites
+   *  diverged or locally-ahead branches. */
+  refreshFromBaseRef?: boolean
 }
 
 export interface WorktreeHandle {
   branch: string
   worktreePath: string
+}
+
+async function fastForwardExistingBranch(
+  git: GitRunner,
+  repoDir: string,
+  branch: string,
+  baseRef: string | undefined,
+  mountedWorktreePath?: string,
+): Promise<void> {
+  if (!baseRef) return
+  if (mountedWorktreePath) {
+    const ancestor = await git.run(['merge-base', '--is-ancestor', 'HEAD', baseRef], mountedWorktreePath)
+    if (ancestor.code !== 0) return
+    await git.run(['merge', '--ff-only', baseRef], mountedWorktreePath).catch(() => {})
+    return
+  }
+
+  const localRef = `refs/heads/${branch}`
+  const ancestor = await git.run(['merge-base', '--is-ancestor', localRef, baseRef], repoDir)
+  if (ancestor.code !== 0) return
+  await git.run(['update-ref', localRef, baseRef], repoDir).catch(() => {})
 }
 
 /**
@@ -118,9 +143,16 @@ export async function createWorktree(git: GitRunner, input: CreateWorktreeInput)
     // at local-only. Detached HEAD / a git failure falls back to the input.
     const head = await git.run(['rev-parse', '--abbrev-ref', 'HEAD'], wt)
     const actual = head.code === 0 ? head.stdout.trim() : ''
-    return { branch: actual && actual !== 'HEAD' ? actual : branch, worktreePath: wt }
+    const actualBranch = actual && actual !== 'HEAD' ? actual : branch
+    if (input.refreshFromBaseRef && actualBranch === branch) {
+      await fastForwardExistingBranch(git, input.repoDir, branch, input.baseRef, wt)
+    }
+    return { branch: actualBranch, worktreePath: wt }
   }
   const hasBranch = (await git.run(['rev-parse', '--verify', '--quiet', `refs/heads/${branch}`], input.repoDir)).code === 0
+  if (hasBranch && input.refreshFromBaseRef) {
+    await fastForwardExistingBranch(git, input.repoDir, branch, input.baseRef)
+  }
   const args = hasBranch
     ? ['worktree', 'add', wt, branch]
     : ['worktree', 'add', '-b', branch, wt, base]


### PR DESCRIPTION
## Summary
- detect explicit PR references in on-review ticket titles/descriptions, including `PR #123` and `/pull/123`
- fetch explicitly mentioned PRs with `gh pr view` so older open PRs are not missed by the open-PR list page
- rank PR-number matches above Jira/ticket/title matches so review follow-ups continue the intended historical branch
- anonymize active-PR continuation tests away from organization-specific URLs

## Validation
- npx vitest run server/rail-isolated-launch.test.ts
- npm run typecheck
- git diff --check

Note: the isolated worktree does not have node_modules, so the test/typecheck commands were validated in the primary checkout before committing; the clean worktree passed git diff --check and contains only the two committed files.