### PR TITLE
feat(agent): add favorite missions sidebar section

### DIFF
--- a/.claude/commands/opsx/apply.md
+++ b/.claude/commands/opsx/apply.md
@@ -26,6 +26,7 @@ Implement tasks from an OpenSpec change.
    ```
    Parse the JSON to understand:
    - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
    - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
 
 3. **Get apply instructions**
@@ -44,6 +45,8 @@ Implement tasks from an OpenSpec change.
    - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
    - If `state: "all_done"`: congratulate, suggest archive
    - Otherwise: proceed to implementation
+
+   **Workspace guard:** If status JSON reports `actionContext.mode: "workspace-planning"` and `allowedEditRoots` is empty, explain that full workspace apply is not supported in this slice. Treat linked repos and folders as read-only context, ask the user to select an affected area through an explicit implementation workflow, and STOP before editing files.
 
 4. **Read context files**
 

--- a/.claude/commands/opsx/archive.md
+++ b/.claude/commands/opsx/archive.md
@@ -26,7 +26,10 @@ Archive a completed change in the experimental workflow.
 
    Parse the JSON to understand:
    - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
    - `artifacts`: List of artifacts with their status (`done` or other)
+
+   If status reports `actionContext.mode: "workspace-planning"`, explain that workspace archive is not supported in this slice and STOP. Do not move workspace changes into repo-local archives or edit linked repos.
 
    **If any artifacts are not `done`:**
    - Display warning listing incomplete artifacts
@@ -48,7 +51,7 @@ Archive a completed change in the experimental workflow.
 
 4. **Assess delta spec sync state**
 
-   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON to check for delta specs. If none exist, proceed without sync prompt.
 
    **If delta specs exist:**
    - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
@@ -63,19 +66,19 @@ Archive a completed change in the experimental workflow.
 
 5. **Perform the archive**
 
-   Create the archive directory if it doesn't exist:
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
    ```bash
-   mkdir -p openspec/changes/archive
+   mkdir -p "<planningHome.changesDir>/archive"
    ```
 
    Generate target name using current date: `YYYY-MM-DD-<change-name>`
 
    **Check if target already exists:**
    - If yes: Fail with error, suggest renaming existing archive or using different date
-   - If no: Move the change directory to archive
+   - If no: Move `changeRoot` to the archive directory
 
    ```bash
-   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
    ```
 
 6. **Display summary**
@@ -94,7 +97,7 @@ Archive a completed change in the experimental workflow.
 
 **Change:** <change-name>
 **Schema:** <schema-name>
-**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
 **Specs:** ✓ Synced to main specs
 
 All artifacts complete. All tasks complete.
@@ -107,7 +110,7 @@ All artifacts complete. All tasks complete.
 
 **Change:** <change-name>
 **Schema:** <schema-name>
-**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
 **Specs:** No delta specs
 
 All artifacts complete. All tasks complete.
@@ -120,7 +123,7 @@ All artifacts complete. All tasks complete.
 
 **Change:** <change-name>
 **Schema:** <schema-name>
-**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
 **Specs:** Sync skipped (user chose to skip)
 
 **Warnings:**
@@ -137,7 +140,7 @@ Review the archive if this was not intentional.
 ## Archive Failed
 
 **Change:** <change-name>
-**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Target:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
 
 Target archive directory already exists.
 

--- a/.claude/commands/opsx/bulk-archive.md
+++ b/.claude/commands/opsx/bulk-archive.md
@@ -33,14 +33,16 @@ This skill allows you to batch-archive changes, handling spec conflicts intellig
    For each selected change, collect:
 
    a. **Artifact status** - Run `openspec status --change "<name>" --json`
-      - Parse `schemaName` and `artifacts` list
+      - Parse `schemaName`, `artifacts`, `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`
       - Note which artifacts are `done` vs other states
 
-   b. **Task completion** - Read `openspec/changes/<name>/tasks.md`
+      If any selected change reports `actionContext.mode: "workspace-planning"`, explain that workspace bulk archive is not supported in this slice and STOP before syncing specs or moving changes. Do not fall back to repo-local paths or edit linked repos.
+
+   b. **Task completion** - Read `artifactPaths.tasks.existingOutputPaths` from status JSON
       - Count `- [ ]` (incomplete) vs `- [x]` (complete)
       - If no tasks file exists, note as "No tasks"
 
-   c. **Delta specs** - Check `openspec/changes/<name>/specs/` directory
+   c. **Delta specs** - Check `artifactPaths.specs.existingOutputPaths` from status JSON
       - List which capability specs exist
       - For each, extract requirement names (lines matching `### Requirement: <name>`)
 
@@ -123,8 +125,8 @@ This skill allows you to batch-archive changes, handling spec conflicts intellig
 
    b. **Perform the archive**:
       ```bash
-      mkdir -p openspec/changes/archive
-      mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+      mkdir -p "<planningHome.changesDir>/archive"
+      mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
       ```
 
    c. **Track outcome** for each change:

--- a/.claude/commands/opsx/continue.md
+++ b/.claude/commands/opsx/continue.md
@@ -33,6 +33,7 @@ Continue working on a change by creating the next artifact.
    - `schemaName`: The workflow schema being used (e.g., "spec-driven")
    - `artifacts`: Array of artifacts with their status ("done", "ready", "blocked")
    - `isComplete`: Boolean indicating if all artifacts are complete
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
 
 3. **Act based on status**:
 
@@ -57,13 +58,13 @@ Continue working on a change by creating the next artifact.
      - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
      - `template`: The structure to use for your output file
      - `instruction`: Schema-specific guidance
-     - `outputPath`: Where to write the artifact
+     - `resolvedOutputPath`: Resolved path or pattern to write the artifact
      - `dependencies`: Completed artifacts to read for context
    - **Create the artifact file**:
      - Read any completed dependency files for context
      - Use `template` as the structure - fill in its sections
      - Apply `context` and `rules` as constraints when writing - but do NOT copy them into the file
-     - Write to the output path specified in instructions
+     - Write to the `resolvedOutputPath` specified in instructions. If it is a glob pattern, choose the concrete file path using the schema instruction and workspace planning context
    - Show what was created and what's now unlocked
    - STOP after creating ONE artifact
 

--- a/.claude/commands/opsx/explore.md
+++ b/.claude/commands/opsx/explore.md
@@ -107,11 +107,10 @@ Think freely. When insights crystallize, you might offer:
 
 If the user mentions a change or you detect one is relevant:
 
-1. **Read existing artifacts for context**
-   - `openspec/changes/<name>/proposal.md`
-   - `openspec/changes/<name>/design.md`
-   - `openspec/changes/<name>/tasks.md`
-   - etc.
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
 
 2. **Reference them naturally in conversation**
    - "Your design mentions using Redis, but we just realized SQLite fits better..."

--- a/.claude/commands/opsx/ff.md
+++ b/.claude/commands/opsx/ff.md
@@ -24,7 +24,7 @@ Fast-forward through artifact creation - generate everything needed to start imp
    ```bash
    openspec new change "<name>"
    ```
-   This creates a scaffolded change at `openspec/changes/<name>/`.
+   This creates a scaffolded change in the planning home resolved by the CLI.
 
 3. **Get the artifact build order**
    ```bash
@@ -33,6 +33,7 @@ Fast-forward through artifact creation - generate everything needed to start imp
    Parse the JSON to get:
    - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
    - `artifacts`: list of all artifacts with their status and dependencies
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
 
 4. **Create artifacts in sequence until apply-ready**
 
@@ -50,10 +51,10 @@ Fast-forward through artifact creation - generate everything needed to start imp
         - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
         - `template`: The structure to use for your output file
         - `instruction`: Schema-specific guidance for this artifact type
-        - `outputPath`: Where to write the artifact
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
         - `dependencies`: Completed artifacts to read for context
       - Read any completed dependency files for context
-      - Create the artifact file using `template` as the structure
+      - Create the artifact file using `template` as the structure and write it to `resolvedOutputPath`
       - Apply `context` and `rules` as constraints - but do NOT copy them into the file
       - Show brief progress: "✓ Created <artifact-id>"
 

--- a/.claude/commands/opsx/new.md
+++ b/.claude/commands/opsx/new.md
@@ -35,13 +35,13 @@ Start a new change using the experimental artifact-driven approach.
    openspec new change "<name>"
    ```
    Add `--schema <name>` only if the user requested a specific workflow.
-   This creates a scaffolded change at `openspec/changes/<name>/` with the selected schema.
+   This creates a scaffolded change in the planning home resolved by the CLI.
 
 4. **Show the artifact status**
    ```bash
-   openspec status --change "<name>"
+   openspec status --change "<name>" --json
    ```
-   This shows which artifacts need to be created and which are ready (dependencies satisfied).
+   Use the returned `planningHome`, `changeRoot`, `artifactPaths`, and `nextSteps` instead of assuming repo-local paths.
 
 5. **Get instructions for the first artifact**
    The first artifact depends on the schema. Check the status output to find the first artifact with status "ready".

--- a/.claude/commands/opsx/onboard.md
+++ b/.claude/commands/opsx/onboard.md
@@ -163,7 +163,7 @@ Now let's create a change to hold our work.
 ```
 ## Creating a Change
 
-A "change" in OpenSpec is a container for all the thinking and planning around a piece of work. It lives in `openspec/changes/<name>/` and holds your artifacts—proposal, specs, design, tasks.
+A "change" in OpenSpec is a container for all the thinking and planning around a piece of work. It lives at the `changeRoot` reported by `openspec status --change "<name>" --json` and holds your artifacts—proposal, specs, design, tasks.
 
 Let me create one for our task.
 ```
@@ -175,11 +175,11 @@ openspec new change "<derived-name>"
 
 **SHOW:**
 ```
-Created: `openspec/changes/<name>/`
+Created: <changeRoot from status JSON>
 
 The folder structure:
 ```
-openspec/changes/<name>/
+<changeRoot>/
 ├── proposal.md    ← Why we're doing this (empty, we'll fill it)
 ├── design.md      ← How we'll build it (empty)
 ├── specs/         ← Detailed requirements (empty)
@@ -241,7 +241,7 @@ After approval, save the proposal:
 ```bash
 openspec instructions proposal --change "<name>" --json
 ```
-Then write the content to `openspec/changes/<name>/proposal.md`.
+Then write the content to the `resolvedOutputPath` from `openspec instructions proposal --change "<name>" --json`.
 
 ```
 Proposal saved. This is your "why" document—you can always come back and refine it as understanding evolves.
@@ -262,12 +262,10 @@ Specs define **what** we're building in precise, testable terms. They use a requ
 For a small task like this, we might only need one spec file.
 ```
 
-**DO:** Create the spec file:
+**DO:** Resolve where the spec file should be created:
 ```bash
-# Unix/macOS
-mkdir -p openspec/changes/<name>/specs/<capability-name>
-# Windows (PowerShell)
-# New-Item -ItemType Directory -Force -Path "openspec/changes/<name>/specs/<capability-name>"
+openspec instructions specs --change "<name>" --json
+# Use resolvedOutputPath from the JSON. If it is a glob, choose the concrete file path using the schema instruction and workspace planning context.
 ```
 
 Draft the spec content:
@@ -294,7 +292,7 @@ Here's the spec:
 This format—WHEN/THEN/AND—makes requirements testable. You can literally read them as test cases.
 ```
 
-Save to `openspec/changes/<name>/specs/<capability>/spec.md`.
+Save to the concrete file path chosen from `resolvedOutputPath`.
 
 ---
 
@@ -339,7 +337,7 @@ Here's the design:
 For a small task, this captures the key decisions without over-engineering.
 ```
 
-Save to `openspec/changes/<name>/design.md`.
+Save to the `resolvedOutputPath` from `openspec instructions design --change "<name>" --json`.
 
 ---
 
@@ -377,7 +375,7 @@ Each checkbox becomes a unit of work in the apply phase. Ready to implement?
 
 **PAUSE** - Wait for user to confirm they're ready to implement.
 
-Save to `openspec/changes/<name>/tasks.md`.
+Save to the `resolvedOutputPath` from `openspec instructions tasks --change "<name>" --json`.
 
 ---
 
@@ -421,7 +419,7 @@ The change is implemented! One more step—let's archive it.
 ```
 ## Archiving
 
-When a change is complete, we archive it. This moves it from `openspec/changes/` to `openspec/changes/archive/YYYY-MM-DD-<name>/`.
+When a change is complete, we archive it. The archive path is derived from `planningHome.changesDir` and the date.
 
 Archived changes become your project's decision history—you can always find them later to understand why something was built a certain way.
 ```
@@ -433,7 +431,7 @@ openspec archive "<name>"
 
 **SHOW:**
 ```
-Archived to: `openspec/changes/archive/YYYY-MM-DD-<name>/`
+Archived to: `<planningHome.changesDir>/archive/YYYY-MM-DD-<name>/`
 
 The change is now part of your project's history. The code is in your codebase, the decision record is preserved.
 ```
@@ -496,7 +494,7 @@ Try `/opsx:propose` on something you actually want to build. You've got the rhyt
 If the user says they need to stop, want to pause, or seem disengaged:
 
 ```
-No problem! Your change is saved at `openspec/changes/<name>/`.
+No problem! Your change is saved at the `changeRoot` reported by `openspec status --change "<name>" --json`.
 
 To pick up where we left off later:
 - `/opsx:continue <name>` - Resume artifact creation

--- a/.claude/commands/opsx/sync.md
+++ b/.claude/commands/opsx/sync.md
@@ -21,9 +21,18 @@ This is an **agent-driven** operation - you will read delta specs and directly e
 
    **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
 
-2. **Find delta specs**
+2. **Resolve change context**
 
-   Look for delta spec files in `openspec/changes/<name>/specs/*/spec.md`.
+   Run:
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+
+   If status reports `actionContext.mode: "workspace-planning"`, explain that workspace spec sync is not supported in this slice and STOP. Do not fall back to repo-local paths or edit linked repos.
+
+3. **Find delta specs**
+
+   Use `artifactPaths.specs.existingOutputPaths` from the status JSON as the list of delta spec files.
 
    Each delta spec file contains sections like:
    - `## ADDED Requirements` - New requirements to add
@@ -33,9 +42,9 @@ This is an **agent-driven** operation - you will read delta specs and directly e
 
    If no delta specs found, inform user and stop.
 
-3. **For each delta spec, apply changes to main specs**
+4. **For each delta spec, apply changes to main specs**
 
-   For each capability with a delta spec at `openspec/changes/<name>/specs/<capability>/spec.md`:
+   For each repo-local capability delta spec path returned by the CLI:
 
    a. **Read the delta spec** to understand the intended changes
 
@@ -66,7 +75,7 @@ This is an **agent-driven** operation - you will read delta specs and directly e
       - Add Purpose section (can be brief, mark as TBD)
       - Add Requirements section with the ADDED requirements
 
-4. **Show summary**
+5. **Show summary**
 
    After applying all changes, summarize:
    - Which capabilities were updated

--- a/.claude/commands/opsx/verify.md
+++ b/.claude/commands/opsx/verify.md
@@ -27,9 +27,12 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
    ```
    Parse the JSON to understand:
    - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
    - Which artifacts exist for this change
 
-3. **Get the change directory and load artifacts**
+   If status reports `actionContext.mode: "workspace-planning"`, explain that full workspace implementation verification is not supported in this slice and STOP. Do not infer repo-local implementation ownership or edit linked repos.
+
+3. **Get planning context and load artifacts**
 
    ```bash
    openspec instructions apply --change "<name>" --json
@@ -57,7 +60,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
      - Recommendation: "Complete task: <description>" or "Mark as done if already implemented"
 
    **Spec Coverage**:
-   - If delta specs exist in `openspec/changes/<name>/specs/`:
+   - If delta specs exist in `contextFiles.specs`:
      - Extract all requirements (marked with "### Requirement:")
      - For each requirement:
        - Search codebase for keywords related to the requirement

--- a/.claude/skills/openspec-apply-change/SKILL.md
+++ b/.claude/skills/openspec-apply-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.3.1"
+  generatedBy: "1.4.1"
 ---
 
 Implement tasks from an OpenSpec change.
@@ -30,6 +30,7 @@ Implement tasks from an OpenSpec change.
    ```
    Parse the JSON to understand:
    - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
    - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
 
 3. **Get apply instructions**
@@ -48,6 +49,8 @@ Implement tasks from an OpenSpec change.
    - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
    - If `state: "all_done"`: congratulate, suggest archive
    - Otherwise: proceed to implementation
+
+   **Workspace guard:** If status JSON reports `actionContext.mode: "workspace-planning"` and `allowedEditRoots` is empty, explain that full workspace apply is not supported in this slice. Treat linked repos and folders as read-only context, ask the user to select an affected area through an explicit implementation workflow, and STOP before editing files.
 
 4. **Read context files**
 

--- a/.claude/skills/openspec-archive-change/SKILL.md
+++ b/.claude/skills/openspec-archive-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.3.1"
+  generatedBy: "1.4.1"
 ---
 
 Archive a completed change in the experimental workflow.
@@ -30,7 +30,10 @@ Archive a completed change in the experimental workflow.
 
    Parse the JSON to understand:
    - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
    - `artifacts`: List of artifacts with their status (`done` or other)
+
+   If status reports `actionContext.mode: "workspace-planning"`, explain that workspace archive is not supported in this slice and STOP. Do not move workspace changes into repo-local archives or edit linked repos.
 
    **If any artifacts are not `done`:**
    - Display warning listing incomplete artifacts
@@ -52,7 +55,7 @@ Archive a completed change in the experimental workflow.
 
 4. **Assess delta spec sync state**
 
-   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON to check for delta specs. If none exist, proceed without sync prompt.
 
    **If delta specs exist:**
    - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
@@ -67,19 +70,19 @@ Archive a completed change in the experimental workflow.
 
 5. **Perform the archive**
 
-   Create the archive directory if it doesn't exist:
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
    ```bash
-   mkdir -p openspec/changes/archive
+   mkdir -p "<planningHome.changesDir>/archive"
    ```
 
    Generate target name using current date: `YYYY-MM-DD-<change-name>`
 
    **Check if target already exists:**
    - If yes: Fail with error, suggest renaming existing archive or using different date
-   - If no: Move the change directory to archive
+   - If no: Move `changeRoot` to the archive directory
 
    ```bash
-   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
    ```
 
 6. **Display summary**
@@ -98,7 +101,7 @@ Archive a completed change in the experimental workflow.
 
 **Change:** <change-name>
 **Schema:** <schema-name>
-**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
 **Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
 
 All artifacts complete. All tasks complete.

--- a/.claude/skills/openspec-bulk-archive-change/SKILL.md
+++ b/.claude/skills/openspec-bulk-archive-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.3.1"
+  generatedBy: "1.4.1"
 ---
 
 Archive multiple completed changes in a single operation.
@@ -37,14 +37,16 @@ This skill allows you to batch-archive changes, handling spec conflicts intellig
    For each selected change, collect:
 
    a. **Artifact status** - Run `openspec status --change "<name>" --json`
-      - Parse `schemaName` and `artifacts` list
+      - Parse `schemaName`, `artifacts`, `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`
       - Note which artifacts are `done` vs other states
 
-   b. **Task completion** - Read `openspec/changes/<name>/tasks.md`
+      If any selected change reports `actionContext.mode: "workspace-planning"`, explain that workspace bulk archive is not supported in this slice and STOP before syncing specs or moving changes. Do not fall back to repo-local paths or edit linked repos.
+
+   b. **Task completion** - Read `artifactPaths.tasks.existingOutputPaths` from status JSON
       - Count `- [ ]` (incomplete) vs `- [x]` (complete)
       - If no tasks file exists, note as "No tasks"
 
-   c. **Delta specs** - Check `openspec/changes/<name>/specs/` directory
+   c. **Delta specs** - Check `artifactPaths.specs.existingOutputPaths` from status JSON
       - List which capability specs exist
       - For each, extract requirement names (lines matching `### Requirement: <name>`)
 
@@ -127,8 +129,8 @@ This skill allows you to batch-archive changes, handling spec conflicts intellig
 
    b. **Perform the archive**:
       ```bash
-      mkdir -p openspec/changes/archive
-      mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+      mkdir -p "<planningHome.changesDir>/archive"
+      mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
       ```
 
    c. **Track outcome** for each change:

--- a/.claude/skills/openspec-continue-change/SKILL.md
+++ b/.claude/skills/openspec-continue-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.3.1"
+  generatedBy: "1.4.1"
 ---
 
 Continue working on a change by creating the next artifact.
@@ -37,6 +37,7 @@ Continue working on a change by creating the next artifact.
    - `schemaName`: The workflow schema being used (e.g., "spec-driven")
    - `artifacts`: Array of artifacts with their status ("done", "ready", "blocked")
    - `isComplete`: Boolean indicating if all artifacts are complete
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
 
 3. **Act based on status**:
 
@@ -61,13 +62,13 @@ Continue working on a change by creating the next artifact.
      - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
      - `template`: The structure to use for your output file
      - `instruction`: Schema-specific guidance
-     - `outputPath`: Where to write the artifact
+     - `resolvedOutputPath`: Resolved path or pattern to write the artifact
      - `dependencies`: Completed artifacts to read for context
    - **Create the artifact file**:
      - Read any completed dependency files for context
      - Use `template` as the structure - fill in its sections
      - Apply `context` and `rules` as constraints when writing - but do NOT copy them into the file
-     - Write to the output path specified in instructions
+     - Write to the `resolvedOutputPath` specified in instructions. If it is a glob pattern, choose the concrete file path using the schema instruction and workspace planning context
    - Show what was created and what's now unlocked
    - STOP after creating ONE artifact
 

--- a/.claude/skills/openspec-explore/SKILL.md
+++ b/.claude/skills/openspec-explore/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.3.1"
+  generatedBy: "1.4.1"
 ---
 
 Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
@@ -102,11 +102,10 @@ Think freely. When insights crystallize, you might offer:
 
 If the user mentions a change or you detect one is relevant:
 
-1. **Read existing artifacts for context**
-   - `openspec/changes/<name>/proposal.md`
-   - `openspec/changes/<name>/design.md`
-   - `openspec/changes/<name>/tasks.md`
-   - etc.
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
 
 2. **Reference them naturally in conversation**
    - "Your design mentions using Redis, but we just realized SQLite fits better..."

--- a/.claude/skills/openspec-ff-change/SKILL.md
+++ b/.claude/skills/openspec-ff-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.3.1"
+  generatedBy: "1.4.1"
 ---
 
 Fast-forward through artifact creation - generate everything needed to start implementation in one go.
@@ -28,7 +28,7 @@ Fast-forward through artifact creation - generate everything needed to start imp
    ```bash
    openspec new change "<name>"
    ```
-   This creates a scaffolded change at `openspec/changes/<name>/`.
+   This creates a scaffolded change in the planning home resolved by the CLI.
 
 3. **Get the artifact build order**
    ```bash
@@ -37,6 +37,7 @@ Fast-forward through artifact creation - generate everything needed to start imp
    Parse the JSON to get:
    - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
    - `artifacts`: list of all artifacts with their status and dependencies
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
 
 4. **Create artifacts in sequence until apply-ready**
 
@@ -54,10 +55,10 @@ Fast-forward through artifact creation - generate everything needed to start imp
         - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
         - `template`: The structure to use for your output file
         - `instruction`: Schema-specific guidance for this artifact type
-        - `outputPath`: Where to write the artifact
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
         - `dependencies`: Completed artifacts to read for context
       - Read any completed dependency files for context
-      - Create the artifact file using `template` as the structure
+      - Create the artifact file using `template` as the structure and write it to `resolvedOutputPath`
       - Apply `context` and `rules` as constraints - but do NOT copy them into the file
       - Show brief progress: "✓ Created <artifact-id>"
 

--- a/.claude/skills/openspec-new-change/SKILL.md
+++ b/.claude/skills/openspec-new-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.3.1"
+  generatedBy: "1.4.1"
 ---
 
 Start a new change using the experimental artifact-driven approach.
@@ -39,13 +39,13 @@ Start a new change using the experimental artifact-driven approach.
    openspec new change "<name>"
    ```
    Add `--schema <name>` only if the user requested a specific workflow.
-   This creates a scaffolded change at `openspec/changes/<name>/` with the selected schema.
+   This creates a scaffolded change in the planning home resolved by the CLI.
 
 4. **Show the artifact status**
    ```bash
-   openspec status --change "<name>"
+   openspec status --change "<name>" --json
    ```
-   This shows which artifacts need to be created and which are ready (dependencies satisfied).
+   Use the returned `planningHome`, `changeRoot`, `artifactPaths`, and `nextSteps` instead of assuming repo-local paths.
 
 5. **Get instructions for the first artifact**
    The first artifact depends on the schema (e.g., `proposal` for spec-driven).

--- a/.claude/skills/openspec-onboard/SKILL.md
+++ b/.claude/skills/openspec-onboard/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.3.1"
+  generatedBy: "1.4.1"
 ---
 
 Guide the user through their first complete OpenSpec workflow cycle. This is a teaching experience—you'll do real work in their codebase while explaining each step.
@@ -167,7 +167,7 @@ Now let's create a change to hold our work.
 ```
 ## Creating a Change
 
-A "change" in OpenSpec is a container for all the thinking and planning around a piece of work. It lives in `openspec/changes/<name>/` and holds your artifacts—proposal, specs, design, tasks.
+A "change" in OpenSpec is a container for all the thinking and planning around a piece of work. It lives at the `changeRoot` reported by `openspec status --change "<name>" --json` and holds your artifacts—proposal, specs, design, tasks.
 
 Let me create one for our task.
 ```
@@ -179,11 +179,11 @@ openspec new change "<derived-name>"
 
 **SHOW:**
 ```
-Created: `openspec/changes/<name>/`
+Created: <changeRoot from status JSON>
 
 The folder structure:
 ```
-openspec/changes/<name>/
+<changeRoot>/
 ├── proposal.md    ← Why we're doing this (empty, we'll fill it)
 ├── design.md      ← How we'll build it (empty)
 ├── specs/         ← Detailed requirements (empty)
@@ -245,7 +245,7 @@ After approval, save the proposal:
 ```bash
 openspec instructions proposal --change "<name>" --json
 ```
-Then write the content to `openspec/changes/<name>/proposal.md`.
+Then write the content to the `resolvedOutputPath` from `openspec instructions proposal --change "<name>" --json`.
 
 ```
 Proposal saved. This is your "why" document—you can always come back and refine it as understanding evolves.
@@ -266,12 +266,10 @@ Specs define **what** we're building in precise, testable terms. They use a requ
 For a small task like this, we might only need one spec file.
 ```
 
-**DO:** Create the spec file:
+**DO:** Resolve where the spec file should be created:
 ```bash
-# Unix/macOS
-mkdir -p openspec/changes/<name>/specs/<capability-name>
-# Windows (PowerShell)
-# New-Item -ItemType Directory -Force -Path "openspec/changes/<name>/specs/<capability-name>"
+openspec instructions specs --change "<name>" --json
+# Use resolvedOutputPath from the JSON. If it is a glob, choose the concrete file path using the schema instruction and workspace planning context.
 ```
 
 Draft the spec content:
@@ -298,7 +296,7 @@ Here's the spec:
 This format—WHEN/THEN/AND—makes requirements testable. You can literally read them as test cases.
 ```
 
-Save to `openspec/changes/<name>/specs/<capability>/spec.md`.
+Save to the concrete file path chosen from `resolvedOutputPath`.
 
 ---
 
@@ -343,7 +341,7 @@ Here's the design:
 For a small task, this captures the key decisions without over-engineering.
 ```
 
-Save to `openspec/changes/<name>/design.md`.
+Save to the `resolvedOutputPath` from `openspec instructions design --change "<name>" --json`.
 
 ---
 
@@ -381,7 +379,7 @@ Each checkbox becomes a unit of work in the apply phase. Ready to implement?
 
 **PAUSE** - Wait for user to confirm they're ready to implement.
 
-Save to `openspec/changes/<name>/tasks.md`.
+Save to the `resolvedOutputPath` from `openspec instructions tasks --change "<name>" --json`.
 
 ---
 
@@ -425,7 +423,7 @@ The change is implemented! One more step—let's archive it.
 ```
 ## Archiving
 
-When a change is complete, we archive it. This moves it from `openspec/changes/` to `openspec/changes/archive/YYYY-MM-DD-<name>/`.
+When a change is complete, we archive it. The archive path is derived from `planningHome.changesDir` and the date.
 
 Archived changes become your project's decision history—you can always find them later to understand why something was built a certain way.
 ```
@@ -437,7 +435,7 @@ openspec archive "<name>"
 
 **SHOW:**
 ```
-Archived to: `openspec/changes/archive/YYYY-MM-DD-<name>/`
+Archived to: `<planningHome.changesDir>/archive/YYYY-MM-DD-<name>/`
 
 The change is now part of your project's history. The code is in your codebase, the decision record is preserved.
 ```
@@ -500,7 +498,7 @@ Try `/opsx:propose` on something you actually want to build. You've got the rhyt
 If the user says they need to stop, want to pause, or seem disengaged:
 
 ```
-No problem! Your change is saved at `openspec/changes/<name>/`.
+No problem! Your change is saved at the `changeRoot` reported by `openspec status --change "<name>" --json`.
 
 To pick up where we left off later:
 - `/opsx:continue <name>` - Resume artifact creation

--- a/.claude/skills/openspec-sync-specs/SKILL.md
+++ b/.claude/skills/openspec-sync-specs/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.3.1"
+  generatedBy: "1.4.1"
 ---
 
 Sync delta specs from a change to main specs.
@@ -25,9 +25,18 @@ This is an **agent-driven** operation - you will read delta specs and directly e
 
    **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
 
-2. **Find delta specs**
+2. **Resolve change context**
 
-   Look for delta spec files in `openspec/changes/<name>/specs/*/spec.md`.
+   Run:
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+
+   If status reports `actionContext.mode: "workspace-planning"`, explain that workspace spec sync is not supported in this slice and STOP. Do not fall back to repo-local paths or edit linked repos.
+
+3. **Find delta specs**
+
+   Use `artifactPaths.specs.existingOutputPaths` from the status JSON as the list of delta spec files.
 
    Each delta spec file contains sections like:
    - `## ADDED Requirements` - New requirements to add
@@ -37,9 +46,9 @@ This is an **agent-driven** operation - you will read delta specs and directly e
 
    If no delta specs found, inform user and stop.
 
-3. **For each delta spec, apply changes to main specs**
+4. **For each delta spec, apply changes to main specs**
 
-   For each capability with a delta spec at `openspec/changes/<name>/specs/<capability>/spec.md`:
+   For each repo-local capability delta spec path returned by the CLI:
 
    a. **Read the delta spec** to understand the intended changes
 
@@ -70,7 +79,7 @@ This is an **agent-driven** operation - you will read delta specs and directly e
       - Add Purpose section (can be brief, mark as TBD)
       - Add Requirements section with the ADDED requirements
 
-4. **Show summary**
+5. **Show summary**
 
    After applying all changes, summarize:
    - Which capabilities were updated

--- a/.claude/skills/openspec-verify-change/SKILL.md
+++ b/.claude/skills/openspec-verify-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.3.1"
+  generatedBy: "1.4.1"
 ---
 
 Verify that an implementation matches the change artifacts (specs, tasks, design).
@@ -31,9 +31,12 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
    ```
    Parse the JSON to understand:
    - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
    - Which artifacts exist for this change
 
-3. **Get the change directory and load artifacts**
+   If status reports `actionContext.mode: "workspace-planning"`, explain that full workspace implementation verification is not supported in this slice and STOP. Do not infer repo-local implementation ownership or edit linked repos.
+
+3. **Get planning context and load artifacts**
 
    ```bash
    openspec instructions apply --change "<name>" --json
@@ -61,7 +64,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
      - Recommendation: "Complete task: <description>" or "Mark as done if already implemented"
 
    **Spec Coverage**:
-   - If delta specs exist in `openspec/changes/<name>/specs/`:
+   - If delta specs exist in `contextFiles.specs`:
      - Extract all requirements (marked with "### Requirement:")
      - For each requirement:
        - Search codebase for keywords related to the requirement

--- a/.codex/skills/openspec-apply-change/SKILL.md
+++ b/.codex/skills/openspec-apply-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.2.0"
+  generatedBy: "1.4.1"
 ---
 
 Implement tasks from an OpenSpec change.
@@ -30,6 +30,7 @@ Implement tasks from an OpenSpec change.
    ```
    Parse the JSON to understand:
    - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
    - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
 
 3. **Get apply instructions**
@@ -39,7 +40,7 @@ Implement tasks from an OpenSpec change.
    ```
 
    This returns:
-   - Context file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
    - Progress (total, complete, remaining)
    - Task list with status
    - Dynamic instruction based on current state
@@ -49,9 +50,11 @@ Implement tasks from an OpenSpec change.
    - If `state: "all_done"`: congratulate, suggest archive
    - Otherwise: proceed to implementation
 
+   **Workspace guard:** If status JSON reports `actionContext.mode: "workspace-planning"` and `allowedEditRoots` is empty, explain that full workspace apply is not supported in this slice. Treat linked repos and folders as read-only context, ask the user to select an affected area through an explicit implementation workflow, and STOP before editing files.
+
 4. **Read context files**
 
-   Read the files listed in `contextFiles` from the apply instructions output.
+   Read every file path listed under `contextFiles` from the apply instructions output.
    The files depend on the schema being used:
    - **spec-driven**: proposal, specs, design, tasks
    - Other schemas: follow the contextFiles from CLI output

--- a/.codex/skills/openspec-archive-change/SKILL.md
+++ b/.codex/skills/openspec-archive-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.2.0"
+  generatedBy: "1.4.1"
 ---
 
 Archive a completed change in the experimental workflow.
@@ -30,7 +30,10 @@ Archive a completed change in the experimental workflow.
 
    Parse the JSON to understand:
    - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
    - `artifacts`: List of artifacts with their status (`done` or other)
+
+   If status reports `actionContext.mode: "workspace-planning"`, explain that workspace archive is not supported in this slice and STOP. Do not move workspace changes into repo-local archives or edit linked repos.
 
    **If any artifacts are not `done`:**
    - Display warning listing incomplete artifacts
@@ -52,7 +55,7 @@ Archive a completed change in the experimental workflow.
 
 4. **Assess delta spec sync state**
 
-   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON to check for delta specs. If none exist, proceed without sync prompt.
 
    **If delta specs exist:**
    - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
@@ -67,19 +70,19 @@ Archive a completed change in the experimental workflow.
 
 5. **Perform the archive**
 
-   Create the archive directory if it doesn't exist:
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
    ```bash
-   mkdir -p openspec/changes/archive
+   mkdir -p "<planningHome.changesDir>/archive"
    ```
 
    Generate target name using current date: `YYYY-MM-DD-<change-name>`
 
    **Check if target already exists:**
    - If yes: Fail with error, suggest renaming existing archive or using different date
-   - If no: Move the change directory to archive
+   - If no: Move `changeRoot` to the archive directory
 
    ```bash
-   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
    ```
 
 6. **Display summary**
@@ -98,7 +101,7 @@ Archive a completed change in the experimental workflow.
 
 **Change:** <change-name>
 **Schema:** <schema-name>
-**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
 **Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
 
 All artifacts complete. All tasks complete.

--- a/.codex/skills/openspec-bulk-archive-change/SKILL.md
+++ b/.codex/skills/openspec-bulk-archive-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.2.0"
+  generatedBy: "1.4.1"
 ---
 
 Archive multiple completed changes in a single operation.
@@ -37,14 +37,16 @@ This skill allows you to batch-archive changes, handling spec conflicts intellig
    For each selected change, collect:
 
    a. **Artifact status** - Run `openspec status --change "<name>" --json`
-      - Parse `schemaName` and `artifacts` list
+      - Parse `schemaName`, `artifacts`, `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`
       - Note which artifacts are `done` vs other states
 
-   b. **Task completion** - Read `openspec/changes/<name>/tasks.md`
+      If any selected change reports `actionContext.mode: "workspace-planning"`, explain that workspace bulk archive is not supported in this slice and STOP before syncing specs or moving changes. Do not fall back to repo-local paths or edit linked repos.
+
+   b. **Task completion** - Read `artifactPaths.tasks.existingOutputPaths` from status JSON
       - Count `- [ ]` (incomplete) vs `- [x]` (complete)
       - If no tasks file exists, note as "No tasks"
 
-   c. **Delta specs** - Check `openspec/changes/<name>/specs/` directory
+   c. **Delta specs** - Check `artifactPaths.specs.existingOutputPaths` from status JSON
       - List which capability specs exist
       - For each, extract requirement names (lines matching `### Requirement: <name>`)
 
@@ -84,7 +86,7 @@ This skill allows you to batch-archive changes, handling spec conflicts intellig
    Display a table summarizing all changes:
 
    ```
-   | Change               | Artifacts | Tasks | Specs   | Conflicts | Status |
+   | Change              | Artifacts | Tasks | Specs   | Conflicts | Status |
    |---------------------|-----------|-------|---------|-----------|--------|
    | schema-management   | Done      | 5/5   | 2 delta | None      | Ready  |
    | project-config      | Done      | 3/3   | 1 delta | None      | Ready  |
@@ -127,8 +129,8 @@ This skill allows you to batch-archive changes, handling spec conflicts intellig
 
    b. **Perform the archive**:
       ```bash
-      mkdir -p openspec/changes/archive
-      mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+      mkdir -p "<planningHome.changesDir>/archive"
+      mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
       ```
 
    c. **Track outcome** for each change:

--- a/.codex/skills/openspec-continue-change/SKILL.md
+++ b/.codex/skills/openspec-continue-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.2.0"
+  generatedBy: "1.4.1"
 ---
 
 Continue working on a change by creating the next artifact.
@@ -37,6 +37,7 @@ Continue working on a change by creating the next artifact.
    - `schemaName`: The workflow schema being used (e.g., "spec-driven")
    - `artifacts`: Array of artifacts with their status ("done", "ready", "blocked")
    - `isComplete`: Boolean indicating if all artifacts are complete
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
 
 3. **Act based on status**:
 
@@ -61,13 +62,13 @@ Continue working on a change by creating the next artifact.
      - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
      - `template`: The structure to use for your output file
      - `instruction`: Schema-specific guidance
-     - `outputPath`: Where to write the artifact
+     - `resolvedOutputPath`: Resolved path or pattern to write the artifact
      - `dependencies`: Completed artifacts to read for context
    - **Create the artifact file**:
      - Read any completed dependency files for context
      - Use `template` as the structure - fill in its sections
      - Apply `context` and `rules` as constraints when writing - but do NOT copy them into the file
-     - Write to the output path specified in instructions
+     - Write to the `resolvedOutputPath` specified in instructions. If it is a glob pattern, choose the concrete file path using the schema instruction and workspace planning context
    - Show what was created and what's now unlocked
    - STOP after creating ONE artifact
 

--- a/.codex/skills/openspec-explore/SKILL.md
+++ b/.codex/skills/openspec-explore/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.2.0"
+  generatedBy: "1.4.1"
 ---
 
 Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
@@ -56,10 +56,10 @@ Depending on what the user brings, you might:
 │     Use ASCII diagrams liberally        │
 ├─────────────────────────────────────────┤
 │                                         │
-│   ┌────────┐         ┌────────┐        │
-│   │ State  │────────▶│ State  │        │
-│   │   A    │         │   B    │        │
-│   └────────┘         └────────┘        │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
 │                                         │
 │   System diagrams, state machines,      │
 │   data flows, architecture sketches,    │
@@ -102,11 +102,10 @@ Think freely. When insights crystallize, you might offer:
 
 If the user mentions a change or you detect one is relevant:
 
-1. **Read existing artifacts for context**
-   - `openspec/changes/<name>/proposal.md`
-   - `openspec/changes/<name>/design.md`
-   - `openspec/changes/<name>/tasks.md`
-   - etc.
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
 
 2. **Reference them naturally in conversation**
    - "Your design mentions using Redis, but we just realized SQLite fits better..."
@@ -114,14 +113,14 @@ If the user mentions a change or you detect one is relevant:
 
 3. **Offer to capture when decisions are made**
 
-   | Insight Type | Where to Capture |
-   |--------------|------------------|
-   | New requirement discovered | `specs/<capability>/spec.md` |
-   | Requirement changed | `specs/<capability>/spec.md` |
-   | Design decision made | `design.md` |
-   | Scope changed | `proposal.md` |
-   | New work identified | `tasks.md` |
-   | Assumption invalidated | Relevant artifact |
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
 
    Example offers:
    - "That's a design decision. Capture it in design.md?"
@@ -227,7 +226,7 @@ User: A CLI tool that tracks local dev environments
 You: That changes everything.
 
      ┌─────────────────────────────────────────────────┐
-     │         CLI TOOL DATA STORAGE                  │
+     │          CLI TOOL DATA STORAGE                  │
      └─────────────────────────────────────────────────┘
 
      Key constraints:

--- a/.codex/skills/openspec-ff-change/SKILL.md
+++ b/.codex/skills/openspec-ff-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.2.0"
+  generatedBy: "1.4.1"
 ---
 
 Fast-forward through artifact creation - generate everything needed to start implementation in one go.
@@ -28,7 +28,7 @@ Fast-forward through artifact creation - generate everything needed to start imp
    ```bash
    openspec new change "<name>"
    ```
-   This creates a scaffolded change at `openspec/changes/<name>/`.
+   This creates a scaffolded change in the planning home resolved by the CLI.
 
 3. **Get the artifact build order**
    ```bash
@@ -37,6 +37,7 @@ Fast-forward through artifact creation - generate everything needed to start imp
    Parse the JSON to get:
    - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
    - `artifacts`: list of all artifacts with their status and dependencies
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
 
 4. **Create artifacts in sequence until apply-ready**
 
@@ -54,10 +55,10 @@ Fast-forward through artifact creation - generate everything needed to start imp
         - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
         - `template`: The structure to use for your output file
         - `instruction`: Schema-specific guidance for this artifact type
-        - `outputPath`: Where to write the artifact
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
         - `dependencies`: Completed artifacts to read for context
       - Read any completed dependency files for context
-      - Create the artifact file using `template` as the structure
+      - Create the artifact file using `template` as the structure and write it to `resolvedOutputPath`
       - Apply `context` and `rules` as constraints - but do NOT copy them into the file
       - Show brief progress: "✓ Created <artifact-id>"
 

--- a/.codex/skills/openspec-new-change/SKILL.md
+++ b/.codex/skills/openspec-new-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.2.0"
+  generatedBy: "1.4.1"
 ---
 
 Start a new change using the experimental artifact-driven approach.
@@ -39,13 +39,13 @@ Start a new change using the experimental artifact-driven approach.
    openspec new change "<name>"
    ```
    Add `--schema <name>` only if the user requested a specific workflow.
-   This creates a scaffolded change at `openspec/changes/<name>/` with the selected schema.
+   This creates a scaffolded change in the planning home resolved by the CLI.
 
 4. **Show the artifact status**
    ```bash
-   openspec status --change "<name>"
+   openspec status --change "<name>" --json
    ```
-   This shows which artifacts need to be created and which are ready (dependencies satisfied).
+   Use the returned `planningHome`, `changeRoot`, `artifactPaths`, and `nextSteps` instead of assuming repo-local paths.
 
 5. **Get instructions for the first artifact**
    The first artifact depends on the schema (e.g., `proposal` for spec-driven).

--- a/.codex/skills/openspec-onboard/SKILL.md
+++ b/.codex/skills/openspec-onboard/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.2.0"
+  generatedBy: "1.4.1"
 ---
 
 Guide the user through their first complete OpenSpec workflow cycle. This is a teaching experience—you'll do real work in their codebase while explaining each step.
@@ -167,7 +167,7 @@ Now let's create a change to hold our work.
 ```
 ## Creating a Change
 
-A "change" in OpenSpec is a container for all the thinking and planning around a piece of work. It lives in `openspec/changes/<name>/` and holds your artifacts—proposal, specs, design, tasks.
+A "change" in OpenSpec is a container for all the thinking and planning around a piece of work. It lives at the `changeRoot` reported by `openspec status --change "<name>" --json` and holds your artifacts—proposal, specs, design, tasks.
 
 Let me create one for our task.
 ```
@@ -179,11 +179,11 @@ openspec new change "<derived-name>"
 
 **SHOW:**
 ```
-Created: `openspec/changes/<name>/`
+Created: <changeRoot from status JSON>
 
 The folder structure:
 ```
-openspec/changes/<name>/
+<changeRoot>/
 ├── proposal.md    ← Why we're doing this (empty, we'll fill it)
 ├── design.md      ← How we'll build it (empty)
 ├── specs/         ← Detailed requirements (empty)
@@ -245,7 +245,7 @@ After approval, save the proposal:
 ```bash
 openspec instructions proposal --change "<name>" --json
 ```
-Then write the content to `openspec/changes/<name>/proposal.md`.
+Then write the content to the `resolvedOutputPath` from `openspec instructions proposal --change "<name>" --json`.
 
 ```
 Proposal saved. This is your "why" document—you can always come back and refine it as understanding evolves.
@@ -266,12 +266,10 @@ Specs define **what** we're building in precise, testable terms. They use a requ
 For a small task like this, we might only need one spec file.
 ```
 
-**DO:** Create the spec file:
+**DO:** Resolve where the spec file should be created:
 ```bash
-# Unix/macOS
-mkdir -p openspec/changes/<name>/specs/<capability-name>
-# Windows (PowerShell)
-# New-Item -ItemType Directory -Force -Path "openspec/changes/<name>/specs/<capability-name>"
+openspec instructions specs --change "<name>" --json
+# Use resolvedOutputPath from the JSON. If it is a glob, choose the concrete file path using the schema instruction and workspace planning context.
 ```
 
 Draft the spec content:
@@ -298,7 +296,7 @@ Here's the spec:
 This format—WHEN/THEN/AND—makes requirements testable. You can literally read them as test cases.
 ```
 
-Save to `openspec/changes/<name>/specs/<capability>/spec.md`.
+Save to the concrete file path chosen from `resolvedOutputPath`.
 
 ---
 
@@ -343,7 +341,7 @@ Here's the design:
 For a small task, this captures the key decisions without over-engineering.
 ```
 
-Save to `openspec/changes/<name>/design.md`.
+Save to the `resolvedOutputPath` from `openspec instructions design --change "<name>" --json`.
 
 ---
 
@@ -381,7 +379,7 @@ Each checkbox becomes a unit of work in the apply phase. Ready to implement?
 
 **PAUSE** - Wait for user to confirm they're ready to implement.
 
-Save to `openspec/changes/<name>/tasks.md`.
+Save to the `resolvedOutputPath` from `openspec instructions tasks --change "<name>" --json`.
 
 ---
 
@@ -425,7 +423,7 @@ The change is implemented! One more step—let's archive it.
 ```
 ## Archiving
 
-When a change is complete, we archive it. This moves it from `openspec/changes/` to `openspec/changes/archive/YYYY-MM-DD-<name>/`.
+When a change is complete, we archive it. The archive path is derived from `planningHome.changesDir` and the date.
 
 Archived changes become your project's decision history—you can always find them later to understand why something was built a certain way.
 ```
@@ -437,7 +435,7 @@ openspec archive "<name>"
 
 **SHOW:**
 ```
-Archived to: `openspec/changes/archive/YYYY-MM-DD-<name>/`
+Archived to: `<planningHome.changesDir>/archive/YYYY-MM-DD-<name>/`
 
 The change is now part of your project's history. The code is in your codebase, the decision record is preserved.
 ```
@@ -468,21 +466,21 @@ This same rhythm works for any size change—a small fix or a major feature.
 
 **Core workflow:**
 
-| Command | What it does |
-|---------|--------------|
-| `/opsx:propose` | Create a change and generate all artifacts |
-| `/opsx:explore` | Think through problems before/during work |
-| `/opsx:apply` | Implement tasks from a change |
-| `/opsx:archive` | Archive a completed change |
+ | Command           | What it does                               |
+ |-------------------|--------------------------------------------|
+ | `/opsx:propose` | Create a change and generate all artifacts |
+ | `/opsx:explore` | Think through problems before/during work  |
+ | `/opsx:apply`   | Implement tasks from a change              |
+ | `/opsx:archive` | Archive a completed change                 |
 
 **Additional commands:**
 
-| Command | What it does |
-|---------|--------------|
-| `/opsx:new` | Start a new change, step through artifacts one at a time |
-| `/opsx:continue` | Continue working on an existing change |
-| `/opsx:ff` | Fast-forward: create all artifacts at once |
-| `/opsx:verify` | Verify implementation matches artifacts |
+ | Command            | What it does                                             |
+ |--------------------|----------------------------------------------------------|
+ | `/opsx:new`      | Start a new change, step through artifacts one at a time |
+ | `/opsx:continue` | Continue working on an existing change                   |
+ | `/opsx:ff`       | Fast-forward: create all artifacts at once               |
+ | `/opsx:verify`   | Verify implementation matches artifacts                  |
 
 ---
 
@@ -500,7 +498,7 @@ Try `/opsx:propose` on something you actually want to build. You've got the rhyt
 If the user says they need to stop, want to pause, or seem disengaged:
 
 ```
-No problem! Your change is saved at `openspec/changes/<name>/`.
+No problem! Your change is saved at the `changeRoot` reported by `openspec status --change "<name>" --json`.
 
 To pick up where we left off later:
 - `/opsx:continue <name>` - Resume artifact creation
@@ -520,21 +518,21 @@ If the user says they just want to see the commands or skip the tutorial:
 
 **Core workflow:**
 
-| Command | What it does |
-|---------|--------------|
-| `/opsx:propose <name>` | Create a change and generate all artifacts |
-| `/opsx:explore` | Think through problems (no code changes) |
-| `/opsx:apply <name>` | Implement tasks |
-| `/opsx:archive <name>` | Archive when done |
+ | Command                  | What it does                               |
+ |--------------------------|--------------------------------------------|
+ | `/opsx:propose <name>` | Create a change and generate all artifacts |
+ | `/opsx:explore`        | Think through problems (no code changes)   |
+ | `/opsx:apply <name>`   | Implement tasks                            |
+ | `/opsx:archive <name>` | Archive when done                          |
 
 **Additional commands:**
 
-| Command | What it does |
-|---------|--------------|
-| `/opsx:new <name>` | Start a new change, step by step |
-| `/opsx:continue <name>` | Continue an existing change |
-| `/opsx:ff <name>` | Fast-forward: all artifacts at once |
-| `/opsx:verify <name>` | Verify implementation |
+ | Command                   | What it does                        |
+ |---------------------------|-------------------------------------|
+ | `/opsx:new <name>`      | Start a new change, step by step    |
+ | `/opsx:continue <name>` | Continue an existing change         |
+ | `/opsx:ff <name>`       | Fast-forward: all artifacts at once |
+ | `/opsx:verify <name>`   | Verify implementation               |
 
 Try `/opsx:propose` to start your first change.
 ```

--- a/.codex/skills/openspec-sync-specs/SKILL.md
+++ b/.codex/skills/openspec-sync-specs/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.2.0"
+  generatedBy: "1.4.1"
 ---
 
 Sync delta specs from a change to main specs.
@@ -25,9 +25,18 @@ This is an **agent-driven** operation - you will read delta specs and directly e
 
    **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
 
-2. **Find delta specs**
+2. **Resolve change context**
 
-   Look for delta spec files in `openspec/changes/<name>/specs/*/spec.md`.
+   Run:
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+
+   If status reports `actionContext.mode: "workspace-planning"`, explain that workspace spec sync is not supported in this slice and STOP. Do not fall back to repo-local paths or edit linked repos.
+
+3. **Find delta specs**
+
+   Use `artifactPaths.specs.existingOutputPaths` from the status JSON as the list of delta spec files.
 
    Each delta spec file contains sections like:
    - `## ADDED Requirements` - New requirements to add
@@ -37,9 +46,9 @@ This is an **agent-driven** operation - you will read delta specs and directly e
 
    If no delta specs found, inform user and stop.
 
-3. **For each delta spec, apply changes to main specs**
+4. **For each delta spec, apply changes to main specs**
 
-   For each capability with a delta spec at `openspec/changes/<name>/specs/<capability>/spec.md`:
+   For each repo-local capability delta spec path returned by the CLI:
 
    a. **Read the delta spec** to understand the intended changes
 
@@ -70,7 +79,7 @@ This is an **agent-driven** operation - you will read delta specs and directly e
       - Add Purpose section (can be brief, mark as TBD)
       - Add Requirements section with the ADDED requirements
 
-4. **Show summary**
+5. **Show summary**
 
    After applying all changes, summarize:
    - Which capabilities were updated

--- a/.codex/skills/openspec-verify-change/SKILL.md
+++ b/.codex/skills/openspec-verify-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.2.0"
+  generatedBy: "1.4.1"
 ---
 
 Verify that an implementation matches the change artifacts (specs, tasks, design).
@@ -31,15 +31,18 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
    ```
    Parse the JSON to understand:
    - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
    - Which artifacts exist for this change
 
-3. **Get the change directory and load artifacts**
+   If status reports `actionContext.mode: "workspace-planning"`, explain that full workspace implementation verification is not supported in this slice and STOP. Do not infer repo-local implementation ownership or edit linked repos.
+
+3. **Get planning context and load artifacts**
 
    ```bash
    openspec instructions apply --change "<name>" --json
    ```
 
-   This returns the change directory and context files. Read all available artifacts from `contextFiles`.
+   This returns the change directory and `contextFiles` (artifact ID -> array of concrete file paths). Read all available artifacts from `contextFiles`.
 
 4. **Initialize verification report structure**
 
@@ -53,7 +56,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
 5. **Verify Completeness**
 
    **Task Completion**:
-   - If tasks.md exists in contextFiles, read it
+   - If `contextFiles.tasks` exists, read every file path in it
    - Parse checkboxes: `- [ ]` (incomplete) vs `- [x]` (complete)
    - Count complete vs total tasks
    - If incomplete tasks exist:
@@ -61,7 +64,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
      - Recommendation: "Complete task: <description>" or "Mark as done if already implemented"
 
    **Spec Coverage**:
-   - If delta specs exist in `openspec/changes/<name>/specs/`:
+   - If delta specs exist in `contextFiles.specs`:
      - Extract all requirements (marked with "### Requirement:")
      - For each requirement:
        - Search codebase for keywords related to the requirement
@@ -92,7 +95,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
 7. **Verify Coherence**
 
    **Design Adherence**:
-   - If design.md exists in contextFiles:
+   - If `contextFiles.design` exists:
      - Extract key decisions (look for sections like "Decision:", "Approach:", "Architecture:")
      - Verify implementation follows those decisions
      - If contradiction detected:

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -236,12 +236,13 @@ function DesktopApp() {
     location.pathname.startsWith('/loops') || location.pathname.startsWith('/docs')
 
   // ─── Hoisted terminal panel (single instance, both modes) ───────────────────
-  // BottomPanel + StatusBar live here (not in ProjectLayout) so the terminal
+  // BottomPanel lives here (not in ProjectLayout) so the terminal
   // survives when the center is the agent surface rather than a project route.
   // Exactly one BottomPanel/TerminalViewport is ever mounted → the terminal
   // single-adopter invariant holds.
   const { connectionStatus } = usePipeline()
   const panelState = useProjectTerminals(activeProjectId)
+  const statusBarHeight = uiMode === 'agent' ? 0 : STATUSBAR_HEIGHT_PX
   const mainColRef = useRef<HTMLDivElement | null>(null)
   const [viewportHeight, setViewportHeight] = useState<number>(
     typeof window !== 'undefined' ? window.innerHeight : 820,
@@ -353,9 +354,9 @@ function DesktopApp() {
           )}
         </div>
 
-        {/* Hoisted terminal panel + status bar — single instance shared by both
-            modes. Footer chevron entry point is gated to Kanban (in Agent Mode
-            the entry point is the workspace sidebar's Terminal tool). */}
+        {/* Hoisted terminal panel — single instance shared by both modes.
+            Footer status/chevron chrome is Kanban-only; in Agent Mode the
+            entry point is the workspace sidebar's Terminal tool. */}
         {FEATURE_TERMINAL_PANEL && activeProjectId && activeProject && (
           <BottomPanel
             projectId={activeProjectId}
@@ -363,10 +364,10 @@ function DesktopApp() {
             providers={projectProviders(activeProject)}
             state={panelState}
             viewportHeight={viewportHeight}
-            statusBarHeight={STATUSBAR_HEIGHT_PX}
+            statusBarHeight={statusBarHeight}
           />
         )}
-        <StatusBar connectionStatus={connectionStatus} rightSlot={chevronSlot} minimal={uiMode === 'agent'} />
+        {uiMode !== 'agent' && <StatusBar connectionStatus={connectionStatus} rightSlot={chevronSlot} />}
       </div>
 
       {/* Right sidebar — full height. In Agent Mode this is the "On workspace"

--- a/client/src/components/ArcSidebar.tsx
+++ b/client/src/components/ArcSidebar.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo, useRef, lazy, Suspense } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { PanelLeft, FolderOpen, Plus, BarChart2, BookOpen, Settings, X, Workflow, ChevronRight, ChevronDown, MessageSquare, Bot, LayoutGrid, Search, Home } from 'lucide-react'
+import { PanelLeft, FolderOpen, Plus, BarChart2, BookOpen, Settings, X, Workflow, ChevronRight, ChevronDown, MessageSquare, Bot, LayoutGrid, Search, Home, Heart } from 'lucide-react'
 import { cn } from '../lib/utils'
 import { useResizableSidebar } from '../hooks/useResizableSidebar'
 import { SidebarResizeGrip } from './SidebarResizeGrip'
@@ -49,7 +49,9 @@ function ConversationRow({
   active,
   expanded,
   streaming = false,
+  favorite = false,
   onSelect,
+  onToggleFavorite,
   onDelete,
 }: {
   conversation: AgentConversation
@@ -58,7 +60,9 @@ function ConversationRow({
   /** A live agent turn (prompt sent / reply streaming) — sweeps a highlight
    *  over the title; on stop the sweep fades out slowly. */
   streaming?: boolean
+  favorite?: boolean
   onSelect: () => void
+  onToggleFavorite?: () => void
   onDelete: () => void
 }) {
   const { t } = useTranslation('agent')
@@ -99,6 +103,11 @@ function ConversationRow({
         confirmTimerRef.current = null
       }, 3000)
     }
+  }
+
+  function handleFavoriteClick(e: React.MouseEvent) {
+    e.stopPropagation()
+    onToggleFavorite?.()
   }
 
   function handleSelectKeyDown(e: React.KeyboardEvent) {
@@ -162,6 +171,20 @@ function ConversationRow({
           </span>
           <button
             type="button"
+            onClick={handleFavoriteClick}
+            className={cn(
+              'flex-shrink-0 items-center justify-center rounded-sm transition-colors hover:bg-muted',
+              favorite
+                ? 'flex w-3.5 h-3.5 text-accent-primary hover:text-accent-primary'
+                : 'hidden group-hover:flex w-3.5 h-3.5 text-muted-foreground/60 hover:text-accent-primary',
+            )}
+            aria-label={favorite ? t('removeFavoriteConversation', { title: label }) : t('addFavoriteConversation', { title: label })}
+            title={favorite ? t('removeFavoriteConversation', { title: label }) : t('addFavoriteConversation', { title: label })}
+          >
+            <Heart className="w-2.5 h-2.5" fill={favorite ? 'currentColor' : 'none'} />
+          </button>
+          <button
+            type="button"
             onClick={handleDeleteClick}
             className={cn(
               'flex-shrink-0 items-center justify-center rounded-sm transition-colors hover:bg-muted',
@@ -201,6 +224,7 @@ function ProjectItem({
   activeConversationId = null,
   streamingConversationIds,
   onSelectConversation,
+  onToggleConversationFavorite,
   onDeleteConversation,
   onOpenProjectSettings,
 }: {
@@ -219,6 +243,7 @@ function ProjectItem({
    *  their title shimmer, not just the focused one. */
   streamingConversationIds?: ReadonlySet<string>
   onSelectConversation?: (id: string) => void
+  onToggleConversationFavorite?: (id: string) => void
   onDeleteConversation?: (id: string) => void
   /** Hover gear (Agent Mode): open this project's settings modal. */
   onOpenProjectSettings?: () => void
@@ -337,6 +362,7 @@ function ProjectItem({
               streaming={streamingConversationIds?.has(c.id) ?? false}
               expanded={expanded}
               onSelect={() => onSelectConversation?.(c.id)}
+              onToggleFavorite={() => onToggleConversationFavorite?.(c.id)}
               onDelete={() => onDeleteConversation?.(c.id)}
             />
           ))}
@@ -379,13 +405,18 @@ export function ArcSidebar({
     const map = new Map<string, AgentConversation[]>()
     const liveProjectIds = new Set(projects.map((p) => p.id))
     for (const c of agentChat.conversations) {
+      if (agentChat.favoriteConversationIds.has(c.id)) continue
       const key = c.pinned_project_id && liveProjectIds.has(c.pinned_project_id) ? c.pinned_project_id : HOME_KEY
       const arr = map.get(key)
       if (arr) arr.push(c)
       else map.set(key, [c])
     }
     return map
-  }, [agentChat.conversations, projects])
+  }, [agentChat.conversations, agentChat.favoriteConversationIds, projects])
+  const favoriteConversations = useMemo(
+    () => agentChat.conversations.filter((c) => agentChat.favoriteConversationIds.has(c.id)),
+    [agentChat.conversations, agentChat.favoriteConversationIds],
+  )
   const homeConversations = grouped.get(HOME_KEY) ?? []
 
   const [expandedTree, setExpandedTree] = useState<Set<string>>(loadExpanded)
@@ -425,6 +456,10 @@ export function ArcSidebar({
     agentChat.deleteConversation(id).catch(() => {
       /* network failure — the list refresh on next open reconciles */
     })
+  }
+
+  const handleToggleFavoriteConversation = (id: string) => {
+    agentChat.toggleFavoriteConversation(id)
   }
 
   // Selecting a project from the sidebar. When the user is on a GLOBAL route
@@ -622,6 +657,29 @@ export function ArcSidebar({
 
       {/* Projects list */}
       <div className="flex-1 overflow-y-auto py-2 px-1.5 space-y-0.5">
+        {agentMode && favoriteConversations.length > 0 && (
+          <div className={cn('space-y-0.5', expanded && 'mb-2 border-b border-border/70 pb-2')}>
+            {expanded && (
+              <div className="flex items-center gap-1.5 px-2 pb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground/60">
+                <Heart className="h-3 w-3 fill-current text-accent-primary/80" aria-hidden />
+                <span className="truncate">{tAgent('favoriteMissions')}</span>
+              </div>
+            )}
+            {favoriteConversations.map((c) => (
+              <ConversationRow
+                key={c.id}
+                conversation={c}
+                active={c.id === agentChat.active?.id}
+                streaming={agentChat.streamingConversationIds.has(c.id)}
+                favorite
+                expanded={expanded}
+                onSelect={() => handleSelectConversation(c.id)}
+                onToggleFavorite={() => handleToggleFavoriteConversation(c.id)}
+                onDelete={() => handleDeleteConversation(c.id)}
+              />
+            ))}
+          </div>
+        )}
         {/* Home group (agent mode) — conversations with no pinned project */}
         {agentMode && homeConversations.length > 0 && (
           <div>
@@ -652,6 +710,7 @@ export function ArcSidebar({
                     streaming={agentChat.streamingConversationIds.has(c.id)}
                     expanded={expanded}
                     onSelect={() => handleSelectConversation(c.id)}
+                    onToggleFavorite={() => handleToggleFavoriteConversation(c.id)}
                     onDelete={() => handleDeleteConversation(c.id)}
                   />
                 ))}
@@ -677,6 +736,7 @@ export function ArcSidebar({
               activeConversationId={agentChat.active?.id ?? null}
               streamingConversationIds={agentChat.streamingConversationIds}
               onSelectConversation={handleSelectConversation}
+              onToggleConversationFavorite={handleToggleFavoriteConversation}
               onDeleteConversation={handleDeleteConversation}
               onOpenProjectSettings={agentMode ? () => {
                 // The settings sections talk to the ACTIVE project's API base —

--- a/client/src/components/ArcSidebar.tsx
+++ b/client/src/components/ArcSidebar.tsx
@@ -661,7 +661,7 @@ export function ArcSidebar({
       {/* Projects list */}
       <div className="flex-1 overflow-y-auto py-2 px-1.5 space-y-0.5">
         {agentMode && favoriteConversations.length > 0 && (
-          <div className={cn('space-y-0.5', expanded && 'mb-2 border-b border-border/70 pb-2')}>
+          <div className="mb-2 space-y-0.5 border-b border-border/70 pb-2">
             <button
               type="button"
               onClick={() => toggleTree(FAVORITES_KEY)}

--- a/client/src/components/ArcSidebar.tsx
+++ b/client/src/components/ArcSidebar.tsx
@@ -43,6 +43,8 @@ function openCommandPalette(): void {
 
 /** Sentinel key for the Home (null-pinned) conversation group. */
 const HOME_KEY = '__home__'
+/** Sentinel key for the virtual Favorite missions group. */
+const FAVORITES_KEY = '__favorites__'
 
 function ConversationRow({
   conversation,
@@ -420,6 +422,7 @@ export function ArcSidebar({
   const homeConversations = grouped.get(HOME_KEY) ?? []
 
   const [expandedTree, setExpandedTree] = useState<Set<string>>(loadExpanded)
+  const favoriteTreeOpen = expandedTree.has(FAVORITES_KEY)
   // Per-project settings modal (Agent Mode hover gear on a project folder).
   const [projectSettingsOpen, setProjectSettingsOpen] = useState(false)
   // Default-expand the active project the first time we enter Agent Mode.
@@ -659,25 +662,40 @@ export function ArcSidebar({
       <div className="flex-1 overflow-y-auto py-2 px-1.5 space-y-0.5">
         {agentMode && favoriteConversations.length > 0 && (
           <div className={cn('space-y-0.5', expanded && 'mb-2 border-b border-border/70 pb-2')}>
-            {expanded && (
-              <div className="flex items-center gap-1.5 px-2 pb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground/60">
-                <Heart className="h-3 w-3 fill-current text-accent-primary/80" aria-hidden />
-                <span className="truncate">{tAgent('favoriteMissions')}</span>
+            <button
+              type="button"
+              onClick={() => toggleTree(FAVORITES_KEY)}
+              className={cn(
+                'flex items-center gap-2 w-full h-8 rounded-md transition-colors',
+                'text-muted-foreground hover:text-foreground hover:bg-muted/50',
+                expanded ? 'px-2' : 'px-0 justify-center',
+              )}
+              aria-label={tAgent('favoriteMissions')}
+              aria-expanded={favoriteTreeOpen}
+              title={!expanded ? tAgent('favoriteMissions') : undefined}
+            >
+              {expanded
+                ? (favoriteTreeOpen ? <ChevronDown className="w-3.5 h-3.5 flex-shrink-0" /> : <ChevronRight className="w-3.5 h-3.5 flex-shrink-0" />)
+                : <Heart className="w-4 h-4 flex-shrink-0 fill-current text-accent-primary" />}
+              {expanded && <span className="text-xs truncate flex-1 text-left">{tAgent('favoriteMissions')}</span>}
+            </button>
+            {favoriteTreeOpen && expanded && (
+              <div className="mt-0.5 space-y-0.5">
+                {favoriteConversations.map((c) => (
+                  <ConversationRow
+                    key={c.id}
+                    conversation={c}
+                    active={c.id === agentChat.active?.id}
+                    streaming={agentChat.streamingConversationIds.has(c.id)}
+                    favorite
+                    expanded={expanded}
+                    onSelect={() => handleSelectConversation(c.id)}
+                    onToggleFavorite={() => handleToggleFavoriteConversation(c.id)}
+                    onDelete={() => handleDeleteConversation(c.id)}
+                  />
+                ))}
               </div>
             )}
-            {favoriteConversations.map((c) => (
-              <ConversationRow
-                key={c.id}
-                conversation={c}
-                active={c.id === agentChat.active?.id}
-                streaming={agentChat.streamingConversationIds.has(c.id)}
-                favorite
-                expanded={expanded}
-                onSelect={() => handleSelectConversation(c.id)}
-                onToggleFavorite={() => handleToggleFavoriteConversation(c.id)}
-                onDelete={() => handleDeleteConversation(c.id)}
-              />
-            ))}
           </div>
         )}
         {/* Home group (agent mode) — conversations with no pinned project */}

--- a/client/src/components/ArcSidebar.tsx
+++ b/client/src/components/ArcSidebar.tsx
@@ -284,6 +284,14 @@ function ProjectItem({
   }
 
   const showChevron = agentMode && hasTree && expanded
+  const projectIcon = (
+    <FolderOpen
+      className={cn(
+        'flex-shrink-0 w-4 h-4',
+        isActive && 'text-accent-primary'
+      )}
+    />
+  )
 
   return (
     <div>
@@ -303,22 +311,22 @@ function ProjectItem({
         aria-current={isActive ? 'page' : undefined}
       >
         {showChevron ? (
-          <button
-            type="button"
-            onClick={(e) => { e.stopPropagation(); onToggleTree?.() }}
-            className="flex-shrink-0 flex items-center justify-center w-4 h-4 rounded-sm hover:bg-muted"
-            aria-label={treeOpen ? t('projects.collapse', { name: project.name }) : t('projects.expand', { name: project.name })}
-            aria-expanded={treeOpen}
-          >
-            {treeOpen ? <ChevronDown className="w-3.5 h-3.5" /> : <ChevronRight className="w-3.5 h-3.5" />}
-          </button>
+          <span className="relative flex h-4 w-4 flex-shrink-0 items-center justify-center">
+            <span className="flex transition-opacity group-hover:opacity-0 group-focus-within:opacity-0">
+              {projectIcon}
+            </span>
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); onToggleTree?.() }}
+              className="absolute inset-0 hidden items-center justify-center rounded-sm hover:bg-muted group-hover:flex group-focus-within:flex"
+              aria-label={treeOpen ? t('projects.collapse', { name: project.name }) : t('projects.expand', { name: project.name })}
+              aria-expanded={treeOpen}
+            >
+              {treeOpen ? <ChevronDown className="w-3.5 h-3.5" /> : <ChevronRight className="w-3.5 h-3.5" />}
+            </button>
+          </span>
         ) : (
-          <FolderOpen
-            className={cn(
-              'flex-shrink-0 w-4 h-4',
-              isActive && 'text-accent-primary'
-            )}
-          />
+          projectIcon
         )}
         {expanded && (
           <>
@@ -666,7 +674,7 @@ export function ArcSidebar({
               type="button"
               onClick={() => toggleTree(FAVORITES_KEY)}
               className={cn(
-                'flex items-center gap-2 w-full h-8 rounded-md transition-colors',
+                'group flex items-center gap-2 w-full h-8 rounded-md transition-colors',
                 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
                 expanded ? 'px-2' : 'px-0 justify-center',
               )}
@@ -675,7 +683,14 @@ export function ArcSidebar({
               title={!expanded ? tAgent('favoriteMissions') : undefined}
             >
               {expanded
-                ? (favoriteTreeOpen ? <ChevronDown className="w-3.5 h-3.5 flex-shrink-0" /> : <ChevronRight className="w-3.5 h-3.5 flex-shrink-0" />)
+                ? (
+                    <span className="relative flex h-4 w-4 flex-shrink-0 items-center justify-center">
+                      <Heart className="h-4 w-4 fill-current text-accent-primary transition-opacity group-hover:opacity-0 group-focus-visible:opacity-0" />
+                      <span className="absolute inset-0 hidden items-center justify-center group-hover:flex group-focus-visible:flex">
+                        {favoriteTreeOpen ? <ChevronDown className="w-3.5 h-3.5" /> : <ChevronRight className="w-3.5 h-3.5" />}
+                      </span>
+                    </span>
+                  )
                 : <Heart className="w-4 h-4 flex-shrink-0 fill-current text-accent-primary" />}
               {expanded && <span className="text-xs truncate flex-1 text-left">{tAgent('favoriteMissions')}</span>}
             </button>
@@ -705,7 +720,7 @@ export function ArcSidebar({
               type="button"
               onClick={() => toggleTree(HOME_KEY)}
               className={cn(
-                'flex items-center gap-2 w-full h-8 rounded-md transition-colors',
+                'group flex items-center gap-2 w-full h-8 rounded-md transition-colors',
                 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
                 expanded ? 'px-2' : 'px-0 justify-center',
               )}
@@ -714,7 +729,14 @@ export function ArcSidebar({
               title={!expanded ? tAgent('home') : undefined}
             >
               {expanded
-                ? (expandedTree.has(HOME_KEY) ? <ChevronDown className="w-3.5 h-3.5 flex-shrink-0" /> : <ChevronRight className="w-3.5 h-3.5 flex-shrink-0" />)
+                ? (
+                    <span className="relative flex h-4 w-4 flex-shrink-0 items-center justify-center">
+                      <Home className="h-4 w-4 transition-opacity group-hover:opacity-0 group-focus-visible:opacity-0" />
+                      <span className="absolute inset-0 hidden items-center justify-center group-hover:flex group-focus-visible:flex">
+                        {expandedTree.has(HOME_KEY) ? <ChevronDown className="w-3.5 h-3.5" /> : <ChevronRight className="w-3.5 h-3.5" />}
+                      </span>
+                    </span>
+                  )
                 : <Home className="w-4 h-4 flex-shrink-0" />}
               {expanded && <span className="text-xs truncate flex-1 text-left">{tAgent('home')}</span>}
             </button>

--- a/client/src/components/__tests__/ArcSidebarAgentConversations.test.tsx
+++ b/client/src/components/__tests__/ArcSidebarAgentConversations.test.tsx
@@ -42,11 +42,13 @@ function conv(id: string, title: string | null, pinned: string | null): AgentCon
 
 const mockDeleteConversation = vi.fn(() => Promise.resolve())
 const mockSelectConversation = vi.fn(() => Promise.resolve())
+const mockToggleFavoriteConversation = vi.fn()
 
 // Mutable so individual tests can activate a conversation / streaming state.
-const agentChatState: { active: AgentConversation | null; streamingIds: Set<string> } = {
+const agentChatState: { active: AgentConversation | null; streamingIds: Set<string>; favoriteIds: Set<string> } = {
   active: null,
   streamingIds: new Set(),
+  favoriteIds: new Set(),
 }
 
 vi.mock('../../context/AgentChatContext', () => ({
@@ -55,8 +57,10 @@ vi.mock('../../context/AgentChatContext', () => ({
     active: agentChatState.active,
     isStreaming: agentChatState.active ? agentChatState.streamingIds.has(agentChatState.active.id) : false,
     streamingConversationIds: agentChatState.streamingIds,
+    favoriteConversationIds: agentChatState.favoriteIds,
     selectConversation: mockSelectConversation,
     deleteConversation: mockDeleteConversation,
+    toggleFavoriteConversation: mockToggleFavoriteConversation,
     startNewConversation: vi.fn(),
   }),
 }))
@@ -80,6 +84,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   agentChatState.active = null
   agentChatState.streamingIds = new Set()
+  agentChatState.favoriteIds = new Set()
 })
 
 describe('ArcSidebar agent-mode conversation rows', () => {
@@ -122,6 +127,28 @@ describe('ArcSidebar agent-mode conversation rows', () => {
     renderExpanded()
     fireEvent.click(screen.getByRole('button', { name: 'Delete "Fix the build"' }))
     expect(mockSelectConversation).not.toHaveBeenCalled()
+  })
+
+  it('favorite heart toggles a project mission without selecting it', () => {
+    renderExpanded()
+    fireEvent.click(screen.getByRole('button', { name: 'Add "Fix the build" to favorites' }))
+    expect(mockToggleFavoriteConversation).toHaveBeenCalledWith('c-1')
+    expect(mockSelectConversation).not.toHaveBeenCalled()
+  })
+
+  it('renders favorite missions above projects and removes them from the project tree', () => {
+    agentChatState.favoriteIds = new Set(['c-1'])
+    renderExpanded()
+    expect(screen.getByText('Favorite missions')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Remove "Fix the build" from favorites' })).toBeInTheDocument()
+    expect(screen.getAllByText('Fix the build')).toHaveLength(1)
+  })
+
+  it('removing a favorite from the favorite section calls the same toggle', () => {
+    agentChatState.favoriteIds = new Set(['c-1'])
+    renderExpanded()
+    fireEvent.click(screen.getByRole('button', { name: 'Remove "Fix the build" from favorites' }))
+    expect(mockToggleFavoriteConversation).toHaveBeenCalledWith('c-1')
   })
 
   it('untitled Home conversation gets a delete button labelled with the fallback title', () => {

--- a/client/src/components/__tests__/ArcSidebarAgentConversations.test.tsx
+++ b/client/src/components/__tests__/ArcSidebarAgentConversations.test.tsx
@@ -148,7 +148,9 @@ describe('ArcSidebar agent-mode conversation rows', () => {
   it('collapses favorite missions behind a single favorites icon when the sidebar is collapsed', () => {
     agentChatState.favoriteIds = new Set(['c-1'])
     render(<ArcSidebar {...defaultProps} />)
-    expect(screen.getByRole('button', { name: 'Favorite missions' })).toBeInTheDocument()
+    const favoritesButton = screen.getByRole('button', { name: 'Favorite missions' })
+    expect(favoritesButton).toBeInTheDocument()
+    expect(favoritesButton.parentElement?.className).toContain('border-b')
     expect(screen.queryByText('Favorite missions')).not.toBeInTheDocument()
     expect(screen.queryByText('Fix the build')).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Remove "Fix the build" from favorites' })).not.toBeInTheDocument()

--- a/client/src/components/__tests__/ArcSidebarAgentConversations.test.tsx
+++ b/client/src/components/__tests__/ArcSidebarAgentConversations.test.tsx
@@ -139,14 +139,35 @@ describe('ArcSidebar agent-mode conversation rows', () => {
   it('renders favorite missions above projects and removes them from the project tree', () => {
     agentChatState.favoriteIds = new Set(['c-1'])
     renderExpanded()
+    fireEvent.click(screen.getByRole('button', { name: 'Favorite missions' }))
     expect(screen.getByText('Favorite missions')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Remove "Fix the build" from favorites' })).toBeInTheDocument()
     expect(screen.getAllByText('Fix the build')).toHaveLength(1)
   })
 
+  it('collapses favorite missions behind a single favorites icon when the sidebar is collapsed', () => {
+    agentChatState.favoriteIds = new Set(['c-1'])
+    render(<ArcSidebar {...defaultProps} />)
+    expect(screen.getByRole('button', { name: 'Favorite missions' })).toBeInTheDocument()
+    expect(screen.queryByText('Favorite missions')).not.toBeInTheDocument()
+    expect(screen.queryByText('Fix the build')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Remove "Fix the build" from favorites' })).not.toBeInTheDocument()
+  })
+
+  it('favorite missions section expands and collapses like a project tree', () => {
+    agentChatState.favoriteIds = new Set(['c-1'])
+    renderExpanded()
+    expect(screen.queryByRole('button', { name: 'Remove "Fix the build" from favorites' })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Favorite missions' }))
+    expect(screen.getByRole('button', { name: 'Remove "Fix the build" from favorites' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Favorite missions' }))
+    expect(screen.queryByRole('button', { name: 'Remove "Fix the build" from favorites' })).not.toBeInTheDocument()
+  })
+
   it('removing a favorite from the favorite section calls the same toggle', () => {
     agentChatState.favoriteIds = new Set(['c-1'])
     renderExpanded()
+    fireEvent.click(screen.getByRole('button', { name: 'Favorite missions' }))
     fireEvent.click(screen.getByRole('button', { name: 'Remove "Fix the build" from favorites' }))
     expect(mockToggleFavoriteConversation).toHaveBeenCalledWith('c-1')
   })

--- a/client/src/components/agent-chat/AgentConversationHeader.tsx
+++ b/client/src/components/agent-chat/AgentConversationHeader.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { motion, AnimatePresence } from 'motion/react'
-import { MoreVertical, Pencil, Copy, Check, ChevronRight, Trash2 } from 'lucide-react'
+import { MoreVertical, Pencil, Copy, Check, ChevronRight, Trash2, Heart } from 'lucide-react'
 import { toast } from 'sonner'
 import { useAgentChat } from '../../context/AgentChatContext'
 import { useDesktop } from '../../hooks/useDesktop'
@@ -17,7 +17,7 @@ import { cn } from '../../lib/utils'
  */
 export function AgentConversationHeader() {
   const { t } = useTranslation('agent')
-  const { active, renameConversation, deleteConversation, startNewConversation } = useAgentChat()
+  const { active, renameConversation, deleteConversation, startNewConversation, favoriteConversationIds, toggleFavoriteConversation } = useAgentChat()
   const { projects } = useDesktop()
   const [menuOpen, setMenuOpen] = useState(false)
   const [editing, setEditing] = useState(false)
@@ -31,6 +31,7 @@ export function AgentConversationHeader() {
     ? projects.find((p) => p.id === active.pinned_project_id) ?? null
     : null
   const title = active?.title?.trim() || t('header.untitled')
+  const isFavorite = active ? favoriteConversationIds.has(active.id) : false
 
   // Close the menu on outside-click / Esc.
   useEffect(() => {
@@ -95,6 +96,12 @@ export function AgentConversationHeader() {
       toast.error(t('header.deleteFailed'))
     }
   }, [active, deleteConversation, startNewConversation, t])
+
+  const toggleFavorite = useCallback(() => {
+    if (!active) return
+    toggleFavoriteConversation(active.id)
+    setMenuOpen(false)
+  }, [active, toggleFavoriteConversation])
 
   if (!active) return null
 
@@ -217,6 +224,22 @@ export function AgentConversationHeader() {
             >
               <Pencil className="h-3.5 w-3.5 shrink-0 text-foreground/50" />
               {t('header.rename')}
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              data-testid="agent-conv-favorite"
+              onClick={toggleFavorite}
+              className="flex w-full items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-sm text-foreground/85 transition-colors hover:bg-surface/80"
+            >
+              <Heart
+                className={cn(
+                  'h-3.5 w-3.5 shrink-0',
+                  isFavorite ? 'text-accent-primary' : 'text-foreground/50',
+                )}
+                fill={isFavorite ? 'currentColor' : 'none'}
+              />
+              {isFavorite ? t('header.removeFavorite') : t('header.addFavorite')}
             </button>
             <button
               type="button"

--- a/client/src/components/agent-chat/__tests__/agent-conversation-header.test.tsx
+++ b/client/src/components/agent-chat/__tests__/agent-conversation-header.test.tsx
@@ -4,11 +4,20 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 const renameConversation = vi.fn(async () => {})
 const deleteConversation = vi.fn(async () => {})
 const startNewConversation = vi.fn()
+const toggleFavoriteConversation = vi.fn()
 let active: { id: string; title: string | null; pinned_project_id: string | null } | null = {
   id: 'conv-1', title: 'Greeting And Friendly Introduction', pinned_project_id: 'p1',
 }
+let favoriteConversationIds = new Set<string>()
 vi.mock('../../../context/AgentChatContext', () => ({
-  useAgentChat: () => ({ active, renameConversation, deleteConversation, startNewConversation }),
+  useAgentChat: () => ({
+    active,
+    renameConversation,
+    deleteConversation,
+    startNewConversation,
+    favoriteConversationIds,
+    toggleFavoriteConversation,
+  }),
 }))
 vi.mock('../../../hooks/useDesktop', () => ({
   useDesktop: () => ({ projects: [{ id: 'p1', slug: 'outrun', name: 'outrun', path: '/Users/javi/repos/outrun' }] }),
@@ -21,6 +30,7 @@ const writeText = vi.fn(async () => {})
 beforeEach(() => {
   vi.clearAllMocks()
   active = { id: 'conv-1', title: 'Greeting And Friendly Introduction', pinned_project_id: 'p1' }
+  favoriteConversationIds = new Set()
   Object.assign(navigator, { clipboard: { writeText } })
 })
 
@@ -43,6 +53,7 @@ describe('AgentConversationHeader', () => {
     fireEvent.click(screen.getByTestId('agent-conv-menu-trigger'))
     expect(screen.getByTestId('agent-conv-menu')).toBeInTheDocument()
     expect(screen.getByTestId('agent-conv-rename')).toBeInTheDocument()
+    expect(screen.getByTestId('agent-conv-favorite')).toHaveTextContent('Add to favorites')
     expect(screen.getByTestId('agent-conv-copy-name')).toBeInTheDocument()
     expect(screen.getByTestId('agent-conv-copy-id')).toBeInTheDocument()
     expect(screen.getByTestId('agent-conv-copy-project')).toBeInTheDocument()
@@ -81,6 +92,22 @@ describe('AgentConversationHeader', () => {
     fireEvent.click(screen.getByTestId('agent-conv-menu-trigger'))
     fireEvent.click(screen.getByTestId('agent-conv-copy-path'))
     await waitFor(() => expect(writeText).toHaveBeenCalledWith('/Users/javi/repos/outrun'))
+  })
+
+  it('Add to favorites toggles the active mission favorite state', () => {
+    render(<AgentConversationHeader />)
+    fireEvent.click(screen.getByTestId('agent-conv-menu-trigger'))
+    fireEvent.click(screen.getByTestId('agent-conv-favorite'))
+    expect(toggleFavoriteConversation).toHaveBeenCalledWith('conv-1')
+  })
+
+  it('shows Remove from favorites when the active mission is already favorited', () => {
+    favoriteConversationIds = new Set(['conv-1'])
+    render(<AgentConversationHeader />)
+    fireEvent.click(screen.getByTestId('agent-conv-menu-trigger'))
+    expect(screen.getByTestId('agent-conv-favorite')).toHaveTextContent('Remove from favorites')
+    fireEvent.click(screen.getByTestId('agent-conv-favorite'))
+    expect(toggleFavoriteConversation).toHaveBeenCalledWith('conv-1')
   })
 })
 

--- a/client/src/components/terminal/BottomPanel.tsx
+++ b/client/src/components/terminal/BottomPanel.tsx
@@ -20,6 +20,9 @@ import { TerminalViewport } from './TerminalViewport'
 import { TerminalDragHandle } from './TerminalDragHandle'
 import { EmptyTerminalPlaceholder } from './EmptyTerminalPlaceholder'
 
+const PANEL_CURTAIN_MS = 300
+type PanelCurtainPhase = 'hidden' | 'opening' | 'open' | 'closing'
+
 interface BottomPanelProps {
   projectId: string
   /** Project's primary CLI provider — drives the Sparkles shortcut label when a
@@ -42,6 +45,10 @@ export function BottomPanel({ projectId, provider = 'claude', providers, state, 
   const [settings, setSettings] = useState<TerminalSettings>(DEFAULT_TERMINAL_SETTINGS)
   const [shortcutMenu, setShortcutMenu] = useState<{ x: number; y: number; kind: 'browser' | 'script' } | null>(null)
   const [cliMenu, setCliMenu] = useState<{ x: number; y: number } | null>(null)
+  const [curtainPhase, setCurtainPhase] = useState<PanelCurtainPhase>(() =>
+    state.visibility === 'hidden' ? 'hidden' : 'open',
+  )
+  const didMountRef = useRef(false)
   const installedProviders = providers && providers.length > 0 ? providers : [provider]
   const multiProvider = installedProviders.length > 1
 
@@ -77,9 +84,32 @@ export function BottomPanel({ projectId, provider = 'claude', providers, state, 
   const height =
     state.visibility === 'maximized' ? Math.max(PANEL_MIN_HEIGHT, viewportHeight - statusBarHeight) :
     livePreviewHeight ?? userHeight
+  const curtainOpen = curtainPhase === 'open'
+  const visualHeight = curtainOpen ? height : 0
 
   const canCreate = state.sessions.length < TERMINAL_MAX_PER_PROJECT
   const hasActive = state.activeId !== null
+
+  useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true
+      return
+    }
+
+    let timeout: ReturnType<typeof setTimeout> | null = null
+    let frame: number | null = null
+    if (state.visibility === 'hidden') {
+      setCurtainPhase('closing')
+      timeout = setTimeout(() => setCurtainPhase('hidden'), PANEL_CURTAIN_MS)
+    } else {
+      setCurtainPhase('opening')
+      frame = requestAnimationFrame(() => setCurtainPhase('open'))
+    }
+    return () => {
+      if (timeout) clearTimeout(timeout)
+      if (frame !== null) cancelAnimationFrame(frame)
+    }
+  }, [state.visibility])
 
   useEffect(() => {
     let disposed = false
@@ -178,16 +208,22 @@ export function BottomPanel({ projectId, provider = 'claude', providers, state, 
   // Reset live preview when visibility changes (e.g. maximize)
   useEffect(() => { setLivePreviewHeight(null) }, [state.visibility])
 
-  if (state.visibility === 'hidden') return null
+  if (curtainPhase === 'hidden') return null
 
   return (
     <div
       ref={panelRef}
       className={cn(
-        'relative flex flex-col shrink-0 bg-background/95',
+        'relative flex flex-col shrink-0 overflow-hidden origin-bottom transform-gpu bg-background/95',
         'border-t border-border/40',
+        'transition-[height,opacity,transform,clip-path] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none',
       )}
-      style={{ height }}
+      style={{
+        height: visualHeight,
+        opacity: curtainOpen ? 1 : 0,
+        transform: curtainOpen ? 'translateY(0) scaleY(1)' : 'translateY(8px) scaleY(0.985)',
+        clipPath: curtainOpen ? 'inset(0 0 0 0)' : 'inset(100% 0 0 0)',
+      }}
       data-testid="terminal-bottom-panel"
     >
       <TerminalDragHandle

--- a/client/src/components/terminal/BottomPanel.tsx
+++ b/client/src/components/terminal/BottomPanel.tsx
@@ -45,8 +45,9 @@ export function BottomPanel({ projectId, provider = 'claude', providers, state, 
   const [settings, setSettings] = useState<TerminalSettings>(DEFAULT_TERMINAL_SETTINGS)
   const [shortcutMenu, setShortcutMenu] = useState<{ x: number; y: number; kind: 'browser' | 'script' } | null>(null)
   const [cliMenu, setCliMenu] = useState<{ x: number; y: number } | null>(null)
+  const animateInitialOpenRef = useRef(statusBarHeight === 0 && state.visibility !== 'hidden')
   const [curtainPhase, setCurtainPhase] = useState<PanelCurtainPhase>(() =>
-    state.visibility === 'hidden' ? 'hidden' : 'open',
+    state.visibility === 'hidden' ? 'hidden' : animateInitialOpenRef.current ? 'opening' : 'open',
   )
   const didMountRef = useRef(false)
   const installedProviders = providers && providers.length > 0 ? providers : [provider]
@@ -92,23 +93,36 @@ export function BottomPanel({ projectId, provider = 'claude', providers, state, 
   const hasActive = state.activeId !== null
 
   useEffect(() => {
-    if (!didMountRef.current) {
-      didMountRef.current = true
-      return
-    }
-
     let timeout: ReturnType<typeof setTimeout> | null = null
     let frame: number | null = null
+    let nextFrame: number | null = null
+
+    const scheduleOpenAfterPaint = () => {
+      setCurtainPhase('opening')
+      frame = requestAnimationFrame(() => {
+        nextFrame = requestAnimationFrame(() => setCurtainPhase('open'))
+      })
+    }
+
+    if (!didMountRef.current) {
+      didMountRef.current = true
+      if (animateInitialOpenRef.current) scheduleOpenAfterPaint()
+      return () => {
+        if (frame !== null) cancelAnimationFrame(frame)
+        if (nextFrame !== null) cancelAnimationFrame(nextFrame)
+      }
+    }
+
     if (state.visibility === 'hidden') {
       setCurtainPhase('closing')
       timeout = setTimeout(() => setCurtainPhase('hidden'), PANEL_CURTAIN_MS)
     } else {
-      setCurtainPhase('opening')
-      frame = requestAnimationFrame(() => setCurtainPhase('open'))
+      scheduleOpenAfterPaint()
     }
     return () => {
       if (timeout) clearTimeout(timeout)
       if (frame !== null) cancelAnimationFrame(frame)
+      if (nextFrame !== null) cancelAnimationFrame(nextFrame)
     }
   }, [state.visibility])
 

--- a/client/src/components/terminal/BottomPanel.tsx
+++ b/client/src/components/terminal/BottomPanel.tsx
@@ -86,6 +86,7 @@ export function BottomPanel({ projectId, provider = 'claude', providers, state, 
     livePreviewHeight ?? userHeight
   const curtainOpen = curtainPhase === 'open'
   const visualHeight = curtainOpen ? height : 0
+  const footerless = statusBarHeight === 0
 
   const canCreate = state.sessions.length < TERMINAL_MAX_PER_PROJECT
   const hasActive = state.activeId !== null
@@ -221,7 +222,9 @@ export function BottomPanel({ projectId, provider = 'claude', providers, state, 
       style={{
         height: visualHeight,
         opacity: curtainOpen ? 1 : 0,
-        transform: curtainOpen ? 'translateY(0) scaleY(1)' : 'translateY(8px) scaleY(0.985)',
+        transform: curtainOpen
+          ? 'translateY(0) scaleY(1)'
+          : `translateY(${footerless ? 14 : 8}px) scaleY(${footerless ? 0.96 : 0.985})`,
         clipPath: curtainOpen ? 'inset(0 0 0 0)' : 'inset(100% 0 0 0)',
       }}
       data-testid="terminal-bottom-panel"

--- a/client/src/components/terminal/__tests__/BottomPanel.test.tsx
+++ b/client/src/components/terminal/__tests__/BottomPanel.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, fireEvent, waitFor } from '@testing-library/react'
+import { act, render, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { BottomPanel } from '../BottomPanel'
 import { TerminalsProvider } from '../../../context/TerminalsContext'
@@ -92,6 +92,32 @@ describe('BottomPanel', () => {
     )
     const panel = getByTestId('terminal-bottom-panel') as HTMLElement
     expect(panel.style.height).toBe('400px')
+  })
+
+  it('plays a curtain close before unmounting when hidden after being open', () => {
+    vi.useFakeTimers()
+    try {
+      const { getByTestId, queryByTestId, rerender } = wrap(
+        <BottomPanel projectId="p" state={makeState({ visibility: 'restored', userHeight: 400 })} viewportHeight={800} statusBarHeight={28} />,
+      )
+      expect((getByTestId('terminal-bottom-panel') as HTMLElement).style.height).toBe('400px')
+
+      rerender(
+        <MemoryRouter>
+          <TerminalsProvider activeProjectId="p">
+            <BottomPanel projectId="p" state={makeState({ visibility: 'hidden', userHeight: 400 })} viewportHeight={800} statusBarHeight={28} />
+          </TerminalsProvider>
+        </MemoryRouter>,
+      )
+      const closingPanel = getByTestId('terminal-bottom-panel') as HTMLElement
+      expect(closingPanel.style.height).toBe('0px')
+      expect(closingPanel.style.opacity).toBe('0')
+
+      act(() => { vi.advanceTimersByTime(310) })
+      expect(queryByTestId('terminal-bottom-panel')).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('renders at viewport-statusbar in maximized mode', () => {

--- a/client/src/components/terminal/__tests__/BottomPanel.test.tsx
+++ b/client/src/components/terminal/__tests__/BottomPanel.test.tsx
@@ -94,6 +94,44 @@ describe('BottomPanel', () => {
     expect(panel.style.height).toBe('400px')
   })
 
+  it('opens through a painted curtain frame in mission mode', () => {
+    const rafCallbacks: FrameRequestCallback[] = []
+    const requestFrame = vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb) => {
+      rafCallbacks.push(cb)
+      return rafCallbacks.length
+    })
+    const cancelFrame = vi.spyOn(globalThis, 'cancelAnimationFrame').mockImplementation(() => {})
+
+    try {
+      const { getByTestId, queryByTestId, rerender } = wrap(
+        <BottomPanel projectId="p" state={makeState({ visibility: 'hidden', userHeight: 400 })} viewportHeight={800} statusBarHeight={0} />,
+      )
+      expect(queryByTestId('terminal-bottom-panel')).toBeNull()
+
+      rerender(
+        <MemoryRouter>
+          <TerminalsProvider activeProjectId="p">
+            <BottomPanel projectId="p" state={makeState({ visibility: 'restored', userHeight: 400 })} viewportHeight={800} statusBarHeight={0} />
+          </TerminalsProvider>
+        </MemoryRouter>,
+      )
+
+      const openingPanel = getByTestId('terminal-bottom-panel') as HTMLElement
+      expect(openingPanel.style.height).toBe('0px')
+      expect(openingPanel.style.transform).toBe('translateY(14px) scaleY(0.96)')
+
+      act(() => { rafCallbacks.shift()?.(0) })
+      expect(openingPanel.style.height).toBe('0px')
+
+      act(() => { rafCallbacks.shift()?.(16) })
+      expect(openingPanel.style.height).toBe('400px')
+      expect(openingPanel.style.transform).toBe('translateY(0) scaleY(1)')
+    } finally {
+      requestFrame.mockRestore()
+      cancelFrame.mockRestore()
+    }
+  })
+
   it('plays a curtain close before unmounting when hidden after being open', () => {
     vi.useFakeTimers()
     try {

--- a/client/src/components/terminal/__tests__/BottomPanel.test.tsx
+++ b/client/src/components/terminal/__tests__/BottomPanel.test.tsx
@@ -120,6 +120,30 @@ describe('BottomPanel', () => {
     }
   })
 
+  it('uses a stronger curtain offset without the footer bar', () => {
+    vi.useFakeTimers()
+    try {
+      const { getByTestId, rerender } = wrap(
+        <BottomPanel projectId="p" state={makeState({ visibility: 'restored', userHeight: 400 })} viewportHeight={800} statusBarHeight={0} />,
+      )
+
+      rerender(
+        <MemoryRouter>
+          <TerminalsProvider activeProjectId="p">
+            <BottomPanel projectId="p" state={makeState({ visibility: 'hidden', userHeight: 400 })} viewportHeight={800} statusBarHeight={0} />
+          </TerminalsProvider>
+        </MemoryRouter>,
+      )
+
+      const closingPanel = getByTestId('terminal-bottom-panel') as HTMLElement
+      expect(closingPanel.style.transform).toBe('translateY(14px) scaleY(0.96)')
+
+      act(() => { vi.advanceTimersByTime(310) })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('renders at viewport-statusbar in maximized mode', () => {
     const { getByTestId } = wrap(
       <BottomPanel projectId="p" state={makeState({ visibility: 'maximized', userHeight: 400 })} viewportHeight={800} statusBarHeight={28} />,

--- a/client/src/context/AgentChatContext.tsx
+++ b/client/src/context/AgentChatContext.tsx
@@ -58,6 +58,27 @@ export interface AgentConvLive {
 }
 
 const EMPTY_LIVE: AgentConvLive = { streamingText: '', isStreaming: false, liveTools: [], queued: [] }
+const FAVORITE_CONVERSATIONS_KEY = 'specrails-desktop:favorite-agent-conversations'
+
+function loadFavoriteConversationIds(): Set<string> {
+  try {
+    const raw = localStorage.getItem(FAVORITE_CONVERSATIONS_KEY)
+    if (!raw) return new Set()
+    const parsed = JSON.parse(raw) as unknown
+    return Array.isArray(parsed) ? new Set(parsed.filter((x): x is string => typeof x === 'string')) : new Set()
+  } catch {
+    return new Set()
+  }
+}
+
+function saveFavoriteConversationIds(ids: ReadonlySet<string>): void {
+  try { localStorage.setItem(FAVORITE_CONVERSATIONS_KEY, JSON.stringify([...ids])) } catch { /* ignore */ }
+}
+
+function pruneFavoriteConversationIds(prev: ReadonlySet<string>, conversations: AgentConversation[]): Set<string> {
+  const valid = new Set(conversations.map((c) => c.id))
+  return new Set([...prev].filter((id) => valid.has(id)))
+}
 
 export interface AgentChatContextValue {
   visibility: AgentVisibility
@@ -79,6 +100,8 @@ export interface AgentChatContextValue {
   /** Per-conversation live slices (stream/tools/queue) — feeds the mission
    *  selector's queued-count badges without flattening to the active thread. */
   liveByConversation: ReadonlyMap<string, AgentConvLive>
+  /** Mission IDs surfaced in the left sidebar's Favorite missions section. */
+  favoriteConversationIds: ReadonlySet<string>
 
   mcpEnabled: boolean
   enablingMcp: boolean
@@ -117,6 +140,8 @@ export interface AgentChatContextValue {
   deleteConversation: (id: string) => Promise<void>
   /** Rename a conversation (optimistic; blank clears to auto-title). */
   renameConversation: (id: string, title: string) => Promise<void>
+  /** Toggle the sidebar Favorite missions membership without changing project pinning. */
+  toggleFavoriteConversation: (id: string) => void
   /** Refresh the conversation list WITHOUT opening the floating panel. Used on
    *  entering Agent Mode (open() would mount the now-suppressed panel). */
   refreshConversations: () => Promise<void>
@@ -147,6 +172,7 @@ export function AgentChatProvider({ children }: { children: ReactNode }) {
   const [conversations, setConversations] = useState<AgentConversation[]>([])
   const [active, setActive] = useState<AgentConversation | null>(null)
   const [messages, setMessages] = useState<AgentMessage[]>([])
+  const [favoriteConversationIds, setFavoriteConversationIds] = useState<ReadonlySet<string>>(loadFavoriteConversationIds)
   // Live turn state is PER CONVERSATION: agents keep working in the background,
   // so switching threads never drops streamed text, tool chips or queued
   // messages. The view derives the active conversation's slice below.
@@ -212,7 +238,14 @@ export function AgentChatProvider({ children }: { children: ReactNode }) {
   // Refresh the conversation list + MCP status lazily on first open.
   const refreshConversations = useCallback(async () => {
     try {
-      setConversations(await listAgentConversations())
+      const list = await listAgentConversations()
+      setConversations(list)
+      setFavoriteConversationIds((prev) => {
+        const next = pruneFavoriteConversationIds(prev, list)
+        if (next.size === prev.size) return prev
+        saveFavoriteConversationIds(next)
+        return next
+      })
     } catch {
       /* surfaced elsewhere */
     }
@@ -366,6 +399,12 @@ export function AgentChatProvider({ children }: { children: ReactNode }) {
     if (active) return active
     const list = await listAgentConversations()
     setConversations(list)
+    setFavoriteConversationIds((prev) => {
+      const next = pruneFavoriteConversationIds(prev, list)
+      if (next.size === prev.size) return prev
+      saveFavoriteConversationIds(next)
+      return next
+    })
     if (list.length > 0) {
       await loadConversation(list[0].id)
       return list[0]
@@ -565,6 +604,13 @@ export function AgentChatProvider({ children }: { children: ReactNode }) {
   const deleteConversation = useCallback(async (id: string) => {
     await deleteAgentConversation(id)
     setConversations((c) => c.filter((x) => x.id !== id))
+    setFavoriteConversationIds((prev) => {
+      if (!prev.has(id)) return prev
+      const next = new Set(prev)
+      next.delete(id)
+      saveFavoriteConversationIds(next)
+      return next
+    })
     patchLive(id, () => null)
     if (activeIdRef.current === id) {
       setActive(null)
@@ -592,6 +638,16 @@ export function AgentChatProvider({ children }: { children: ReactNode }) {
     }
   }, [])
 
+  const toggleFavoriteConversation = useCallback((id: string): void => {
+    setFavoriteConversationIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      saveFavoriteConversationIds(next)
+      return next
+    })
+  }, [])
+
   const enableMcpServer = useCallback(async () => {
     setEnablingMcp(true)
     try {
@@ -606,22 +662,23 @@ export function AgentChatProvider({ children }: { children: ReactNode }) {
     visibility, open, close, minimize, toggle,
     conversations, active, messages, streamingText, isStreaming, liveTools,
     queuedMessages, streamingConversationIds, liveByConversation: liveByConv,
+    favoriteConversationIds,
     mcpEnabled, enablingMcp, enableMcpServer, providersReady,
     send, abort, editQueuedMessage, wasQueueConsumed,
     cycleTier, setTier, setProvider, setModel, setPinnedProject,
     newConversation, startNewConversation, draftPinnedProjectId,
     draftProvider, draftModel, draftTierLevel, draftEffort, setEffort,
-    selectConversation, deleteConversation, renameConversation, refreshConversations,
+    selectConversation, deleteConversation, renameConversation, toggleFavoriteConversation, refreshConversations,
   }), [
     visibility, open, close, minimize, toggle,
     conversations, active, messages, streamingText, isStreaming, liveTools,
-    queuedMessages, streamingConversationIds, liveByConv,
+    queuedMessages, streamingConversationIds, liveByConv, favoriteConversationIds,
     mcpEnabled, enablingMcp, enableMcpServer, providersReady,
     send, abort, editQueuedMessage, wasQueueConsumed,
     cycleTier, setTier, setProvider, setModel, setPinnedProject,
     newConversation, startNewConversation, draftPinnedProjectId,
     draftProvider, draftModel, draftTierLevel, draftEffort, setEffort,
-    selectConversation, deleteConversation, renameConversation, refreshConversations,
+    selectConversation, deleteConversation, renameConversation, toggleFavoriteConversation, refreshConversations,
   ])
 
   // In Agent Mode the conversation UI is the full-screen surface, so the
@@ -646,6 +703,7 @@ const NOOP_AGENT_CHAT: AgentChatContextValue = {
   conversations: [], active: null, messages: [], streamingText: '', isStreaming: false, liveTools: [],
   queuedMessages: [], streamingConversationIds: new Set<string>(),
   liveByConversation: new Map<string, AgentConvLive>(),
+  favoriteConversationIds: new Set<string>(),
   mcpEnabled: true, enablingMcp: false, enableMcpServer: async () => {}, providersReady: true,
   send: async () => {}, abort: async () => {},
   editQueuedMessage: async () => 'conflict', wasQueueConsumed: () => false,
@@ -655,6 +713,7 @@ const NOOP_AGENT_CHAT: AgentChatContextValue = {
   draftProvider: 'claude', draftModel: null, draftTierLevel: 0,
   draftEffort: null, setEffort: async () => {},
   selectConversation: async () => {}, deleteConversation: async () => {}, renameConversation: async () => {},
+  toggleFavoriteConversation: () => {},
   refreshConversations: async () => {},
 }
 

--- a/client/src/locales/de/agent.json
+++ b/client/src/locales/de/agent.json
@@ -147,6 +147,7 @@
   "switchToKanban": "Zum Board wechseln",
   "search": "Suchen",
   "home": "Start",
+  "favoriteMissions": "Lieblingsmissionen",
   "untitled": "Ohne Titel",
   "workspace": {
     "title": "Im Workspace",
@@ -168,6 +169,8 @@
   "attachFile": "Datei anhängen",
   "deleteConversation": "„{{title}}“ löschen",
   "confirmDeleteConversation": "Löschen von „{{title}}“ bestätigen",
+  "addFavoriteConversation": "„{{title}}“ zu Favoriten hinzufügen",
+  "removeFavoriteConversation": "„{{title}}“ aus Favoriten entfernen",
   "confirmShort": "bestätigen?",
   "imagesUnsupported": "Dieser Anbieter kann noch keine Bilder lesen — hänge stattdessen Textdateien an",
   "effort": {
@@ -270,6 +273,8 @@
     "renamePlaceholder": "Name der Mission",
     "renameHint": "Zum Umbenennen doppelklicken",
     "renameFailed": "Umbenennen fehlgeschlagen",
+    "addFavorite": "Zu Favoriten hinzufügen",
+    "removeFavorite": "Aus Favoriten entfernen",
     "copyName": "Missionsname kopieren",
     "copyId": "Missions-ID kopieren",
     "copyProject": "Projektname kopieren",

--- a/client/src/locales/en/agent.json
+++ b/client/src/locales/en/agent.json
@@ -147,6 +147,7 @@
   "switchToKanban": "Switch to Board",
   "search": "Search",
   "home": "Home",
+  "favoriteMissions": "Favorite missions",
   "untitled": "Untitled",
   "workspace": {
     "title": "On workspace",
@@ -168,6 +169,8 @@
   "attachFile": "Attach file",
   "deleteConversation": "Delete \"{{title}}\"",
   "confirmDeleteConversation": "Confirm delete \"{{title}}\"",
+  "addFavoriteConversation": "Add \"{{title}}\" to favorites",
+  "removeFavoriteConversation": "Remove \"{{title}}\" from favorites",
   "confirmShort": "confirm?",
   "imagesUnsupported": "This provider can't read images yet — attach text files instead",
   "effort": {
@@ -270,6 +273,8 @@
     "renamePlaceholder": "Mission name",
     "renameHint": "Double-click to rename",
     "renameFailed": "Could not rename",
+    "addFavorite": "Add to favorites",
+    "removeFavorite": "Remove from favorites",
     "copyName": "Copy mission name",
     "copyId": "Copy mission ID",
     "copyProject": "Copy project name",

--- a/client/src/locales/es/agent.json
+++ b/client/src/locales/es/agent.json
@@ -147,6 +147,7 @@
   "switchToKanban": "Cambiar al tablero",
   "search": "Buscar",
   "home": "Inicio",
+  "favoriteMissions": "Misiones favoritas",
   "untitled": "Sin título",
   "workspace": {
     "title": "En el workspace",
@@ -168,6 +169,8 @@
   "attachFile": "Adjuntar archivo",
   "deleteConversation": "Borrar «{{title}}»",
   "confirmDeleteConversation": "Confirmar borrado de «{{title}}»",
+  "addFavoriteConversation": "Añadir «{{title}}» a favoritas",
+  "removeFavoriteConversation": "Quitar «{{title}}» de favoritas",
   "confirmShort": "¿confirmar?",
   "imagesUnsupported": "Este proveedor aún no lee imágenes — adjunta archivos de texto",
   "effort": {
@@ -270,6 +273,8 @@
     "renamePlaceholder": "Nombre de la misión",
     "renameHint": "Doble clic para renombrar",
     "renameFailed": "No se pudo renombrar",
+    "addFavorite": "Añadir a favoritas",
+    "removeFavorite": "Quitar de favoritas",
     "copyName": "Copiar nombre de la misión",
     "copyId": "Copiar ID de la misión",
     "copyProject": "Copiar nombre del proyecto",

--- a/client/src/locales/fr/agent.json
+++ b/client/src/locales/fr/agent.json
@@ -147,6 +147,7 @@
   "switchToKanban": "Passer au tableau",
   "search": "Rechercher",
   "home": "Accueil",
+  "favoriteMissions": "Missions favorites",
   "untitled": "Sans titre",
   "workspace": {
     "title": "Espace de travail",
@@ -168,6 +169,8 @@
   "attachFile": "Joindre un fichier",
   "deleteConversation": "Supprimer « {{title}} »",
   "confirmDeleteConversation": "Confirmer la suppression de « {{title}} »",
+  "addFavoriteConversation": "Ajouter « {{title}} » aux favorites",
+  "removeFavoriteConversation": "Retirer « {{title}} » des favorites",
   "confirmShort": "confirmer ?",
   "imagesUnsupported": "Ce fournisseur ne lit pas encore les images — joignez plutôt des fichiers texte",
   "effort": {
@@ -270,6 +273,8 @@
     "renamePlaceholder": "Nom de la mission",
     "renameHint": "Double-clic pour renommer",
     "renameFailed": "Renommage impossible",
+    "addFavorite": "Ajouter aux favorites",
+    "removeFavorite": "Retirer des favorites",
     "copyName": "Copier le nom de la mission",
     "copyId": "Copier l'ID de la mission",
     "copyProject": "Copier le nom du projet",

--- a/client/src/locales/it/agent.json
+++ b/client/src/locales/it/agent.json
@@ -147,6 +147,7 @@
   "switchToKanban": "Passa alla board",
   "search": "Cerca",
   "home": "Home",
+  "favoriteMissions": "Missioni preferite",
   "untitled": "Senza titolo",
   "workspace": {
     "title": "Nel workspace",
@@ -168,6 +169,8 @@
   "attachFile": "Allega file",
   "deleteConversation": "Elimina «{{title}}»",
   "confirmDeleteConversation": "Conferma eliminazione di «{{title}}»",
+  "addFavoriteConversation": "Aggiungi «{{title}}» ai preferiti",
+  "removeFavoriteConversation": "Rimuovi «{{title}}» dai preferiti",
   "confirmShort": "confermare?",
   "imagesUnsupported": "Questo provider non legge ancora le immagini — allega file di testo",
   "effort": {
@@ -270,6 +273,8 @@
     "renamePlaceholder": "Nome della missione",
     "renameHint": "Doppio clic per rinominare",
     "renameFailed": "Impossibile rinominare",
+    "addFavorite": "Aggiungi ai preferiti",
+    "removeFavorite": "Rimuovi dai preferiti",
     "copyName": "Copia nome missione",
     "copyId": "Copia ID missione",
     "copyProject": "Copia nome progetto",

--- a/client/src/locales/ja/agent.json
+++ b/client/src/locales/ja/agent.json
@@ -147,6 +147,7 @@
   "switchToKanban": "ボードに切り替え",
   "search": "検索",
   "home": "ホーム",
+  "favoriteMissions": "お気に入りミッション",
   "untitled": "無題",
   "workspace": {
     "title": "ワークスペース",
@@ -168,6 +169,8 @@
   "attachFile": "ファイルを添付",
   "deleteConversation": "「{{title}}」を削除",
   "confirmDeleteConversation": "「{{title}}」の削除を確認",
+  "addFavoriteConversation": "「{{title}}」をお気に入りに追加",
+  "removeFavoriteConversation": "「{{title}}」をお気に入りから削除",
   "confirmShort": "削除しますか？",
   "imagesUnsupported": "このプロバイダーはまだ画像を読み取れません — テキストファイルを添付してください",
   "effort": {
@@ -270,6 +273,8 @@
     "renamePlaceholder": "ミッション名",
     "renameHint": "ダブルクリックで名前を変更",
     "renameFailed": "名前を変更できませんでした",
+    "addFavorite": "お気に入りに追加",
+    "removeFavorite": "お気に入りから削除",
     "copyName": "ミッション名をコピー",
     "copyId": "ミッション ID をコピー",
     "copyProject": "プロジェクト名をコピー",

--- a/client/src/locales/pt/agent.json
+++ b/client/src/locales/pt/agent.json
@@ -147,6 +147,7 @@
   "switchToKanban": "Mudar para o quadro",
   "search": "Buscar",
   "home": "Início",
+  "favoriteMissions": "Missões favoritas",
   "untitled": "Sem título",
   "workspace": {
     "title": "No workspace",
@@ -168,6 +169,8 @@
   "attachFile": "Anexar arquivo",
   "deleteConversation": "Excluir \"{{title}}\"",
   "confirmDeleteConversation": "Confirmar exclusão de \"{{title}}\"",
+  "addFavoriteConversation": "Adicionar \"{{title}}\" aos favoritos",
+  "removeFavoriteConversation": "Remover \"{{title}}\" dos favoritos",
   "confirmShort": "confirmar?",
   "imagesUnsupported": "Este provedor ainda não lê imagens — anexe arquivos de texto",
   "effort": {
@@ -270,6 +273,8 @@
     "renamePlaceholder": "Nome da missão",
     "renameHint": "Duplo clique para renomear",
     "renameFailed": "Não foi possível renomear",
+    "addFavorite": "Adicionar aos favoritos",
+    "removeFavorite": "Remover dos favoritos",
     "copyName": "Copiar nome da missão",
     "copyId": "Copiar ID da missão",
     "copyProject": "Copiar nome do projeto",

--- a/client/src/locales/zh/agent.json
+++ b/client/src/locales/zh/agent.json
@@ -147,6 +147,7 @@
   "switchToKanban": "切换到看板",
   "search": "搜索",
   "home": "主页",
+  "favoriteMissions": "收藏任务",
   "untitled": "未命名",
   "workspace": {
     "title": "工作区",
@@ -168,6 +169,8 @@
   "attachFile": "附加文件",
   "deleteConversation": "删除「{{title}}」",
   "confirmDeleteConversation": "确认删除「{{title}}」",
+  "addFavoriteConversation": "将「{{title}}」添加到收藏",
+  "removeFavoriteConversation": "从收藏中移除「{{title}}」",
   "confirmShort": "确认？",
   "imagesUnsupported": "该提供商暂不支持读取图片 — 请附加文本文件",
   "effort": {
@@ -270,6 +273,8 @@
     "renamePlaceholder": "任务名称",
     "renameHint": "双击重命名",
     "renameFailed": "无法重命名",
+    "addFavorite": "添加到收藏",
+    "removeFavorite": "从收藏中移除",
     "copyName": "复制任务名称",
     "copyId": "复制任务 ID",
     "copyProject": "复制项目名称",


### PR DESCRIPTION
Summary: Add persistent favorite missions in Agent Mode, render a Favorite missions section above Projects, and expose heart toggles in the sidebar row and mission menu. Tests: npx vitest run src/components/__tests__/ArcSidebarAgentConversations.test.tsx src/components/agent-chat/__tests__/agent-conversation-header.test.tsx src/lib/__tests__/locale-parity.test.ts; npm run typecheck