### PR TITLE
[5]feat - add Integrations entry to the Agent Mode sidebar with a full-size modal

### DIFF
--- a/.specrails
+++ b/.specrails
@@ -1,0 +1,1 @@
+/Users/javi/.specrails/projects/specrails-desktop/workspace/.specrails

--- a/client/src/components/agent-chat/AgentIntegrationsModal.tsx
+++ b/client/src/components/agent-chat/AgentIntegrationsModal.tsx
@@ -1,0 +1,82 @@
+import { useEffect } from 'react'
+import { createPortal } from 'react-dom'
+import { useTranslation } from 'react-i18next'
+import { Puzzle, X } from 'lucide-react'
+import type { ReactElement } from 'react'
+import IntegrationsPage from '../../pages/IntegrationsPage'
+import { useMovableResizableModal } from '../../hooks/useMovableResizableModal'
+import { ResizeGrips } from '../ui/ResizeGrips'
+import { TooltipProvider } from '../ui/tooltip'
+
+interface AgentIntegrationsModalProps {
+  onClose: () => void
+}
+
+export function AgentIntegrationsModal({ onClose }: AgentIntegrationsModalProps): ReactElement {
+  const { t } = useTranslation('nav')
+  const { t: tCommon } = useTranslation('common')
+  const {
+    panelRef,
+    panelStyle,
+    headerHandleProps,
+    resizeHandles,
+    isFloating,
+    guardBackdrop,
+  } = useMovableResizableModal({
+    minWidth: 320,
+    minHeight: 200,
+    persistKey: 'specrails-desktop:agent-integrations-modal',
+  })
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [onClose])
+
+  return createPortal(
+    <TooltipProvider delayDuration={400}>
+      <div className="fixed inset-0 z-[65] flex items-stretch justify-center">
+        <div
+          className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+          onClick={guardBackdrop(onClose)}
+        />
+
+        <div
+          ref={panelRef}
+          className="relative m-3 flex w-full flex-col overflow-hidden rounded-xl border border-border/30 glass-card animate-in fade-in zoom-in-95 duration-200"
+          style={panelStyle}
+        >
+          <div
+            {...headerHandleProps}
+            className={`flex items-center justify-between border-b border-border/30 px-4 py-3${isFloating ? ' cursor-grab active:cursor-grabbing' : ''}`}
+          >
+            <div className="flex min-w-0 items-center gap-2">
+              <Puzzle className="h-4 w-4 flex-shrink-0 text-accent-primary" />
+              <h2 className="truncate text-sm font-semibold text-foreground">
+                {t('rightSidebar.integrations')}
+              </h2>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label={tCommon('actions.close')}
+              className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-surface/50 hover:text-foreground"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-auto">
+            <IntegrationsPage />
+          </div>
+        </div>
+
+        <ResizeGrips handles={resizeHandles} />
+      </div>
+    </TooltipProvider>,
+    document.body,
+  )
+}

--- a/client/src/components/agent-chat/AgentModeSurface.tsx
+++ b/client/src/components/agent-chat/AgentModeSurface.tsx
@@ -19,6 +19,9 @@ const AgentModeJobsPane = lazy(() =>
 const AgentBrowserCapture = lazy(() =>
   import('./AgentBrowserCapture').then((m) => ({ default: m.AgentBrowserCapture })),
 )
+const AgentIntegrationsModal = lazy(() =>
+  import('./AgentIntegrationsModal').then((m) => ({ default: m.AgentIntegrationsModal })),
+)
 
 /**
  * The full-screen Agent-Mode center surface. EMPTY (no active conversation) is a
@@ -29,7 +32,7 @@ const AgentBrowserCapture = lazy(() =>
 export function AgentModeSurface() {
   const { t } = useTranslation('agent')
   const { active, refreshConversations } = useAgentChat()
-  const { codePaneOpen, jobsPaneOpen, browserOpen } = useAgentWorkspace()
+  const { codePaneOpen, jobsPaneOpen, browserOpen, integrationsModalOpen, closeIntegrationsModal } = useAgentWorkspace()
   const { activeProjectId } = useDesktop()
   const activeTheme = useActiveTheme()
   const isGalaxy = activeTheme.id === 'galaxy'
@@ -46,6 +49,7 @@ export function AgentModeSurface() {
   // falling back to a Home key when no conversation is open yet).
   const showCode = codePaneOpen && !!activeProjectId
   const showJobs = jobsPaneOpen && !!activeProjectId
+  const showIntegrations = integrationsModalOpen && !!activeProjectId
 
   return (
     <MotionConfig reducedMotion="user">
@@ -109,6 +113,12 @@ export function AgentModeSurface() {
       {browserOpen && activeProjectId && (
         <Suspense fallback={null}>
           <AgentBrowserCapture projectId={activeProjectId} conversationId={active?.id ?? null} />
+        </Suspense>
+      )}
+
+      {showIntegrations && (
+        <Suspense fallback={null}>
+          <AgentIntegrationsModal onClose={closeIntegrationsModal} />
         </Suspense>
       )}
     </div>

--- a/client/src/components/agent-chat/AgentWorkspaceSidebar.tsx
+++ b/client/src/components/agent-chat/AgentWorkspaceSidebar.tsx
@@ -1,16 +1,17 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Globe, TerminalSquare, FileCode2, PanelRight, Briefcase } from 'lucide-react'
+import { Globe, TerminalSquare, FileCode2, PanelRight, Briefcase, Puzzle } from 'lucide-react'
 import { cn } from '../../lib/utils'
 import { useResizableSidebar } from '../../hooks/useResizableSidebar'
 import { SidebarResizeGrip } from '../SidebarResizeGrip'
 import { useSidebarPin } from '../../context/SidebarPinContext'
-import { useDesktop } from '../../hooks/useDesktop'
+import { projectProviders, useDesktop } from '../../hooks/useDesktop'
 import { useTerminals } from '../../context/TerminalsContext'
 import { useAgentWorkspace } from '../../context/AgentWorkspaceContext'
 import { useAgentChat } from '../../context/AgentChatContext'
 import { FEATURE_CODE_EXPLORER, FEATURE_TERMINAL_PANEL } from '../../lib/feature-flags'
 import { isBrowserCaptureEnabled } from '../../lib/browser-capture'
+import { sectionVisibleForProviders } from '../../lib/provider-capabilities'
 
 const RIGHT_PIN_LABEL_KEY: Record<'pinned-open' | 'pinned-collapsed' | 'unpinned', string> = {
   'pinned-open': 'sidebarPin.right.pinnedOpen',
@@ -28,7 +29,7 @@ export function AgentWorkspaceSidebar() {
   const { t } = useTranslation('agent')
   const { t: tNav } = useTranslation('nav')
   const { rightMode, cycleRightMode } = useSidebarPin()
-  const { activeProjectId } = useDesktop()
+  const { projects, activeProjectId } = useDesktop()
   const terminals = useTerminals()
   const workspace = useAgentWorkspace()
   const { active } = useAgentChat()
@@ -42,6 +43,9 @@ export function AgentWorkspaceSidebar() {
   const lit = rightMode !== 'unpinned'
   const pinLabel = tNav(RIGHT_PIN_LABEL_KEY[rightMode])
   const noProject = !activeProjectId
+  const activeProject = projects.find((p) => p.id === activeProjectId)
+  const providers = activeProject ? projectProviders(activeProject) : ['claude']
+  const showIntegrations = sectionVisibleForProviders('integrations', providers)
 
   const tools = [
     // Jobs sits ABOVE Browser: the executions the agent launches are the first
@@ -72,6 +76,13 @@ export function AgentWorkspaceSidebar() {
       ? [{
           key: 'files', icon: FileCode2, label: t('workspace.files'),
           onClick: () => workspace.toggleCodePane(),
+          disabled: noProject, disabledTitle: t('workspace.requiresProject'),
+        }]
+      : []),
+    ...(showIntegrations
+      ? [{
+          key: 'integrations', icon: Puzzle, label: tNav('rightSidebar.integrations'),
+          onClick: () => workspace.toggleIntegrationsModal(),
           disabled: noProject, disabledTitle: t('workspace.requiresProject'),
         }]
       : []),

--- a/client/src/components/agent-chat/__tests__/AgentIntegrationsModal.test.tsx
+++ b/client/src/components/agent-chat/__tests__/AgentIntegrationsModal.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { AgentIntegrationsModal } from '../AgentIntegrationsModal'
+
+const guardBackdrop = vi.fn((cb: () => void) => cb)
+
+vi.mock('../../../pages/IntegrationsPage', () => ({
+  default: () => <div data-testid="integrations-page">Integrations page content</div>,
+}))
+
+vi.mock('../../../hooks/useMovableResizableModal', () => ({
+  useMovableResizableModal: vi.fn(() => ({
+    panelRef: vi.fn(),
+    panelStyle: {},
+    headerHandleProps: {},
+    resizeHandles: [],
+    isFloating: false,
+    guardBackdrop,
+  })),
+}))
+
+describe('AgentIntegrationsModal', () => {
+  it('portals a fixed overlay with existing IntegrationsPage content and close controls', async () => {
+    const onClose = vi.fn()
+    const { container } = render(
+      <div data-testid="agent-panel">
+        <AgentIntegrationsModal onClose={onClose} />
+      </div>,
+    )
+
+    const overlay = document.body.querySelector('div.fixed.inset-0')
+    expect(overlay).not.toBeNull()
+    expect(overlay!.classList.contains('z-[65]')).toBe(true)
+    expect(container.contains(overlay)).toBe(false)
+    expect(overlay!.querySelector('.glass-card')).not.toBeNull()
+    expect(screen.getByTestId('integrations-page')).toHaveTextContent('Integrations page content')
+
+    fireEvent.click(screen.getByRole('button', { name: /close/i }))
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/client/src/components/agent-chat/__tests__/AgentModeSurface.test.tsx
+++ b/client/src/components/agent-chat/__tests__/AgentModeSurface.test.tsx
@@ -3,7 +3,10 @@ import { render, screen } from '@testing-library/react'
 import { AgentModeSurface } from '../AgentModeSurface'
 
 let activeThemeId = 'dracula'
+let activeProjectId: string | null = 'project-1'
+let integrationsModalOpen = false
 const refreshConversations = vi.fn()
+const closeIntegrationsModal = vi.fn()
 
 vi.mock('../../../context/ThemeContext', () => ({
   useActiveTheme: () => ({ id: activeThemeId }),
@@ -21,11 +24,13 @@ vi.mock('../../../context/AgentWorkspaceContext', () => ({
     codePaneOpen: false,
     jobsPaneOpen: false,
     browserOpen: false,
+    integrationsModalOpen,
+    closeIntegrationsModal,
   }),
 }))
 
 vi.mock('../../../hooks/useDesktop', () => ({
-  useDesktop: () => ({ activeProjectId: 'project-1' }),
+  useDesktop: () => ({ activeProjectId }),
 }))
 
 vi.mock('../../theme-effects/Starfield', () => ({
@@ -40,10 +45,21 @@ vi.mock('../AgentConversationView', () => ({
   AgentConversationView: () => <div data-testid="agent-conversation" />,
 }))
 
+vi.mock('../AgentIntegrationsModal', () => ({
+  AgentIntegrationsModal: ({ onClose }: { onClose: () => void }) => (
+    <button type="button" data-testid="agent-integrations-modal" onClick={onClose}>
+      Agent integrations modal
+    </button>
+  ),
+}))
+
 describe('AgentModeSurface', () => {
   beforeEach(() => {
     activeThemeId = 'dracula'
+    activeProjectId = 'project-1'
+    integrationsModalOpen = false
     refreshConversations.mockClear()
+    closeIntegrationsModal.mockClear()
   })
 
   it('exposes a narrow root styling hook', () => {
@@ -62,5 +78,22 @@ describe('AgentModeSurface', () => {
     rerender(<AgentModeSurface />)
 
     expect(screen.queryByTestId('agent-mode-starfield')).toBeNull()
+  })
+
+  it('renders the integrations modal when it is open for an active project', async () => {
+    integrationsModalOpen = true
+
+    render(<AgentModeSurface />)
+
+    expect(await screen.findByTestId('agent-integrations-modal')).toBeInTheDocument()
+  })
+
+  it('does not render the integrations modal without an active project', () => {
+    integrationsModalOpen = true
+    activeProjectId = null
+
+    render(<AgentModeSurface />)
+
+    expect(screen.queryByTestId('agent-integrations-modal')).not.toBeInTheDocument()
   })
 })

--- a/client/src/components/agent-chat/__tests__/AgentWorkspaceSidebar.test.tsx
+++ b/client/src/components/agent-chat/__tests__/AgentWorkspaceSidebar.test.tsx
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '../../../test-utils'
+import { AgentWorkspaceSidebar } from '../AgentWorkspaceSidebar'
+
+const toggleIntegrationsModal = vi.fn()
+let visibleForProviders = true
+
+vi.mock('../../../hooks/useDesktop', async () => {
+  const actual = await vi.importActual<typeof import('../../../hooks/useDesktop')>('../../../hooks/useDesktop')
+  return {
+    ...actual,
+    useDesktop: () => ({
+      activeProjectId: 'project-1',
+      projects: [{
+        id: 'project-1',
+        slug: 'project-1',
+        name: 'Project 1',
+        path: '/tmp/project-1',
+        db_path: '/tmp/project-1/.specrails/specrails.db',
+        provider: 'claude',
+        providers: ['claude'],
+        added_at: '2026-01-01T00:00:00Z',
+        last_seen_at: '2026-01-01T00:00:00Z',
+      }],
+    }),
+  }
+})
+
+vi.mock('../../../context/TerminalsContext', () => ({
+  useTerminals: () => ({ togglePanel: vi.fn() }),
+}))
+
+vi.mock('../../../context/AgentWorkspaceContext', () => ({
+  useAgentWorkspace: () => ({
+    toggleJobsPane: vi.fn(),
+    openBrowser: vi.fn(),
+    toggleCodePane: vi.fn(),
+    toggleIntegrationsModal,
+  }),
+}))
+
+vi.mock('../../../context/AgentChatContext', () => ({
+  useAgentChat: () => ({ active: { id: 'conversation-1' } }),
+}))
+
+vi.mock('../../../lib/provider-capabilities', async () => {
+  const actual = await vi.importActual<typeof import('../../../lib/provider-capabilities')>('../../../lib/provider-capabilities')
+  return {
+    ...actual,
+    sectionVisibleForProviders: vi.fn(() => visibleForProviders),
+  }
+})
+
+describe('AgentWorkspaceSidebar', () => {
+  beforeEach(() => {
+    toggleIntegrationsModal.mockClear()
+    visibleForProviders = true
+  })
+
+  it('shows Integrations immediately after Files and toggles the modal', () => {
+    const { container } = render(<AgentWorkspaceSidebar />)
+
+    fireEvent.mouseEnter(container.firstChild as Element)
+
+    const toolLabels = screen.getAllByRole('button').map((button) => button.textContent)
+    expect(toolLabels).toEqual(expect.arrayContaining(['Files', 'Integrations']))
+    expect(toolLabels.indexOf('Integrations')).toBe(toolLabels.indexOf('Files') + 1)
+
+    fireEvent.click(screen.getByRole('button', { name: /integrations/i }))
+
+    expect(toggleIntegrationsModal).toHaveBeenCalledTimes(1)
+  })
+
+  it('hides Integrations when provider visibility rejects it', () => {
+    visibleForProviders = false
+
+    const { container } = render(<AgentWorkspaceSidebar />)
+    fireEvent.mouseEnter(container.firstChild as Element)
+
+    expect(screen.queryByRole('button', { name: /integrations/i })).not.toBeInTheDocument()
+  })
+})

--- a/client/src/components/theme-effects/Starfield.tsx
+++ b/client/src/components/theme-effects/Starfield.tsx
@@ -48,24 +48,34 @@ export function Starfield() {
     const ctx: CanvasRenderingContext2D = ctx2d
 
     let stars: Star[] = []
-    let width = 1
-    let height = 1
+    let width = 0
+    let height = 0
+    let currentDpr = 0
     let rafId = 0
     let lastTime = 0
     let visible = !document.hidden
 
     function resize() {
       const size = getCanvasSize(canvas)
+      const dpr = window.devicePixelRatio || 1
+      // Nothing changed → skip (avoids resetting stars on every observer tick).
+      if (size.width === width && size.height === height && dpr === currentDpr) return
+      const dimsChanged = size.width !== width || size.height !== height
       width = size.width
       height = size.height
-      const dpr = window.devicePixelRatio || 1
-      canvas.width = Math.max(1, Math.floor(width * dpr))
-      canvas.height = Math.max(1, Math.floor(height * dpr))
+      currentDpr = dpr
+      // Backing store must match the DISPLAYED CSS size 1:1, or the browser
+      // upscales the canvas and stars render as fat, blurry dots. Round (not
+      // floor) keeps it closest to the real container size.
+      canvas.width = Math.max(1, Math.round(width * dpr))
+      canvas.height = Math.max(1, Math.round(height * dpr))
       canvas.style.width = '100%'
       canvas.style.height = '100%'
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
-      const count = Math.min(MAX_STARS, Math.max(MIN_STARS, Math.floor(width * height * STAR_DENSITY)))
-      stars = Array.from({ length: count }, () => makeStar(width, height))
+      if (dimsChanged || stars.length === 0) {
+        const count = Math.min(MAX_STARS, Math.max(MIN_STARS, Math.floor(width * height * STAR_DENSITY)))
+        stars = Array.from({ length: count }, () => makeStar(width, height))
+      }
     }
 
     function draw(deltaSeconds: number) {
@@ -103,13 +113,41 @@ export function Starfield() {
       }
     }
 
+    // Re-arm a DPR listener each time it changes (matchMedia fires once per
+    // threshold), so moving the window between monitors or zooming rebuilds the
+    // backing store at the new pixel density instead of stretching.
+    let dprMql: MediaQueryList | null = null
+    function onDprChange() {
+      if (dprMql) dprMql.removeEventListener('change', onDprChange)
+      resize()
+      watchDpr()
+    }
+    function watchDpr() {
+      const dpr = window.devicePixelRatio || 1
+      dprMql = window.matchMedia(`(resolution: ${dpr}dppx)`)
+      dprMql.addEventListener('change', onDprChange)
+    }
+
     resize()
+    // The canvas lives in a bounded, position:relative container whose size
+    // changes without a window resize (layout settling after mount, sidebar
+    // toggles, panels). Observe the parent so the backing store always tracks
+    // the real displayed size — the fix for "fat dots" in production.
+    let ro: ResizeObserver | null = null
+    const observed = canvas.parentElement
+    if (typeof ResizeObserver !== 'undefined' && observed) {
+      ro = new ResizeObserver(() => resize())
+      ro.observe(observed)
+    }
     window.addEventListener('resize', resize)
+    watchDpr()
     document.addEventListener('visibilitychange', onVisibility)
     if (visible) rafId = requestAnimationFrame(tick)
 
     return () => {
       cancelAnimationFrame(rafId)
+      if (ro) ro.disconnect()
+      if (dprMql) dprMql.removeEventListener('change', onDprChange)
       window.removeEventListener('resize', resize)
       document.removeEventListener('visibilitychange', onVisibility)
     }

--- a/client/src/context/AgentWorkspaceContext.tsx
+++ b/client/src/context/AgentWorkspaceContext.tsx
@@ -16,6 +16,10 @@ interface AgentWorkspaceContextValue {
   openJobsPane: () => void
   closeJobsPane: () => void
   toggleJobsPane: () => void
+  integrationsModalOpen: boolean
+  openIntegrationsModal: () => void
+  closeIntegrationsModal: () => void
+  toggleIntegrationsModal: () => void
   browserOpen: boolean
   openBrowser: () => void
   closeBrowser: () => void
@@ -31,6 +35,7 @@ const AgentWorkspaceContext = createContext<AgentWorkspaceContextValue | null>(n
 export function AgentWorkspaceProvider({ children }: { children: ReactNode }) {
   const [codePaneOpen, setCodePaneOpen] = useState(false)
   const [jobsPaneOpen, setJobsPaneOpen] = useState(false)
+  const [integrationsModalOpen, setIntegrationsModalOpen] = useState(false)
   const [browserOpen, setBrowserOpen] = useState(false)
   const [pendingCaptures, setPendingCaptures] = useState<AgentAttachment[]>([])
 
@@ -40,6 +45,9 @@ export function AgentWorkspaceProvider({ children }: { children: ReactNode }) {
   const openJobsPane = useCallback(() => setJobsPaneOpen(true), [])
   const closeJobsPane = useCallback(() => setJobsPaneOpen(false), [])
   const toggleJobsPane = useCallback(() => setJobsPaneOpen((v) => !v), [])
+  const openIntegrationsModal = useCallback(() => setIntegrationsModalOpen(true), [])
+  const closeIntegrationsModal = useCallback(() => setIntegrationsModalOpen(false), [])
+  const toggleIntegrationsModal = useCallback(() => setIntegrationsModalOpen((v) => !v), [])
   const openBrowser = useCallback(() => setBrowserOpen(true), [])
   const closeBrowser = useCallback(() => setBrowserOpen(false), [])
   const queueCapture = useCallback((att: AgentAttachment) => {
@@ -58,10 +66,11 @@ export function AgentWorkspaceProvider({ children }: { children: ReactNode }) {
     () => ({
       codePaneOpen, openCodePane, closeCodePane, toggleCodePane,
       jobsPaneOpen, openJobsPane, closeJobsPane, toggleJobsPane,
+      integrationsModalOpen, openIntegrationsModal, closeIntegrationsModal, toggleIntegrationsModal,
       browserOpen, openBrowser, closeBrowser,
       pendingCaptures, queueCapture, consumePendingCaptures,
     }),
-    [codePaneOpen, openCodePane, closeCodePane, toggleCodePane, jobsPaneOpen, openJobsPane, closeJobsPane, toggleJobsPane, browserOpen, openBrowser, closeBrowser, pendingCaptures, queueCapture, consumePendingCaptures],
+    [codePaneOpen, openCodePane, closeCodePane, toggleCodePane, jobsPaneOpen, openJobsPane, closeJobsPane, toggleJobsPane, integrationsModalOpen, openIntegrationsModal, closeIntegrationsModal, toggleIntegrationsModal, browserOpen, openBrowser, closeBrowser, pendingCaptures, queueCapture, consumePendingCaptures],
   )
   return <AgentWorkspaceContext.Provider value={value}>{children}</AgentWorkspaceContext.Provider>
 }
@@ -75,6 +84,10 @@ const NOOP: AgentWorkspaceContextValue = {
   openJobsPane: () => {},
   closeJobsPane: () => {},
   toggleJobsPane: () => {},
+  integrationsModalOpen: false,
+  openIntegrationsModal: () => {},
+  closeIntegrationsModal: () => {},
+  toggleIntegrationsModal: () => {},
   browserOpen: false,
   openBrowser: () => {},
   closeBrowser: () => {},

--- a/client/src/context/__tests__/AgentWorkspaceContext.test.tsx
+++ b/client/src/context/__tests__/AgentWorkspaceContext.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { AgentWorkspaceProvider, useAgentWorkspace } from '../AgentWorkspaceContext'
+
+function IntegrationsStateProbe() {
+  const workspace = useAgentWorkspace()
+  return (
+    <div>
+      <div data-testid="integrations-state">
+        {workspace.integrationsModalOpen ? 'open' : 'closed'}
+      </div>
+      <button type="button" onClick={workspace.toggleIntegrationsModal}>
+        Toggle integrations
+      </button>
+    </div>
+  )
+}
+
+describe('AgentWorkspaceContext', () => {
+  it('defaults the integrations modal closed and toggles it open', () => {
+    render(
+      <AgentWorkspaceProvider>
+        <IntegrationsStateProbe />
+      </AgentWorkspaceProvider>,
+    )
+
+    expect(screen.getByTestId('integrations-state')).toHaveTextContent('closed')
+
+    fireEvent.click(screen.getByRole('button', { name: /toggle integrations/i }))
+
+    expect(screen.getByTestId('integrations-state')).toHaveTextContent('open')
+  })
+})

--- a/openspec/changes/archive/2026-07-07-add-integrations-entry-to-agent-mode-sidebar-with-full-size-modal/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-07-add-integrations-entry-to-agent-mode-sidebar-with-full-size-modal/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-07

--- a/openspec/changes/archive/2026-07-07-add-integrations-entry-to-agent-mode-sidebar-with-full-size-modal/design.md
+++ b/openspec/changes/archive/2026-07-07-add-integrations-entry-to-agent-mode-sidebar-with-full-size-modal/design.md
@@ -1,0 +1,88 @@
+# Design - add-integrations-entry-to-agent-mode-sidebar-with-full-size-modal
+
+## Context
+Agent Mode already exposes workspace tools through `AgentWorkspaceSidebar`, with panel/modal state centralized in `AgentWorkspaceContext` and rendered from `AgentModeSurface`. Board mode gates Integrations visibility with `sectionVisibleForProviders('integrations', providers)` from `client/src/lib/provider-capabilities.ts`; the Agent Mode entry should use the same helper. `IntegrationsPage` is currently a route-level full-page component, but its internal install/uninstall confirmation dialogs already use their own modal shell and must remain nested.
+
+Scope: frontend
+
+## Goal
+Add an Agent Mode Integrations sidebar action that opens existing integrations content in a large movable/resizable modal without navigating away from the current Agent Mode workspace.
+
+## Non-Goals
+- Do not change board mode Integrations routing or `ProjectRightSidebar` behavior.
+- Do not change integration provider business logic or plugin/Jira card behavior.
+- Do not alter the existing IntegrationsPage install/uninstall confirmation modal behavior.
+- Do not add new provider capability rules beyond reusing the existing Integrations visibility gate.
+
+## Design
+
+### Architecture
+Extend `AgentWorkspaceContext` with `integrationsModalOpen` plus open/close/toggle functions following the `jobsPaneOpen` pattern. `AgentWorkspaceSidebar` derives the active project providers from `useDesktop()`, checks `sectionVisibleForProviders('integrations', providers)`, and appends an Integrations tool entry immediately after the Files entry when visible. The entry calls `workspace.toggleIntegrationsModal()` and is disabled when no project is active.
+
+`AgentModeSurface` lazy-loads a new `AgentIntegrationsModal` component and renders it when `integrationsModalOpen && activeProjectId`. The modal portals to `document.body`, uses `fixed inset-0 z-[65]`, a `glass-card` panel, and `useMovableResizableModal({ minWidth: 320, minHeight: 200, persistKey: 'specrails-desktop:agent-integrations-modal' })`. The modal body renders `<IntegrationsPage />`, so plugin cards and the Jira card stay source-of-truth in the current route component.
+
+### Data shapes
+```ts
+interface AgentWorkspaceContextValue {
+  integrationsModalOpen: boolean
+  openIntegrationsModal: () => void
+  closeIntegrationsModal: () => void
+  toggleIntegrationsModal: () => void
+}
+```
+
+```ts
+type AgentWorkspaceSidebarToolEntry = {
+  key: string
+  icon: ComponentType
+  label: string
+  onClick: () => void
+  disabled?: boolean
+  disabledTitle?: string
+}
+```
+
+### State & lifecycle
+```text
+integrationsModalOpen: false
+  -- sidebar Integrations click / toggleIntegrationsModal --> true
+  -- close button or backdrop / closeIntegrationsModal -----> false
+```
+
+The modal should only render for an active project. If the project disappears while open, `AgentModeSurface` naturally unmounts the modal because `activeProjectId` is falsey; the context boolean may remain true until the next close/toggle, matching the lightweight panel state pattern already used in Agent Mode.
+
+### Public API / surface
+```ts
+// client/src/context/AgentWorkspaceContext.tsx
+const {
+  integrationsModalOpen,
+  openIntegrationsModal,
+  closeIntegrationsModal,
+  toggleIntegrationsModal,
+} = useAgentWorkspace()
+```
+
+```tsx
+// client/src/components/agent-chat/AgentIntegrationsModal.tsx
+export function AgentIntegrationsModal({ onClose }: { onClose: () => void }): JSX.Element
+```
+
+No HTTP routes, CLI flags, backend APIs, or external integration data shapes change.
+
+## Trade-offs
+
+| Option | Pros | Cons | Chosen? |
+|---|---|---|---|
+| Wrap existing `IntegrationsPage` in a new Agent Mode modal | Reuses current content, cache, WebSocket refresh, plugin cards, Jira card, and nested confirmation dialogs | Route-level heading/layout comes along inside the modal | Yes |
+| Extract a shared `IntegrationsContent` component first | Cleaner separation between route and modal shell | Larger refactor and more regression risk for board mode | No |
+| Navigate Agent Mode to `/integrations` | Minimal implementation | Violates the requirement to keep the current chat/session workspace in place | No |
+
+The chosen option keeps the behavior change small and preserves the existing IntegrationsPage as the single content source.
+
+## Risks
+- Nested portal/backdrop interactions could close the outer modal during install/uninstall confirmation flows; mitigate by using the same backdrop guard pattern as `JobDetailModal` and relying on nested modal event handling.
+- Provider visibility could drift from board mode; mitigate by importing the same `sectionVisibleForProviders` helper and deriving providers with `projectProviders(activeProject)`.
+- Tests may miss lazy-loaded modal behavior; mitigate with focused component tests that mock `AgentIntegrationsModal` or wait for Suspense resolution.
+
+## Open questions
+- None.

--- a/openspec/changes/archive/2026-07-07-add-integrations-entry-to-agent-mode-sidebar-with-full-size-modal/proposal.md
+++ b/openspec/changes/archive/2026-07-07-add-integrations-entry-to-agent-mode-sidebar-with-full-size-modal/proposal.md
@@ -1,0 +1,15 @@
+# Add Integrations entry to the Agent Mode sidebar with a full-size modal
+
+## Why
+Agent Mode users can reach Jobs, Browser, Terminal, and Files from the right workspace sidebar, but Integrations is only available through board mode navigation. That forces users to leave the current agent chat/session context just to manage existing integrations.
+
+## What changes
+- Add an Agent Mode right-sidebar Integrations tool immediately after Files when provider visibility allows it.
+- Add workspace context state and a toggle for the Agent Mode integrations modal.
+- Render the existing IntegrationsPage content inside a new near-fullscreen, movable, resizable modal from Agent Mode.
+- Preserve board mode Integrations routing and the existing small install/uninstall confirmation modals inside IntegrationsPage.
+
+## Impact
+- Affected specs: agent-mode-integrations
+- Affected code: Agent Mode sidebar wiring, AgentWorkspaceContext state, AgentModeSurface conditional rendering, and a new AgentIntegrationsModal component that wraps the existing IntegrationsPage content with the established movable/resizable modal chrome.
+- Out of scope: Board mode's existing Integrations nav link and page routing; the small install/uninstall confirmation ModalShell inside IntegrationsPage; new integration providers.

--- a/openspec/changes/archive/2026-07-07-add-integrations-entry-to-agent-mode-sidebar-with-full-size-modal/specs/agent-mode-integrations/spec.md
+++ b/openspec/changes/archive/2026-07-07-add-integrations-entry-to-agent-mode-sidebar-with-full-size-modal/specs/agent-mode-integrations/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Agent Mode exposes provider-gated Integrations
+
+Agent Mode SHALL show an Integrations entry in the right workspace sidebar immediately after the Files entry when `sectionVisibleForProviders('integrations', providers)` returns true for the active project's providers.
+
+#### Scenario: Integrations appears after Files
+- **GIVEN** Agent Mode is open with an active project whose providers can see the integrations section
+- **WHEN** the right workspace sidebar renders with the Files entry enabled by feature flags
+- **THEN** the sidebar SHALL render an Integrations entry immediately after Files
+
+#### Scenario: Provider gate hides Integrations
+- **GIVEN** Agent Mode is open with an active project whose providers do not satisfy `sectionVisibleForProviders('integrations', providers)`
+- **WHEN** the right workspace sidebar renders
+- **THEN** the Integrations entry SHALL NOT be shown
+
+### Requirement: Agent Mode Integrations opens in a movable modal
+
+Clicking the Agent Mode Integrations entry SHALL open a modal over the current Agent Mode workspace instead of navigating to the board-mode `/integrations` route. The modal SHALL use the same near-fullscreen custom-overlay pattern as `JobDetailModal`: portal to `document.body`, `fixed inset-0 z-[65]`, `glass-card` panel, and `useMovableResizableModal` with minimum dimensions of 320 by 200.
+
+#### Scenario: Sidebar click opens modal without navigation
+- **GIVEN** Agent Mode is open on an active conversation or empty composer
+- **WHEN** the user clicks the Integrations sidebar entry
+- **THEN** the current Agent Mode workspace SHALL remain mounted
+- **AND** an Integrations modal SHALL open above it
+- **AND** the app SHALL NOT navigate to `/integrations`
+
+#### Scenario: Modal can be closed back to Agent Mode
+- **GIVEN** the Agent Mode Integrations modal is open
+- **WHEN** the user activates the modal close control or closes through the backdrop
+- **THEN** the modal SHALL close
+- **AND** the user SHALL remain in the same Agent Mode workspace
+
+### Requirement: Modal renders existing Integrations content
+
+The Agent Mode Integrations modal SHALL render the same integration management content as board mode's `IntegrationsPage`, including Jira integration content and plugin cards, while preserving the existing install/uninstall confirmation dialogs nested inside that page.
+
+#### Scenario: Existing content appears in modal
+- **GIVEN** the Agent Mode Integrations modal is open for an active project
+- **WHEN** integrations data is loaded
+- **THEN** the modal SHALL display the Jira integration card and applicable plugin cards from `IntegrationsPage`
+
+#### Scenario: Confirmation dialogs remain nested
+- **GIVEN** the Agent Mode Integrations modal is open
+- **WHEN** the user starts an install or uninstall flow from an integration card
+- **THEN** the existing IntegrationsPage confirmation dialog SHALL open inside the modal flow
+- **AND** board mode's Integrations route behavior SHALL remain unchanged

--- a/openspec/changes/archive/2026-07-07-add-integrations-entry-to-agent-mode-sidebar-with-full-size-modal/tasks.md
+++ b/openspec/changes/archive/2026-07-07-add-integrations-entry-to-agent-mode-sidebar-with-full-size-modal/tasks.md
@@ -1,0 +1,29 @@
+# Implementation Tasks
+
+> The developer agent runs these in order. Each "## N." block is a single TDD cycle: write the failing test, run it to confirm it fails, write production code, run again to confirm it passes. Do NOT skip the failing-test step.
+
+## 1. Workspace context exposes Integrations modal state
+- [x] 1.1 Write a failing test covering `AgentWorkspaceContext` or a small consumer component that asserts `integrationsModalOpen` defaults to false and `toggleIntegrationsModal` flips it. Run the targeted client test; the new test MUST fail.
+- [x] 1.2 Extend `client/src/context/AgentWorkspaceContext.tsx` with `integrationsModalOpen`, `openIntegrationsModal`, `closeIntegrationsModal`, and `toggleIntegrationsModal`, mirroring the existing jobs pane pattern. Run the targeted client test; ALL tests MUST pass.
+- [x] 1.3 Refactor if needed without changing behavior. Run the targeted client test again; all tests still pass.
+
+## 2. Sidebar shows provider-gated Integrations after Files
+- [x] 2.1 Write a failing test for `client/src/components/agent-chat/AgentWorkspaceSidebar.tsx` that renders the sidebar with an active project and verifies the Integrations entry appears immediately after Files and calls `toggleIntegrationsModal` when clicked. Run the targeted client test; the new test MUST fail.
+- [x] 2.2 Update `AgentWorkspaceSidebar.tsx` to import `Puzzle`, `projectProviders`, and `sectionVisibleForProviders`, derive providers from the active project, and insert the `integrations` tool entry immediately after `files` when visible. Use the same tool-entry shape and disabled project behavior as Files. Run the targeted client test; ALL tests MUST pass.
+- [x] 2.3 Add or extend the sidebar test to cover the provider-hidden case by mocking `sectionVisibleForProviders` false. Run the targeted client test; all tests still pass.
+
+## 3. Full-size Agent Integrations modal wraps existing page content
+- [x] 3.1 Write a failing test for a new `AgentIntegrationsModal` that mocks `IntegrationsPage`, renders the modal, and asserts the modal portals a fixed z-[65] overlay with the IntegrationsPage content and close control. Run the targeted client test; the new test MUST fail.
+- [x] 3.2 Create `client/src/components/agent-chat/AgentIntegrationsModal.tsx` using `createPortal`, `useMovableResizableModal({ minWidth: 320, minHeight: 200, persistKey: 'specrails-desktop:agent-integrations-modal' })`, `ResizeGrips`, `glass-card`, and `<IntegrationsPage />` in the scrollable body. Keep the internal IntegrationsPage confirmation dialogs untouched. Run the targeted client test; ALL tests MUST pass.
+- [x] 3.3 Refactor if needed without changing behavior. Run the targeted client test again; all tests still pass.
+
+## 4. AgentModeSurface mounts modal without navigation
+- [x] 4.1 Write a failing `AgentModeSurface` test that mocks `useAgentWorkspace()` with `integrationsModalOpen: true`, mocks `AgentIntegrationsModal`, and asserts the modal renders when an active project exists. Run the targeted client test; the new test MUST fail.
+- [x] 4.2 Update `client/src/components/agent-chat/AgentModeSurface.tsx` to lazy-load `AgentIntegrationsModal`, include `integrationsModalOpen` from workspace context, compute `showIntegrations`, and render the modal with `closeIntegrationsModal`. Run the targeted client test; ALL tests MUST pass.
+- [x] 4.3 Add or extend a test asserting the modal does not render without an active project. Run the targeted client test again; all tests still pass.
+
+## 5. Validation gate
+- [x] 5.1 Run the targeted client tests for the changed Agent Mode and integrations modal files; all pass.
+- [x] 5.2 Run the full client test suite (`cd client && npm run test`); all pass.
+- [x] 5.3 Run the client build (`cd client && npm run build`); succeeds.
+- [x] 5.4 No `console.log`, debug prints, or commented-out code in the diff.

--- a/openspec/specs/agent-mode-integrations/spec.md
+++ b/openspec/specs/agent-mode-integrations/spec.md
@@ -1,0 +1,51 @@
+# agent-mode-integrations Specification
+
+## Purpose
+TBD - created by archiving change add-integrations-entry-to-agent-mode-sidebar-with-full-size-modal. Update Purpose after archive.
+## Requirements
+### Requirement: Agent Mode exposes provider-gated Integrations
+
+Agent Mode SHALL show an Integrations entry in the right workspace sidebar immediately after the Files entry when `sectionVisibleForProviders('integrations', providers)` returns true for the active project's providers.
+
+#### Scenario: Integrations appears after Files
+- **GIVEN** Agent Mode is open with an active project whose providers can see the integrations section
+- **WHEN** the right workspace sidebar renders with the Files entry enabled by feature flags
+- **THEN** the sidebar SHALL render an Integrations entry immediately after Files
+
+#### Scenario: Provider gate hides Integrations
+- **GIVEN** Agent Mode is open with an active project whose providers do not satisfy `sectionVisibleForProviders('integrations', providers)`
+- **WHEN** the right workspace sidebar renders
+- **THEN** the Integrations entry SHALL NOT be shown
+
+### Requirement: Agent Mode Integrations opens in a movable modal
+
+Clicking the Agent Mode Integrations entry SHALL open a modal over the current Agent Mode workspace instead of navigating to the board-mode `/integrations` route. The modal SHALL use the same near-fullscreen custom-overlay pattern as `JobDetailModal`: portal to `document.body`, `fixed inset-0 z-[65]`, `glass-card` panel, and `useMovableResizableModal` with minimum dimensions of 320 by 200.
+
+#### Scenario: Sidebar click opens modal without navigation
+- **GIVEN** Agent Mode is open on an active conversation or empty composer
+- **WHEN** the user clicks the Integrations sidebar entry
+- **THEN** the current Agent Mode workspace SHALL remain mounted
+- **AND** an Integrations modal SHALL open above it
+- **AND** the app SHALL NOT navigate to `/integrations`
+
+#### Scenario: Modal can be closed back to Agent Mode
+- **GIVEN** the Agent Mode Integrations modal is open
+- **WHEN** the user activates the modal close control or closes through the backdrop
+- **THEN** the modal SHALL close
+- **AND** the user SHALL remain in the same Agent Mode workspace
+
+### Requirement: Modal renders existing Integrations content
+
+The Agent Mode Integrations modal SHALL render the same integration management content as board mode's `IntegrationsPage`, including Jira integration content and plugin cards, while preserving the existing install/uninstall confirmation dialogs nested inside that page.
+
+#### Scenario: Existing content appears in modal
+- **GIVEN** the Agent Mode Integrations modal is open for an active project
+- **WHEN** integrations data is loaded
+- **THEN** the modal SHALL display the Jira integration card and applicable plugin cards from `IntegrationsPage`
+
+#### Scenario: Confirmation dialogs remain nested
+- **GIVEN** the Agent Mode Integrations modal is open
+- **WHEN** the user starts an install or uninstall flow from an integration card
+- **THEN** the existing IntegrationsPage confirmation dialog SHALL open inside the modal flow
+- **AND** board mode's Integrations route behavior SHALL remain unchanged
+


### PR DESCRIPTION
This pull request delivers 1 ticket (#5) implemented by the **Implement** run against `main`. Each ticket below describes the problem it addresses, the approach taken, and the test files touched by its diff.

## #5 — Add Integrations entry to the Agent Mode sidebar with a full-size modal

**Problem**

In board mode, users reach Integrations via a dedicated sidebar link (ProjectRightSidebar.tsx) that navigates to a full page (IntegrationsPage.tsx). In Agent Mode, the right sidebar (AgentWorkspaceSidebar.tsx) only exposes Jobs/Browser/Terminal/Files — there is no way to reach Integrations without leaving the agent chat and switching back to board mode.

**Solution**

**Proposed Solution** — Add a new "Integrations" entry to AgentWorkspaceSidebar.tsx's `tools` array, placed immediately after the existing "files" entry (AgentWorkspaceSidebar.tsx:73-79), following the same {key, icon, label, onClick, disabled, disabledTitle} shape used by the other entries. Clicking it opens a new large modal (not a page navigation) that renders the same IntegrationsPage content, styled and sized like JobDetailModal.tsx (portal to document.body, fixed inset-0 z-[65], glass-card panel, driven by useMovableResizableModal for near-fullscreen/resizable/movable behavior), instead of IntegrationsPage's own small max-w-md ModalShell (which stays reserved for install/uninstall confirmations). Open/close state should follow the same toggle pattern already used for jobsPaneOpen in AgentWorkspaceContext.tsx.

**Tests**

- `client/src/components/agent-chat/__tests__/AgentIntegrationsModal.test.tsx`
- `client/src/components/agent-chat/__tests__/AgentModeSurface.test.tsx`
- `client/src/components/agent-chat/__tests__/AgentWorkspaceSidebar.test.tsx`
- `client/src/context/__tests__/AgentWorkspaceContext.test.tsx`

## Changes

- `feat/5-add-integrations-entry-to-the-agent` — 18 files changed, +555 −9