### PR TITLE
Support configurable web dev ports

### DIFF
--- a/client/src/lib/__tests__/vite-config.test.ts
+++ b/client/src/lib/__tests__/vite-config.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import type { ConfigEnv, UserConfig } from 'vite'
+import config from '../../../vite.config'
+
+const ORIGINAL_SERVER_PORT = process.env.SPECRAILS_DEV_SERVER_PORT
+const ORIGINAL_CLIENT_PORT = process.env.SPECRAILS_DEV_CLIENT_PORT
+
+function resolveConfig(mode = 'development'): UserConfig {
+  const factory = config as (env: ConfigEnv) => UserConfig
+  return factory({ mode, command: 'serve', isSsrBuild: false, isPreview: false })
+}
+
+function serverConfig(cfg: UserConfig): { port?: number; proxy?: Record<string, string> } {
+  return cfg.server as { port?: number; proxy?: Record<string, string> }
+}
+
+afterEach(() => {
+  if (ORIGINAL_SERVER_PORT === undefined) delete process.env.SPECRAILS_DEV_SERVER_PORT
+  else process.env.SPECRAILS_DEV_SERVER_PORT = ORIGINAL_SERVER_PORT
+  if (ORIGINAL_CLIENT_PORT === undefined) delete process.env.SPECRAILS_DEV_CLIENT_PORT
+  else process.env.SPECRAILS_DEV_CLIENT_PORT = ORIGINAL_CLIENT_PORT
+})
+
+describe('vite dev port config', () => {
+  it('preserves the default web dev ports', () => {
+    delete process.env.SPECRAILS_DEV_SERVER_PORT
+    delete process.env.SPECRAILS_DEV_CLIENT_PORT
+
+    const cfg = resolveConfig()
+    expect(serverConfig(cfg).port).toBe(4201)
+    expect(serverConfig(cfg).proxy).toEqual({
+      '/api': 'http://localhost:4200',
+      '/hooks': 'http://localhost:4200',
+    })
+    expect((cfg.define as Record<string, string>).__WS_URL__).toBe(JSON.stringify('ws://localhost:4200'))
+  })
+
+  it('uses SPECRAILS_DEV_SERVER_PORT and SPECRAILS_DEV_CLIENT_PORT for web dev', () => {
+    process.env.SPECRAILS_DEV_SERVER_PORT = '4300'
+    process.env.SPECRAILS_DEV_CLIENT_PORT = '4301'
+
+    const cfg = resolveConfig()
+    expect(serverConfig(cfg).port).toBe(4301)
+    expect(serverConfig(cfg).proxy).toEqual({
+      '/api': 'http://localhost:4300',
+      '/hooks': 'http://localhost:4300',
+    })
+    expect((cfg.define as Record<string, string>).__WS_URL__).toBe(JSON.stringify('ws://localhost:4300'))
+  })
+
+  it('keeps production builds from injecting a dev websocket URL', () => {
+    process.env.SPECRAILS_DEV_SERVER_PORT = '4300'
+    const cfg = resolveConfig('production')
+    expect((cfg.define as Record<string, string>).__WS_URL__).toBe(JSON.stringify(''))
+  })
+})

--- a/client/tsconfig.node.json
+++ b/client/tsconfig.node.json
@@ -7,5 +7,5 @@
     "allowSyntheticDefaultImports": true,
     "strict": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "../server/dev-ports.ts"]
 }

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,19 +1,24 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import { resolveWebDevPorts } from '../server/dev-ports'
 
-export default defineConfig(({ mode }) => ({
-  plugins: [tailwindcss(), react()],
-  define: {
-    __WS_URL__: mode === 'development'
-      ? JSON.stringify('ws://localhost:4200')
-      : JSON.stringify(''),
-  },
-  server: {
-    port: 4201,
-    proxy: {
-      '/api': 'http://localhost:4200',
-      '/hooks': 'http://localhost:4200',
+export default defineConfig(({ mode }) => {
+  const devPorts = resolveWebDevPorts(process.env)
+
+  return {
+    plugins: [tailwindcss(), react()],
+    define: {
+      __WS_URL__: mode === 'development'
+        ? JSON.stringify(devPorts.wsUrl)
+        : JSON.stringify(''),
     },
-  },
-}))
+    server: {
+      port: devPorts.clientPort,
+      proxy: {
+        '/api': devPorts.serverOrigin,
+        '/hooks': devPorts.serverOrigin,
+      },
+    },
+  }
+})

--- a/openspec/changes/archive/2026-07-07-configurable-web-dev-ports/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-07-configurable-web-dev-ports/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-07

--- a/openspec/changes/archive/2026-07-07-configurable-web-dev-ports/design.md
+++ b/openspec/changes/archive/2026-07-07-configurable-web-dev-ports/design.md
@@ -1,0 +1,40 @@
+## Context
+
+`npm run dev` starts two independent development processes:
+
+- `npm run dev:server`, which runs `server/index.ts` and currently defaults to port `4200`
+- `npm run dev:client`, which runs Vite from `client/vite.config.ts` and currently defaults to port `4201` while proxying `/api` and `/hooks` to `http://localhost:4200`
+
+That hardcoded pair prevents a developer from keeping the Desktop/Tauri app on `4200/4201` while running a second web-only debug stack on another pair such as `4300/4301`.
+
+## Decision
+
+Add environment-variable overrides for the browser-only dev workflow:
+
+- `SPECRAILS_DEV_SERVER_PORT`: backend Express port
+- `SPECRAILS_DEV_CLIENT_PORT`: Vite frontend port
+
+`server/index.ts` should resolve the backend port in this order:
+
+1. explicit `--port <n>` CLI argument
+2. `SPECRAILS_DEV_SERVER_PORT`
+3. `SPECRAILS_PORT`
+4. default `4200`
+
+`client/vite.config.ts` should resolve:
+
+- frontend port from `SPECRAILS_DEV_CLIENT_PORT`, defaulting to `4201`
+- backend target from `SPECRAILS_DEV_SERVER_PORT`, defaulting to `4200`
+- `__WS_URL__` from the same backend target in development mode
+
+## Out of Scope
+
+- Tauri dev port configurability
+- Production static serving port behavior
+- Desktop sidecar startup, CSP, `origin.ts`, `auth.ts`, or Tauri fallback URLs
+- Changing published defaults
+
+## Risks
+
+- Invalid env var values could make Vite or Express fail in confusing ways. Keep parsing conservative: only accept positive integer port values; fall back to defaults otherwise.
+- Tests that assume `4200` in dev configuration need to keep passing when env vars are absent.

--- a/openspec/changes/archive/2026-07-07-configurable-web-dev-ports/proposal.md
+++ b/openspec/changes/archive/2026-07-07-configurable-web-dev-ports/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Developers sometimes need to run the Tauri/Desktop app on its default local ports while also running a separate web-only dev instance for debugging. Today the web dev stack assumes backend port `4200` and frontend port `4201`, so a second local instance collides with the desktop runtime.
+
+## What Changes
+
+- Allow the web dev backend port to be configured with `SPECRAILS_DEV_SERVER_PORT`.
+- Allow the Vite web dev frontend port to be configured with `SPECRAILS_DEV_CLIENT_PORT`.
+- Make the Vite dev proxy and injected WebSocket URL point at the configured backend port.
+- Preserve existing defaults: backend `4200`, frontend `4201`.
+- Keep Tauri/Desktop development behavior unchanged for this change.
+
+## Capabilities
+
+### New Capabilities
+- `web-dev-ports`: configurable ports for the browser-only local development server pair.
+
+### Modified Capabilities
+<!-- None. This adds a web-only development capability without changing Tauri/Desktop runtime requirements. -->
+
+## Impact
+
+- **Client dev config**: `client/vite.config.ts`
+- **Server startup**: `server/index.ts`
+- **Tests**: add focused coverage for server port resolution and Vite dev port/proxy configuration
+- **No production/runtime dependency changes**

--- a/openspec/changes/archive/2026-07-07-configurable-web-dev-ports/specs/web-dev-ports/spec.md
+++ b/openspec/changes/archive/2026-07-07-configurable-web-dev-ports/specs/web-dev-ports/spec.md
@@ -1,0 +1,48 @@
+# web-dev-ports Specification
+
+## Purpose
+
+Allow developers to run a browser-only Specrails dev stack on non-default local ports while keeping Desktop/Tauri on the default ports.
+
+## Requirements
+
+### Requirement: Web dev backend port can be configured by environment
+The web dev backend SHALL use `SPECRAILS_DEV_SERVER_PORT` as its default port when no explicit `--port` argument is provided.
+
+#### Scenario: Env var sets backend dev port
+- **WHEN** the server dev process starts with `SPECRAILS_DEV_SERVER_PORT=4300`
+- **AND** no `--port` argument is provided
+- **THEN** the Express server listens on port `4300`
+
+#### Scenario: CLI port keeps highest priority
+- **WHEN** the server dev process starts with `SPECRAILS_DEV_SERVER_PORT=4300`
+- **AND** `--port 4400` is provided
+- **THEN** the Express server listens on port `4400`
+
+#### Scenario: Defaults are preserved
+- **WHEN** no dev port environment variable or CLI port is provided
+- **THEN** the Express server listens on port `4200`
+
+### Requirement: Vite web dev server can be configured by environment
+The Vite web dev server SHALL use `SPECRAILS_DEV_CLIENT_PORT` for its own port and `SPECRAILS_DEV_SERVER_PORT` for backend proxy targets and the injected WebSocket URL.
+
+#### Scenario: Env vars set web dev pair
+- **WHEN** Vite starts with `SPECRAILS_DEV_SERVER_PORT=4300`
+- **AND** `SPECRAILS_DEV_CLIENT_PORT=4301`
+- **THEN** the Vite dev server uses port `4301`
+- **AND** `/api` and `/hooks` proxy to `http://localhost:4300`
+- **AND** `__WS_URL__` is `ws://localhost:4300`
+
+#### Scenario: Vite defaults are preserved
+- **WHEN** no dev port environment variables are provided
+- **THEN** the Vite dev server uses port `4201`
+- **AND** `/api` and `/hooks` proxy to `http://localhost:4200`
+- **AND** `__WS_URL__` is `ws://localhost:4200`
+
+### Requirement: Tauri/Desktop defaults remain unchanged
+This change SHALL NOT alter Tauri/Desktop dev URL, CSP, sidecar startup, or client runtime fallbacks that intentionally point to `4200`/`4201`.
+
+#### Scenario: Desktop config remains fixed
+- **WHEN** the configurable web dev ports are added
+- **THEN** `src-tauri/tauri.conf.json` still declares the existing Desktop/Tauri dev URL and CSP behavior
+- **AND** browser-only Vite proxy configuration is the only frontend development path changed

--- a/openspec/changes/archive/2026-07-07-configurable-web-dev-ports/tasks.md
+++ b/openspec/changes/archive/2026-07-07-configurable-web-dev-ports/tasks.md
@@ -1,0 +1,7 @@
+## Tasks
+
+- [x] Add a shared, testable dev-port parser for positive integer port environment values.
+- [x] Update `server/index.ts` so `SPECRAILS_DEV_SERVER_PORT` controls the default backend dev port while preserving `--port` precedence and the `4200` fallback.
+- [x] Update `client/vite.config.ts` so `SPECRAILS_DEV_CLIENT_PORT` controls Vite's port and `SPECRAILS_DEV_SERVER_PORT` controls proxy/`__WS_URL__` targets.
+- [x] Add focused tests for server port resolution and Vite default/custom port configuration.
+- [x] Run typecheck and relevant server/client tests.

--- a/openspec/specs/web-dev-ports/spec.md
+++ b/openspec/specs/web-dev-ports/spec.md
@@ -1,0 +1,48 @@
+# web-dev-ports Specification
+
+## Purpose
+
+Allow developers to run a browser-only Specrails dev stack on non-default local ports while keeping Desktop/Tauri on the default ports.
+
+## Requirements
+
+### Requirement: Web dev backend port can be configured by environment
+The web dev backend SHALL use `SPECRAILS_DEV_SERVER_PORT` as its default port when no explicit `--port` argument is provided.
+
+#### Scenario: Env var sets backend dev port
+- **WHEN** the server dev process starts with `SPECRAILS_DEV_SERVER_PORT=4300`
+- **AND** no `--port` argument is provided
+- **THEN** the Express server listens on port `4300`
+
+#### Scenario: CLI port keeps highest priority
+- **WHEN** the server dev process starts with `SPECRAILS_DEV_SERVER_PORT=4300`
+- **AND** `--port 4400` is provided
+- **THEN** the Express server listens on port `4400`
+
+#### Scenario: Defaults are preserved
+- **WHEN** no dev port environment variable or CLI port is provided
+- **THEN** the Express server listens on port `4200`
+
+### Requirement: Vite web dev server can be configured by environment
+The Vite web dev server SHALL use `SPECRAILS_DEV_CLIENT_PORT` for its own port and `SPECRAILS_DEV_SERVER_PORT` for backend proxy targets and the injected WebSocket URL.
+
+#### Scenario: Env vars set web dev pair
+- **WHEN** Vite starts with `SPECRAILS_DEV_SERVER_PORT=4300`
+- **AND** `SPECRAILS_DEV_CLIENT_PORT=4301`
+- **THEN** the Vite dev server uses port `4301`
+- **AND** `/api` and `/hooks` proxy to `http://localhost:4300`
+- **AND** `__WS_URL__` is `ws://localhost:4300`
+
+#### Scenario: Vite defaults are preserved
+- **WHEN** no dev port environment variables are provided
+- **THEN** the Vite dev server uses port `4201`
+- **AND** `/api` and `/hooks` proxy to `http://localhost:4200`
+- **AND** `__WS_URL__` is `ws://localhost:4200`
+
+### Requirement: Tauri/Desktop defaults remain unchanged
+This change SHALL NOT alter Tauri/Desktop dev URL, CSP, sidecar startup, or client runtime fallbacks that intentionally point to `4200`/`4201`.
+
+#### Scenario: Desktop config remains fixed
+- **WHEN** the configurable web dev ports are added
+- **THEN** `src-tauri/tauri.conf.json` still declares the existing Desktop/Tauri dev URL and CSP behavior
+- **AND** browser-only Vite proxy configuration is the only frontend development path changed

--- a/server/dev-ports.test.ts
+++ b/server/dev-ports.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_DEV_CLIENT_PORT,
+  DEFAULT_DEV_SERVER_PORT,
+  parseDevPort,
+  resolveServerPort,
+  resolveWebDevPorts,
+} from './dev-ports'
+
+describe('dev port resolution', () => {
+  it('parses only positive integer TCP ports', () => {
+    expect(parseDevPort('4300', 4200)).toBe(4300)
+    expect(parseDevPort('0', 4200)).toBe(4200)
+    expect(parseDevPort('-1', 4200)).toBe(4200)
+    expect(parseDevPort('abc', 4200)).toBe(4200)
+    expect(parseDevPort('65536', 4200)).toBe(4200)
+    expect(parseDevPort(undefined, 4200)).toBe(4200)
+  })
+
+  it('resolves the server port from env with legacy fallback', () => {
+    expect(resolveServerPort(['node', 'server'], {})).toBe(DEFAULT_DEV_SERVER_PORT)
+    expect(resolveServerPort(['node', 'server'], { SPECRAILS_PORT: '4250' })).toBe(4250)
+    expect(resolveServerPort(['node', 'server'], { SPECRAILS_PORT: '4250', SPECRAILS_DEV_SERVER_PORT: '4300' })).toBe(4300)
+  })
+
+  it('keeps --port above env defaults', () => {
+    expect(resolveServerPort(['node', 'server', '--port', '4400'], { SPECRAILS_DEV_SERVER_PORT: '4300' })).toBe(4400)
+    expect(resolveServerPort(['node', 'server', '--port', 'bad'], { SPECRAILS_DEV_SERVER_PORT: '4300' })).toBe(4300)
+  })
+
+  it('resolves the web dev frontend/backend pair', () => {
+    expect(resolveWebDevPorts({})).toEqual({
+      serverPort: DEFAULT_DEV_SERVER_PORT,
+      clientPort: DEFAULT_DEV_CLIENT_PORT,
+      serverOrigin: 'http://localhost:4200',
+      wsUrl: 'ws://localhost:4200',
+    })
+    expect(resolveWebDevPorts({ SPECRAILS_DEV_SERVER_PORT: '4300', SPECRAILS_DEV_CLIENT_PORT: '4301' })).toEqual({
+      serverPort: 4300,
+      clientPort: 4301,
+      serverOrigin: 'http://localhost:4300',
+      wsUrl: 'ws://localhost:4300',
+    })
+  })
+})

--- a/server/dev-ports.ts
+++ b/server/dev-ports.ts
@@ -1,0 +1,39 @@
+export const DEFAULT_DEV_SERVER_PORT = 4200
+export const DEFAULT_DEV_CLIENT_PORT = 4201
+
+export type EnvLike = Record<string, string | undefined>
+
+export function parseDevPort(value: string | undefined, fallback: number): number {
+  if (value == null || value.trim() === '') return fallback
+  const port = Number(value)
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) return fallback
+  return port
+}
+
+export function resolveServerPort(argv: readonly string[], env: EnvLike = process.env): number {
+  let port = parseDevPort(env.SPECRAILS_DEV_SERVER_PORT ?? env.SPECRAILS_PORT, DEFAULT_DEV_SERVER_PORT)
+
+  for (let i = 2; i < argv.length; i++) {
+    if (argv[i] === '--port' && argv[i + 1]) {
+      port = parseDevPort(argv[++i], port)
+    }
+  }
+
+  return port
+}
+
+export function resolveWebDevPorts(env: EnvLike = process.env): {
+  serverPort: number
+  clientPort: number
+  serverOrigin: string
+  wsUrl: string
+} {
+  const serverPort = parseDevPort(env.SPECRAILS_DEV_SERVER_PORT, DEFAULT_DEV_SERVER_PORT)
+  const clientPort = parseDevPort(env.SPECRAILS_DEV_CLIENT_PORT, DEFAULT_DEV_CLIENT_PORT)
+  return {
+    serverPort,
+    clientPort,
+    serverOrigin: `http://localhost:${serverPort}`,
+    wsUrl: `ws://localhost:${serverPort}`,
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -33,6 +33,7 @@ import { runCompactionForAll } from './telemetry-compactor'
 import { FrameworkManager } from './framework-manager'
 import { withFileLock } from './artifact-registry'
 import { resolveStartupPath, augmentPathFromLoginShell, augmentAuthEnvFromLoginShell, getPathDiagnostic, ensureWindowsBaseEnv } from './path-resolver'
+import { resolveServerPort } from './dev-ports'
 // Side-effect import: registers every bundled ProviderAdapter (claude, codex,
 // future providers) so `getAdapter`/`hasAdapter`/`listAdapters` are populated
 // before any manager constructs a project context. See
@@ -90,13 +91,7 @@ if (parentPidArg) {
 
 // ─── Parse CLI args ───────────────────────────────────────────────────────────
 
-let port = 4200
-
-for (let i = 2; i < process.argv.length; i++) {
-  if (process.argv[i] === '--port' && process.argv[i + 1]) {
-    port = parseInt(process.argv[++i], 10)
-  }
-}
+const port = resolveServerPort(process.argv)
 
 // ─── PID file management ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Add shared dev-port resolution for the web-only local dev stack.
- Let SPECRAILS_DEV_SERVER_PORT drive the backend default, proxy target, and WebSocket URL.
- Let SPECRAILS_DEV_CLIENT_PORT drive Vite's frontend dev port.
- Preserve the 4200/4201 defaults and leave Tauri/Desktop config untouched.
- Add and archive the OpenSpec change for web dev ports.

## Verification
- npx vitest run server/dev-ports.test.ts
- cd client && npx vitest run src/lib/__tests__/vite-config.test.ts
- npm run typecheck
- npm test
- npm run test:client