### PR TITLE
Surface failed implement loops on implementation cards

### DIFF
--- a/client/src/components/RailPrDecisionStrip.tsx
+++ b/client/src/components/RailPrDecisionStrip.tsx
@@ -127,6 +127,7 @@ export function RailPrDecisionStrip({ decision, density, act, checkout }: RailPr
   const iconCls = compact ? 'w-2.5 h-2.5' : 'w-3 h-3'
   const spinner = <Loader2 className={`${iconCls} animate-spin`} aria-hidden />
   const busy = inFlight !== null || checkingOut
+  const discardTitle = d === 'implementation_failed' ? t('railPr.implementationFailedHint') : t('railPr.discardTooltip')
 
   const linkChip = decision.prUrl ? (
     <a
@@ -160,7 +161,7 @@ export function RailPrDecisionStrip({ decision, density, act, checkout }: RailPr
       type="button"
       data-testid="rail-pr-discard"
       disabled={busy}
-      title={t('railPr.discardTooltip')}
+      title={discardTitle}
       onClick={(e) => { e.stopPropagation(); setConfirmDiscard(true) }}
       className={ghostBtn}
     >

--- a/client/src/components/RailPrDecisionStrip.tsx
+++ b/client/src/components/RailPrDecisionStrip.tsx
@@ -318,6 +318,18 @@ export function RailPrDecisionStrip({ decision, density, act, checkout }: RailPr
         {discardBtn}
       </>
     )
+  } else if (d === 'implementation_failed') {
+    pill = (
+      <span className={`${pillBase} border-destructive/30 bg-destructive/10 text-destructive`} title={t('railPr.implementationFailedHint')}>
+        <AlertTriangle className={iconCls} aria-hidden />
+        {t('railPr.implementationFailed')}
+      </span>
+    )
+    actions = (
+      <>
+        {discardBtn}
+      </>
+    )
   }
 
   return (

--- a/client/src/components/__tests__/RailPrDecisionStrip.test.tsx
+++ b/client/src/components/__tests__/RailPrDecisionStrip.test.tsx
@@ -141,6 +141,16 @@ describe('RailPrDecisionStrip states (via RailRow, both densities)', () => {
         expect(within(strip).getByTestId('rail-pr-create')).toHaveTextContent('Retry')
         expect(within(strip).getByTestId('rail-pr-discard')).toBeInTheDocument()
       })
+
+      it('implementation_failed → destructive pill + Discard only', () => {
+        renderRail(snapshot({ decision: 'implementation_failed' }), density)
+        const strip = screen.getByTestId('rail-pr-strip')
+        expect(strip).toHaveAttribute('data-decision', 'implementation_failed')
+        expect(within(strip).getByText('Implementation failed')).toBeInTheDocument()
+        expect(within(strip).getByTestId('rail-pr-discard')).toBeInTheDocument()
+        expect(within(strip).queryByTestId('rail-pr-create')).toBeNull()
+        expect(within(strip).queryByTestId('rail-pr-merge-local')).toBeNull()
+      })
     })
   }
 })
@@ -295,6 +305,7 @@ describe('merge-local action', () => {
     for (const snap of [
       snapshot({ decision: 'pr_draft', prUrl: 'https://github.com/o/r/pull/7', prNumber: 7, prState: 'pr-created' }),
       snapshot({ decision: 'pr_ready', prUrl: 'https://github.com/o/r/pull/7', prNumber: 7, prState: 'pr-created' }),
+      snapshot({ decision: 'implementation_failed' }),
     ]) {
       const { unmount } = render(<RailPrDecisionStrip decision={snap} density="normal" act={vi.fn()} />)
       expect(screen.queryByTestId('rail-pr-merge-local')).toBeNull()

--- a/client/src/components/__tests__/RailPrDecisionStrip.test.tsx
+++ b/client/src/components/__tests__/RailPrDecisionStrip.test.tsx
@@ -147,7 +147,7 @@ describe('RailPrDecisionStrip states (via RailRow, both densities)', () => {
         const strip = screen.getByTestId('rail-pr-strip')
         expect(strip).toHaveAttribute('data-decision', 'implementation_failed')
         expect(within(strip).getByText('Implementation failed')).toBeInTheDocument()
-        expect(within(strip).getByTestId('rail-pr-discard')).toBeInTheDocument()
+        expect(within(strip).getByTestId('rail-pr-discard')).toHaveAttribute('title', expect.stringContaining('implementation run failed'))
         expect(within(strip).queryByTestId('rail-pr-create')).toBeNull()
         expect(within(strip).queryByTestId('rail-pr-merge-local')).toBeNull()
       })

--- a/client/src/components/agent-chat/AgentPrDecisionCard.tsx
+++ b/client/src/components/agent-chat/AgentPrDecisionCard.tsx
@@ -40,6 +40,7 @@ const HEADER_ICON: Record<AgentPrDecisionEnvelope['decision'], typeof GitBranch>
   on_review: GitBranch,
   pr_draft: GitPullRequest,
   pr_ready: GitPullRequest,
+  implementation_failed: AlertTriangle,
   pr_failed: AlertTriangle,
   merged: GitMerge,
   discarded: XCircle,
@@ -50,6 +51,7 @@ const HEADER_ICON_TONE: Record<AgentPrDecisionEnvelope['decision'], string> = {
   on_review: 'text-accent-primary',
   pr_draft: 'text-accent-info',
   pr_ready: 'text-accent-info',
+  implementation_failed: 'text-destructive',
   pr_failed: 'text-destructive',
   merged: 'text-accent-success',
   discarded: 'text-foreground/40',
@@ -506,6 +508,17 @@ export function AgentPrDecisionCard({ envelope }: { envelope: AgentPrDecisionEnv
               {primaryAction('create-pr', t('prCard.retry'))}
               {!prUrl && mergeLocalAction}
               {discardAction}
+            </div>
+          )}
+          {decision === 'implementation_failed' && (
+            <div className="space-y-2">
+              <p className="flex items-start gap-1.5 text-[11px] leading-4 text-destructive">
+                <AlertTriangle className="mt-px h-3 w-3 shrink-0" />
+                {t('prCard.implementationFailedNote')}
+              </p>
+              <div className="flex items-center gap-1.5">
+                {discardAction}
+              </div>
             </div>
           )}
           {decision === 'merged' && (

--- a/client/src/components/agent-chat/AgentPrPinnedDock.tsx
+++ b/client/src/components/agent-chat/AgentPrPinnedDock.tsx
@@ -12,6 +12,7 @@ const PILL_TONE: Record<AgentPrDecisionValue, string> = {
   on_review: 'border-accent-primary/40 bg-accent-primary/10 text-accent-primary',
   pr_draft: 'border-accent-info/40 bg-accent-info/10 text-accent-info',
   pr_ready: 'border-accent-info/40 bg-accent-info/10 text-accent-info',
+  implementation_failed: 'border-destructive/40 bg-destructive/10 text-destructive',
   pr_failed: 'border-destructive/40 bg-destructive/10 text-destructive',
   merged: 'border-accent-success/40 bg-accent-success/10 text-accent-success',
   discarded: 'border-border/60 bg-surface/60 text-foreground/50',

--- a/client/src/components/agent-chat/__tests__/agent-pr-decision.test.tsx
+++ b/client/src/components/agent-chat/__tests__/agent-pr-decision.test.tsx
@@ -150,6 +150,15 @@ describe('AgentPrDecisionCard states', () => {
     expect(screen.getByRole('button', { name: 'Discard' })).toBeInTheDocument()
   })
 
+  it('implementation_failed: failed implementation note + Discard only', () => {
+    render(<AgentPrDecisionCard envelope={env({ decision: 'implementation_failed', runIds: ['run-1'] })} />)
+    expect(screen.getByText('Implementation failed')).toBeInTheDocument()
+    expect(screen.getByText(/implementation run failed/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Discard' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Integrate locally' })).not.toBeInTheDocument()
+  })
+
   // Terminal/building cards carry NO decision actions — the only buttons left
   // are the always-present clickable ticket ref chips (#N → TicketDetailModal).
   const nonChipButtons = () =>

--- a/client/src/components/agent-chat/__tests__/agent-pr-pinned-dock.test.tsx
+++ b/client/src/components/agent-chat/__tests__/agent-pr-pinned-dock.test.tsx
@@ -135,6 +135,7 @@ describe('derivePrCards / pin-state matrix', () => {
     ['building', true],
     ['on_review', true],
     ['pr_draft', true],
+    ['implementation_failed', true],
     ['pr_failed', true],
     ['pr_ready', false],
     ['merged', false],
@@ -162,7 +163,7 @@ describe('derivePrCards / pin-state matrix', () => {
 
 // ── Pinned slot in the floating panel ─────────────────────────────────────────
 describe('pinned dock (floating panel)', () => {
-  it.each(['building', 'on_review', 'pr_draft', 'pr_failed'] as const)(
+  it.each(['building', 'on_review', 'pr_draft', 'implementation_failed', 'pr_failed'] as const)(
     'a %s card is PINNED above the composer with a history marker in its slot',
     async (decision) => {
       await renderPanelWithMessages([sysRow('s1', { decision })])

--- a/client/src/components/agent-chat/agent-pr-pinning.ts
+++ b/client/src/components/agent-chat/agent-pr-pinning.ts
@@ -9,12 +9,14 @@ import {
 // While a delivery still DEMANDS ATTENTION its card is pinned above the chat
 // composer; once published or terminal it unpins back into chat history.
 // Locked semantics: PINNED while decision ∈ {building, on_review, pr_draft,
-// pr_failed}; UNPINNED at pr_ready (published), merged, discarded.
+// implementation_failed, pr_failed}; UNPINNED at pr_ready (published), merged,
+// discarded.
 
 export const PINNED_PR_DECISIONS: ReadonlySet<AgentPrDecisionValue> = new Set([
   'building',
   'on_review',
   'pr_draft',
+  'implementation_failed',
   'pr_failed',
 ])
 

--- a/client/src/lib/agent-api.ts
+++ b/client/src/lib/agent-api.ts
@@ -192,12 +192,12 @@ export async function editQueuedAgentMessage(
 // `agent_pr_decision` WS event.
 
 export type AgentPrDecisionValue =
-  | 'building' | 'on_review' | 'pr_draft' | 'pr_ready' | 'merged' | 'discarded' | 'pr_failed'
+  | 'building' | 'on_review' | 'pr_draft' | 'pr_ready' | 'merged' | 'discarded' | 'implementation_failed' | 'pr_failed'
 
 export type AgentPrDeliveryState = 'none' | 'local-only' | 'pushed' | 'pr-created'
 
 const PR_DECISION_VALUES: readonly string[] =
-  ['building', 'on_review', 'pr_draft', 'pr_ready', 'merged', 'discarded', 'pr_failed']
+  ['building', 'on_review', 'pr_draft', 'pr_ready', 'merged', 'discarded', 'implementation_failed', 'pr_failed']
 const PR_DELIVERY_STATES: readonly string[] = ['none', 'local-only', 'pushed', 'pr-created']
 
 /** Parsed content of a `system` pr_decision row (mirrors the server envelope). */

--- a/client/src/locales/de/agent.json
+++ b/client/src/locales/de/agent.json
@@ -229,6 +229,7 @@
       "pr_draft": "Entwurfs-PR erstellt",
       "pr_draft_degraded": "PR-Auslieferung unvollständig",
       "pr_ready": "PR bereit zum Merge",
+      "implementation_failed": "Implementierung fehlgeschlagen",
       "pr_failed": "PR-Erstellung fehlgeschlagen",
       "merged": "PR gemergt",
       "discarded": "Verworfen"
@@ -248,6 +249,7 @@
     "confirmDiscard": "Verwerfen bestätigen?",
     "mergedNote": "Gemergt — Specs nach Fertig verschoben",
     "discardedNote": "Verworfen — Specs zurück ins Backlog",
+    "implementationFailedNote": "Der Implementierungslauf ist fehlgeschlagen, bevor etwas Auslieferbares entstanden ist. Öffne das Run-Protokoll, um den Fehler zu prüfen, und verwirf diese Karte vor einem erneuten Start.",
     "degraded": {
       "pushed": "Der Branch wurde gepusht, aber die PR konnte nicht erstellt werden — erneut versuchen, um abzuschließen.",
       "localOnly": "Die Änderungen wurden lokal zusammengeführt, aber nicht gepusht — erneut versuchen, um die PR zu veröffentlichen."
@@ -272,6 +274,7 @@
         "on_review": "Review",
         "pr_draft": "Entwurfs-PR",
         "pr_ready": "Veröffentlicht",
+        "implementation_failed": "Fehlgeschlagen",
         "pr_failed": "Fehlgeschlagen",
         "merged": "Gemerged",
         "discarded": "Verworfen"

--- a/client/src/locales/de/dashboard.json
+++ b/client/src/locales/de/dashboard.json
@@ -40,6 +40,8 @@
     "branchPushedHint": "Der Branch wurde gepusht, aber die PR konnte nicht erstellt werden (GitHub CLI nicht verfügbar). Erneut versuchen, um sie zu erstellen.",
     "iteratingPr": "PR wird aktualisiert",
     "prReady": "PR bereit",
+    "implementationFailed": "Implementierung fehlgeschlagen",
+    "implementationFailedHint": "Der Implementierungslauf ist fehlgeschlagen. Öffne das Run-Protokoll und verwirf diese Karte vor einem erneuten Start.",
     "prFailed": "PR fehlgeschlagen",
     "prFailedDetail": "PR fehlgeschlagen: {{detail}}",
     "createDegraded": "PR konnte nicht veröffentlicht werden — {{detail}}. Nach Behebung erneut versuchen.",

--- a/client/src/locales/en/agent.json
+++ b/client/src/locales/en/agent.json
@@ -229,6 +229,7 @@
       "pr_draft": "Draft PR created",
       "pr_draft_degraded": "PR delivery incomplete",
       "pr_ready": "PR ready for merge",
+      "implementation_failed": "Implementation failed",
       "pr_failed": "PR creation failed",
       "merged": "PR merged",
       "discarded": "Discarded"
@@ -248,6 +249,7 @@
     "confirmDiscard": "Confirm discard?",
     "mergedNote": "Merged — specs moved to Done",
     "discardedNote": "Discarded — specs returned to the backlog",
+    "implementationFailedNote": "The implementation run failed before there was anything deliverable. Open the run log to inspect the failure, then discard this card before relaunching.",
     "degraded": {
       "pushed": "The branch was pushed but the PR could not be created — retry to finish.",
       "localOnly": "The changes were assembled locally but not pushed — retry to publish the PR."
@@ -272,6 +274,7 @@
         "on_review": "Review",
         "pr_draft": "Draft PR",
         "pr_ready": "Published",
+        "implementation_failed": "Failed",
         "pr_failed": "Failed",
         "merged": "Merged",
         "discarded": "Discarded"

--- a/client/src/locales/en/dashboard.json
+++ b/client/src/locales/en/dashboard.json
@@ -40,6 +40,8 @@
     "branchPushedHint": "The branch was pushed but the PR couldn't be created (GitHub CLI unavailable). Retry to create it.",
     "iteratingPr": "Updating PR",
     "prReady": "PR ready",
+    "implementationFailed": "Implementation failed",
+    "implementationFailedHint": "The implementation run failed. Open the run log, then discard this card before relaunching.",
     "prFailed": "PR failed",
     "prFailedDetail": "PR failed: {{detail}}",
     "createDegraded": "Couldn't publish the PR — {{detail}}. Retry when resolved.",

--- a/client/src/locales/es/agent.json
+++ b/client/src/locales/es/agent.json
@@ -229,6 +229,7 @@
       "pr_draft": "PR en borrador creada",
       "pr_draft_degraded": "Entrega de la PR incompleta",
       "pr_ready": "PR lista para el merge",
+      "implementation_failed": "La implementación ha fallado",
       "pr_failed": "No se pudo crear la PR",
       "merged": "Merge de la PR completado",
       "discarded": "Descartada"
@@ -248,6 +249,7 @@
     "confirmDiscard": "¿Confirmar descarte?",
     "mergedNote": "Merge completado — las specs han pasado a Hecho",
     "discardedNote": "Descartada — las specs han vuelto al backlog",
+    "implementationFailedNote": "El run de implementación falló antes de generar algo entregable. Abre el log del run para revisar el fallo y descarta esta card antes de relanzar.",
     "degraded": {
       "pushed": "La rama se subió pero no se pudo crear la PR — reintenta para terminar.",
       "localOnly": "Los cambios se ensamblaron en local pero no se subieron — reintenta para publicar la PR."
@@ -272,6 +274,7 @@
         "on_review": "Revisión",
         "pr_draft": "PR borrador",
         "pr_ready": "Publicada",
+        "implementation_failed": "Fallida",
         "pr_failed": "Fallida",
         "merged": "Fusionada",
         "discarded": "Descartada"

--- a/client/src/locales/es/dashboard.json
+++ b/client/src/locales/es/dashboard.json
@@ -40,6 +40,8 @@
     "branchPushedHint": "La rama se subió pero no se pudo crear la PR (GitHub CLI no disponible). Reintenta para crearla.",
     "iteratingPr": "Actualizando PR",
     "prReady": "PR lista",
+    "implementationFailed": "Implementación fallida",
+    "implementationFailedHint": "El run de implementación ha fallado. Abre el log del run y descarta esta card antes de relanzar.",
     "prFailed": "PR fallida",
     "prFailedDetail": "PR fallida: {{detail}}",
     "createDegraded": "No se pudo publicar la PR — {{detail}}. Reintenta cuando esté resuelto.",

--- a/client/src/locales/fr/agent.json
+++ b/client/src/locales/fr/agent.json
@@ -229,6 +229,7 @@
       "pr_draft": "PR en brouillon créée",
       "pr_draft_degraded": "Livraison de la PR incomplète",
       "pr_ready": "PR prête à être fusionnée",
+      "implementation_failed": "Échec de l’implémentation",
       "pr_failed": "Échec de la création de la PR",
       "merged": "PR fusionnée",
       "discarded": "Abandonnée"
@@ -248,6 +249,7 @@
     "confirmDiscard": "Confirmer l'abandon ?",
     "mergedNote": "Fusionnée — specs passées en Terminé",
     "discardedNote": "Abandonnée — specs renvoyées vers le backlog",
+    "implementationFailedNote": "Le run d’implémentation a échoué avant de produire quelque chose de livrable. Ouvrez le journal du run pour inspecter l’échec, puis abandonnez cette carte avant de relancer.",
     "degraded": {
       "pushed": "La branche a été poussée mais la PR n'a pas pu être créée — réessayez pour terminer.",
       "localOnly": "Les modifications ont été assemblées en local mais pas poussées — réessayez pour publier la PR."
@@ -272,6 +274,7 @@
         "on_review": "Revue",
         "pr_draft": "PR brouillon",
         "pr_ready": "Publiée",
+        "implementation_failed": "Échec",
         "pr_failed": "Échec",
         "merged": "Fusionnée",
         "discarded": "Abandonnée"

--- a/client/src/locales/fr/dashboard.json
+++ b/client/src/locales/fr/dashboard.json
@@ -40,6 +40,8 @@
     "branchPushedHint": "La branche a été poussée mais la PR n'a pas pu être créée (GitHub CLI indisponible). Réessayez pour la créer.",
     "iteratingPr": "Mise à jour de la PR",
     "prReady": "PR prête",
+    "implementationFailed": "Échec de l’implémentation",
+    "implementationFailedHint": "Le run d’implémentation a échoué. Ouvrez le journal du run, puis abandonnez cette carte avant de relancer.",
     "prFailed": "PR en échec",
     "prFailedDetail": "PR en échec : {{detail}}",
     "createDegraded": "Impossible de publier la PR — {{detail}}. Réessayez une fois le problème résolu.",

--- a/client/src/locales/it/agent.json
+++ b/client/src/locales/it/agent.json
@@ -229,6 +229,7 @@
       "pr_draft": "PR in bozza creata",
       "pr_draft_degraded": "Consegna della PR incompleta",
       "pr_ready": "PR pronta per il merge",
+      "implementation_failed": "Implementazione non riuscita",
       "pr_failed": "Creazione della PR non riuscita",
       "merged": "Merge della PR effettuato",
       "discarded": "Scartata"
@@ -248,6 +249,7 @@
     "confirmDiscard": "Confermare lo scarto?",
     "mergedNote": "Merge effettuato — le spec sono passate a Completato",
     "discardedNote": "Scartata — le spec sono tornate nel backlog",
+    "implementationFailedNote": "Il run di implementazione non è riuscito prima di produrre qualcosa di consegnabile. Apri il log del run per controllare l'errore, poi scarta questa scheda prima di rilanciare.",
     "degraded": {
       "pushed": "Il ramo è stato inviato ma non è stato possibile creare la PR — riprova per completare.",
       "localOnly": "Le modifiche sono state assemblate in locale ma non inviate — riprova per pubblicare la PR."
@@ -272,6 +274,7 @@
         "on_review": "Revisione",
         "pr_draft": "PR bozza",
         "pr_ready": "Pubblicata",
+        "implementation_failed": "Fallita",
         "pr_failed": "Fallita",
         "merged": "Unita",
         "discarded": "Scartata"

--- a/client/src/locales/it/dashboard.json
+++ b/client/src/locales/it/dashboard.json
@@ -40,6 +40,8 @@
     "branchPushedHint": "Il ramo è stato inviato ma non è stato possibile creare la PR (GitHub CLI non disponibile). Riprova per crearla.",
     "iteratingPr": "Aggiornamento PR",
     "prReady": "PR pronta",
+    "implementationFailed": "Implementazione non riuscita",
+    "implementationFailedHint": "Il run di implementazione non è riuscito. Apri il log del run, poi scarta questa scheda prima di rilanciare.",
     "prFailed": "PR non riuscita",
     "prFailedDetail": "PR non riuscita: {{detail}}",
     "createDegraded": "Impossibile pubblicare la PR — {{detail}}. Riprova una volta risolto.",

--- a/client/src/locales/ja/agent.json
+++ b/client/src/locales/ja/agent.json
@@ -229,6 +229,7 @@
       "pr_draft": "ドラフト PR を作成しました",
       "pr_draft_degraded": "PR の公開が未完了",
       "pr_ready": "PR のマージ準備完了",
+      "implementation_failed": "実装に失敗しました",
       "pr_failed": "PR の作成に失敗しました",
       "merged": "PR がマージされました",
       "discarded": "破棄済み"
@@ -248,6 +249,7 @@
     "confirmDiscard": "破棄しますか？",
     "mergedNote": "マージ済み — スペックは完了に移動しました",
     "discardedNote": "破棄済み — スペックはバックログに戻されました",
+    "implementationFailedNote": "実装の実行は、配信可能な成果物が生成される前に失敗しました。実行ログで失敗内容を確認し、再実行する前にこのカードを破棄してください。",
     "degraded": {
       "pushed": "ブランチはプッシュされましたが、PR を作成できませんでした — 再試行して完了してください。",
       "localOnly": "変更はローカルで組み立てられましたが、プッシュされていません — 再試行して PR を公開してください。"
@@ -272,6 +274,7 @@
         "on_review": "レビュー",
         "pr_draft": "ドラフト PR",
         "pr_ready": "公開済み",
+        "implementation_failed": "失敗",
         "pr_failed": "失敗",
         "merged": "マージ済み",
         "discarded": "破棄済み"

--- a/client/src/locales/ja/dashboard.json
+++ b/client/src/locales/ja/dashboard.json
@@ -40,6 +40,8 @@
     "branchPushedHint": "ブランチはプッシュされましたが、PR を作成できませんでした（GitHub CLI が利用できません）。再試行して作成してください。",
     "iteratingPr": "PR 更新中",
     "prReady": "PR 準備完了",
+    "implementationFailed": "実装に失敗しました",
+    "implementationFailedHint": "実装の実行に失敗しました。実行ログを開き、再実行する前にこのカードを破棄してください。",
     "prFailed": "PR 失敗",
     "prFailedDetail": "PR 失敗: {{detail}}",
     "createDegraded": "PR を公開できませんでした — {{detail}}。解決後に再試行してください。",

--- a/client/src/locales/pt/agent.json
+++ b/client/src/locales/pt/agent.json
@@ -229,6 +229,7 @@
       "pr_draft": "PR em rascunho criada",
       "pr_draft_degraded": "Entrega da PR incompleta",
       "pr_ready": "PR pronta para merge",
+      "implementation_failed": "Implementação falhou",
       "pr_failed": "Falha ao criar a PR",
       "merged": "Merge da PR concluído",
       "discarded": "Descartada"
@@ -248,6 +249,7 @@
     "confirmDiscard": "Confirmar descarte?",
     "mergedNote": "Merge concluído — specs movidas para Concluído",
     "discardedNote": "Descartada — specs devolvidas ao backlog",
+    "implementationFailedNote": "A execução de implementação falhou antes de produzir algo entregável. Abra o log da execução para inspecionar a falha e descarte este cartão antes de relançar.",
     "degraded": {
       "pushed": "O ramo foi enviado mas não foi possível criar a PR — tente novamente para concluir.",
       "localOnly": "As alterações foram montadas localmente mas não enviadas — tente novamente para publicar a PR."
@@ -272,6 +274,7 @@
         "on_review": "Revisão",
         "pr_draft": "PR rascunho",
         "pr_ready": "Publicada",
+        "implementation_failed": "Falhou",
         "pr_failed": "Falhou",
         "merged": "Integrada",
         "discarded": "Descartada"

--- a/client/src/locales/pt/dashboard.json
+++ b/client/src/locales/pt/dashboard.json
@@ -40,6 +40,8 @@
     "branchPushedHint": "O ramo foi enviado mas não foi possível criar a PR (GitHub CLI indisponível). Tente novamente para a criar.",
     "iteratingPr": "A atualizar PR",
     "prReady": "PR pronta",
+    "implementationFailed": "Implementação falhou",
+    "implementationFailedHint": "A execução de implementação falhou. Abra o log da execução e descarte este cartão antes de relançar.",
     "prFailed": "PR falhou",
     "prFailedDetail": "PR falhou: {{detail}}",
     "createDegraded": "Não foi possível publicar a PR — {{detail}}. Tente novamente quando estiver resolvido.",

--- a/client/src/locales/zh/agent.json
+++ b/client/src/locales/zh/agent.json
@@ -229,6 +229,7 @@
       "pr_draft": "已创建草稿 PR",
       "pr_draft_degraded": "PR 交付未完成",
       "pr_ready": "PR 已就绪，可合并",
+      "implementation_failed": "实现失败",
       "pr_failed": "PR 创建失败",
       "merged": "PR 已合并",
       "discarded": "已丢弃"
@@ -248,6 +249,7 @@
     "confirmDiscard": "确认丢弃？",
     "mergedNote": "已合并 — Spec 已移至完成",
     "discardedNote": "已丢弃 — Spec 已退回待办",
+    "implementationFailedNote": "实现运行在生成可交付内容前失败。请打开运行日志查看失败原因，然后在重新启动前丢弃此卡片。",
     "degraded": {
       "pushed": "分支已推送，但无法创建 PR — 请重试以完成。",
       "localOnly": "更改已在本地组装但未推送 — 请重试以发布 PR。"
@@ -272,6 +274,7 @@
         "on_review": "待审阅",
         "pr_draft": "草稿 PR",
         "pr_ready": "已发布",
+        "implementation_failed": "失败",
         "pr_failed": "失败",
         "merged": "已合并",
         "discarded": "已丢弃"

--- a/client/src/locales/zh/dashboard.json
+++ b/client/src/locales/zh/dashboard.json
@@ -40,6 +40,8 @@
     "branchPushedHint": "分支已推送，但无法创建 PR（GitHub CLI 不可用）。请重试以创建。",
     "iteratingPr": "正在更新 PR",
     "prReady": "PR 已就绪",
+    "implementationFailed": "实现失败",
+    "implementationFailedHint": "实现运行失败。请打开运行日志，然后在重新启动前丢弃此卡片。",
     "prFailed": "PR 失败",
     "prFailedDetail": "PR 失败：{{detail}}",
     "createDegraded": "无法发布 PR — {{detail}}。解决后请重试。",

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -264,6 +264,7 @@ export type RailPrDecision =
   | 'pr_ready'
   | 'merged'
   | 'discarded'
+  | 'implementation_failed'
   | 'pr_failed'
 
 /** How far a Create-PR attempt got (the pr-publisher degradation ladder). */
@@ -366,4 +367,3 @@ export interface LocalTicket {
    *  Done card. Cleared on the next clean completion. */
   needs_review?: boolean
 }
-

--- a/server/db.ts
+++ b/server/db.ts
@@ -783,7 +783,7 @@ const MIGRATIONS: Migration[] = [
 
   // Migration 36: rail_pr_deliveries — one row per isolated rail LAUNCH tracking
   // the ask-first PR decision lifecycle (building → on_review → pr_draft →
-  // pr_ready → merged | discarded | pr_failed). The durable single source of
+  // pr_ready → merged | discarded | implementation_failed | pr_failed). The durable single source of
   // truth both decision surfaces (rail row + agent chat) read and write, so a
   // refresh/restart never loses a pending PR decision. `branches` captures the
   // per-unit DeliverBranch records at build-settle (deferred deliverRailAsPr

--- a/server/rail-isolated-launch.test.ts
+++ b/server/rail-isolated-launch.test.ts
@@ -301,18 +301,18 @@ describe('launchIsolatedRail — ask-first PR delivery (rail_pr_deliveries lifec
     expect(mockRunMergeBack).not.toHaveBeenCalled()
   })
 
-  it('settle (0 succeeded) → auto-discarded (terminal), branches persisted with succeeded:false', async () => {
+  it('settle (0 succeeded) → implementation_failed with run logs, branches persisted with succeeded:false', async () => {
     const { ctx, db, broadcast } = fakeCtx(settlingRun('failure'))
 
-    await launchIsolatedRail(input([1], ctx), okIo())
+    const ids = await launchIsolatedRail(input([1], ctx), okIo())
 
-    await vi.waitFor(() => expect(listActivePrDeliveries(db)).toHaveLength(0))
-    // terminal row kept for audit, never deleted
+    await vi.waitFor(() => expect(getActivePrDeliveryByRail(db, 0)?.decision).toBe('implementation_failed'))
     const all = db.prepare('SELECT decision, branches FROM rail_pr_deliveries').all() as { decision: string; branches: string }[]
     expect(all).toHaveLength(1)
-    expect(all[0].decision).toBe('discarded')
+    expect(all[0].decision).toBe('implementation_failed')
     expect(JSON.parse(all[0].branches)).toEqual([{ ticketId: 1, branch: 'sr/p/ticket-1', succeeded: false }])
-    expect(prStates(broadcast).map((m) => m.decision)).toEqual(['building', 'building', 'discarded'])
+    expect(prStates(broadcast).map((m) => m.decision)).toEqual(['building', 'building', 'implementation_failed'])
+    expect(prStates(broadcast).at(-1)?.runIds).toEqual(ids)
     expect(mockRunMergeBack).not.toHaveBeenCalled()
   })
 
@@ -395,7 +395,7 @@ describe('launchIsolatedRail — ask-first PR delivery (rail_pr_deliveries lifec
       })
     })
 
-    it('auto-discarded settle (0 succeeded) also updates the card so the origin learns the terminal outcome', async () => {
+    it('failed settle (0 succeeded) also updates the card so the origin learns the failed job outcome', async () => {
       const { updatePrDecisionCard } = fakeAgentChat()
       const { ctx } = fakeCtx(settlingRun('failure'))
 
@@ -405,10 +405,10 @@ describe('launchIsolatedRail — ask-first PR delivery (rail_pr_deliveries lifec
       )
 
       // calls[0] is the allocation runIds update; the LAST call carries the
-      // terminal outcome.
+      // failed implementation outcome.
       await vi.waitFor(() => expect(updatePrDecisionCard).toHaveBeenCalledTimes(2))
       expect(updatePrDecisionCard.mock.calls[1][0]).toBe('conv-9')
-      expect(updatePrDecisionCard.mock.calls[1][1]).toMatchObject({ kind: 'pr_decision', decision: 'discarded' })
+      expect(updatePrDecisionCard.mock.calls[1][1]).toMatchObject({ kind: 'pr_decision', decision: 'implementation_failed' })
     })
 
     it('dashboard launch (origin null) → the card is never posted nor updated', async () => {
@@ -922,20 +922,20 @@ describe('launchIsolatedRail — stale mounted worktree from a prior run (live #
   })
 })
 
-describe('launchIsolatedRail — auto-discard cleanup (0 succeeded)', () => {
+describe('launchIsolatedRail — failed-implementation cleanup (0 succeeded)', () => {
   beforeEach(() => { delete process.env.SPECRAILS_RAIL_DELIVER_PR }) // PR mode default-on
 
   const gitOk = () => ({ run: async () => ({ code: 0, stdout: '', stderr: '' }) })
   const okCreate = () =>
     vi.fn(async (_g: unknown, { ticketId }: { ticketId: number }) => ({ branch: `sr/p/ticket-${ticketId}`, worktreePath: `/wt/ticket-${ticketId}` }))
 
-  it('unmounts every worktree at the auto-discard settle (branches KEPT for resume; ledger terminal)', async () => {
+  it('unmounts every worktree at the failed-implementation settle (branches KEPT for resume; ledger terminal)', async () => {
     const { ctx, db } = fakeCtx(settlingRun('failure'))
     const remove = vi.fn(async () => {})
 
     await launchIsolatedRail(input([1, 2], ctx), { git: gitOk(), create: okCreate(), remove })
 
-    await vi.waitFor(() => expect(listActivePrDeliveries(db)).toHaveLength(0))
+    await vi.waitFor(() => expect(getActivePrDeliveryByRail(db, 0)?.decision).toBe('implementation_failed'))
     await vi.waitFor(() => expect(remove).toHaveBeenCalledTimes(2))
     // Worktrees unmounted NOW (not left to poison the next run of the same
     // ticket) — but the branches survive: partial work stays resumable and

--- a/server/rail-isolated-launch.ts
+++ b/server/rail-isolated-launch.ts
@@ -528,8 +528,9 @@ export async function launchIsolatedRail(input: IsolatedLaunchInput, io: Isolate
       // Build-settle: persist the per-unit branch outcomes + this launch's
       // worktree ledger ids on the row (the deferred create-pr / discard actions
       // reconstruct their inputs from these — nothing survives in memory), then
-      // hand the decision to the user. 0 succeeded units → nothing deliverable
-      // → auto-close (per-run settle already reverted the tickets).
+      // hand the decision to the user. 0 succeeded units → nothing deliverable;
+      // keep the implementation card visible as a failed job state with run-log
+      // chips instead of silently auto-discarding or leaving it at "building".
       const worktreeIds = allocated.map((a) => a.ledgerId)
       const anySucceeded = results.some((r) => r.succeeded)
       const settledContinuation = anySucceeded ? launchContinuation : null
@@ -553,7 +554,7 @@ export async function launchIsolatedRail(input: IsolatedLaunchInput, io: Isolate
                 ? 'pr_failed' as const
                 : (settledContinuation.isDraft === false ? 'pr_ready' as const : 'pr_draft' as const))
             : 'on_review' as const)
-        : 'discarded' as const
+        : 'implementation_failed' as const
       const patch = settledContinuation
         ? {
             branches,
@@ -574,7 +575,7 @@ export async function launchIsolatedRail(input: IsolatedLaunchInput, io: Isolate
         syncOriginCard('update')
       }
       if (!anySucceeded) {
-        // AUTO-DISCARD CLEANUP (0 succeeded): unmount every worktree NOW rather
+        // FAILED-IMPLEMENTATION CLEANUP (0 succeeded): unmount every worktree NOW rather
         // than leaving it for a restart's reconcile sweep — a still-mounted
         // worktree POISONS the next run of the same ticket: the worktree path is
         // keyed by ticketId, so the next allocation silently reuses this

--- a/server/rail-pr-decision.test.ts
+++ b/server/rail-pr-decision.test.ts
@@ -850,6 +850,25 @@ describe('discard', () => {
     expect(readTicketStatuses(ticketFile)['1']).toBe('todo')
     expect(jira.onRailDiscard).toHaveBeenCalledWith([1, 2], row.id)
   })
+
+  it('discard from implementation_failed does not close an existing PR or delete its branch', async () => {
+    const { git, calls: gitCalls } = fakeGit()
+    const { exec, calls: execCalls } = fakeExec()
+    const row = mkRow({
+      decision: 'implementation_failed',
+      prUrl: PR_URL,
+      prState: 'pr-created',
+      branches: [{ ticketId: 1, branch: 'feat/existing-pr', succeeded: false }],
+    })
+    const { deps } = mkDeps({ git, exec })
+
+    const r = await executePrDecision(deps, { prDeliveryId: row.id, action: 'discard', expectedDecision: 'implementation_failed' })
+
+    expect(r.status).toBe(200)
+    expect(getPrDelivery(db, row.id)?.decision).toBe('discarded')
+    expect(execCalls.some((c) => c.cmd === 'gh' && c.args[0] === 'pr' && c.args[1] === 'close')).toBe(false)
+    expect(gitCalls.some((c) => c.args[0] === 'branch' && c.args[1] === '-D')).toBe(false)
+  })
 })
 
 // ─── poll-merge ───────────────────────────────────────────────────────────────

--- a/server/rail-pr-decision.test.ts
+++ b/server/rail-pr-decision.test.ts
@@ -169,8 +169,8 @@ const PR_URL = 'https://github.com/o/r/pull/7'
 // ─── Guards (404 / CAS / legality) ────────────────────────────────────────────
 
 describe('executePrDecision guards', () => {
-  it('isPrDecisionAction accepts the four actions and rejects everything else', () => {
-    for (const a of ['create-pr', 'publish', 'discard', 'poll-merge']) expect(isPrDecisionAction(a)).toBe(true)
+  it('isPrDecisionAction accepts the decision actions and rejects everything else', () => {
+    for (const a of ['create-pr', 'publish', 'discard', 'poll-merge', 'merge-local']) expect(isPrDecisionAction(a)).toBe(true)
     for (const a of ['ready', 'merge', 'approve', '', 42, null, undefined]) expect(isPrDecisionAction(a)).toBe(false)
   })
 
@@ -195,9 +195,13 @@ describe('executePrDecision guards', () => {
     ['create-pr', 'pr_ready'],
     ['publish', 'on_review'],
     ['publish', 'pr_failed'],
+    ['publish', 'implementation_failed'],
     ['discard', 'building'],
     ['poll-merge', 'on_review'],
     ['poll-merge', 'pr_failed'],
+    ['poll-merge', 'implementation_failed'],
+    ['create-pr', 'implementation_failed'],
+    ['merge-local', 'implementation_failed'],
     ['create-pr', 'merged'],
     ['discard', 'discarded'],
   ] as const)('409 illegal_action: %s from %s', async (action, decision) => {
@@ -831,6 +835,18 @@ describe('discard', () => {
     const r = await executePrDecision(deps, { prDeliveryId: row.id, action: 'discard', expectedDecision: 'pr_failed' })
 
     expect(r.status).toBe(200)
+    expect(readTicketStatuses(ticketFile)['1']).toBe('todo')
+    expect(jira.onRailDiscard).toHaveBeenCalledWith([1, 2], row.id)
+  })
+
+  it('discard from implementation_failed clears the failed implementation card', async () => {
+    const row = mkRow({ decision: 'implementation_failed', branches: branchRecords([1]) })
+    const { deps, jira } = mkDeps()
+
+    const r = await executePrDecision(deps, { prDeliveryId: row.id, action: 'discard', expectedDecision: 'implementation_failed' })
+
+    expect(r.status).toBe(200)
+    expect(getPrDelivery(db, row.id)?.decision).toBe('discarded')
     expect(readTicketStatuses(ticketFile)['1']).toBe('todo')
     expect(jira.onRailDiscard).toHaveBeenCalledWith([1, 2], row.id)
   })

--- a/server/rail-pr-decision.ts
+++ b/server/rail-pr-decision.ts
@@ -447,10 +447,16 @@ async function runPublish(deps: PrDecisionDeps, row: RailPrDeliveryRow): Promise
 
 async function runDiscard(deps: PrDecisionDeps, row: RailPrDeliveryRow): Promise<PrDecisionResult> {
   const snap = toPrDeliverySnapshot(row)
+  const implementationFailed = row.decision === 'implementation_failed'
 
   // 1. Close the PR (drops its head branch) when one exists. Best-effort — a
   //    gh failure must never leave the discard half-done.
-  if (row.pr_url) {
+  //
+  // Implementation-failed rows are different: the implement run produced no
+  // deliverable update. If the row belongs to an existing-PR continuation it may
+  // still carry that PR's url/branch from launch time; clearing the failed card
+  // must not close or delete the user's existing review branch.
+  if (row.pr_url && !implementationFailed) {
     try {
       const r = await deps.exec.run('gh', ['pr', 'close', row.pr_url, '--delete-branch'], deps.project.path)
       if (r.code !== 0) {
@@ -464,11 +470,11 @@ async function runDiscard(deps: PrDecisionDeps, row: RailPrDeliveryRow): Promise
   // 2. Remove the launch's worktrees (still on disk unless a restart already
   //    swept them) and close their ledger rows — the reconcile-style removal,
   //    branch deletion deferred to step 3 (a checked-out branch can't be -D'd).
-  const branchSet = new Set<string>(snap.branches.map((b) => b.branch))
+  const branchSet = new Set<string>(implementationFailed ? [] : snap.branches.map((b) => b.branch))
   for (const wtId of snap.worktreeIds) {
     const wt = getRailWorktree(deps.db, wtId)
     if (!wt) continue
-    branchSet.add(wt.branch)
+    if (!implementationFailed) branchSet.add(wt.branch)
     await removeWorktree(deps.git, {
       repoDir: deps.project.path, worktreePath: wt.worktree_path, branch: wt.branch, deleteBranch: false,
     }).catch(() => {})
@@ -480,18 +486,20 @@ async function runDiscard(deps: PrDecisionDeps, row: RailPrDeliveryRow): Promise
   //    best-effort from the same ticket data the create-pr path names it from
   //    (the delivered head is already covered by row.branch). Missing branches
   //    are tolerated; the integration branch is NEVER deleted.
-  if (row.branch) branchSet.add(row.branch)
-  const succeededUnits = snap.branches.filter((b) => b.succeeded)
-  if (succeededUnits.length > 1) {
-    try {
-      branchSet.add(batchBranchNameFor(loadPrTicketData(deps, succeededUnits.map((b) => b.ticketId))))
-    } catch {
-      /* best-effort defense-in-depth only */
+  if (!implementationFailed) {
+    if (row.branch) branchSet.add(row.branch)
+    const succeededUnits = snap.branches.filter((b) => b.succeeded)
+    if (succeededUnits.length > 1) {
+      try {
+        branchSet.add(batchBranchNameFor(loadPrTicketData(deps, succeededUnits.map((b) => b.ticketId))))
+      } catch {
+        /* best-effort defense-in-depth only */
+      }
     }
-  }
-  for (const branch of branchSet) {
-    if (!branch || branch === row.base_branch) continue
-    await deps.git.run(['branch', '-D', branch], deps.project.path).catch(() => {})
+    for (const branch of branchSet) {
+      if (!branch || branch === row.base_branch) continue
+      await deps.git.run(['branch', '-D', branch], deps.project.path).catch(() => {})
+    }
   }
 
   const conflict = casTransition(deps, row, 'discarded')

--- a/server/rail-pr-decision.ts
+++ b/server/rail-pr-decision.ts
@@ -110,7 +110,8 @@ function actionAllowed(action: PrDecisionAction, row: RailPrDeliveryRow): boolea
       return row.decision === 'pr_draft' && row.pr_url !== null
     case 'discard':
       return row.decision === 'on_review' || row.decision === 'pr_draft' ||
-        row.decision === 'pr_ready' || row.decision === 'pr_failed'
+        row.decision === 'pr_ready' || row.decision === 'implementation_failed' ||
+        row.decision === 'pr_failed'
     case 'poll-merge':
       return (row.decision === 'pr_draft' || row.decision === 'pr_ready') && row.pr_url !== null
     case 'merge-local':

--- a/server/rail-pr-store.test.ts
+++ b/server/rail-pr-store.test.ts
@@ -6,6 +6,7 @@ import {
   getActivePrDeliveryByRail,
   listActivePrDeliveries,
   transitionDecision,
+  reconcileFailedBuildingPrDeliveries,
   toPrDeliverySnapshot,
   toRailPrStateMessage,
   toPrDecisionCardEnvelope,
@@ -14,6 +15,7 @@ import {
   ACTIVE_PR_DECISIONS,
   type CreatePrDeliveryInput,
 } from './rail-pr-store'
+import { createLoopRun, finishLoopRun } from './loop-runs-store'
 
 let db: DbInstance
 beforeEach(() => { db = initDb(':memory:') })
@@ -189,6 +191,12 @@ describe('active queries', () => {
     expect(getActivePrDeliveryByRail(db, 0)?.id).toBe('a')
   })
 
+  it('implementation_failed counts as active (needs discard)', () => {
+    mk('a', 0)
+    transitionDecision(db, 'a', 'building', 'implementation_failed')
+    expect(getActivePrDeliveryByRail(db, 0)?.id).toBe('a')
+  })
+
   it('listActivePrDeliveries returns every non-terminal row ordered by rail', () => {
     mk('r1', 1)
     mk('r0-done', 0)
@@ -215,12 +223,67 @@ describe('decision sets', () => {
     expect(isTerminalPrDecision('on_review')).toBe(false)
     expect(isTerminalPrDecision('pr_draft')).toBe(false)
     expect(isTerminalPrDecision('pr_ready')).toBe(false)
+    expect(isTerminalPrDecision('implementation_failed')).toBe(false)
     expect(isTerminalPrDecision('pr_failed')).toBe(false)
   })
 
   it('ACTIVE and TERMINAL sets partition the decision space', () => {
     for (const d of ACTIVE_PR_DECISIONS) expect(TERMINAL_PR_DECISIONS.has(d)).toBe(false)
-    expect(ACTIVE_PR_DECISIONS.size + TERMINAL_PR_DECISIONS.size).toBe(7)
+    expect(ACTIVE_PR_DECISIONS.size + TERMINAL_PR_DECISIONS.size).toBe(8)
+  })
+})
+
+describe('reconcileFailedBuildingPrDeliveries', () => {
+  it('turns a stranded building row with only failed settled runs into implementation_failed', () => {
+    mk('a', 0)
+    transitionDecision(db, 'a', 'building', 'building', { runIds: ['run-1'] })
+    createLoopRun(db, {
+      id: 'run-1',
+      projectId: 'proj',
+      loopId: 'factory:implement',
+      loopName: 'Implement',
+      railIndex: 0,
+      ticketId: 1,
+      iterationLimit: 1,
+      startedAt: '2026-07-07T00:00:00.000Z',
+    })
+    finishLoopRun(db, 'run-1', { outcome: 'failed', finishedAt: '2026-07-07T00:01:00.000Z' })
+
+    const reconciled = reconcileFailedBuildingPrDeliveries(db)
+
+    expect(reconciled.map((row) => row.id)).toEqual(['a'])
+    expect(getPrDelivery(db, 'a')?.decision).toBe('implementation_failed')
+  })
+
+  it('leaves building rows alone while a run is still running or any run succeeded', () => {
+    mk('running', 0)
+    transitionDecision(db, 'running', 'building', 'building', { runIds: ['run-running'] })
+    createLoopRun(db, {
+      id: 'run-running',
+      projectId: 'proj',
+      loopId: 'factory:implement',
+      railIndex: 0,
+      ticketId: 1,
+      iterationLimit: 1,
+      startedAt: '2026-07-07T00:00:00.000Z',
+    })
+
+    mk('success', 1)
+    transitionDecision(db, 'success', 'building', 'building', { runIds: ['run-success'] })
+    createLoopRun(db, {
+      id: 'run-success',
+      projectId: 'proj',
+      loopId: 'factory:implement',
+      railIndex: 1,
+      ticketId: 2,
+      iterationLimit: 1,
+      startedAt: '2026-07-07T00:00:00.000Z',
+    })
+    finishLoopRun(db, 'run-success', { outcome: 'success', finishedAt: '2026-07-07T00:01:00.000Z' })
+
+    expect(reconcileFailedBuildingPrDeliveries(db)).toEqual([])
+    expect(getPrDelivery(db, 'running')?.decision).toBe('building')
+    expect(getPrDelivery(db, 'success')?.decision).toBe('building')
   })
 })
 

--- a/server/rail-pr-store.ts
+++ b/server/rail-pr-store.ts
@@ -13,7 +13,8 @@ import { newId } from './ids'
 
 /**
  * building → on_review → pr_draft → pr_ready → merged, with discarded reachable
- * from every non-terminal state and pr_failed the retryable create-PR failure.
+ * from every non-terminal state. `pr_failed` is the retryable create-PR failure;
+ * `implementation_failed` is the pre-delivery job/loop failure state.
  */
 export type PrDecision =
   | 'building'
@@ -22,6 +23,7 @@ export type PrDecision =
   | 'pr_ready'
   | 'merged'
   | 'discarded'
+  | 'implementation_failed'
   | 'pr_failed'
 
 /** How far a Create-PR attempt got (the pr-publisher degradation ladder), independent of `decision`. */
@@ -46,6 +48,7 @@ export const ACTIVE_PR_DECISIONS: ReadonlySet<PrDecision> = new Set([
   'on_review',
   'pr_draft',
   'pr_ready',
+  'implementation_failed',
   'pr_failed',
 ])
 
@@ -149,6 +152,39 @@ export function listActivePrDeliveries(db: DbInstance): RailPrDeliveryRow[] {
        ORDER BY rail_index, created_at DESC, rowid DESC`
     )
     .all() as RailPrDeliveryRow[]
+}
+
+/**
+ * Recover implementation cards stranded at `building` after the loop process
+ * already settled all associated run ids without a success. This covers server
+ * restarts and the settle gap where loop_runs/worktrees mark failure but the
+ * PR-delivery row never receives its final card state.
+ */
+export function reconcileFailedBuildingPrDeliveries(db: DbInstance): RailPrDeliveryRow[] {
+  const rows = db
+    .prepare(`SELECT * FROM rail_pr_deliveries WHERE decision = 'building' ORDER BY created_at ASC, rowid ASC`)
+    .all() as RailPrDeliveryRow[]
+  const reconciled: RailPrDeliveryRow[] = []
+
+  for (const row of rows) {
+    const runIds = parseJsonArray<string>(row.run_ids ?? '[]')
+    if (runIds.length === 0) continue
+    const uniqueRunIds = [...new Set(runIds)]
+    const placeholders = uniqueRunIds.map(() => '?').join(',')
+    const runs = db
+      .prepare(`SELECT id, status, final_outcome FROM loop_runs WHERE id IN (${placeholders})`)
+      .all(...uniqueRunIds) as Array<{ id: string; status: string; final_outcome: string | null }>
+    if (runs.length !== uniqueRunIds.length) continue
+    if (runs.some((run) => run.status !== 'completed')) continue
+    if (runs.some((run) => run.final_outcome === 'success')) continue
+
+    if (transitionDecision(db, row.id, 'building', 'implementation_failed')) {
+      const updated = getPrDelivery(db, row.id)
+      if (updated) reconciled.push(updated)
+    }
+  }
+
+  return reconciled
 }
 
 /** Optional column updates riding a decision transition. */

--- a/server/rails-router.ts
+++ b/server/rails-router.ts
@@ -20,6 +20,7 @@ import {
   getActivePrDeliveryByRail,
   getPrDelivery,
   listActivePrDeliveries,
+  reconcileFailedBuildingPrDeliveries,
   toPrDecisionCardEnvelope,
   toPrDeliverySnapshot,
   toRailPrStateMessage,
@@ -70,6 +71,12 @@ function emitPrDeliveryUpdate(c: ProjectContext, prDeliveryId: string): void {
       row.origin_conversation_id,
       toPrDecisionCardEnvelope(c.project.id, snap),
     )
+  }
+}
+
+function reconcileAndEmitFailedPrDeliveries(c: ProjectContext): void {
+  for (const row of reconcileFailedBuildingPrDeliveries(c.db)) {
+    emitPrDeliveryUpdate(c, row.id)
   }
 }
 
@@ -145,6 +152,7 @@ export function createRailsRouter(): Router {
       // (non-terminal) delivery per rail slot, so a refreshed client re-renders
       // the decision surface without waiting for a broadcast. The store lists
       // newest-first within each rail — keep the first per index.
+      reconcileAndEmitFailedPrDeliveries(c)
       const prDeliveries: Record<number, PrDeliverySnapshot> = {}
       for (const row of listActivePrDeliveries(c.db)) {
         if (!(row.rail_index in prDeliveries)) prDeliveries[row.rail_index] = toPrDeliverySnapshot(row)
@@ -657,7 +665,7 @@ export function createRailsRouter(): Router {
                 if (current.pr_state === 'pr-created' && current.pr_url && current.branch) {
                   const succeeded = settled.every((s) => s.status === 'fulfilled' && s.value === true)
                   if (!succeeded) {
-                    if (transitionDecision(c.db, fallbackPrDeliveryId!, 'building', 'pr_failed', { prState: 'local-only' })) {
+                    if (transitionDecision(c.db, fallbackPrDeliveryId!, 'building', 'implementation_failed')) {
                       emitPrDeliveryUpdate(c, fallbackPrDeliveryId!)
                     }
                     return

--- a/server/types.ts
+++ b/server/types.ts
@@ -799,7 +799,7 @@ export interface RailPrStateMessage {
   prNumber: number | null
   /** How far a Create-PR attempt got (the pr-publisher degradation ladder). */
   prState: 'none' | 'local-only' | 'pushed' | 'pr-created'
-  decision: 'building' | 'on_review' | 'pr_draft' | 'pr_ready' | 'merged' | 'discarded' | 'pr_failed'
+  decision: 'building' | 'on_review' | 'pr_draft' | 'pr_ready' | 'merged' | 'discarded' | 'implementation_failed' | 'pr_failed'
   /** The launch's loop-run ids, in ticket order ([] until allocation lands) —
    *  each links a per-run log (JobDetailModal) + live vitals on the decision
    *  surfaces. */
@@ -1282,7 +1282,7 @@ export interface PrDecisionCardEnvelope {
   projectId: string
   baseBranch: string
   ticketIds: number[]
-  decision: 'building' | 'on_review' | 'pr_draft' | 'pr_ready' | 'merged' | 'discarded' | 'pr_failed'
+  decision: 'building' | 'on_review' | 'pr_draft' | 'pr_ready' | 'merged' | 'discarded' | 'implementation_failed' | 'pr_failed'
   prUrl: string | null
   prNumber: number | null
   prState: 'none' | 'local-only' | 'pushed' | 'pr-created'


### PR DESCRIPTION
## Summary
- Add an explicit implementation_failed PR-delivery state for implement loops that fail before producing deliverable work.
- Move isolated and shared fallback implement failures from an endless building card into that failed implementation state while preserving run-log chips.
- Reconcile stranded building deliveries whose loop run ids already settled without success, so existing stuck cards recover on /rails hydration.
- Render the failed implementation state in the rail strip and agent implementation card, pinned until discarded, with EN/ES/IT copy.

## Verification
- npx vitest run server/rail-pr-store.test.ts server/rail-pr-decision.test.ts server/rail-isolated-launch.test.ts
- npx vitest run server/rails-router.test.ts server/mcp/tools/rails-launch-all.test.ts server/mcp/tools/rails-origin.test.ts
- cd client && npx vitest run src/components/__tests__/RailPrDecisionStrip.test.tsx src/components/agent-chat/__tests__/agent-pr-decision.test.tsx src/components/agent-chat/__tests__/agent-pr-pinned-dock.test.tsx
- npm run typecheck