### PR TITLE
feat(projects): configure worktree env passthrough

### DIFF
--- a/client/src/components/__tests__/ProjectWorktreeEnvSection.test.tsx
+++ b/client/src/components/__tests__/ProjectWorktreeEnvSection.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import { ProjectWorktreeEnvSection } from '../settings/ProjectSettingsSections'
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+vi.mock('../../hooks/useDesktop', () => ({ useDesktop: () => ({ activeProjectId: 'proj-1' }) }))
+vi.mock('../../lib/api', () => ({ getApiBase: () => '/api/projects/proj-1' }))
+
+function jsonRes(body: unknown, ok = true) {
+  return { ok, json: async () => body } as Response
+}
+
+describe('ProjectWorktreeEnvSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      const method = init?.method ?? 'GET'
+      if (url.endsWith('/settings') && method === 'GET') {
+        return jsonRes({ worktreeEnvPassthrough: ['AWS_PROFILE'] })
+      }
+      if (url.endsWith('/settings') && method === 'PATCH') {
+        const body = JSON.parse(String(init?.body ?? '{}'))
+        return jsonRes({ ok: true, settings: { worktreeEnvPassthrough: body.worktreeEnvPassthrough } })
+      }
+      return jsonRes({})
+    }) as unknown as typeof fetch
+  })
+
+  it('adds pasted names, removes chips, and saves only the configured names', async () => {
+    render(<ProjectWorktreeEnvSection />)
+    const input = await screen.findByTestId('worktree-env-input')
+    expect(within(screen.getByTestId('worktree-env-list')).getByText('AWS_PROFILE')).toBeInTheDocument()
+
+    fireEvent.change(input, { target: { value: 'NODE_AUTH_TOKEN, NPM_TOKEN NODE_AUTH_TOKEN' } })
+    fireEvent.click(screen.getByTestId('worktree-env-add'))
+
+    const list = within(screen.getByTestId('worktree-env-list'))
+    expect(list.getByText('NODE_AUTH_TOKEN')).toBeInTheDocument()
+    expect(list.getByText('NPM_TOKEN')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove AWS_PROFILE' }))
+    fireEvent.click(screen.getByTestId('worktree-env-save'))
+
+    await waitFor(() => {
+      const calls = (global.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls
+      const patch = calls.find((c) => String(c[0]).endsWith('/settings') && c[1]?.method === 'PATCH')
+      expect(patch).toBeTruthy()
+      expect(JSON.parse(patch![1]!.body as string)).toEqual({
+        worktreeEnvPassthrough: ['NODE_AUTH_TOKEN', 'NPM_TOKEN'],
+      })
+    })
+  })
+
+  it('rejects KEY=value input before it can be saved as a secret', async () => {
+    render(<ProjectWorktreeEnvSection />)
+    const input = await screen.findByTestId('worktree-env-input')
+
+    fireEvent.change(input, { target: { value: 'NODE_AUTH_TOKEN=secret' } })
+    fireEvent.click(screen.getByTestId('worktree-env-add'))
+
+    expect(screen.getByTestId('worktree-env-error')).toHaveTextContent('Add only variable names here')
+    const calls = (global.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls
+    expect(calls.some((c) => String(c[0]).endsWith('/settings') && c[1]?.method === 'PATCH')).toBe(false)
+  })
+})

--- a/client/src/components/settings/ProjectSettingsDialog.tsx
+++ b/client/src/components/settings/ProjectSettingsDialog.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Settings, SlidersHorizontal, Wallet, Activity, TerminalSquare } from 'lucide-react'
+import { Settings, SlidersHorizontal, Wallet, Activity, TerminalSquare, KeyRound } from 'lucide-react'
 import { cn } from '../../lib/utils'
 import { useDesktop } from '../../hooks/useDesktop'
 import {
@@ -15,10 +15,12 @@ import {
   ProjectTelemetrySection,
   ProjectPrePromptsSection,
   ProjectBudgetSection,
+  ProjectWorktreeEnvSection,
 } from './ProjectSettingsSections'
 
 const PROJECT_SETTINGS_SECTIONS = [
   { id: 'general', icon: SlidersHorizontal, labelKey: 'projectDialog.nav.general' },
+  { id: 'environment', icon: KeyRound, labelKey: 'projectDialog.nav.environment' },
   { id: 'budget', icon: Wallet, labelKey: 'projectDialog.nav.budget' },
   { id: 'telemetry', icon: Activity, labelKey: 'projectDialog.nav.telemetry' },
   { id: 'terminal', icon: TerminalSquare, labelKey: 'projectDialog.nav.terminal' },
@@ -80,6 +82,9 @@ export function ProjectSettingsDialog({ open, onClose }: { open: boolean; onClos
           <div className="min-w-0 flex-1 overflow-y-auto pr-1">
             <div className={paneCls('general')}>
               <ProjectPrePromptsSection />
+            </div>
+            <div className={paneCls('environment')}>
+              <ProjectWorktreeEnvSection />
             </div>
             <div className={paneCls('budget')}>
               <ProjectBudgetSection />

--- a/client/src/components/settings/ProjectSettingsSections.tsx
+++ b/client/src/components/settings/ProjectSettingsSections.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { useTranslation, Trans } from 'react-i18next'
+import { Plus, X } from 'lucide-react'
 import { getApiBase } from '../../lib/api'
 import { useDesktop } from '../../hooks/useDesktop'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../ui/card'
@@ -17,6 +18,7 @@ interface ProjectSettingsPayload {
   prePrompt?: string
   freestylePrePrompt?: string
   integrationBranch?: string
+  worktreeEnvPassthrough?: string[]
 }
 
 /** Skeleton shown until a section's GET settles — fields never flash empty and
@@ -189,6 +191,180 @@ export function ProjectIntegrationBranchSection() {
         <Button size="sm" onClick={save} disabled={isSaving} data-testid="integration-branch-save">
           {t('integrationBranch.save')}
         </Button>
+      </CardContent>
+    </Card>
+  )
+}
+
+const ENV_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
+const ENV_EXAMPLES = ['NODE_AUTH_TOKEN', 'NPM_TOKEN', 'AWS_PROFILE']
+
+function splitEnvDraft(value: string): string[] {
+  return value
+    .split(/[,\s]+/)
+    .map((v) => v.trim())
+    .filter(Boolean)
+}
+
+/** Project-level env passthrough names for rail jobs and isolated loop worktrees.
+ *  Stores NAMES ONLY. Values are read from the server process env at spawn time. */
+export function ProjectWorktreeEnvSection() {
+  const { t } = useTranslation('settings')
+  const { activeProjectId } = useDesktop()
+  const [names, setNames] = useState<string[]>([])
+  const [draft, setDraft] = useState('')
+  const [error, setError] = useState('')
+  const [isSaving, setIsSaving] = useState(false)
+  const [loaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    if (!activeProjectId) return
+    let cancelled = false
+    setLoaded(false)
+    setError('')
+    fetch(`${getApiBase()}/settings`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: ProjectSettingsPayload | null) => {
+        if (!cancelled && data) setNames(Array.isArray(data.worktreeEnvPassthrough) ? data.worktreeEnvPassthrough : [])
+      })
+      .catch(() => {})
+      .finally(() => { if (!cancelled) setLoaded(true) })
+    return () => { cancelled = true }
+  }, [activeProjectId])
+
+  if (!loaded) return <SectionSkeleton />
+
+  function addNames(raw: string) {
+    const entries = splitEnvDraft(raw)
+    if (entries.length === 0) return
+    const next = [...names]
+    for (const entry of entries) {
+      if (entry.includes('=')) {
+        setError(t('worktreeEnv.noValues'))
+        return
+      }
+      if (!ENV_NAME_RE.test(entry)) {
+        setError(t('worktreeEnv.invalidName', { name: entry }))
+        return
+      }
+      if (!next.includes(entry)) next.push(entry)
+    }
+    setNames(next)
+    setDraft('')
+    setError('')
+  }
+
+  async function save() {
+    setIsSaving(true)
+    try {
+      const res = await fetch(`${getApiBase()}/settings`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ worktreeEnvPassthrough: names }),
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({} as { error?: string }))
+        throw new Error(body.error || 'Failed to save')
+      }
+      const data = await res.json() as { settings?: ProjectSettingsPayload }
+      setNames(data.settings?.worktreeEnvPassthrough ?? names)
+      toast.success(t('worktreeEnv.saved'))
+    } catch (err) {
+      toast.error(t('worktreeEnv.saveFailed'), { description: (err as Error).message })
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('worktreeEnv.title')}</CardTitle>
+        <CardDescription>{t('worktreeEnv.description')}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <label htmlFor="worktree-env-name" className="text-xs font-medium">
+            {t('worktreeEnv.label')}
+          </label>
+          <div className="flex gap-2">
+            <Input
+              id="worktree-env-name"
+              value={draft}
+              onChange={(e) => { setDraft(e.target.value); setError('') }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  addNames(draft)
+                }
+              }}
+              placeholder={t('worktreeEnv.placeholder')}
+              aria-invalid={Boolean(error)}
+              data-testid="worktree-env-input"
+            />
+            <Button
+              type="button"
+              size="sm"
+              variant="secondary"
+              className="h-9 shrink-0"
+              onClick={() => addNames(draft)}
+              disabled={!draft.trim()}
+              data-testid="worktree-env-add"
+            >
+              <Plus className="w-3.5 h-3.5" />
+              {t('worktreeEnv.add')}
+            </Button>
+          </div>
+          {error ? (
+            <p className="text-[10px] text-destructive" data-testid="worktree-env-error">{error}</p>
+          ) : (
+            <p className="text-[10px] text-muted-foreground">{t('worktreeEnv.helper')}</p>
+          )}
+        </div>
+
+        <div className="flex flex-wrap gap-1.5">
+          {ENV_EXAMPLES.map((name) => (
+            <button
+              key={name}
+              type="button"
+              onClick={() => addNames(name)}
+              className="rounded-md border border-border bg-muted/30 px-2 py-1 font-mono text-[10px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              {name}
+            </button>
+          ))}
+        </div>
+
+        {names.length > 0 ? (
+          <div className="flex flex-wrap gap-2" data-testid="worktree-env-list">
+            {names.map((name) => (
+              <span
+                key={name}
+                className="inline-flex items-center gap-1 rounded-md border border-border bg-background px-2 py-1 font-mono text-[11px]"
+              >
+                {name}
+                <button
+                  type="button"
+                  onClick={() => setNames(names.filter((n) => n !== name))}
+                  className="rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                  aria-label={t('worktreeEnv.remove', { name })}
+                >
+                  <X className="w-3 h-3" />
+                </button>
+              </span>
+            ))}
+          </div>
+        ) : (
+          <p className="rounded-md border border-dashed border-border bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
+            {t('worktreeEnv.empty')}
+          </p>
+        )}
+
+        <div className="flex justify-end">
+          <Button size="sm" onClick={save} disabled={isSaving} data-testid="worktree-env-save">
+            {isSaving ? t('common:states.saving') : t('worktreeEnv.save')}
+          </Button>
+        </div>
       </CardContent>
     </Card>
   )

--- a/client/src/components/settings/__tests__/ProjectSettingsDialog.test.tsx
+++ b/client/src/components/settings/__tests__/ProjectSettingsDialog.test.tsx
@@ -23,13 +23,21 @@ beforeEach(() => {
   global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) })
 })
 
+async function waitForSelfFetchingSections() {
+  await waitFor(() => expect(document.getElementById('project-pre-prompt')).toBeTruthy())
+  await screen.findByTestId('worktree-env-input')
+  await waitFor(() => expect(screen.getByLabelText('Enable pipeline telemetry')).toBeInTheDocument())
+  await waitFor(() => expect(screen.getByPlaceholderText('e.g. 5.00')).toBeInTheDocument())
+}
+
 describe('ProjectSettingsDialog', () => {
-  it('shows the project name in the title and the four section entries', () => {
+  it('shows the project name in the title and the section entries', async () => {
     render(<ProjectSettingsDialog open onClose={vi.fn()} />)
     expect(screen.getByText('acme-api — Settings')).toBeInTheDocument()
-    for (const label of ['General', 'Budget', 'Telemetry', 'Terminal']) {
+    for (const label of ['General', 'Environment', 'Budget', 'Telemetry', 'Terminal']) {
       expect(screen.getByRole('button', { name: label })).toBeInTheDocument()
     }
+    await waitForSelfFetchingSections()
   })
 
   it('starts on General (pre-prompts visible) and switches panes on nav click', async () => {
@@ -47,9 +55,10 @@ describe('ProjectSettingsDialog', () => {
     expect(generalField.closest('.hidden')).not.toBeNull()
   })
 
-  it('closes through onOpenChange', () => {
+  it('closes through onOpenChange', async () => {
     const onClose = vi.fn()
     render(<ProjectSettingsDialog open onClose={onClose} />)
+    await waitForSelfFetchingSections()
     fireEvent.keyDown(document.body, { key: 'Escape' })
     expect(onClose).toHaveBeenCalled()
   })

--- a/client/src/locales/de/settings.json
+++ b/client/src/locales/de/settings.json
@@ -246,9 +246,10 @@
   },
   "projectDialog": {
     "title": "{{name}} — Einstellungen",
-    "description": "Projektkonfiguration: Prompts, Budget, Telemetrie und Terminal.",
+    "description": "Projektkonfiguration: Prompts, Umgebung, Budget, Telemetrie und Terminal.",
     "nav": {
       "general": "Allgemein",
+      "environment": "Umgebung",
       "budget": "Budget",
       "telemetry": "Telemetrie",
       "terminal": "Terminal"
@@ -262,5 +263,20 @@
     "save": "Branch speichern",
     "saved": "Integrationszweig gespeichert",
     "saveFailed": "Integrationszweig konnte nicht gespeichert werden"
+  },
+  "worktreeEnv": {
+    "title": "Worktree-Umgebung",
+    "description": "Wählen Sie die Namen der Umgebungsvariablen, die dieses Projekt an Rail-Jobs und isolierte Loop-Worktrees weitergibt. Gespeichert werden nur Namen; Werte werden beim Start gelesen und bei Bedarf aus der Login-Shell nachgeladen.",
+    "label": "Umgebungsvariable",
+    "placeholder": "NODE_AUTH_TOKEN",
+    "helper": "Drücken Sie Enter oder Hinzufügen. Mehrere Namen können durch Kommas oder Leerzeichen getrennt eingefügt werden.",
+    "add": "Hinzufügen",
+    "empty": "Für dieses Projekt sind noch keine eigenen Variablen konfiguriert.",
+    "remove": "{{name}} entfernen",
+    "save": "Umgebung speichern",
+    "saved": "Worktree-Umgebung gespeichert",
+    "saveFailed": "Worktree-Umgebung konnte nicht gespeichert werden",
+    "invalidName": "{{name}} ist kein gültiger Name für eine Umgebungsvariable",
+    "noValues": "Fügen Sie hier nur Variablennamen hinzu, keine KEY=value-Geheimnisse."
   }
 }

--- a/client/src/locales/en/settings.json
+++ b/client/src/locales/en/settings.json
@@ -246,9 +246,10 @@
   },
   "projectDialog": {
     "title": "{{name}} — Settings",
-    "description": "Project-level configuration: prompts, budget, telemetry and terminal.",
+    "description": "Project-level configuration: prompts, environment, budget, telemetry and terminal.",
     "nav": {
       "general": "General",
+      "environment": "Environment",
       "budget": "Budget",
       "telemetry": "Telemetry",
       "terminal": "Terminal"
@@ -262,5 +263,20 @@
     "save": "Save branch",
     "saved": "Integration branch saved",
     "saveFailed": "Could not save the integration branch"
+  },
+  "worktreeEnv": {
+    "title": "Worktree environment",
+    "description": "Choose environment variable names this project passes to rail jobs and isolated loop worktrees. Only names are saved; values are read when a run starts, with login-shell recovery when the desktop process is missing them.",
+    "label": "Environment variable",
+    "placeholder": "NODE_AUTH_TOKEN",
+    "helper": "Press Enter or Add. You can paste several names separated by commas or spaces.",
+    "add": "Add",
+    "empty": "No project-specific variables configured yet.",
+    "remove": "Remove {{name}}",
+    "save": "Save environment",
+    "saved": "Worktree environment saved",
+    "saveFailed": "Could not save the worktree environment",
+    "invalidName": "{{name}} is not a valid environment variable name",
+    "noValues": "Add only variable names here, not KEY=value secrets."
   }
 }

--- a/client/src/locales/es/settings.json
+++ b/client/src/locales/es/settings.json
@@ -246,9 +246,10 @@
   },
   "projectDialog": {
     "title": "{{name}} — Ajustes",
-    "description": "Configuración del proyecto: prompts, presupuesto, telemetría y terminal.",
+    "description": "Configuración del proyecto: prompts, entorno, presupuesto, telemetría y terminal.",
     "nav": {
       "general": "General",
+      "environment": "Entorno",
       "budget": "Presupuesto",
       "telemetry": "Telemetría",
       "terminal": "Terminal"
@@ -262,5 +263,20 @@
     "save": "Guardar rama",
     "saved": "Rama de integración guardada",
     "saveFailed": "No se pudo guardar la rama de integración"
+  },
+  "worktreeEnv": {
+    "title": "Entorno de worktrees",
+    "description": "Elige los nombres de variables de entorno que este proyecto pasa a jobs de rail y worktrees aislados de loops. Solo se guardan nombres; los valores se leen al iniciar la ejecución, recuperándolos del login shell si faltan en el proceso de escritorio.",
+    "label": "Variable de entorno",
+    "placeholder": "NODE_AUTH_TOKEN",
+    "helper": "Pulsa Enter o Añadir. Puedes pegar varios nombres separados por comas o espacios.",
+    "add": "Añadir",
+    "empty": "Aún no hay variables específicas para este proyecto.",
+    "remove": "Quitar {{name}}",
+    "save": "Guardar entorno",
+    "saved": "Entorno de worktrees guardado",
+    "saveFailed": "No se pudo guardar el entorno de worktrees",
+    "invalidName": "{{name}} no es un nombre válido de variable de entorno",
+    "noValues": "Añade solo nombres de variables, no secretos KEY=value."
   }
 }

--- a/client/src/locales/fr/settings.json
+++ b/client/src/locales/fr/settings.json
@@ -246,9 +246,10 @@
   },
   "projectDialog": {
     "title": "{{name}} — Paramètres",
-    "description": "Configuration du projet : prompts, budget, télémétrie et terminal.",
+    "description": "Configuration du projet : prompts, environnement, budget, télémétrie et terminal.",
     "nav": {
       "general": "Général",
+      "environment": "Environnement",
       "budget": "Budget",
       "telemetry": "Télémétrie",
       "terminal": "Terminal"
@@ -262,5 +263,20 @@
     "save": "Enregistrer la branche",
     "saved": "Branche d'intégration enregistrée",
     "saveFailed": "Impossible d'enregistrer la branche d'intégration"
+  },
+  "worktreeEnv": {
+    "title": "Environnement des worktrees",
+    "description": "Choisissez les noms de variables d'environnement que ce projet transmet aux jobs de rail et aux worktrees isolés des loops. Seuls les noms sont enregistrés ; les valeurs sont lues au démarrage, avec récupération depuis le login shell si le processus Desktop ne les a pas.",
+    "label": "Variable d'environnement",
+    "placeholder": "NODE_AUTH_TOKEN",
+    "helper": "Appuyez sur Entrée ou Ajouter. Vous pouvez coller plusieurs noms séparés par des virgules ou des espaces.",
+    "add": "Ajouter",
+    "empty": "Aucune variable propre à ce projet n'est encore configurée.",
+    "remove": "Supprimer {{name}}",
+    "save": "Enregistrer l'environnement",
+    "saved": "Environnement des worktrees enregistré",
+    "saveFailed": "Impossible d'enregistrer l'environnement des worktrees",
+    "invalidName": "{{name}} n'est pas un nom de variable d'environnement valide",
+    "noValues": "Ajoutez uniquement des noms de variables, pas de secrets KEY=value."
   }
 }

--- a/client/src/locales/it/settings.json
+++ b/client/src/locales/it/settings.json
@@ -246,9 +246,10 @@
   },
   "projectDialog": {
     "title": "{{name}} — Impostazioni",
-    "description": "Configurazione del progetto: prompt, budget, telemetria e terminale.",
+    "description": "Configurazione del progetto: prompt, ambiente, budget, telemetria e terminale.",
     "nav": {
       "general": "Generale",
+      "environment": "Ambiente",
       "budget": "Budget",
       "telemetry": "Telemetria",
       "terminal": "Terminale"
@@ -262,5 +263,20 @@
     "save": "Salva ramo",
     "saved": "Ramo di integrazione salvato",
     "saveFailed": "Impossibile salvare il ramo di integrazione"
+  },
+  "worktreeEnv": {
+    "title": "Ambiente dei worktree",
+    "description": "Scegli i nomi delle variabili d'ambiente che questo progetto passa ai job dei rail e ai worktree isolati dei loop. Vengono salvati solo i nomi; i valori vengono letti all'avvio dell'esecuzione, recuperandoli dalla login shell se mancano nel processo Desktop.",
+    "label": "Variabile d'ambiente",
+    "placeholder": "NODE_AUTH_TOKEN",
+    "helper": "Premi Invio o Aggiungi. Puoi incollare più nomi separati da virgole o spazi.",
+    "add": "Aggiungi",
+    "empty": "Non ci sono ancora variabili specifiche per questo progetto.",
+    "remove": "Rimuovi {{name}}",
+    "save": "Salva ambiente",
+    "saved": "Ambiente dei worktree salvato",
+    "saveFailed": "Impossibile salvare l'ambiente dei worktree",
+    "invalidName": "{{name}} non è un nome valido per una variabile d'ambiente",
+    "noValues": "Aggiungi solo nomi di variabili, non segreti KEY=value."
   }
 }

--- a/client/src/locales/ja/settings.json
+++ b/client/src/locales/ja/settings.json
@@ -246,9 +246,10 @@
   },
   "projectDialog": {
     "title": "{{name}} — 設定",
-    "description": "プロジェクト設定：プロンプト、予算、テレメトリ、ターミナル。",
+    "description": "プロジェクト設定：プロンプト、環境、予算、テレメトリ、ターミナル。",
     "nav": {
       "general": "一般",
+      "environment": "環境",
       "budget": "予算",
       "telemetry": "テレメトリ",
       "terminal": "ターミナル"
@@ -262,5 +263,20 @@
     "save": "ブランチを保存",
     "saved": "統合ブランチを保存しました",
     "saveFailed": "統合ブランチを保存できませんでした"
+  },
+  "worktreeEnv": {
+    "title": "Worktree 環境",
+    "description": "このプロジェクトが rail ジョブと分離された loop worktree に渡す環境変数名を選びます。保存されるのは名前だけで、値は実行開始時に読み取られ、Desktop プロセスにない場合は login shell から復元を試みます。",
+    "label": "環境変数",
+    "placeholder": "NODE_AUTH_TOKEN",
+    "helper": "Enter または追加を押します。カンマやスペース区切りで複数の名前を貼り付けられます。",
+    "add": "追加",
+    "empty": "このプロジェクト固有の変数はまだ設定されていません。",
+    "remove": "{{name}} を削除",
+    "save": "環境を保存",
+    "saved": "Worktree 環境を保存しました",
+    "saveFailed": "Worktree 環境を保存できませんでした",
+    "invalidName": "{{name}} は有効な環境変数名ではありません",
+    "noValues": "ここには変数名だけを追加してください。KEY=value のシークレットは入力しないでください。"
   }
 }

--- a/client/src/locales/pt/settings.json
+++ b/client/src/locales/pt/settings.json
@@ -246,9 +246,10 @@
   },
   "projectDialog": {
     "title": "{{name}} — Configurações",
-    "description": "Configuração do projeto: prompts, orçamento, telemetria e terminal.",
+    "description": "Configuração do projeto: prompts, ambiente, orçamento, telemetria e terminal.",
     "nav": {
       "general": "Geral",
+      "environment": "Ambiente",
       "budget": "Orçamento",
       "telemetry": "Telemetria",
       "terminal": "Terminal"
@@ -262,5 +263,20 @@
     "save": "Guardar ramo",
     "saved": "Ramo de integração guardado",
     "saveFailed": "Não foi possível guardar o ramo de integração"
+  },
+  "worktreeEnv": {
+    "title": "Ambiente dos worktrees",
+    "description": "Escolha os nomes das variáveis de ambiente que este projeto passa para jobs de rail e worktrees isolados de loops. Só os nomes são guardados; os valores são lidos quando a execução começa, com recuperação a partir do login shell se faltarem no processo Desktop.",
+    "label": "Variável de ambiente",
+    "placeholder": "NODE_AUTH_TOKEN",
+    "helper": "Prima Enter ou Adicionar. Pode colar vários nomes separados por vírgulas ou espaços.",
+    "add": "Adicionar",
+    "empty": "Ainda não há variáveis específicas para este projeto.",
+    "remove": "Remover {{name}}",
+    "save": "Guardar ambiente",
+    "saved": "Ambiente dos worktrees guardado",
+    "saveFailed": "Não foi possível guardar o ambiente dos worktrees",
+    "invalidName": "{{name}} não é um nome válido de variável de ambiente",
+    "noValues": "Adicione apenas nomes de variáveis, não segredos KEY=value."
   }
 }

--- a/client/src/locales/zh/settings.json
+++ b/client/src/locales/zh/settings.json
@@ -246,9 +246,10 @@
   },
   "projectDialog": {
     "title": "{{name}} — 设置",
-    "description": "项目级配置：提示词、预算、遥测和终端。",
+    "description": "项目级配置：提示词、环境、预算、遥测和终端。",
     "nav": {
       "general": "常规",
+      "environment": "环境",
       "budget": "预算",
       "telemetry": "遥测",
       "terminal": "终端"
@@ -262,5 +263,20 @@
     "save": "保存分支",
     "saved": "集成分支已保存",
     "saveFailed": "无法保存集成分支"
+  },
+  "worktreeEnv": {
+    "title": "Worktree 环境",
+    "description": "选择此项目传递给 rail job 和隔离 loop worktree 的环境变量名称。只保存名称；值会在运行开始时读取，如果 Desktop 进程中缺失，会尝试从 login shell 恢复。",
+    "label": "环境变量",
+    "placeholder": "NODE_AUTH_TOKEN",
+    "helper": "按 Enter 或添加。可以粘贴多个用逗号或空格分隔的名称。",
+    "add": "添加",
+    "empty": "尚未为此项目配置专用变量。",
+    "remove": "移除 {{name}}",
+    "save": "保存环境",
+    "saved": "Worktree 环境已保存",
+    "saveFailed": "无法保存 Worktree 环境",
+    "invalidName": "{{name}} 不是有效的环境变量名",
+    "noValues": "这里只添加变量名，不要添加 KEY=value 形式的密钥。"
   }
 }

--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -10,6 +10,7 @@ import {
   ProjectPrePromptsSection,
   ProjectBudgetSection,
   ProjectIntegrationBranchSection,
+  ProjectWorktreeEnvSection,
 } from '../components/settings/ProjectSettingsSections'
 
 export default function SettingsPage() {
@@ -107,6 +108,8 @@ export default function SettingsPage() {
       <ProjectPrePromptsSection />
 
       <ProjectIntegrationBranchSection />
+
+      <ProjectWorktreeEnvSection />
 
       <ProjectBudgetSection />
 

--- a/client/src/pages/__tests__/SettingsPage.test.tsx
+++ b/client/src/pages/__tests__/SettingsPage.test.tsx
@@ -97,6 +97,17 @@ describe('SettingsPage', () => {
     })
   })
 
+  it('shows Worktree environment section after load', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => mockConfig,
+    })
+    render(<SettingsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Worktree environment')).toBeInTheDocument()
+    })
+  })
+
   it('shows Rail Pre-prompt section after load', async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,

--- a/server/db.ts
+++ b/server/db.ts
@@ -1497,6 +1497,41 @@ export interface ProjectSettings {
    *  target draft PRs at. Empty string = auto-resolve (repo default → HEAD) via
    *  `resolveIntegrationBranch`. */
   integrationBranch: string
+  /** Environment variable names to explicitly pass through to project jobs and
+   *  isolated loop worktrees. Values are read from the server process env at
+   *  spawn time and are never stored in SQLite. */
+  worktreeEnvPassthrough: string[]
+}
+
+export const WORKTREE_ENV_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
+const WORKTREE_ENV_MAX_NAMES = 64
+const WORKTREE_ENV_MAX_NAME_LENGTH = 128
+
+export function normalizeWorktreeEnvPassthrough(value: unknown): string[] {
+  if (!Array.isArray(value)) throw new Error('worktreeEnvPassthrough must be an array of environment variable names')
+  const out: string[] = []
+  const seen = new Set<string>()
+  for (const raw of value) {
+    if (typeof raw !== 'string') throw new Error('worktreeEnvPassthrough entries must be strings')
+    const name = raw.trim()
+    if (!name) continue
+    if (name.length > WORKTREE_ENV_MAX_NAME_LENGTH) throw new Error(`environment variable name is too long: ${name.slice(0, 24)}...`)
+    if (!WORKTREE_ENV_NAME_RE.test(name)) throw new Error(`invalid environment variable name: ${name}`)
+    if (seen.has(name)) continue
+    seen.add(name)
+    out.push(name)
+    if (out.length > WORKTREE_ENV_MAX_NAMES) throw new Error(`worktreeEnvPassthrough can contain at most ${WORKTREE_ENV_MAX_NAMES} names`)
+  }
+  return out
+}
+
+function parseWorktreeEnvPassthrough(raw: string | undefined): string[] {
+  if (!raw) return []
+  try {
+    return normalizeWorktreeEnvPassthrough(JSON.parse(raw))
+  } catch {
+    return []
+  }
 }
 
 export function getProjectSettings(db: DbInstance): ProjectSettings {
@@ -1515,12 +1550,16 @@ export function getProjectSettings(db: DbInstance): ProjectSettings {
   const integrationBranchRow = db.prepare(
     `SELECT value FROM queue_state WHERE key = 'config.integration_branch'`
   ).get() as { value: string } | undefined
+  const worktreeEnvPassthroughRow = db.prepare(
+    `SELECT value FROM queue_state WHERE key = 'config.worktree_env_passthrough'`
+  ).get() as { value: string } | undefined
   return {
     pipelineTelemetryEnabled: telemetryRow?.value === 'true',
     orchestratorModel: modelRow?.value ?? 'sonnet',
     prePrompt: prePromptRow?.value ?? '',
     freestylePrePrompt: freestylePrePromptRow?.value ?? '',
     integrationBranch: integrationBranchRow?.value ?? '',
+    worktreeEnvPassthrough: parseWorktreeEnvPassthrough(worktreeEnvPassthroughRow?.value),
   }
 }
 
@@ -1567,6 +1606,16 @@ export function updateProjectSettings(db: DbInstance, patch: Partial<ProjectSett
       db.prepare(
         `INSERT OR REPLACE INTO queue_state (key, value) VALUES ('config.integration_branch', ?)`
       ).run(patch.integrationBranch.trim())
+    }
+  }
+  if (patch.worktreeEnvPassthrough !== undefined) {
+    const names = normalizeWorktreeEnvPassthrough(patch.worktreeEnvPassthrough)
+    if (names.length === 0) {
+      db.prepare(`DELETE FROM queue_state WHERE key = 'config.worktree_env_passthrough'`).run()
+    } else {
+      db.prepare(
+        `INSERT OR REPLACE INTO queue_state (key, value) VALUES ('config.worktree_env_passthrough', ?)`
+      ).run(JSON.stringify(names))
     }
   }
 }

--- a/server/mcp/tools/catalog.test.ts
+++ b/server/mcp/tools/catalog.test.ts
@@ -1,3 +1,6 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { z } from 'zod'
 import { initDesktopDb, type DbInstance } from '../../desktop-db'
@@ -10,14 +13,14 @@ import { setActiveProject } from './types'
 // A registry stub exposing one project so requireProject() resolves; apiCall is
 // exercised against a mocked fetch so we cover every domain handler's switch
 // branches without a live server.
-function makeCtx(db: DbInstance): McpToolContext {
-  const project = { id: 'p1', slug: 'p1', name: 'P1', path: '/tmp/p1', provider: 'claude', providers: ['claude'] } as unknown as ProjectContext['project']
+function makeCtx(db: DbInstance, repoPath = '/tmp/p1'): McpToolContext {
+  const project = { id: 'p1', slug: 'p1', name: 'P1', path: repoPath, provider: 'claude', providers: ['claude'] } as unknown as ProjectContext['project']
   const pc = { project } as ProjectContext
   const registry = {
     desktopDb: db,
     listContexts: () => [pc],
     getContext: (id: string) => (id === 'p1' ? pc : undefined),
-    getContextByPath: (p: string) => (p === '/tmp/p1' ? pc : undefined),
+    getContextByPath: (p: string) => (p === repoPath ? pc : undefined),
     removeProject: () => undefined,
   } as unknown as ProjectRegistry
   return { registry, desktopDb: db, broadcast: () => {}, eventBus: new MobileEventBus(), desktopPort: 4299 }
@@ -175,6 +178,104 @@ describe('tool catalog smoke (all domains)', () => {
       const body = launchBody()
       expect(body).not.toHaveProperty('originConversationId')
       expect(body).not.toHaveProperty('originSurface')
+    })
+  })
+})
+
+describe('specrails_env tool', () => {
+  let db: DbInstance
+  let ctx: McpToolContext
+  let tmpDir: string | null = null
+
+  beforeEach(() => {
+    db = initDesktopDb(':memory:')
+    ctx = makeCtx(db)
+    setActiveProject('p1')
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    setActiveProject(null)
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true })
+    tmpDir = null
+  })
+
+  const envSpec = () => buildToolSpecs().find((s) => s.name === 'specrails_env')!
+
+  function mockSettingsFetch(initial: string[] = []) {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const method = init?.method ?? 'GET'
+      if (String(url).endsWith('/settings') && method === 'GET') {
+        return {
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify({ worktreeEnvPassthrough: initial }),
+        }
+      }
+      if (String(url).endsWith('/settings') && method === 'PATCH') {
+        const body = JSON.parse(String(init?.body ?? '{}')) as { worktreeEnvPassthrough?: string[] }
+        return {
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify({ ok: true, settings: { worktreeEnvPassthrough: body.worktreeEnvPassthrough ?? [] } }),
+        }
+      }
+      return { ok: false, status: 404, text: async () => JSON.stringify({ error: 'not found' }) }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    return fetchMock
+  }
+
+  it('is registered with read actions and write actions at the correct tiers', () => {
+    const spec = envSpec()
+    expect(spec).toBeTruthy()
+    expect(actionOptions(spec)).toEqual(['get', 'scan', 'set', 'auto_configure'])
+    const tier = spec.tier as (a: Record<string, unknown>) => string
+    expect(tier({ action: 'get' })).toBe('read')
+    expect(tier({ action: 'scan' })).toBe('read')
+    expect(tier({ action: 'set' })).toBe('write')
+    expect(tier({ action: 'auto_configure' })).toBe('write')
+  })
+
+  it('set merges requested names with existing settings and writes names only', async () => {
+    const fetchMock = mockSettingsFetch(['AWS_PROFILE'])
+
+    const res = await envSpec().handler(ctx, {
+      action: 'set',
+      projectId: 'p1',
+      names: ['NODE_AUTH_TOKEN', 'AWS_PROFILE', 'NODE_AUTH_TOKEN'],
+    }) as { names: string[]; changed: string[] }
+
+    expect(res.names).toEqual(['AWS_PROFILE', 'NODE_AUTH_TOKEN'])
+    expect(res.changed).toEqual(['NODE_AUTH_TOKEN'])
+    const patch = fetchMock.mock.calls.find(([url, init]) => String(url).endsWith('/settings') && (init as RequestInit | undefined)?.method === 'PATCH')
+    expect(patch).toBeTruthy()
+    expect(JSON.parse(String((patch![1] as RequestInit).body))).toEqual({
+      worktreeEnvPassthrough: ['AWS_PROFILE', 'NODE_AUTH_TOKEN'],
+    })
+    expect(JSON.stringify(patch)).not.toContain('secret')
+  })
+
+  it('auto_configure scans the repo and merges discovered package-token candidates', async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'specrails-mcp-env-'))
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({
+      dependencies: { '@busuu/design-system': '1.0.0' },
+    }))
+    ctx = makeCtx(db, tmpDir)
+    const fetchMock = mockSettingsFetch(['AWS_PROFILE'])
+
+    const res = await envSpec().handler(ctx, { action: 'auto_configure', projectId: 'p1' }) as {
+      names: string[]
+      changed: string[]
+      scan: { candidates: Array<{ name: string }> }
+    }
+
+    expect(res.scan.candidates.map((c) => c.name)).toEqual(['NODE_AUTH_TOKEN', 'NPM_TOKEN'])
+    expect(res.names).toEqual(['AWS_PROFILE', 'NODE_AUTH_TOKEN', 'NPM_TOKEN'])
+    expect(res.changed).toEqual(['NODE_AUTH_TOKEN', 'NPM_TOKEN'])
+    const patch = fetchMock.mock.calls.find(([url, init]) => String(url).endsWith('/settings') && (init as RequestInit | undefined)?.method === 'PATCH')
+    expect(JSON.parse(String((patch![1] as RequestInit).body))).toEqual({
+      worktreeEnvPassthrough: ['AWS_PROFILE', 'NODE_AUTH_TOKEN', 'NPM_TOKEN'],
     })
   })
 })

--- a/server/mcp/tools/catalog.ts
+++ b/server/mcp/tools/catalog.ts
@@ -16,6 +16,7 @@ import { setupTools } from './setup'
 import { analyticsTools } from './analytics'
 import { gitTools } from './git'
 import { supportTools } from './support'
+import { envTools } from './env'
 
 /**
  * The full MCP tool catalog. Domain-facade tools each expose an `action` enum
@@ -41,6 +42,7 @@ export function buildToolSpecs(): McpToolSpec[] {
   specs.push(...setupTools())
   specs.push(...analyticsTools())
   specs.push(...gitTools())
+  specs.push(...envTools())
   specs.push(...supportTools())
   // Meta last (needs the full list for search/describe)
   specs.push(...metaTools(() => specs))

--- a/server/mcp/tools/env.ts
+++ b/server/mcp/tools/env.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod'
+import type { McpToolSpec } from './types'
+import { apiCall, projectPath, requireProject } from './types'
+import { scanWorktreeEnvRequirements } from '../../worktree-env-discovery'
+
+function uniq(names: unknown[]): string[] {
+  const out: string[] = []
+  for (const v of names) {
+    if (typeof v !== 'string') continue
+    const name = v.trim()
+    if (name && !out.includes(name)) out.push(name)
+  }
+  return out
+}
+
+export function envTools(): McpToolSpec[] {
+  return [
+    {
+      name: 'specrails_env',
+      title: 'Project worktree environment',
+      description:
+        'Read, scan, and configure the per-project environment variable NAME allowlist used for rail jobs and isolated loop worktrees. ' +
+        'Values are never read or stored by this tool; runs read them from the server environment and can recover configured names from the login shell when the desktop process is missing them. scan inspects safe repo config files such as package.json, .npmrc, .yarnrc.yml and pnpm-workspace.yaml for ${VAR} / process.env.VAR references and private @busuu/* package hints. ' +
+        'Actions: get (read current names), scan (discover candidates), set (write names), auto_configure (scan then merge discovered names into settings).',
+      hintTier: 'read',
+      tier: (args) => (args.action === 'set' || args.action === 'auto_configure' ? 'write' : 'read'),
+      inputSchema: {
+        action: z.enum(['get', 'scan', 'set', 'auto_configure']).describe('Operation'),
+        projectId: z.string().optional().describe('Project id (defaults to the active project)'),
+        names: z.array(z.string()).optional().describe('set: env var names to configure'),
+        merge: z.boolean().optional().describe('set: merge with existing names instead of replacing them (default true)'),
+      },
+      async handler(ctx, args) {
+        const action = args.action as string
+        const base = projectPath(ctx, args.projectId as string | undefined)
+        if (action === 'get') {
+          const settings = await apiCall(ctx, 'GET', `${base}/settings`) as { worktreeEnvPassthrough?: unknown }
+          return { names: Array.isArray(settings.worktreeEnvPassthrough) ? settings.worktreeEnvPassthrough : [] }
+        }
+        if (action === 'scan') {
+          const project = requireProject(ctx, args.projectId as string | undefined).project
+          return scanWorktreeEnvRequirements(project.path)
+        }
+        if (action === 'set') {
+          const incoming = uniq(Array.isArray(args.names) ? args.names : [])
+          if (incoming.length === 0) throw new Error('set requires at least one env var name in "names".')
+          const merge = args.merge !== false
+          const current = await apiCall(ctx, 'GET', `${base}/settings`) as { worktreeEnvPassthrough?: unknown }
+          const existing = Array.isArray(current.worktreeEnvPassthrough) ? uniq(current.worktreeEnvPassthrough) : []
+          const next = merge ? uniq([...existing, ...incoming]) : incoming
+          const res = await apiCall(ctx, 'PATCH', `${base}/settings`, { worktreeEnvPassthrough: next }) as { settings?: { worktreeEnvPassthrough?: string[] } }
+          return { ok: true, names: res.settings?.worktreeEnvPassthrough ?? next, changed: next.filter((n) => !existing.includes(n)) }
+        }
+        if (action === 'auto_configure') {
+          const project = requireProject(ctx, args.projectId as string | undefined).project
+          const scan = scanWorktreeEnvRequirements(project.path)
+          const discovered = scan.candidates.map((c) => c.name)
+          const current = await apiCall(ctx, 'GET', `${base}/settings`) as { worktreeEnvPassthrough?: unknown }
+          const existing = Array.isArray(current.worktreeEnvPassthrough) ? uniq(current.worktreeEnvPassthrough) : []
+          if (discovered.length === 0) return { ok: true, names: existing, changed: [], scan }
+          const next = uniq([...existing, ...discovered])
+          const res = await apiCall(ctx, 'PATCH', `${base}/settings`, { worktreeEnvPassthrough: next }) as { settings?: { worktreeEnvPassthrough?: string[] } }
+          return { ok: true, names: res.settings?.worktreeEnvPassthrough ?? next, changed: next.filter((n) => !existing.includes(n)), scan }
+        }
+        throw new Error(`Unknown action "${action}".`)
+      },
+    },
+  ]
+}

--- a/server/path-resolver.test.ts
+++ b/server/path-resolver.test.ts
@@ -7,6 +7,8 @@ import {
   resolveStartupPath,
   augmentPathFromLoginShell,
   augmentAuthEnvFromLoginShell,
+  augmentEnvFromLoginShell,
+  augmentEnvFromLoginShellSync,
   parseLoginShellOutput,
   parseLoginShellEnv,
   getPathDiagnostic,
@@ -566,11 +568,13 @@ describe('parseLoginShellEnv', () => {
 
 describe('augmentAuthEnvFromLoginShell', () => {
   const PREV: Record<string, string | undefined> = {}
+  const EXTRA_PREV: Record<string, string | undefined> = {}
   beforeEach(() => {
     __resetPathResolverForTest()
     delete process.env.VITEST
     process.env.NODE_ENV = 'production'
     for (const k of AUTH_ENV_VARS) { PREV[k] = process.env[k]; delete process.env[k] }
+    for (const k of ['NODE_AUTH_TOKEN', 'NPM_TOKEN']) { EXTRA_PREV[k] = process.env[k]; delete process.env[k] }
   })
   afterEach(() => {
     process.env.VITEST = 'true'
@@ -579,6 +583,10 @@ describe('augmentAuthEnvFromLoginShell', () => {
     for (const k of AUTH_ENV_VARS) {
       if (PREV[k] === undefined) delete process.env[k]
       else process.env[k] = PREV[k]
+    }
+    for (const k of ['NODE_AUTH_TOKEN', 'NPM_TOKEN']) {
+      if (EXTRA_PREV[k] === undefined) delete process.env[k]
+      else process.env[k] = EXTRA_PREV[k]
     }
   })
 
@@ -626,6 +634,35 @@ describe('augmentAuthEnvFromLoginShell', () => {
       augmentAuthEnvFromLoginShell({ spawnFn: hangingSpawn as any, timeoutMs: 30 }),
     ).resolves.toBeUndefined()
     expect(process.env.GEMINI_API_KEY).toBeUndefined()
+  })
+
+  it('backfills project-configured env names from the login shell', async () => {
+    setPlatform('darwin')
+    const fakeSpawn = makeFakeSpawn({
+      stdout: '__SRH_ENV_BEGIN__NODE_AUTH_TOKEN=npm-secret\nNPM_TOKEN=\n__SRH_ENV_END__',
+      exitCode: 0,
+    })
+    await augmentEnvFromLoginShell(['NODE_AUTH_TOKEN', 'NPM_TOKEN'], { spawnFn: fakeSpawn as any })
+    expect(process.env.NODE_AUTH_TOKEN).toBe('npm-secret')
+    expect(process.env.NPM_TOKEN).toBeUndefined()
+  })
+
+  it('sync backfill probes each missing configured name only once', () => {
+    setPlatform('darwin')
+    const spawnSyncFn = vi.fn(() => ({
+      stdout: '__SRH_ENV_BEGIN__NODE_AUTH_TOKEN=sync-secret\n__SRH_ENV_END__',
+      stderr: '',
+      status: 0,
+      signal: null,
+      pid: 123,
+      output: [],
+    }))
+
+    augmentEnvFromLoginShellSync(['NODE_AUTH_TOKEN'], { spawnSyncFn: spawnSyncFn as any })
+    augmentEnvFromLoginShellSync(['NODE_AUTH_TOKEN'], { spawnSyncFn: spawnSyncFn as any })
+
+    expect(process.env.NODE_AUTH_TOKEN).toBe('sync-secret')
+    expect(spawnSyncFn).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/server/path-resolver.ts
+++ b/server/path-resolver.ts
@@ -1,8 +1,8 @@
-import { spawn } from 'child_process'
+import { spawn, spawnSync } from 'child_process'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import type { ChildProcess } from 'child_process'
+import type { ChildProcess, SpawnSyncReturns } from 'child_process'
 import { windowsSpawnEnv, stripWindowsVerbatimPrefix } from './util/win-spawn'
 
 /** Bundled-path env vars set by the Tauri host — normalized at startup. */
@@ -483,6 +483,26 @@ export const AUTH_ENV_VARS = [
   'GOOGLE_APPLICATION_CREDENTIALS',
 ] as const
 
+const LOGIN_SHELL_ENV_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
+const loginShellEnvProbeCache = new Set<string>()
+
+function normalizeLoginShellEnvNames(names: readonly string[]): string[] {
+  const out: string[] = []
+  for (const raw of names) {
+    const name = String(raw).trim()
+    if (!LOGIN_SHELL_ENV_NAME_RE.test(name) || out.includes(name)) continue
+    out.push(name)
+  }
+  return out
+}
+
+function buildLoginShellEnvCommand(names: readonly string[]): string {
+  // `printf` reuses POSIX positional `$VAR` expansion (works in sh/bash/zsh).
+  const fmt = ENV_BEGIN + names.map((v) => `${v}=%s\n`).join('') + ENV_END
+  const refs = names.map((v) => `"$${v}"`).join(' ')
+  return `printf '${fmt}' ${refs}`
+}
+
 /** Parse the `KEY=value` block emitted between the env sentinels. */
 export function parseLoginShellEnv(stdout: string): Record<string, string> {
   const begin = stdout.indexOf(ENV_BEGIN)
@@ -502,26 +522,25 @@ export function parseLoginShellEnv(stdout: string): Record<string, string> {
   return out
 }
 
-/**
- * Spawn the user's login shell once and backfill any provider auth env vars it
- * exposes into `process.env` (only when not already set — never override an
- * explicit value). POSIX-only and runs REGARDLESS of bundle state (unlike the
- * PATH augmentation, which is skipped when the bundle is active): macOS desktop
- * builds bundle node/git, so the PATH login-shell probe is skipped, yet we still
- * need to recover the gemini key. Async, fire-and-forget — must not block
- * startup. No-op on Windows (GUI inherits user env) and in tests.
- */
-export async function augmentAuthEnvFromLoginShell(opts: AugmentOptions = {}): Promise<void> {
+/** Backfill arbitrary, pre-validated environment variable names from the user's
+ * login shell into `process.env` (only when not already set — never override an
+ * explicit value). POSIX-only and runs regardless of bundle state, so macOS GUI
+ * launches can recover tokens exported in `.zshrc`/`.bashrc` without hardcoding
+ * every possible package-manager/provider variable. No-op on Windows and tests. */
+export async function augmentEnvFromLoginShell(
+  names: readonly string[],
+  opts: AugmentOptions = {},
+): Promise<void> {
   if (process.platform === 'win32') return
   if (process.env.NODE_ENV === 'test' || process.env.VITEST === 'true') return
+
+  const wanted = normalizeLoginShellEnvNames(names).filter((name) => !process.env[name])
+  if (wanted.length === 0) return
 
   const spawnFn = opts.spawnFn ?? spawn
   const timeoutMs = opts.timeoutMs ?? LOGIN_SHELL_TIMEOUT_MS
   const shell = process.env.SHELL || '/bin/sh'
-  // `printf` reuses POSIX positional `$VAR` expansion (works in sh/bash/zsh).
-  const fmt = ENV_BEGIN + AUTH_ENV_VARS.map((v) => `${v}=%s\n`).join('') + ENV_END
-  const refs = AUTH_ENV_VARS.map((v) => `"$${v}"`).join(' ')
-  const command = `printf '${fmt}' ${refs}`
+  const command = buildLoginShellEnvCommand(wanted)
 
   await new Promise<void>((resolve) => {
     let child: ChildProcess
@@ -549,7 +568,7 @@ export async function augmentAuthEnvFromLoginShell(opts: AugmentOptions = {}): P
     child.on('error', finish)
     child.on('close', () => {
       const recovered = parseLoginShellEnv(stdout)
-      for (const key of AUTH_ENV_VARS) {
+      for (const key of wanted) {
         const val = recovered[key]
         // Backfill only when unset/empty — never clobber an explicit value.
         if (val && !process.env[key]) process.env[key] = val
@@ -557,6 +576,48 @@ export async function augmentAuthEnvFromLoginShell(opts: AugmentOptions = {}): P
       finish()
     })
   })
+}
+
+/** Synchronous, cached variant for spawn-time env assembly. It probes each
+ * missing name at most once per process to keep loops from paying the login
+ * shell timeout on every step. */
+export function augmentEnvFromLoginShellSync(
+  names: readonly string[],
+  opts: { timeoutMs?: number; spawnSyncFn?: typeof spawnSync } = {},
+): void {
+  if (process.platform === 'win32') return
+  if (process.env.NODE_ENV === 'test' || process.env.VITEST === 'true') return
+
+  const wanted = normalizeLoginShellEnvNames(names).filter((name) => !process.env[name] && !loginShellEnvProbeCache.has(name))
+  if (wanted.length === 0) return
+  for (const name of wanted) loginShellEnvProbeCache.add(name)
+
+  const spawnSyncFn = opts.spawnSyncFn ?? spawnSync
+  const timeoutMs = opts.timeoutMs ?? LOGIN_SHELL_TIMEOUT_MS
+  const shell = process.env.SHELL || '/bin/sh'
+  const command = buildLoginShellEnvCommand(wanted)
+  let res: SpawnSyncReturns<string | Buffer>
+  try {
+    res = spawnSyncFn(shell, ['-l', '-i', '-c', command], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: timeoutMs,
+    })
+  } catch {
+    return
+  }
+  if (res.error) return
+  const stdout = typeof res.stdout === 'string' ? res.stdout : res.stdout?.toString('utf8') ?? ''
+  const recovered = parseLoginShellEnv(stdout)
+  for (const key of wanted) {
+    const val = recovered[key]
+    if (val && !process.env[key]) process.env[key] = val
+  }
+}
+
+/** Startup backfill for the built-in provider auth variables. */
+export async function augmentAuthEnvFromLoginShell(opts: AugmentOptions = {}): Promise<void> {
+  await augmentEnvFromLoginShell(AUTH_ENV_VARS, opts)
 }
 
 function mergeLoginShellPath(rawPath: string): void {
@@ -599,4 +660,5 @@ export function __resetPathResolverForTest(): void {
   diagnostic = { pathSegments: [], pathSources: [], loginShellStatus: 'skipped' }
   warnedLoginShell = false
   bundledRuntimesActive = false
+  loginShellEnvProbeCache.clear()
 }

--- a/server/project-env.test.ts
+++ b/server/project-env.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { initDb, updateProjectSettings } from './db'
+import { resolveWorktreeEnvPassthrough, applyWorktreeEnvPassthrough } from './project-env'
+
+describe('project-env worktree passthrough', () => {
+  it('resolves only configured names that exist in the source env', () => {
+    const db = initDb(':memory:')
+    updateProjectSettings(db, { worktreeEnvPassthrough: ['NODE_AUTH_TOKEN', 'AWS_PROFILE', 'MISSING_VAR'] })
+
+    const env = resolveWorktreeEnvPassthrough(db, {
+      NODE_AUTH_TOKEN: 'npm-secret',
+      AWS_PROFILE: 'busuu-dev',
+      OTHER_SECRET: 'must-not-pass',
+    })
+
+    expect(env).toEqual({
+      NODE_AUTH_TOKEN: 'npm-secret',
+      AWS_PROFILE: 'busuu-dev',
+    })
+  })
+
+  it('merges passthrough values over the caller env without mutating it', () => {
+    const db = initDb(':memory:')
+    updateProjectSettings(db, { worktreeEnvPassthrough: ['NODE_AUTH_TOKEN'] })
+    const base = { PATH: '/bin', NODE_AUTH_TOKEN: 'old' }
+
+    const merged = applyWorktreeEnvPassthrough(db, base, { NODE_AUTH_TOKEN: 'fresh' })
+
+    expect(merged).toEqual({ PATH: '/bin', NODE_AUTH_TOKEN: 'fresh' })
+    expect(base.NODE_AUTH_TOKEN).toBe('old')
+  })
+})

--- a/server/project-env.ts
+++ b/server/project-env.ts
@@ -1,0 +1,34 @@
+import type { DbInstance } from './db'
+import { getProjectSettings } from './db'
+import { augmentEnvFromLoginShellSync } from './path-resolver'
+
+/** Resolve the per-project env passthrough overlay for a spawn.
+ *
+ * The project setting stores names only. Values are read from `sourceEnv` at
+ * spawn time so credentials can rotate without touching SQLite. When the
+ * source is `process.env`, missing configured names get one bounded login-shell
+ * recovery attempt first; unresolved names are still ignored instead of
+ * blocking the run.
+ */
+export function resolveWorktreeEnvPassthrough(
+  db: DbInstance,
+  sourceEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const out: NodeJS.ProcessEnv = {}
+  const names = getProjectSettings(db).worktreeEnvPassthrough
+  if (sourceEnv === process.env) augmentEnvFromLoginShellSync(names)
+  for (const name of names) {
+    const value = sourceEnv[name]
+    if (value !== undefined) out[name] = value
+  }
+  return out
+}
+
+export function applyWorktreeEnvPassthrough(
+  db: DbInstance,
+  env: NodeJS.ProcessEnv,
+  sourceEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const passthrough = resolveWorktreeEnvPassthrough(db, sourceEnv)
+  return Object.keys(passthrough).length === 0 ? env : { ...env, ...passthrough }
+}

--- a/server/project-registry.ts
+++ b/server/project-registry.ts
@@ -24,6 +24,7 @@ import { killTransientChildren } from './transient-children'
 import { dropBlobStatesForProject } from './telemetry-receiver'
 import { mirrorProjectEntry, removeRegistryEntry, reconcileFromProjects, resolveArtifacts, resolveHome } from './artifact-registry'
 import { resolveProjectExecution, resolveLoopBaseEnv } from './workspace-resolution'
+import { applyWorktreeEnvPassthrough } from './project-env'
 import { removeWorkspace } from './workspace-manager'
 import { resolveTicketStoragePath, mutateStore, applyJobOutcomeToTickets, readStore, type JobOutcome } from './ticket-store'
 import { JiraSyncManager } from './jira/jira-sync-manager'
@@ -694,9 +695,14 @@ export class ProjectRegistry {
     // `${ENV:-legacy}` defaults resolve inside the worktree, where only tracked
     // files exist — still reads the real project state. SPECRAILS_REPO_DIR stays
     // per-run (the worktree for isolated runs). Legacy projects keep process.env
-    // byte-identical. See resolveLoopBaseEnv.
+    // byte-identical except for the explicit per-project passthrough overlay.
+    // See resolveLoopBaseEnv.
     const loopRunManager = new LoopRunManager(db, boundBroadcast, createLoopExecutors({
-      env: () => resolveLoopBaseEnv({ slug: project.slug, path: project.path }),
+      env: () => resolveLoopBaseEnv(
+        { slug: project.slug, path: project.path },
+        undefined,
+        applyWorktreeEnvPassthrough(db, process.env),
+      ),
     }))
 
     const getTicketSpec = (ticketId: number): LoopSpec | undefined => {

--- a/server/project-router-settings.ts
+++ b/server/project-router-settings.ts
@@ -12,7 +12,7 @@ import {
   getStats, getPipelineJobs,
   createProposal, getProposal, listProposals, deleteProposal,
   createTemplate, listTemplates, getTemplate, updateTemplate, deleteTemplate,
-  getProjectSettings, updateProjectSettings,
+  getProjectSettings, updateProjectSettings, normalizeWorktreeEnvPassthrough,
   getQuickContractRefineLast, setQuickContractRefineLast, hasQuickContractRefineLast,
   getTelemetryBlob, getTelemetrySummaries, getJobsWithTelemetry, hasJobTelemetry,
 } from './db'
@@ -174,7 +174,7 @@ export function registerSettingsRoutes(deps: ProjectRoutesDeps): void {
   })
 
   router.patch('/:projectId/settings', (req: Request, res: Response) => {
-    const { pipelineTelemetryEnabled, orchestratorModel, prePrompt, freestylePrePrompt } = req.body ?? {}
+    const { pipelineTelemetryEnabled, orchestratorModel, prePrompt, freestylePrePrompt, worktreeEnvPassthrough } = req.body ?? {}
     const patch: Parameters<typeof updateProjectSettings>[1] = {}
     if (pipelineTelemetryEnabled !== undefined) {
       patch.pipelineTelemetryEnabled = Boolean(pipelineTelemetryEnabled)
@@ -200,6 +200,14 @@ export function registerSettingsRoutes(deps: ProjectRoutesDeps): void {
         return
       }
       patch.freestylePrePrompt = freestylePrePrompt
+    }
+    if (worktreeEnvPassthrough !== undefined) {
+      try {
+        patch.worktreeEnvPassthrough = normalizeWorktreeEnvPassthrough(worktreeEnvPassthrough)
+      } catch (err) {
+        res.status(400).json({ error: err instanceof Error ? err.message : 'invalid worktreeEnvPassthrough' })
+        return
+      }
     }
     if (req.body?.integrationBranch !== undefined) {
       const ib = req.body.integrationBranch

--- a/server/project-router.test.ts
+++ b/server/project-router.test.ts
@@ -2286,6 +2286,7 @@ describe('project-router', () => {
       expect(res.body.pipelineTelemetryEnabled).toBe(false)
       expect(res.body.orchestratorModel).toBe('sonnet')
       expect(res.body.prePrompt).toBe('')
+      expect(res.body.worktreeEnvPassthrough).toEqual([])
     })
   })
 
@@ -2377,6 +2378,30 @@ describe('project-router', () => {
         .send({ freestylePrePrompt: 7 })
       expect(res.status).toBe(400)
       expect(res.body.error).toContain('freestylePrePrompt')
+    })
+
+    it('updates worktree env passthrough names without storing values', async () => {
+      const ctx = makeContext(db)
+      const { app } = createApp(new Map([['proj-1', ctx]]))
+      const res = await request(app)
+        .patch('/api/projects/proj-1/settings')
+        .send({ worktreeEnvPassthrough: [' NODE_AUTH_TOKEN ', 'AWS_PROFILE', 'NODE_AUTH_TOKEN', ''] })
+      expect(res.status).toBe(200)
+      expect(res.body.settings.worktreeEnvPassthrough).toEqual(['NODE_AUTH_TOKEN', 'AWS_PROFILE'])
+      expect(JSON.stringify(res.body)).not.toContain('secret-token')
+
+      const get = await request(app).get('/api/projects/proj-1/settings')
+      expect(get.body.worktreeEnvPassthrough).toEqual(['NODE_AUTH_TOKEN', 'AWS_PROFILE'])
+    })
+
+    it('rejects invalid worktree env passthrough names', async () => {
+      const ctx = makeContext(db)
+      const { app } = createApp(new Map([['proj-1', ctx]]))
+      const res = await request(app)
+        .patch('/api/projects/proj-1/settings')
+        .send({ worktreeEnvPassthrough: ['NODE_AUTH_TOKEN=secret'] })
+      expect(res.status).toBe(400)
+      expect(res.body.error).toContain('invalid environment variable name')
     })
   })
 

--- a/server/queue-manager.ts
+++ b/server/queue-manager.ts
@@ -35,6 +35,7 @@ import { binaryOnPath } from './binary-probe'
 import { ensureFrameworkAgents, ensureFrameworkCommandSubtrees } from './workspace-manager'
 import { ensureClaudeTrusted } from './claude-trust'
 import { resolveProjectExecution, type ProjectExecution } from './workspace-resolution'
+import { applyWorktreeEnvPassthrough } from './project-env'
 import { readCurrentFrameworkVersion } from './framework-manager'
 import { ensureOpenspecShim, prependShimToPath, removeOpenspecShim, openspecShimDir } from './openspec-shim'
 import { resolveHome } from './artifact-registry'
@@ -1821,6 +1822,13 @@ export class QueueManager {
     // claude honours OTEL_* env vars natively; codex does not and instead
     // gets signals synthesised by the codex-otel-bridge attached below.
     let spawnEnv: NodeJS.ProcessEnv = process.env
+    // Per-project worktree/job env passthrough. The setting stores names only;
+    // values are read from the server env (with login-shell recovery for missing
+    // names) at spawn time. Apply this before Specrails' own env overlays so
+    // internal SPECRAILS_* control-plane values always win.
+    if (this._db) {
+      spawnEnv = applyWorktreeEnvPassthrough(this._db, spawnEnv)
+    }
     const telemetryEnabled = !!(this._projectId && this._db && getProjectSettings(this._db).pipelineTelemetryEnabled)
     // Resolve the framework version ONCE at spawn time — `framework/current`
     // is read from `~/.specrails/framework/current`. A concurrent atomic swap
@@ -1836,7 +1844,7 @@ export class QueueManager {
       if (profileName) extra['specrails.profile_schema_version'] = '1'
       if (frameworkVersion) extra['specrails.framework_version'] = frameworkVersion
       spawnEnv = {
-        ...process.env,
+        ...spawnEnv,
         ...buildTelemetryEnv(jobId, this._projectId, this._desktopPort, extra, adapter.id),
       }
     }

--- a/server/workspace-resolution.test.ts
+++ b/server/workspace-resolution.test.ts
@@ -167,4 +167,17 @@ describe('resolveLoopBaseEnv (loop-executor base env)', () => {
     // process.env still rides underneath.
     expect(env.PATH).toBe(process.env.PATH)
   })
+
+  it('relocated ⇒ overlays workspace internals on top of a caller-provided base env', () => {
+    const ws = seedRelocated('acme')
+    const env = resolveLoopBaseEnv(
+      { slug: 'acme', path: repo },
+      home,
+      { PATH: '/bin', NODE_AUTH_TOKEN: 'npm-secret', SPECRAILS_WORKSPACE_DIR: '/wrong' },
+    )
+
+    expect(env.NODE_AUTH_TOKEN).toBe('npm-secret')
+    expect(env.PATH).toBe('/bin')
+    expect(env.SPECRAILS_WORKSPACE_DIR).toBe(ws)
+  })
 })

--- a/server/workspace-resolution.ts
+++ b/server/workspace-resolution.ts
@@ -184,11 +184,15 @@ export function resolveProjectExecution(
  *
  * Legacy projects return `process.env` untouched — byte-identical behaviour.
  */
-export function resolveLoopBaseEnv(project: ResolvableProject, home?: string): NodeJS.ProcessEnv {
+export function resolveLoopBaseEnv(
+  project: ResolvableProject,
+  home?: string,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
   const exec = resolveProjectExecution(project, home)
-  if (!exec.relocated) return process.env
+  if (!exec.relocated) return baseEnv
   const { SPECRAILS_REPO_DIR: _perRun, ...projectEnv } = exec.env
-  return { ...process.env, ...projectEnv }
+  return { ...baseEnv, ...projectEnv }
 }
 
 /** Build the legacy (in-repo, byte-identical-to-today) execution. */

--- a/server/worktree-env-discovery.test.ts
+++ b/server/worktree-env-discovery.test.ts
@@ -1,0 +1,68 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { scanWorktreeEnvRequirements } from './worktree-env-discovery'
+
+let tmpDirs: string[] = []
+
+function makeRepo(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'specrails-env-scan-'))
+  tmpDirs.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs) fs.rmSync(dir, { recursive: true, force: true })
+  tmpDirs = []
+})
+
+describe('scanWorktreeEnvRequirements', () => {
+  it('discovers explicit env references and private package auth hints', () => {
+    const repo = makeRepo()
+    fs.writeFileSync(path.join(repo, '.npmrc'), '//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}\n')
+    fs.writeFileSync(path.join(repo, '.yarnrc.yml'), 'npmAuthToken: "${YARN_NPM_AUTH_TOKEN}"\n')
+    fs.writeFileSync(path.join(repo, 'package.json'), JSON.stringify({
+      scripts: { build: 'node -e "console.log(process.env.AWS_PROFILE)"' },
+      dependencies: {
+        '@busuu/design-system': '1.0.0',
+        react: '^18.0.0',
+      },
+    }, null, 2))
+
+    const res = scanWorktreeEnvRequirements(repo)
+
+    expect(res.scannedFiles.sort()).toEqual(['.npmrc', '.yarnrc.yml', 'package.json'])
+    expect(res.candidates.map((c) => c.name)).toEqual([
+      'AWS_PROFILE',
+      'NODE_AUTH_TOKEN',
+      'NPM_TOKEN',
+      'YARN_NPM_AUTH_TOKEN',
+    ])
+    expect(res.candidates.find((c) => c.name === 'AWS_PROFILE')).toMatchObject({
+      confidence: 'high',
+      files: ['package.json'],
+    })
+    expect(res.candidates.find((c) => c.name === 'NODE_AUTH_TOKEN')?.confidence).toBe('high')
+    expect(res.candidates.find((c) => c.name === 'NPM_TOKEN')).toMatchObject({
+      confidence: 'medium',
+      files: ['package.json'],
+    })
+  })
+
+  it('skips dependency folders and never scans arbitrary source files', () => {
+    const repo = makeRepo()
+    fs.mkdirSync(path.join(repo, 'node_modules', 'private-pkg'), { recursive: true })
+    fs.writeFileSync(path.join(repo, 'node_modules', 'private-pkg', 'package.json'), JSON.stringify({
+      scripts: { postinstall: 'echo ${SHOULD_NOT_LEAK}' },
+    }))
+    fs.mkdirSync(path.join(repo, 'src'), { recursive: true })
+    fs.writeFileSync(path.join(repo, 'src', 'index.ts'), 'process.env.RUNTIME_ONLY_SECRET\n')
+    fs.writeFileSync(path.join(repo, 'package.json'), JSON.stringify({ dependencies: {} }))
+
+    const res = scanWorktreeEnvRequirements(repo)
+
+    expect(res.scannedFiles).toEqual(['package.json'])
+    expect(res.candidates).toEqual([])
+  })
+})

--- a/server/worktree-env-discovery.ts
+++ b/server/worktree-env-discovery.ts
@@ -1,0 +1,164 @@
+import fs from 'fs'
+import path from 'path'
+import { WORKTREE_ENV_NAME_RE } from './db'
+
+export type EnvDiscoveryConfidence = 'high' | 'medium'
+
+export interface EnvDiscoveryCandidate {
+  name: string
+  confidence: EnvDiscoveryConfidence
+  reasons: string[]
+  files: string[]
+}
+
+export interface EnvDiscoveryResult {
+  candidates: EnvDiscoveryCandidate[]
+  scannedFiles: string[]
+  skipped: string[]
+}
+
+const MAX_FILES = 250
+const MAX_DEPTH = 4
+const MAX_FILE_BYTES = 512 * 1024
+
+const SCANNED_FILENAMES = new Set([
+  '.npmrc',
+  '.yarnrc.yml',
+  '.yarnrc',
+  '.pnpmrc',
+  'package.json',
+  'pnpm-workspace.yaml',
+  'npm-shrinkwrap.json',
+])
+
+const SKIP_DIRS = new Set([
+  '.git',
+  '.hg',
+  '.svn',
+  'node_modules',
+  'dist',
+  'build',
+  'coverage',
+  '.next',
+  '.nuxt',
+  '.turbo',
+  '.cache',
+  '.specrails',
+])
+
+const ENV_REF_RE =
+  /\$\{([A-Za-z_][A-Za-z0-9_]*)\}|process\.env\.([A-Za-z_][A-Za-z0-9_]*)|process\.env\[['"]([A-Za-z_][A-Za-z0-9_]*)['"]\]/g
+
+function addCandidate(
+  map: Map<string, EnvDiscoveryCandidate>,
+  name: string,
+  confidence: EnvDiscoveryConfidence,
+  reason: string,
+  file: string,
+): void {
+  if (!WORKTREE_ENV_NAME_RE.test(name)) return
+  const existing = map.get(name)
+  if (!existing) {
+    map.set(name, { name, confidence, reasons: [reason], files: [file] })
+    return
+  }
+  if (confidence === 'high') existing.confidence = 'high'
+  if (!existing.reasons.includes(reason)) existing.reasons.push(reason)
+  if (!existing.files.includes(file)) existing.files.push(file)
+}
+
+function walk(root: string): { files: string[]; skipped: string[] } {
+  const files: string[] = []
+  const skipped: string[] = []
+  const visit = (dir: string, depth: number): void => {
+    if (files.length >= MAX_FILES) return
+    let entries: fs.Dirent[]
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true })
+    } catch {
+      skipped.push(path.relative(root, dir) || '.')
+      return
+    }
+    for (const entry of entries) {
+      if (files.length >= MAX_FILES) return
+      const abs = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        if (depth >= MAX_DEPTH || SKIP_DIRS.has(entry.name)) continue
+        visit(abs, depth + 1)
+      } else if (entry.isFile() && SCANNED_FILENAMES.has(entry.name)) {
+        files.push(abs)
+      }
+    }
+  }
+  visit(root, 0)
+  return { files, skipped }
+}
+
+function readSmallText(file: string): string | null {
+  try {
+    const st = fs.statSync(file)
+    if (st.size > MAX_FILE_BYTES) return null
+    return fs.readFileSync(file, 'utf8')
+  } catch {
+    return null
+  }
+}
+
+function scanEnvReferences(raw: string, rel: string, candidates: Map<string, EnvDiscoveryCandidate>): void {
+  for (const match of raw.matchAll(ENV_REF_RE)) {
+    const name = match[1] ?? match[2] ?? match[3]
+    if (!name) continue
+    addCandidate(candidates, name, 'high', 'Referenced explicitly by the repository configuration', rel)
+  }
+}
+
+function packageScopes(pkg: Record<string, unknown>): Set<string> {
+  const scopes = new Set<string>()
+  for (const key of ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies']) {
+    const deps = pkg[key]
+    if (!deps || typeof deps !== 'object' || Array.isArray(deps)) continue
+    for (const name of Object.keys(deps as Record<string, unknown>)) {
+      const m = /^(@[^/]+)\//.exec(name)
+      if (m) scopes.add(m[1])
+    }
+  }
+  return scopes
+}
+
+function scanPackageJson(raw: string, rel: string, candidates: Map<string, EnvDiscoveryCandidate>): void {
+  let pkg: Record<string, unknown>
+  try {
+    pkg = JSON.parse(raw) as Record<string, unknown>
+  } catch {
+    return
+  }
+  const scopes = packageScopes(pkg)
+  if (scopes.has('@busuu')) {
+    addCandidate(candidates, 'NODE_AUTH_TOKEN', 'medium', 'Package dependencies include @busuu/* scoped packages', rel)
+    addCandidate(candidates, 'NPM_TOKEN', 'medium', 'Package dependencies include @busuu/* scoped packages', rel)
+  }
+}
+
+export function scanWorktreeEnvRequirements(repoDir: string): EnvDiscoveryResult {
+  const { files, skipped } = walk(repoDir)
+  const candidates = new Map<string, EnvDiscoveryCandidate>()
+  const scannedFiles: string[] = []
+
+  for (const file of files) {
+    const raw = readSmallText(file)
+    if (raw === null) {
+      skipped.push(path.relative(repoDir, file) || path.basename(file))
+      continue
+    }
+    const rel = path.relative(repoDir, file) || path.basename(file)
+    scannedFiles.push(rel)
+    scanEnvReferences(raw, rel, candidates)
+    if (path.basename(file) === 'package.json') scanPackageJson(raw, rel, candidates)
+  }
+
+  return {
+    candidates: Array.from(candidates.values()).sort((a, b) => a.name.localeCompare(b.name)),
+    scannedFiles,
+    skipped,
+  }
+}


### PR DESCRIPTION
Summary: Add per-project worktree env passthrough settings that store names only. Apply passthrough to rail jobs and loop worktrees with login-shell recovery. Add settings UI, full i18n coverage, and specrails_env MCP get/scan/set/auto_configure actions. Tests: backend focused vitest suite, client settings and i18n vitest suite, npm run typecheck, npm run build.