### PR TITLE
[7]feat - add mission transcript export and copy actions

### DIFF
--- a/client/src/components/agent-chat/AgentConversationHeader.tsx
+++ b/client/src/components/agent-chat/AgentConversationHeader.tsx
@@ -1,11 +1,69 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { motion, AnimatePresence } from 'motion/react'
-import { MoreVertical, Pencil, Copy, Check, ChevronRight, Trash2, Heart } from 'lucide-react'
+import { MoreVertical, Pencil, Copy, Check, ChevronRight, Trash2, Heart, Download } from 'lucide-react'
 import { toast } from 'sonner'
 import { useAgentChat } from '../../context/AgentChatContext'
 import { useDesktop } from '../../hooks/useDesktop'
 import { cn } from '../../lib/utils'
+import type { AgentConversation, AgentMessage } from '../../lib/agent-api'
+
+type TranscriptProject = {
+  name?: string | null
+  path?: string | null
+}
+
+type TranscriptOptions = {
+  exportedAt?: string
+}
+
+type TranscriptConversation = Pick<AgentConversation, 'id' | 'title'>
+
+function roleLabel(role: string): string {
+  if (!role) return 'Unknown'
+  return role.charAt(0).toUpperCase() + role.slice(1)
+}
+
+export function formatMissionTranscript(
+  active: TranscriptConversation,
+  messages: AgentMessage[],
+  project?: TranscriptProject | null,
+  options?: TranscriptOptions,
+): string {
+  const title = active.title?.trim() || 'Untitled mission'
+  const exportedAt = options?.exportedAt ?? new Date().toISOString()
+  const lines = [
+    `Mission: ${title}`,
+    `Mission ID: ${active.id}`,
+  ]
+
+  if (project?.name) lines.push(`Project: ${project.name}`)
+  if (project?.path) lines.push(`Project path: ${project.path}`)
+  lines.push(`Exported at: ${exportedAt}`, '', 'Messages:')
+
+  if (messages.length === 0) {
+    lines.push('No messages loaded.')
+    return lines.join('\n')
+  }
+
+  messages.forEach((message, index) => {
+    if (index > 0) lines.push('')
+    lines.push(`[${message.created_at}] ${roleLabel(message.role)}`, message.content)
+  })
+
+  return lines.join('\n')
+}
+
+export function safeTranscriptFilename(title: string | null | undefined, id: string): string {
+  const slug = (title ?? '')
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  const fallback = id.trim() || 'mission'
+  return `${slug || fallback}.txt`
+}
 
 /**
  * The conversation title bar for the Agent-Mode surface — a quiet breadcrumb
@@ -17,7 +75,7 @@ import { cn } from '../../lib/utils'
  */
 export function AgentConversationHeader() {
   const { t } = useTranslation('agent')
-  const { active, renameConversation, deleteConversation, startNewConversation, favoriteConversationIds, toggleFavoriteConversation } = useAgentChat()
+  const { active, messages, renameConversation, deleteConversation, startNewConversation, favoriteConversationIds, toggleFavoriteConversation } = useAgentChat()
   const { projects } = useDesktop()
   const [menuOpen, setMenuOpen] = useState(false)
   const [editing, setEditing] = useState(false)
@@ -82,6 +140,39 @@ export function AgentConversationHeader() {
       toast.error(t('header.copyFailed'))
     }
   }, [t])
+
+  const handleCopyTranscript = useCallback(async () => {
+    if (!active) return
+    setMenuOpen(false)
+    try {
+      await navigator.clipboard.writeText(formatMissionTranscript(active, messages, project))
+      setCopied('transcript')
+      toast.success(t('header.copyTranscriptSuccess', { defaultValue: 'Transcript copied' }))
+      setTimeout(() => setCopied((c) => (c === 'transcript' ? null : c)), 1400)
+    } catch {
+      toast.error(t('header.copyTranscriptFailed', { defaultValue: 'Could not copy transcript' }))
+    }
+  }, [active, messages, project, t])
+
+  const handleExportTranscript = useCallback(() => {
+    if (!active) return
+    setMenuOpen(false)
+    try {
+      const transcript = formatMissionTranscript(active, messages, project)
+      const blob = new Blob([transcript], { type: 'text/plain;charset=utf-8' })
+      const objectUrl = URL.createObjectURL(blob)
+      const anchor = document.createElement('a')
+      anchor.href = objectUrl
+      anchor.download = safeTranscriptFilename(active.title, active.id)
+      document.body.appendChild(anchor)
+      anchor.click()
+      anchor.remove()
+      URL.revokeObjectURL(objectUrl)
+      toast.success(t('header.exportTranscriptSuccess', { defaultValue: 'Transcript export started' }))
+    } catch {
+      toast.error(t('header.exportTranscriptFailed', { defaultValue: 'Could not export transcript' }))
+    }
+  }, [active, messages, project, t])
 
   const doDelete = useCallback(async () => {
     if (!active) return
@@ -253,6 +344,31 @@ export function AgentConversationHeader() {
             </button>
 
             <div className="my-1 h-px bg-border/50" />
+
+            <button
+              type="button"
+              role="menuitem"
+              data-testid="agent-conv-copy-transcript"
+              onClick={() => void handleCopyTranscript()}
+              className="flex w-full items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-sm text-foreground/85 transition-colors hover:bg-surface/80"
+            >
+              {copied === 'transcript' ? (
+                <Check className="h-3.5 w-3.5 shrink-0 text-accent-success" />
+              ) : (
+                <Copy className="h-3.5 w-3.5 shrink-0 text-foreground/50" />
+              )}
+              <span className="min-w-0 flex-1 truncate text-left">{t('header.copyTranscript', { defaultValue: 'Copy transcript' })}</span>
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              data-testid="agent-conv-export-transcript"
+              onClick={handleExportTranscript}
+              className="flex w-full items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-sm text-foreground/85 transition-colors hover:bg-surface/80"
+            >
+              <Download className="h-3.5 w-3.5 shrink-0 text-foreground/50" />
+              <span className="min-w-0 flex-1 truncate text-left">{t('header.exportTranscript', { defaultValue: 'Export transcript (.txt)' })}</span>
+            </button>
 
             {menuItems.map((item) =>
               item === 'divider' ? null : (

--- a/client/src/components/agent-chat/__tests__/agent-conversation-header.test.tsx
+++ b/client/src/components/agent-chat/__tests__/agent-conversation-header.test.tsx
@@ -8,10 +8,27 @@ const toggleFavoriteConversation = vi.fn()
 let active: { id: string; title: string | null; pinned_project_id: string | null } | null = {
   id: 'conv-1', title: 'Greeting And Friendly Introduction', pinned_project_id: 'p1',
 }
+let messages = [
+  {
+    id: 'msg-1',
+    conversation_id: 'conv-1',
+    role: 'user',
+    content: 'Hello agent\nCan you help?',
+    created_at: '2026-07-07T10:00:00.000Z',
+  },
+  {
+    id: 'msg-2',
+    conversation_id: 'conv-1',
+    role: 'assistant',
+    content: 'Yes, I can.',
+    created_at: '2026-07-07T10:01:00.000Z',
+  },
+]
 let favoriteConversationIds = new Set<string>()
 vi.mock('../../../context/AgentChatContext', () => ({
   useAgentChat: () => ({
     active,
+    messages,
     renameConversation,
     deleteConversation,
     startNewConversation,
@@ -24,17 +41,81 @@ vi.mock('../../../hooks/useDesktop', () => ({
 }))
 vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
 
-import { AgentConversationHeader } from '../AgentConversationHeader'
+import { AgentConversationHeader, formatMissionTranscript, safeTranscriptFilename } from '../AgentConversationHeader'
+import { toast } from 'sonner'
+import enAgent from '../../../locales/en/agent.json'
+import esAgent from '../../../locales/es/agent.json'
+import frAgent from '../../../locales/fr/agent.json'
+import deAgent from '../../../locales/de/agent.json'
+import ptAgent from '../../../locales/pt/agent.json'
+import itAgent from '../../../locales/it/agent.json'
+import zhAgent from '../../../locales/zh/agent.json'
+import jaAgent from '../../../locales/ja/agent.json'
 
 const writeText = vi.fn(async () => {})
+const createObjectURL = vi.fn(() => 'blob:transcript')
+const revokeObjectURL = vi.fn()
+const localeFiles = { en: enAgent, es: esAgent, fr: frAgent, de: deAgent, pt: ptAgent, it: itAgent, zh: zhAgent, ja: jaAgent }
+const transcriptLocaleKeys = [
+  'copyTranscript',
+  'copyTranscriptSuccess',
+  'copyTranscriptFailed',
+  'exportTranscript',
+  'exportTranscriptSuccess',
+  'exportTranscriptFailed',
+]
 beforeEach(() => {
   vi.clearAllMocks()
   active = { id: 'conv-1', title: 'Greeting And Friendly Introduction', pinned_project_id: 'p1' }
+  messages = [
+    {
+      id: 'msg-1',
+      conversation_id: 'conv-1',
+      role: 'user',
+      content: 'Hello agent\nCan you help?',
+      created_at: '2026-07-07T10:00:00.000Z',
+    },
+    {
+      id: 'msg-2',
+      conversation_id: 'conv-1',
+      role: 'assistant',
+      content: 'Yes, I can.',
+      created_at: '2026-07-07T10:01:00.000Z',
+    },
+  ]
   favoriteConversationIds = new Set()
   Object.assign(navigator, { clipboard: { writeText } })
+  Object.assign(URL, { createObjectURL, revokeObjectURL })
 })
 
 describe('AgentConversationHeader', () => {
+  it('defines transcript action header keys in every agent locale', () => {
+    for (const [locale, resource] of Object.entries(localeFiles)) {
+      for (const key of transcriptLocaleKeys) {
+        expect(resource.header, `${locale} missing header.${key}`).toHaveProperty(key)
+      }
+    }
+  })
+
+  it('formats a plain-text transcript with mission metadata and loaded messages in order', () => {
+    const transcript = formatMissionTranscript(
+      { id: 'conv-1', title: 'Greeting And Friendly Introduction' },
+      messages,
+      { name: 'outrun', path: '/Users/javi/repos/outrun' },
+      { exportedAt: '2026-07-07T10:02:00.000Z' },
+    )
+
+    expect(transcript).toContain('Mission: Greeting And Friendly Introduction')
+    expect(transcript).toContain('Mission ID: conv-1')
+    expect(transcript).toContain('Project: outrun')
+    expect(transcript).toContain('Project path: /Users/javi/repos/outrun')
+    expect(transcript).toContain('Exported at: 2026-07-07T10:02:00.000Z')
+    expect(transcript).toContain('[2026-07-07T10:00:00.000Z] User')
+    expect(transcript).toContain('Hello agent\nCan you help?')
+    expect(transcript).toContain('[2026-07-07T10:01:00.000Z] Assistant')
+    expect(transcript.indexOf('Hello agent')).toBeLessThan(transcript.indexOf('Yes, I can.'))
+  })
+
   it('renders the breadcrumb: project path / conversation title', () => {
     render(<AgentConversationHeader />)
     expect(screen.getByText('/Users/javi/repos/outrun')).toBeInTheDocument()
@@ -92,6 +173,56 @@ describe('AgentConversationHeader', () => {
     fireEvent.click(screen.getByTestId('agent-conv-menu-trigger'))
     fireEvent.click(screen.getByTestId('agent-conv-copy-path'))
     await waitFor(() => expect(writeText).toHaveBeenCalledWith('/Users/javi/repos/outrun'))
+  })
+
+  it('Copy transcript writes the full formatted mission transcript to the clipboard', async () => {
+    render(<AgentConversationHeader />)
+    fireEvent.click(screen.getByTestId('agent-conv-menu-trigger'))
+    fireEvent.click(screen.getByTestId('agent-conv-copy-transcript'))
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Mission: Greeting And Friendly Introduction'))
+    })
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Hello agent\nCan you help?'))
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('[2026-07-07T10:01:00.000Z] Assistant'))
+  })
+
+  it('Copy transcript shows a localized failure toast when clipboard write fails', async () => {
+    writeText.mockRejectedValueOnce(new Error('denied'))
+    render(<AgentConversationHeader />)
+    fireEvent.click(screen.getByTestId('agent-conv-menu-trigger'))
+    fireEvent.click(screen.getByTestId('agent-conv-copy-transcript'))
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Could not copy transcript'))
+    expect(active?.id).toBe('conv-1')
+    expect(messages).toHaveLength(2)
+  })
+
+  it('Export transcript downloads a plain-text Blob with a safe mission-title filename', async () => {
+    render(<AgentConversationHeader />)
+    fireEvent.click(screen.getByTestId('agent-conv-menu-trigger'))
+    const anchor = document.createElement('a')
+    const click = vi.spyOn(anchor, 'click').mockImplementation(() => {})
+    const createElement = vi.spyOn(document, 'createElement').mockImplementation((tagName, options) => {
+      if (tagName === 'a') return anchor
+      return Document.prototype.createElement.call(document, tagName, options)
+    })
+
+    fireEvent.click(screen.getByTestId('agent-conv-export-transcript'))
+
+    expect(createObjectURL).toHaveBeenCalledOnce()
+    const blob = createObjectURL.mock.calls[0][0] as Blob
+    expect(blob.type).toBe('text/plain;charset=utf-8')
+    await expect(blob.text()).resolves.toContain('Mission: Greeting And Friendly Introduction')
+    await expect(blob.text()).resolves.toContain('Hello agent\nCan you help?')
+    expect(anchor.download).toBe('greeting-and-friendly-introduction.txt')
+    expect(anchor.href).toBe('blob:transcript')
+    expect(click).toHaveBeenCalledOnce()
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:transcript')
+    createElement.mockRestore()
+  })
+
+  it('falls back to the mission id when the transcript filename title is unsafe', () => {
+    expect(safeTranscriptFilename('!!!', 'conv-1')).toBe('conv-1.txt')
+    expect(safeTranscriptFilename('   ', 'conv-1')).toBe('conv-1.txt')
   })
 
   it('Add to favorites toggles the active mission favorite state', () => {

--- a/client/src/locales/de/agent.json
+++ b/client/src/locales/de/agent.json
@@ -320,6 +320,12 @@
     "copyProject": "Projektname kopieren",
     "copyProjectPath": "Projektpfad kopieren",
     "copyFailed": "Kopieren fehlgeschlagen",
+    "copyTranscript": "Transkript kopieren",
+    "copyTranscriptSuccess": "Transkript kopiert",
+    "copyTranscriptFailed": "Transkript konnte nicht kopiert werden",
+    "exportTranscript": "Transkript exportieren (.txt)",
+    "exportTranscriptSuccess": "Transkriptexport gestartet",
+    "exportTranscriptFailed": "Transkript konnte nicht exportiert werden",
     "delete": "Mission löschen",
     "deleteConfirm": "Diese Mission löschen? Kann nicht rückgängig gemacht werden.",
     "deleteFailed": "Mission konnte nicht gelöscht werden"

--- a/client/src/locales/en/agent.json
+++ b/client/src/locales/en/agent.json
@@ -320,6 +320,12 @@
     "copyProject": "Copy project name",
     "copyProjectPath": "Copy project path",
     "copyFailed": "Couldn't copy",
+    "copyTranscript": "Copy transcript",
+    "copyTranscriptSuccess": "Transcript copied",
+    "copyTranscriptFailed": "Could not copy transcript",
+    "exportTranscript": "Export transcript (.txt)",
+    "exportTranscriptSuccess": "Transcript export started",
+    "exportTranscriptFailed": "Could not export transcript",
     "delete": "Delete mission",
     "deleteConfirm": "Delete this mission? This cannot be undone.",
     "deleteFailed": "Could not delete the mission"

--- a/client/src/locales/es/agent.json
+++ b/client/src/locales/es/agent.json
@@ -320,6 +320,12 @@
     "copyProject": "Copiar nombre del proyecto",
     "copyProjectPath": "Copiar ruta del proyecto",
     "copyFailed": "No se pudo copiar",
+    "copyTranscript": "Copiar transcripción",
+    "copyTranscriptSuccess": "Transcripción copiada",
+    "copyTranscriptFailed": "No se pudo copiar la transcripción",
+    "exportTranscript": "Exportar transcripción (.txt)",
+    "exportTranscriptSuccess": "Exportación de transcripción iniciada",
+    "exportTranscriptFailed": "No se pudo exportar la transcripción",
     "delete": "Borrar misión",
     "deleteConfirm": "¿Borrar esta misión? No se puede deshacer.",
     "deleteFailed": "No se pudo borrar la misión"

--- a/client/src/locales/fr/agent.json
+++ b/client/src/locales/fr/agent.json
@@ -320,6 +320,12 @@
     "copyProject": "Copier le nom du projet",
     "copyProjectPath": "Copier le chemin du projet",
     "copyFailed": "Copie impossible",
+    "copyTranscript": "Copier la transcription",
+    "copyTranscriptSuccess": "Transcription copiée",
+    "copyTranscriptFailed": "Impossible de copier la transcription",
+    "exportTranscript": "Exporter la transcription (.txt)",
+    "exportTranscriptSuccess": "Export de la transcription lancé",
+    "exportTranscriptFailed": "Impossible d'exporter la transcription",
     "delete": "Supprimer la mission",
     "deleteConfirm": "Supprimer cette mission ? Action irréversible.",
     "deleteFailed": "Impossible de supprimer la mission"

--- a/client/src/locales/it/agent.json
+++ b/client/src/locales/it/agent.json
@@ -320,6 +320,12 @@
     "copyProject": "Copia nome progetto",
     "copyProjectPath": "Copia percorso progetto",
     "copyFailed": "Impossibile copiare",
+    "copyTranscript": "Copia trascrizione",
+    "copyTranscriptSuccess": "Trascrizione copiata",
+    "copyTranscriptFailed": "Impossibile copiare la trascrizione",
+    "exportTranscript": "Esporta trascrizione (.txt)",
+    "exportTranscriptSuccess": "Esportazione della trascrizione avviata",
+    "exportTranscriptFailed": "Impossibile esportare la trascrizione",
     "delete": "Elimina missione",
     "deleteConfirm": "Eliminare questa missione? Non è reversibile.",
     "deleteFailed": "Impossibile eliminare la missione"

--- a/client/src/locales/ja/agent.json
+++ b/client/src/locales/ja/agent.json
@@ -320,6 +320,12 @@
     "copyProject": "プロジェクト名をコピー",
     "copyProjectPath": "プロジェクトパスをコピー",
     "copyFailed": "コピーできませんでした",
+    "copyTranscript": "トランスクリプトをコピー",
+    "copyTranscriptSuccess": "トランスクリプトをコピーしました",
+    "copyTranscriptFailed": "トランスクリプトをコピーできませんでした",
+    "exportTranscript": "トランスクリプトをエクスポート (.txt)",
+    "exportTranscriptSuccess": "トランスクリプトのエクスポートを開始しました",
+    "exportTranscriptFailed": "トランスクリプトをエクスポートできませんでした",
     "delete": "ミッションを削除",
     "deleteConfirm": "このミッションを削除しますか？元に戻せません。",
     "deleteFailed": "ミッションを削除できませんでした"

--- a/client/src/locales/pt/agent.json
+++ b/client/src/locales/pt/agent.json
@@ -320,6 +320,12 @@
     "copyProject": "Copiar nome do projeto",
     "copyProjectPath": "Copiar caminho do projeto",
     "copyFailed": "Não foi possível copiar",
+    "copyTranscript": "Copiar transcrição",
+    "copyTranscriptSuccess": "Transcrição copiada",
+    "copyTranscriptFailed": "Não foi possível copiar a transcrição",
+    "exportTranscript": "Exportar transcrição (.txt)",
+    "exportTranscriptSuccess": "Exportação da transcrição iniciada",
+    "exportTranscriptFailed": "Não foi possível exportar a transcrição",
     "delete": "Excluir missão",
     "deleteConfirm": "Excluir esta missão? Não pode ser desfeito.",
     "deleteFailed": "Não foi possível excluir a missão"

--- a/client/src/locales/zh/agent.json
+++ b/client/src/locales/zh/agent.json
@@ -320,6 +320,12 @@
     "copyProject": "复制项目名称",
     "copyProjectPath": "复制项目路径",
     "copyFailed": "无法复制",
+    "copyTranscript": "复制转录",
+    "copyTranscriptSuccess": "转录已复制",
+    "copyTranscriptFailed": "无法复制转录",
+    "exportTranscript": "导出转录 (.txt)",
+    "exportTranscriptSuccess": "转录导出已开始",
+    "exportTranscriptFailed": "无法导出转录",
     "delete": "删除任务",
     "deleteConfirm": "删除此任务？此操作无法撤销。",
     "deleteFailed": "无法删除任务"

--- a/openspec/changes/archive/2026-07-07-add-mission-transcript-export-copy-actions/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-07-add-mission-transcript-export-copy-actions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-07

--- a/openspec/changes/archive/2026-07-07-add-mission-transcript-export-copy-actions/design.md
+++ b/openspec/changes/archive/2026-07-07-add-mission-transcript-export-copy-actions/design.md
@@ -1,0 +1,113 @@
+# Design - add-mission-transcript-export-copy-actions
+
+## Context
+Agent Mode already renders the active mission title bar in `client/src/components/agent-chat/AgentConversationHeader.tsx`, including rename, favorite, delete, and metadata-copy actions in a hand-rolled overflow menu. The component has access to `active` from `useAgentChat()` and pinned project data from `useDesktop()`, and the ticket requires adding transcript actions without changing server persistence, Board-mode mission selection, or existing menu behavior.
+
+Scope: frontend
+
+## Goal
+Add observable copy-all and `.txt` export actions for the currently loaded active mission transcript from the Agent Mode title overflow menu.
+
+## Non-Goals
+- Do not add server routes, database records, or persistent exported-file management.
+- Do not add export formats beyond plain text.
+- Do not add controls to `AgentMissionSelector` or other Board-mode menus.
+- Do not render attachments or binary content beyond text already present on messages.
+- Do not reorder or change the semantics of rename, favorite, delete, or existing metadata-copy actions.
+
+## Design
+
+### Architecture
+Keep the feature local to `AgentConversationHeader.tsx`. Extend the `useAgentChat()` destructure to include `messages`, add a pure exported formatter helper near the component, then add two menu buttons that call small handlers for clipboard copy and object-URL download.
+
+Data flow:
+
+```text
+useAgentChat() active + messages
+useDesktop() projects -> pinned project lookup
+          |
+          v
+formatMissionTranscript(active, messages, project, exportedAt?)
+          |
+          +--> navigator.clipboard.writeText(...)
+          +--> Blob(["..."], { type: "text/plain;charset=utf-8" }) + anchor.download
+```
+
+The formatter should be deterministic for tests by accepting an optional timestamp or options object while defaulting to `new Date().toISOString()` in production handlers. It should preserve the message order as supplied by `messages`; the acceptance criteria define this as chronological order because the current hook's loaded message array is already the active conversation stream.
+
+### Data shapes
+
+```ts
+type TranscriptProject = {
+  name?: string | null
+  path?: string | null
+}
+```
+
+```ts
+type TranscriptOptions = {
+  exportedAt?: string
+}
+```
+
+```ts
+type AgentMessage = {
+  id: string
+  conversation_id: string
+  role: string
+  content: string
+  attachment_ids?: string[]
+  context_refs?: unknown
+  created_at: string
+}
+```
+
+The implementation should use the existing conversation and project shapes rather than introducing app-wide exported types unless TypeScript requires a local structural type.
+
+### State & lifecycle
+The feature adds no durable state. `handleCopyTranscript()` and `handleExportTranscript()` should close the menu before attempting their action, surface localized failures through `toast.error`, and leave `active`, `messages`, and the current mission selection unchanged. Copy success should follow the existing `copied` state pattern with a new key such as `transcript`; export success may show a localized toast so users know the browser download was triggered.
+
+### Public API / surface
+
+```ts
+export function formatMissionTranscript(
+  active: AgentConversationLike,
+  messages: AgentMessage[],
+  project?: TranscriptProject | null,
+  options?: TranscriptOptions,
+): string
+```
+
+The helper is exported from `AgentConversationHeader.tsx` for focused unit coverage. It returns plain text only and never JSX.
+
+```ts
+function handleCopyTranscript(): Promise<void>
+function handleExportTranscript(): void
+```
+
+These remain component-local handlers. Add menu controls with stable test ids, for example `agent-conv-copy-transcript` and `agent-conv-export-transcript`.
+
+```ts
+function safeTranscriptFilename(title: string | null | undefined, id: string): string
+```
+
+This may be component-local or a small exported helper if the tests need direct coverage. It should derive a lower-case safe slug from the mission title and fall back to the mission id when the title is empty or slugifies to nothing.
+
+## Trade-offs
+
+| Option | Pros | Cons | Chosen? |
+|---|---|---|---|
+| Keep formatter and handlers in `AgentConversationHeader.tsx` | Minimal blast radius, matches the ticket contract, easy colocated tests | Header file grows slightly | Yes |
+| Move transcript logic to a new shared lib file | Cleaner separation if other export surfaces appear later | Premature public surface and more files for a single menu feature | No |
+| Use browser download via Blob/object URL | No backend work, matches existing app export pattern | Browser download behavior must be mocked in tests | Yes |
+| Add server-side transcript endpoint | Centralized export could include unloaded messages later | Outside scope and adds backend/API risk | No |
+
+The chosen approach keeps the change client-only and local while leaving the formatter pure enough to test thoroughly.
+
+## Risks
+- Clipboard or URL APIs may be absent in the test or runtime environment; mitigate by catching failures, showing localized errors, and mocking these APIs in tests.
+- Locale files may drift if new keys differ by language; mitigate by adding identical key names under `header` in all eight `agent.json` files.
+- Menu behavior could regress if new actions disturb rename/favorite/delete ordering; mitigate by appending transcript actions near the existing copy section and extending the current header tests.
+- Filenames can become unsafe or empty for non-Latin titles; mitigate with conservative slug sanitization and mission-id fallback.
+
+## Open questions

--- a/openspec/changes/archive/2026-07-07-add-mission-transcript-export-copy-actions/proposal.md
+++ b/openspec/changes/archive/2026-07-07-add-mission-transcript-export-copy-actions/proposal.md
@@ -1,0 +1,16 @@
+# Add mission transcript export and copy actions
+
+## Why
+Users can review a mission inside Specrails, but there is no direct way to take the full chat transcript out of the app. Sharing, archiving, or pasting a mission currently requires manually selecting individual messages, which is slow and easy to get wrong.
+
+## What changes
+- Add copy-all and plain-text export actions to the active mission title overflow menu in Agent Mode.
+- Build a plain-text transcript from the active mission, loaded messages, and pinned project metadata.
+- Include mission title, mission id, project name/path when available, export timestamp, and chronological message entries with role labels, timestamps, and multiline content.
+- Add localized menu labels and success/failure toast strings to every `agent.json` locale.
+- Cover transcript formatting plus the copy-all and export actions in client tests.
+
+## Impact
+- Affected specs: agent-mode-integrations
+- Affected code: The change is contained to the Agent Mode conversation header UI, its colocated component tests, and the `agent` i18n namespace files for English, Spanish, French, German, Portuguese, Italian, Chinese, and Japanese. It reuses the existing clipboard/toast pattern in `AgentConversationHeader.tsx` and the client-side Blob/object-URL download pattern demonstrated in `ExportDropdown.tsx`.
+- Out of scope: No server-side export endpoint or persistent exported file management; no Markdown, JSON, PDF, DOCX, or rich-text export format; no export controls in the floating Board-mode `AgentMissionSelector` dropdown; no inclusion of binary attachments beyond existing message/context text references; no changes to mission deletion, rename, favorite, or existing copy metadata actions.

--- a/openspec/changes/archive/2026-07-07-add-mission-transcript-export-copy-actions/specs/agent-mode-integrations/spec.md
+++ b/openspec/changes/archive/2026-07-07-add-mission-transcript-export-copy-actions/specs/agent-mode-integrations/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Agent Mode SHALL export the active mission transcript as plain text
+
+The active Agent Mode mission title overflow menu MUST provide an action that downloads the currently loaded mission transcript as a `.txt` file.
+
+#### Scenario: Export transcript from active mission menu
+- **GIVEN** Agent Mode is showing an active mission with loaded messages
+- **WHEN** the user opens the mission title overflow menu and chooses the transcript export action
+- **THEN** the browser SHALL download a plain-text `.txt` file
+- **AND** the filename SHALL be derived from a safe slug of the mission title or fall back to the mission id
+
+#### Scenario: Exported transcript contains mission metadata and messages
+- **GIVEN** the active mission has a title, id, pinned project metadata, and loaded messages
+- **WHEN** the transcript text is generated
+- **THEN** it SHALL include the mission title, mission id, project name and path when present, and export timestamp
+- **AND** it SHALL include every currently loaded message in loaded chronological order
+- **AND** each message SHALL include a readable role label, timestamp, and plain-text content while preserving multiline message content
+
+#### Scenario: Export failure is localized and non-destructive
+- **GIVEN** Agent Mode is showing an active mission
+- **WHEN** the browser download setup fails
+- **THEN** the app SHALL show a localized export failure toast
+- **AND** the active mission and loaded messages SHALL remain unchanged
+
+### Requirement: Agent Mode SHALL copy the active mission transcript to the clipboard
+
+The active Agent Mode mission title overflow menu MUST provide an action that copies the currently loaded mission transcript to the clipboard.
+
+#### Scenario: Copy transcript from active mission menu
+- **GIVEN** Agent Mode is showing an active mission with loaded messages
+- **WHEN** the user opens the mission title overflow menu and chooses the copy transcript action
+- **THEN** the app SHALL write the full plain-text transcript to `navigator.clipboard`
+- **AND** the copied transcript SHALL use the same content format as the exported `.txt` transcript
+
+#### Scenario: Clipboard failure is localized and non-destructive
+- **GIVEN** Agent Mode is showing an active mission
+- **WHEN** writing the transcript to the clipboard fails
+- **THEN** the app SHALL show a localized copy failure toast
+- **AND** the active mission and loaded messages SHALL remain unchanged
+
+### Requirement: Mission transcript actions SHALL preserve existing header actions
+
+Adding transcript actions MUST NOT change the behavior of existing Agent Mode mission title menu actions.
+
+#### Scenario: Existing mission menu actions continue to work
+- **GIVEN** Agent Mode is showing an active mission
+- **WHEN** the user uses rename, favorite, delete, copy mission name, copy mission id, copy project name, or copy project path from the mission title menu
+- **THEN** each existing action SHALL keep its previous behavior

--- a/openspec/changes/archive/2026-07-07-add-mission-transcript-export-copy-actions/tasks.md
+++ b/openspec/changes/archive/2026-07-07-add-mission-transcript-export-copy-actions/tasks.md
@@ -1,0 +1,32 @@
+# Implementation Tasks
+
+> The developer agent runs these in order. Each "## N." block is
+> a single TDD cycle: write the failing test, run it to confirm
+> it fails, write production code, run again to confirm it
+> passes. Do NOT skip the failing-test step.
+
+## 1. Transcript formatter
+- [x] 1.1 Write a failing test in `client/src/components/agent-chat/__tests__/agent-conversation-header.test.tsx` that imports `formatMissionTranscript` and asserts the transcript includes mission title, mission id, project name/path, export timestamp, role labels, message timestamps, and multiline content in loaded order. Run `cd client && npx vitest run src/components/agent-chat/__tests__/agent-conversation-header.test.tsx`; the new test MUST fail.
+- [x] 1.2 Implement the minimum production code in `client/src/components/agent-chat/AgentConversationHeader.tsx` to export a pure `formatMissionTranscript` helper and read `messages` from `useAgentChat()`. Run the same test command; ALL tests MUST pass.
+- [x] 1.3 Refactor if needed without changing behavior. Run the same test command; all tests still pass.
+
+## 2. Copy transcript menu action
+- [x] 2.1 Write a failing test in `client/src/components/agent-chat/__tests__/agent-conversation-header.test.tsx` that opens the mission menu, activates the copy-transcript action, and asserts `navigator.clipboard.writeText` receives the full transcript and localized failure handling is used on rejection. Run `cd client && npx vitest run src/components/agent-chat/__tests__/agent-conversation-header.test.tsx`; the new test MUST fail.
+- [x] 2.2 Implement `handleCopyTranscript()` and a `agent-conv-copy-transcript` menu item in `client/src/components/agent-chat/AgentConversationHeader.tsx`, reusing the existing copied/check/toast pattern without changing existing copy-name/id/project/path behavior. Run the same test command; ALL tests MUST pass.
+- [x] 2.3 Refactor if needed without changing behavior. Run the same test command; all tests still pass.
+
+## 3. Export transcript menu action
+- [x] 3.1 Write a failing test in `client/src/components/agent-chat/__tests__/agent-conversation-header.test.tsx` that opens the mission menu, activates the export action, and asserts a `text/plain;charset=utf-8` Blob/object URL download is triggered with a safe `.txt` filename derived from the mission title, plus mission-id fallback coverage. Run `cd client && npx vitest run src/components/agent-chat/__tests__/agent-conversation-header.test.tsx`; the new test MUST fail.
+- [x] 3.2 Implement `handleExportTranscript()`, filename sanitization, and a `agent-conv-export-transcript` menu item in `client/src/components/agent-chat/AgentConversationHeader.tsx` using the same anchor/object-URL pattern as `client/src/components/ExportDropdown.tsx`. Run the same test command; ALL tests MUST pass.
+- [x] 3.3 Refactor if needed without changing behavior. Run the same test command; all tests still pass.
+
+## 4. Localized strings
+- [x] 4.1 Write or extend a failing test/check that verifies the new `header` keys exist in `client/src/locales/en/agent.json`, `client/src/locales/es/agent.json`, `client/src/locales/fr/agent.json`, `client/src/locales/de/agent.json`, `client/src/locales/pt/agent.json`, `client/src/locales/it/agent.json`, `client/src/locales/zh/agent.json`, and `client/src/locales/ja/agent.json`. Run the relevant test command; the new check MUST fail before adding keys.
+- [x] 4.2 Add identical key names for copy/export transcript labels and success/failure messages under `header` in all eight locale files. Run the relevant test command; ALL tests MUST pass.
+- [x] 4.3 Refactor if needed without changing behavior. Run the same test command; all tests still pass.
+
+## 5. Validation gate
+- [x] 5.1 Run the focused client test (`cd client && npx vitest run src/components/agent-chat/__tests__/agent-conversation-header.test.tsx`); all pass.
+- [x] 5.2 Run the full client test suite (`npm run test:client`); all pass.
+- [x] 5.3 Run the project build (`npm run build`); succeeds.
+- [x] 5.4 No `console.log`, debug prints, or commented-out code in the diff.

--- a/openspec/specs/agent-mode-integrations/spec.md
+++ b/openspec/specs/agent-mode-integrations/spec.md
@@ -87,3 +87,51 @@ Agent Mode MUST visually distinguish mission conversations that receive assistan
 - **THEN** the icon SHALL keep the static theme alert accent
 - **AND** the icon SHALL NOT run the breathing glow animation
 
+### Requirement: Agent Mode SHALL export the active mission transcript as plain text
+
+The active Agent Mode mission title overflow menu MUST provide an action that downloads the currently loaded mission transcript as a `.txt` file.
+
+#### Scenario: Export transcript from active mission menu
+- **GIVEN** Agent Mode is showing an active mission with loaded messages
+- **WHEN** the user opens the mission title overflow menu and chooses the transcript export action
+- **THEN** the browser SHALL download a plain-text `.txt` file
+- **AND** the filename SHALL be derived from a safe slug of the mission title or fall back to the mission id
+
+#### Scenario: Exported transcript contains mission metadata and messages
+- **GIVEN** the active mission has a title, id, pinned project metadata, and loaded messages
+- **WHEN** the transcript text is generated
+- **THEN** it SHALL include the mission title, mission id, project name and path when present, and export timestamp
+- **AND** it SHALL include every currently loaded message in loaded chronological order
+- **AND** each message SHALL include a readable role label, timestamp, and plain-text content while preserving multiline message content
+
+#### Scenario: Export failure is localized and non-destructive
+- **GIVEN** Agent Mode is showing an active mission
+- **WHEN** the browser download setup fails
+- **THEN** the app SHALL show a localized export failure toast
+- **AND** the active mission and loaded messages SHALL remain unchanged
+
+### Requirement: Agent Mode SHALL copy the active mission transcript to the clipboard
+
+The active Agent Mode mission title overflow menu MUST provide an action that copies the currently loaded mission transcript to the clipboard.
+
+#### Scenario: Copy transcript from active mission menu
+- **GIVEN** Agent Mode is showing an active mission with loaded messages
+- **WHEN** the user opens the mission title overflow menu and chooses the copy transcript action
+- **THEN** the app SHALL write the full plain-text transcript to `navigator.clipboard`
+- **AND** the copied transcript SHALL use the same content format as the exported `.txt` transcript
+
+#### Scenario: Clipboard failure is localized and non-destructive
+- **GIVEN** Agent Mode is showing an active mission
+- **WHEN** writing the transcript to the clipboard fails
+- **THEN** the app SHALL show a localized copy failure toast
+- **AND** the active mission and loaded messages SHALL remain unchanged
+
+### Requirement: Mission transcript actions SHALL preserve existing header actions
+
+Adding transcript actions MUST NOT change the behavior of existing Agent Mode mission title menu actions.
+
+#### Scenario: Existing mission menu actions continue to work
+- **GIVEN** Agent Mode is showing an active mission
+- **WHEN** the user uses rename, favorite, delete, copy mission name, copy mission id, copy project name, or copy project path from the mission title menu
+- **THEN** each existing action SHALL keep its previous behavior
+


### PR DESCRIPTION
This pull request delivers 1 ticket (#7) implemented by the **Implement** run against `main`. Each ticket below describes the problem it addresses, the approach taken, and the test files touched by its diff.

## #7 — Add mission transcript export and copy actions

**Problem**

Users can review a mission inside Specrails, but there is no direct way to take the full chat transcript out of the app. When they need to share a mission with another tool, archive it, or paste it into a document, they currently have to manually select individual messages, which is slow and error-prone.

**Solution**

**Proposed Solution** — Extend `client/src/components/agent-chat/AgentConversationHeader.tsx`, where the active mission title bar and `⋮` overflow menu already live, with two new actions: export the active mission as a plain-text `.txt` transcript and copy all mission messages to the clipboard. Build the transcript from the current `active`, `messages`, and pinned project data exposed through `useAgentChat()` and `useDesktop()`, including a compact header with mission title, mission id, project name/path when present, export timestamp, then messages in chronological order with role labels and timestamps. Reuse the existing clipboard/toast pattern already present in `AgentConversationHeader.tsx` for copy feedback, and use the browser Blob/object URL download pattern already used by `client/src/components/ExportDropdown.tsx` for the text-file export. Add localized labels, success …

<details>
<summary>Full spec digest</summary>

**Proposed Solution** — Extend `client/src/components/agent-chat/AgentConversationHeader.tsx`, where the active mission title bar and `⋮` overflow menu already live, with two new actions: export the active mission as a plain-text `.txt` transcript and copy all mission messages to the clipboard. Build the transcript from the current `active`, `messages`, and pinned project data exposed through `useAgentChat()` and `useDesktop()`, including a compact header with mission title, mission id, project name/path when present, export timestamp, then messages in chronological order with role labels and timestamps. Reuse the existing clipboard/toast pattern already present in `AgentConversationHeader.tsx` for copy feedback, and use the browser Blob/object URL download pattern already used by `client/src/components/ExportDropdown.tsx` for the text-file export. Add localized labels, success messages, and failure messages under the `header` section in every app language file: `client/src/locales/en/agent.json`, `client/src/locales/es/agent.json`, `client/src/locales/fr/agent.json`, `client/src/locales/de/agent.json`, `client/src/locales/pt/agent.json`, `client/src/locales/it/agent.json`, `client/src/locales/zh/agent.json`, and `client/src/locales/ja/agent.json`.

</details>

**Tests**

- `client/src/components/__tests__/ProjectWorktreeEnvSection.test.tsx`
- `client/src/components/agent-chat/__tests__/agent-conversation-header.test.tsx`
- `client/src/components/settings/__tests__/ProjectSettingsDialog.test.tsx`
- `client/src/pages/__tests__/SettingsPage.test.tsx`
- `server/mcp/tools/catalog.test.ts`
- `server/path-resolver.test.ts`
- `server/project-env.test.ts`
- `server/project-router.test.ts`
- `server/workspace-resolution.test.ts`
- `server/worktree-env-discovery.test.ts`

## Changes

- `feat/7-add-mission-transcript-export-and-copy` — 46 files changed, +1678 −43