### PR TITLE
fix(env): remove vendor-specific package hints

### DIFF
--- a/server/mcp/tools/catalog.test.ts
+++ b/server/mcp/tools/catalog.test.ts
@@ -259,7 +259,7 @@ describe('specrails_env tool', () => {
   it('auto_configure scans the repo and merges discovered package-token candidates', async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'specrails-mcp-env-'))
     fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({
-      dependencies: { '@busuu/design-system': '1.0.0' },
+      dependencies: { '@acme/design-system': '1.0.0' },
     }))
     ctx = makeCtx(db, tmpDir)
     const fetchMock = mockSettingsFetch(['AWS_PROFILE'])

--- a/server/mcp/tools/env.ts
+++ b/server/mcp/tools/env.ts
@@ -20,7 +20,7 @@ export function envTools(): McpToolSpec[] {
       title: 'Project worktree environment',
       description:
         'Read, scan, and configure the per-project environment variable NAME allowlist used for rail jobs and isolated loop worktrees. ' +
-        'Values are never read or stored by this tool; runs read them from the server environment and can recover configured names from the login shell when the desktop process is missing them. scan inspects safe repo config files such as package.json, .npmrc, .yarnrc.yml and pnpm-workspace.yaml for ${VAR} / process.env.VAR references and private @busuu/* package hints. ' +
+        'Values are never read or stored by this tool; runs read them from the server environment and can recover configured names from the login shell when the desktop process is missing them. scan inspects safe repo config files such as package.json, .npmrc, .yarnrc.yml and pnpm-workspace.yaml for ${VAR} / process.env.VAR references and private scoped package auth hints. ' +
         'Actions: get (read current names), scan (discover candidates), set (write names), auto_configure (scan then merge discovered names into settings).',
       hintTier: 'read',
       tier: (args) => (args.action === 'set' || args.action === 'auto_configure' ? 'write' : 'read'),

--- a/server/project-env.test.ts
+++ b/server/project-env.test.ts
@@ -9,13 +9,13 @@ describe('project-env worktree passthrough', () => {
 
     const env = resolveWorktreeEnvPassthrough(db, {
       NODE_AUTH_TOKEN: 'npm-secret',
-      AWS_PROFILE: 'busuu-dev',
+      AWS_PROFILE: 'dev-profile',
       OTHER_SECRET: 'must-not-pass',
     })
 
     expect(env).toEqual({
       NODE_AUTH_TOKEN: 'npm-secret',
-      AWS_PROFILE: 'busuu-dev',
+      AWS_PROFILE: 'dev-profile',
     })
   })
 

--- a/server/worktree-env-discovery.test.ts
+++ b/server/worktree-env-discovery.test.ts
@@ -25,7 +25,7 @@ describe('scanWorktreeEnvRequirements', () => {
     fs.writeFileSync(path.join(repo, 'package.json'), JSON.stringify({
       scripts: { build: 'node -e "console.log(process.env.AWS_PROFILE)"' },
       dependencies: {
-        '@busuu/design-system': '1.0.0',
+        '@acme/design-system': '1.0.0',
         react: '^18.0.0',
       },
     }, null, 2))

--- a/server/worktree-env-discovery.ts
+++ b/server/worktree-env-discovery.ts
@@ -49,6 +49,25 @@ const SKIP_DIRS = new Set([
 const ENV_REF_RE =
   /\$\{([A-Za-z_][A-Za-z0-9_]*)\}|process\.env\.([A-Za-z_][A-Za-z0-9_]*)|process\.env\[['"]([A-Za-z_][A-Za-z0-9_]*)['"]\]/g
 
+const COMMON_PUBLIC_NPM_SCOPES = new Set([
+  '@babel',
+  '@codemirror',
+  '@eslint',
+  '@modelcontextprotocol',
+  '@monaco-editor',
+  '@radix-ui',
+  '@rolldown',
+  '@rollup',
+  '@tailwindcss',
+  '@tauri-apps',
+  '@testing-library',
+  '@types',
+  '@typescript-eslint',
+  '@vitejs',
+  '@vitest',
+  '@xterm',
+])
+
 function addCandidate(
   map: Map<string, EnvDiscoveryCandidate>,
   name: string,
@@ -125,6 +144,10 @@ function packageScopes(pkg: Record<string, unknown>): Set<string> {
   return scopes
 }
 
+function likelyPrivatePackageScopes(scopes: Set<string>): string[] {
+  return Array.from(scopes).filter((scope) => !COMMON_PUBLIC_NPM_SCOPES.has(scope)).sort()
+}
+
 function scanPackageJson(raw: string, rel: string, candidates: Map<string, EnvDiscoveryCandidate>): void {
   let pkg: Record<string, unknown>
   try {
@@ -132,10 +155,10 @@ function scanPackageJson(raw: string, rel: string, candidates: Map<string, EnvDi
   } catch {
     return
   }
-  const scopes = packageScopes(pkg)
-  if (scopes.has('@busuu')) {
-    addCandidate(candidates, 'NODE_AUTH_TOKEN', 'medium', 'Package dependencies include @busuu/* scoped packages', rel)
-    addCandidate(candidates, 'NPM_TOKEN', 'medium', 'Package dependencies include @busuu/* scoped packages', rel)
+  const privateScopes = likelyPrivatePackageScopes(packageScopes(pkg))
+  if (privateScopes.length > 0) {
+    addCandidate(candidates, 'NODE_AUTH_TOKEN', 'medium', 'Package dependencies include scoped packages that may require npm auth', rel)
+    addCandidate(candidates, 'NPM_TOKEN', 'medium', 'Package dependencies include scoped packages that may require npm auth', rel)
   }
 }
 


### PR DESCRIPTION
## Summary
- remove vendor-specific package-scope hints from worktree env discovery
- replace hardcoded scoped package example fixtures with neutral examples
- keep npm auth discovery via generic likely-private scoped package detection

## Verification
- rg --hidden --no-ignore -n -i "busuu" . -g '!.git/**'
- npx vitest run server/worktree-env-discovery.test.ts server/project-env.test.ts server/mcp/tools/catalog.test.ts
- npm run typecheck
- npm test
- npm run build

Release note: no user-facing feature change; removes vendor-specific references and keeps env auto-config behavior generic.