### PR TITLE
Fix Headroom managed install runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ build/
 # specrails
 .claude/agent-memory/
 .specrails/
+.tokensave/
 
 # macOS
 .DS_Store

--- a/cli/specrails-desktop.test.ts
+++ b/cli/specrails-desktop.test.ts
@@ -180,6 +180,15 @@ describe('httpGet', () => {
     expect(res.status).toBe(200); expect(JSON.parse(res.body)).toEqual({ ok: true })
   })
   it('rejects on connection error', async () => { await expect(_internal.httpGet('http://127.0.0.1:19999/nope')).rejects.toThrow() })
+  it('rejects when the response stalls past the request timeout', async () => {
+    server = http.createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.write('{"partial":')
+    })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()))
+    port = (server.address() as net.AddressInfo).port
+    await expect(_internal.httpGet(`http://127.0.0.1:${port}/stall`, 25)).rejects.toThrow(/timed out/)
+  })
 })
 
 describe('httpPost', () => {
@@ -189,6 +198,16 @@ describe('httpPost', () => {
     ;({ server, port } = await createMockServer([{ method: 'POST', path: '/submit', status: 201, body: { created: true } }]))
     const res = await _internal.httpPost(`http://127.0.0.1:${port}/submit`, { data: 'hello' })
     expect(res.status).toBe(201); expect(JSON.parse(res.body)).toEqual({ created: true })
+  })
+  it('rejects when the response stalls past the request timeout', async () => {
+    server = http.createServer((req, res) => {
+      req.resume()
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.write('{"partial":')
+    })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()))
+    port = (server.address() as net.AddressInfo).port
+    await expect(_internal.httpPost(`http://127.0.0.1:${port}/stall`, { ok: true }, 25)).rejects.toThrow(/timed out/)
   })
 })
 

--- a/cli/specrails-desktop.ts
+++ b/cli/specrails-desktop.ts
@@ -31,6 +31,7 @@ import fs from 'fs'
 
 const DEFAULT_PORT = 4200
 const DETECTION_TIMEOUT_MS = 500
+const HTTP_REQUEST_TIMEOUT_MS = 15_000
 
 export const KNOWN_VERBS = new Set([
   'implement',
@@ -282,7 +283,11 @@ function loadDesktopToken(): string | null {
   return null
 }
 
-function httpGet(url: string): Promise<{ status: number; body: string }> {
+function requestTimeoutError(url: string, timeoutMs: number): Error {
+  return new Error(`Request to ${url} timed out after ${timeoutMs}ms`)
+}
+
+function httpGet(url: string, timeoutMs = HTTP_REQUEST_TIMEOUT_MS): Promise<{ status: number; body: string }> {
   return new Promise((resolve, reject) => {
     const token = loadDesktopToken()
     const parsed = new URL(url)
@@ -299,11 +304,14 @@ function httpGet(url: string): Promise<{ status: number; body: string }> {
       res.on('data', (chunk) => { body += chunk })
       res.on('end', () => resolve({ status: res.statusCode ?? 0, body }))
     })
+    req.setTimeout(timeoutMs, () => {
+      req.destroy(requestTimeoutError(url, timeoutMs))
+    })
     req.on('error', reject)
   })
 }
 
-function httpPost(url: string, payload: unknown): Promise<{ status: number; body: string }> {
+function httpPost(url: string, payload: unknown, timeoutMs = HTTP_REQUEST_TIMEOUT_MS): Promise<{ status: number; body: string }> {
   return new Promise((resolve, reject) => {
     const data = JSON.stringify(payload)
     const urlObj = new URL(url)
@@ -324,6 +332,9 @@ function httpPost(url: string, payload: unknown): Promise<{ status: number; body
       let body = ''
       res.on('data', (chunk) => { body += chunk })
       res.on('end', () => resolve({ status: res.statusCode ?? 0, body }))
+    })
+    req.setTimeout(timeoutMs, () => {
+      req.destroy(requestTimeoutError(url, timeoutMs))
     })
     req.on('error', reject)
     req.write(data)
@@ -1332,5 +1343,5 @@ export const _internal = {
   httpGet, httpPost, formatJobDuration, formatJobStarted, printVersion, printHelp,
   handleStatus, handleJobs, handleDesktop, desktopStart, desktopStop, desktopStatus, desktopAdd, desktopRemove, desktopList, desktopServerPath,
   resolveProjectFromCwd, runViaWebManager, runDirect, isPortInUse, readPid, isProcessRunning, main,
-  isTTY, DESKTOP_PID_FILE, DESKTOP_LOG_FILE, EXIT_PATTERN, DEFAULT_PORT, DETECTION_TIMEOUT_MS,
+  isTTY, DESKTOP_PID_FILE, DESKTOP_LOG_FILE, EXIT_PATTERN, DEFAULT_PORT, DETECTION_TIMEOUT_MS, HTTP_REQUEST_TIMEOUT_MS,
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "check-core-compat": "tsx scripts/check-core-compat.ts",
     "test": "vitest run && tsx scripts/check-core-compat.ts",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage",
+    "test:coverage": "vitest run --coverage --maxWorkers=1 --reporter=dot --bail=1",
     "test:client": "cd client && npx vitest run",
     "test:all": "vitest run && cd client && npx vitest run",
     "ci": "npm run typecheck && npm run check-core-compat && npm run test:coverage && cd client && npm run test:coverage"

--- a/server/contract-refine-runner.test.ts
+++ b/server/contract-refine-runner.test.ts
@@ -581,6 +581,7 @@ describe('BUG-PARSER-01: readRefineChildOutput timeout teardown', () => {
     const result = await readRefineChildOutput(child as unknown as ChildProcess, 20, kill)
     expect(result.timedOut).toBe(true)
     expect(result.code).toBeNull()
+    expect(child.stdout.destroyed).toBe(true)
     // SIGTERM fired immediately against the whole subtree (not a bare child.kill).
     expect(kills.some((k) => k.pid === 4242 && k.signal === 'SIGTERM')).toBe(true)
     // SIGKILL escalation fires after the 2s grace window.

--- a/server/contract-refine-runner.ts
+++ b/server/contract-refine-runner.ts
@@ -232,16 +232,26 @@ export function readRefineChildOutput(
       resolve({ fullText, resultEvent, code: -1, timedOut: false })
       return
     }
+    const stdout = child.stdout
     let stderrBuf = ''
-    if (child.stderr) {
-      child.stderr.on('data', (chunk: Buffer | string) => {
-        const s = typeof chunk === 'string' ? chunk : chunk.toString('utf-8')
-        stderrBuf += s
-        if (stderrBuf.length > 8192) stderrBuf = stderrBuf.slice(-8192)
-      })
+    const onStderrData = (chunk: Buffer | string) => {
+      const s = typeof chunk === 'string' ? chunk : chunk.toString('utf-8')
+      stderrBuf += s
+      if (stderrBuf.length > 8192) stderrBuf = stderrBuf.slice(-8192)
     }
+    if (child.stderr) child.stderr.on('data', onStderrData)
     let killEscalation: NodeJS.Timeout | null = null
-    const reader = createInterface({ input: child.stdout, crlfDelay: Infinity })
+    const reader = createInterface({ input: stdout, crlfDelay: Infinity })
+    let outputClosed = false
+    const closeOutputReaders = () => {
+      if (outputClosed) return
+      outputClosed = true
+      reader.removeAllListeners('line')
+      try { reader.close() } catch { /* already closed */ }
+      if (child.stderr) child.stderr.off('data', onStderrData)
+      if (!stdout.destroyed) stdout.destroy()
+      if (child.stderr && !child.stderr.destroyed) child.stderr.destroy()
+    }
     reader.on('line', (line: string) => {
       let parsed: Record<string, unknown> | null = null
       try { parsed = JSON.parse(line) } catch { return }
@@ -262,6 +272,7 @@ export function readRefineChildOutput(
       // BUG-PARSER-01: treeKill the whole subtree (SIGTERM) and SIGKILL-escalate
       // after a grace window so a signal-swallowing CLI tree is force-killed.
       killEscalation = escalateKill(child.pid, kill)
+      closeOutputReaders()
       if (!settled) {
         settled = true
         resolve({ fullText, resultEvent, code: null, timedOut: true })
@@ -272,6 +283,7 @@ export function readRefineChildOutput(
       // The child exited (possibly because SIGTERM was honoured) — cancel the
       // pending SIGKILL escalation.
       if (killEscalation) { clearTimeout(killEscalation); killEscalation = null }
+      closeOutputReaders()
       if (settled) return
       settled = true
       if (code !== 0 && stderrBuf) {
@@ -282,6 +294,7 @@ export function readRefineChildOutput(
     child.on('error', (err) => {
       clearTimeout(timer)
       if (killEscalation) { clearTimeout(killEscalation); killEscalation = null }
+      closeOutputReaders()
       console.log(`[contract-refine-runner] child error: ${(err as Error).message}; stderr=${JSON.stringify(stderrBuf.slice(-2000))}`)
       if (settled) return
       settled = true

--- a/server/explore-cwd-manager.test.ts
+++ b/server/explore-cwd-manager.test.ts
@@ -36,6 +36,17 @@ describe('explore-cwd-manager', () => {
     expect(p).toBe('/tmp/foo/myslug/explore-cwd')
   })
 
+  it('exploreCwdPathFor uses SPECRAILS_REGISTRY_HOME when no baseDir is passed', () => {
+    const previous = process.env.SPECRAILS_REGISTRY_HOME
+    process.env.SPECRAILS_REGISTRY_HOME = baseDir
+    try {
+      expect(exploreCwdPathFor('myslug')).toBe(path.join(baseDir, '.specrails', 'projects', 'myslug', 'explore-cwd'))
+    } finally {
+      if (previous !== undefined) process.env.SPECRAILS_REGISTRY_HOME = previous
+      else delete process.env.SPECRAILS_REGISTRY_HOME
+    }
+  })
+
   it('renderExploreClaudeMd interpolates the project name', () => {
     const out = renderExploreClaudeMd('Acme')
     expect(out).toContain('"Acme"')

--- a/server/explore-cwd-manager.ts
+++ b/server/explore-cwd-manager.ts
@@ -12,7 +12,7 @@ import type { ProviderAdapter, ProviderId } from './providers/types'
  * provider behaviour (instructions file is adapter-driven: CLAUDE.md for
  * claude, AGENTS.md for codex).
  *
- * Layout under `~/.specrails/projects/<slug>/explore-cwd/`:
+ * Layout under `<specrails-home>/.specrails/projects/<slug>/explore-cwd/`:
  *   ├── <adapter.instructionsFilename>  — embedded mini-prompt, app-owned
  *   ├── project                          — symlink/junction → <project.path>
  *   └── project-path.txt                 — fallback when symlink creation fails
@@ -95,12 +95,16 @@ export interface ExploreCwdInput {
   provider?: ProviderId
 }
 
+function homeDir(): string {
+  return process.env.SPECRAILS_REGISTRY_HOME || os.homedir()
+}
+
 /**
  * Compute the explore-cwd path for a project without touching the filesystem.
  * Used by the legacy-cwd env-var short-circuit and by tests.
  */
 export function exploreCwdPathFor(slug: string, baseDir?: string): string {
-  const base = baseDir ?? path.join(os.homedir(), '.specrails', 'projects')
+  const base = baseDir ?? path.join(homeDir(), '.specrails', 'projects')
   return path.join(base, slug, 'explore-cwd')
 }
 
@@ -111,7 +115,7 @@ export function exploreCwdPathFor(slug: string, baseDir?: string): string {
  * When SPECRAILS_EXPLORE_LEGACY_CWD=1 is set, returns `projectPath` directly
  * and performs no filesystem IO — used as the rollback escape hatch.
  *
- * Pass `baseDir` for tests to redirect away from the user's home directory.
+ * Pass `baseDir` for tests that need a specific projects directory.
  */
 export function ensureExploreCwd(input: ExploreCwdInput, baseDir?: string): string {
   if (process.env.SPECRAILS_EXPLORE_LEGACY_CWD === '1') {

--- a/server/headroom-manager.test.ts
+++ b/server/headroom-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
@@ -49,6 +49,11 @@ exit 0
 describe('HeadroomManager', () => {
   let db: DbInstance | null = null
   let tempDir: string | null = null
+  let previousRegistryHome: string | undefined
+
+  beforeEach(() => {
+    previousRegistryHome = process.env.SPECRAILS_REGISTRY_HOME
+  })
 
   afterEach(() => {
     vi.restoreAllMocks()
@@ -56,10 +61,13 @@ describe('HeadroomManager', () => {
     db = null
     if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true })
     tempDir = null
+    if (previousRegistryHome === undefined) delete process.env.SPECRAILS_REGISTRY_HOME
+    else process.env.SPECRAILS_REGISTRY_HOME = previousRegistryHome
   })
 
   it('installs Headroom with an isolated uv-managed Python runtime', () => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'headroom-tools-'))
+    process.env.SPECRAILS_REGISTRY_HOME = tempDir
     vi.spyOn(os, 'homedir').mockReturnValue(tempDir)
 
     const plan = getHeadroomManagedInstallPlan()
@@ -100,6 +108,7 @@ describe('HeadroomManager', () => {
   it('prepares managed Python before installing the Headroom tool', async () => {
     db = initDesktopDb(':memory:')
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'headroom-install-'))
+    process.env.SPECRAILS_REGISTRY_HOME = tempDir
     vi.spyOn(os, 'homedir').mockReturnValue(tempDir)
 
     const previousRuntimePath = process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH
@@ -155,6 +164,7 @@ describe('HeadroomManager', () => {
     db = initDesktopDb(':memory:')
     const fake = makeHeadroomExe()
     tempDir = fake.dir
+    process.env.SPECRAILS_REGISTRY_HOME = tempDir
     setDesktopSetting(db, STATE_KEY, JSON.stringify({
       installed: true,
       version: '0.30.0',
@@ -194,6 +204,7 @@ describe('HeadroomManager', () => {
     db = initDesktopDb(':memory:')
     const fake = makeHeadroomExe()
     tempDir = fake.dir
+    process.env.SPECRAILS_REGISTRY_HOME = tempDir
     setDesktopSetting(db, STATE_KEY, JSON.stringify({
       installed: true,
       version: '0.30.0',

--- a/server/headroom-manager.test.ts
+++ b/server/headroom-manager.test.ts
@@ -3,10 +3,26 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import { initDesktopDb, setDesktopSetting } from './desktop-db'
-import { HeadroomManager } from './headroom-manager'
+import {
+  HEADROOM_MANAGED_PYTHON_VERSION,
+  HeadroomManager,
+  getHeadroomManagedInstallPlan,
+} from './headroom-manager'
 import type { DbInstance } from './db'
 
 const STATE_KEY = 'plugins.headroom.state'
+
+type HeadroomManagerTestHarness = {
+  runCommand: (
+    command: string,
+    args: string[],
+    env: Record<string, string>,
+    logs: string[],
+  ) => Promise<{ code: number | null }>
+  runCommandCapture: () => Promise<{ code: number; output: string }>
+  readHeadroomVersion: () => string
+  detectProviderRoutes: () => Record<'codex' | 'claude', boolean>
+}
 
 function makeHeadroomExe(): { dir: string; exe: string } {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'headroom-manager-'))
@@ -40,6 +56,99 @@ describe('HeadroomManager', () => {
     db = null
     if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true })
     tempDir = null
+  })
+
+  it('installs Headroom with an isolated uv-managed Python runtime', () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'headroom-tools-'))
+    vi.spyOn(os, 'homedir').mockReturnValue(tempDir)
+
+    const plan = getHeadroomManagedInstallPlan()
+
+    expect(plan.pythonVersion).toBe(HEADROOM_MANAGED_PYTHON_VERSION)
+    expect(plan.pythonInstallArgs).toEqual([
+      'python',
+      'install',
+      '3.12',
+      '--managed-python',
+    ])
+    expect(plan.toolInstallArgs).toEqual([
+      'tool',
+      'install',
+      '--python',
+      '3.12',
+      '--managed-python',
+      '--force',
+      'headroom-ai[all]',
+    ])
+    expect(plan.env).toMatchObject({
+      UV_TOOL_DIR: path.join(tempDir, '.specrails', 'tools', 'uv', 'tools'),
+      UV_TOOL_BIN_DIR: path.join(tempDir, '.specrails', 'tools', 'bin'),
+      UV_CACHE_DIR: path.join(tempDir, '.specrails', 'tools', 'uv', 'cache'),
+      UV_PYTHON: '3.12',
+      UV_MANAGED_PYTHON: 'true',
+      UV_PYTHON_DOWNLOADS: 'automatic',
+      UV_PYTHON_PREFERENCE: 'only-managed',
+      UV_PYTHON_INSTALL_DIR: path.join(tempDir, '.specrails', 'tools', 'uv', 'python'),
+      UV_PYTHON_CACHE_DIR: path.join(tempDir, '.specrails', 'tools', 'uv', 'python-cache'),
+      UV_PYTHON_BIN_DIR: path.join(tempDir, '.specrails', 'tools', 'uv', 'python-bin'),
+      UV_PYTHON_NO_REGISTRY: 'true',
+      UV_PYTHON_INSTALL_REGISTRY: 'false',
+      UV_NO_PROGRESS: '1',
+    })
+  })
+
+  it('prepares managed Python before installing the Headroom tool', async () => {
+    db = initDesktopDb(':memory:')
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'headroom-install-'))
+    vi.spyOn(os, 'homedir').mockReturnValue(tempDir)
+
+    const previousRuntimePath = process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH
+    const runtimes = path.join(tempDir, 'runtimes')
+    const uvExe = path.join(
+      runtimes,
+      'uv',
+      process.platform === 'win32' ? 'uv.exe' : path.join('bin', 'uv'),
+    )
+    const managedBin = path.join(tempDir, '.specrails', 'tools', 'bin')
+    const headroomExe = path.join(managedBin, process.platform === 'win32' ? 'headroom.exe' : 'headroom')
+    fs.mkdirSync(path.dirname(uvExe), { recursive: true })
+    fs.mkdirSync(managedBin, { recursive: true })
+    fs.writeFileSync(uvExe, '')
+    fs.writeFileSync(headroomExe, '')
+    process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH = runtimes
+
+    try {
+      const calls: Array<{ command: string; args: string[]; env: Record<string, string> }> = []
+      const manager = new HeadroomManager(db, () => undefined, () => ['codex', 'claude'])
+      const internals = manager as unknown as HeadroomManagerTestHarness
+      internals.runCommand = async (command, args, env) => {
+        calls.push({ command, args, env })
+        return { code: 0 }
+      }
+      internals.runCommandCapture = async () => ({ code: 0, output: '{"by_client":[]}' })
+      internals.readHeadroomVersion = () => '0.30.0'
+      internals.detectProviderRoutes = () => ({ codex: false, claude: false })
+
+      const result = await manager.install()
+
+      expect(result.ok).toBe(true)
+      expect(calls[0]).toMatchObject({
+        command: uvExe,
+        args: ['python', 'install', '3.12', '--managed-python'],
+      })
+      expect(calls[1]).toMatchObject({
+        command: uvExe,
+        args: ['tool', 'install', '--python', '3.12', '--managed-python', '--force', 'headroom-ai[all]'],
+      })
+      expect(calls[1].env).toMatchObject({
+        UV_PYTHON: '3.12',
+        UV_PYTHON_PREFERENCE: 'only-managed',
+        UV_PYTHON_INSTALL_DIR: path.join(tempDir, '.specrails', 'tools', 'uv', 'python'),
+      })
+    } finally {
+      if (previousRuntimePath === undefined) delete process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH
+      else process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH = previousRuntimePath
+    }
   })
 
   it('reports the proxy as running when an active route has a healthy external proxy on the configured port', async () => {

--- a/server/headroom-manager.ts
+++ b/server/headroom-manager.ts
@@ -133,8 +133,12 @@ function nowIso(): string {
   return new Date().toISOString()
 }
 
+function specrailsHome(): string {
+  return process.env.SPECRAILS_REGISTRY_HOME || os.homedir()
+}
+
 function toolRoot(): string {
-  return path.join(os.homedir(), '.specrails', 'tools')
+  return path.join(specrailsHome(), '.specrails', 'tools')
 }
 
 function uvToolDir(): string {

--- a/server/headroom-manager.ts
+++ b/server/headroom-manager.ts
@@ -111,6 +111,7 @@ type Broadcast = (msg: WsMessage) => void
 
 const STATE_KEY = 'plugins.headroom.state'
 const DEFAULT_PORT = 8787
+export const HEADROOM_MANAGED_PYTHON_VERSION = '3.12'
 
 interface PersistedHeadroomState {
   installed?: boolean
@@ -142,6 +143,18 @@ function uvToolDir(): string {
 
 function uvCacheDir(): string {
   return path.join(toolRoot(), 'uv', 'cache')
+}
+
+function uvPythonInstallDir(): string {
+  return path.join(toolRoot(), 'uv', 'python')
+}
+
+function uvPythonCacheDir(): string {
+  return path.join(toolRoot(), 'uv', 'python-cache')
+}
+
+function uvPythonBinDir(): string {
+  return path.join(toolRoot(), 'uv', 'python-bin')
 }
 
 function uvBinDir(): string {
@@ -272,6 +285,47 @@ function classifyInstallFailure(output: string, command: string): HeadroomIssue 
     return issue('package_resolution_failed', output, command)
   }
   return issue('unknown', output, command)
+}
+
+export function getHeadroomManagedInstallPlan(): {
+  pythonVersion: string
+  pythonInstallArgs: string[]
+  toolInstallArgs: string[]
+  env: Record<string, string>
+} {
+  return {
+    pythonVersion: HEADROOM_MANAGED_PYTHON_VERSION,
+    pythonInstallArgs: [
+      'python',
+      'install',
+      HEADROOM_MANAGED_PYTHON_VERSION,
+      '--managed-python',
+    ],
+    toolInstallArgs: [
+      'tool',
+      'install',
+      '--python',
+      HEADROOM_MANAGED_PYTHON_VERSION,
+      '--managed-python',
+      '--force',
+      'headroom-ai[all]',
+    ],
+    env: {
+      UV_TOOL_DIR: uvToolDir(),
+      UV_TOOL_BIN_DIR: uvBinDir(),
+      UV_CACHE_DIR: uvCacheDir(),
+      UV_PYTHON: HEADROOM_MANAGED_PYTHON_VERSION,
+      UV_MANAGED_PYTHON: 'true',
+      UV_PYTHON_DOWNLOADS: 'automatic',
+      UV_PYTHON_PREFERENCE: 'only-managed',
+      UV_PYTHON_INSTALL_DIR: uvPythonInstallDir(),
+      UV_PYTHON_CACHE_DIR: uvPythonCacheDir(),
+      UV_PYTHON_BIN_DIR: uvPythonBinDir(),
+      UV_PYTHON_NO_REGISTRY: 'true',
+      UV_PYTHON_INSTALL_REGISTRY: 'false',
+      UV_NO_PROGRESS: '1',
+    },
+  }
 }
 
 function classifyProxyFailure(output: string, command: string): HeadroomIssue {
@@ -479,21 +533,37 @@ export class HeadroomManager {
     fs.mkdirSync(uvToolDir(), { recursive: true })
     fs.mkdirSync(uvCacheDir(), { recursive: true })
     fs.mkdirSync(uvBinDir(), { recursive: true })
+    fs.mkdirSync(uvPythonInstallDir(), { recursive: true })
+    fs.mkdirSync(uvPythonCacheDir(), { recursive: true })
+    fs.mkdirSync(uvPythonBinDir(), { recursive: true })
 
-    const args = ['tool', 'install', 'headroom-ai[all]', '--force']
-    const command = `${uv} ${args.join(' ')}`
-    const logs: string[] = [`Running ${command}`]
+    const plan = getHeadroomManagedInstallPlan()
+    const pythonCommand = `${uv} ${plan.pythonInstallArgs.join(' ')}`
+    const installCommand = `${uv} ${plan.toolInstallArgs.join(' ')}`
+    const logs: string[] = [
+      `Ensuring Headroom Python runtime (CPython ${plan.pythonVersion})`,
+      `Running ${pythonCommand}`,
+    ]
     this.emit('installing', logs[0])
+    this.emit('installing', logs[1])
 
-    const result = await this.runCommand(uv, args, {
-      UV_TOOL_DIR: uvToolDir(),
-      UV_TOOL_BIN_DIR: uvBinDir(),
-      UV_CACHE_DIR: uvCacheDir(),
-      UV_NO_PROGRESS: '1',
-    }, logs)
+    const pythonResult = await this.runCommand(uv, plan.pythonInstallArgs, plan.env, logs)
+    if (pythonResult.code !== 0) {
+      const failure = classifyInstallFailure(logs.join('\n'), pythonCommand)
+      this.updatePersisted({ lastIssue: failure })
+      this.emit('failed', failure.title)
+      return { ok: false, state: this.getState(), issue: failure, logs }
+    }
+
+    logs.push(`Installing Headroom with managed CPython ${plan.pythonVersion}`)
+    logs.push(`Running ${installCommand}`)
+    this.emit('installing', logs[logs.length - 2])
+    this.emit('installing', logs[logs.length - 1])
+
+    const result = await this.runCommand(uv, plan.toolInstallArgs, plan.env, logs)
 
     if (result.code !== 0) {
-      const failure = classifyInstallFailure(logs.join('\n'), command)
+      const failure = classifyInstallFailure(logs.join('\n'), installCommand)
       this.updatePersisted({ lastIssue: failure })
       this.emit('failed', failure.title)
       return { ok: false, state: this.getState(), issue: failure, logs }
@@ -502,7 +572,7 @@ export class HeadroomManager {
     const exe = this.resolveHeadroomInstall(null, false)?.path ?? null
     const version = exe ? this.readHeadroomVersion(exe) : null
     if (!exe || !version) {
-      const failure = issue('headroom_not_found_after_install', logs.join('\n'), command)
+      const failure = issue('headroom_not_found_after_install', logs.join('\n'), installCommand)
       this.updatePersisted({ lastIssue: failure })
       this.emit('failed', failure.title)
       return { ok: false, state: this.getState(), issue: failure, logs }
@@ -659,6 +729,9 @@ export class HeadroomManager {
       toolDir: uvToolDir(),
       binDir: uvBinDir(),
       cacheDir: uvCacheDir(),
+      pythonInstallDir: uvPythonInstallDir(),
+      pythonBinDir: uvPythonBinDir(),
+      pythonCacheDir: uvPythonCacheDir(),
       proxyTail: this.proxyTail.slice(-4000),
       installSource: state.installSource,
       detectedRoutes: state.detectedRoutes,

--- a/server/terminal-shell-integration.test.ts
+++ b/server/terminal-shell-integration.test.ts
@@ -14,14 +14,19 @@ const ENABLED = { shellIntegrationEnabled: true }
 const DISABLED = { shellIntegrationEnabled: false }
 
 let tmpHome: string
+let originalRegistryHome: string | undefined
 
 beforeEach(() => {
+  originalRegistryHome = process.env.SPECRAILS_REGISTRY_HOME
+  delete process.env.SPECRAILS_REGISTRY_HOME
   tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sr-shim-test-'))
   vi.spyOn(os, 'homedir').mockReturnValue(tmpHome)
 })
 
 afterEach(() => {
   vi.restoreAllMocks()
+  if (originalRegistryHome !== undefined) process.env.SPECRAILS_REGISTRY_HOME = originalRegistryHome
+  else delete process.env.SPECRAILS_REGISTRY_HOME
   try { fs.rmSync(tmpHome, { recursive: true, force: true }) } catch { /* ignore */ }
 })
 
@@ -29,6 +34,16 @@ describe('composeShellIntegrationSpawn', () => {
   it('returns NO_SHELL_INTEGRATION when disabled', () => {
     const got = composeShellIntegrationSpawn('/bin/zsh', 's1', 'proj', DISABLED)
     expect(got).toEqual(NO_SHELL_INTEGRATION)
+  })
+
+  it('uses SPECRAILS_REGISTRY_HOME for per-session shim directories', () => {
+    const registryHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sr-shim-registry-'))
+    process.env.SPECRAILS_REGISTRY_HOME = registryHome
+    try {
+      expect(shimDirFor('proj', 's1')).toBe(path.join(registryHome, '.specrails', 'projects', 'proj', 'terminals', 's1'))
+    } finally {
+      fs.rmSync(registryHome, { recursive: true, force: true })
+    }
   })
 
   it('zsh: writes ZDOTDIR/.zshrc and returns ZDOTDIR + real-ZDOTDIR env', () => {

--- a/server/terminal-shell-integration.ts
+++ b/server/terminal-shell-integration.ts
@@ -65,8 +65,12 @@ function warnShimMissingOnce(name: string): void {
   console.warn(`[terminal-shell-integration] bundled shim not found: ${name} — shell integration disabled for this shell`)
 }
 
+function specrailsHome(): string {
+  return process.env.SPECRAILS_REGISTRY_HOME || os.homedir()
+}
+
 function projectsRoot(): string {
-  return path.join(os.homedir(), '.specrails', 'projects')
+  return path.join(specrailsHome(), '.specrails', 'projects')
 }
 
 export function shimDirFor(projectSlug: string, sessionId: string): string {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     setupFiles: ['server/vitest-setup.ts'],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'lcov', 'html'],
+      reporter: ['text-summary', 'lcov', 'html'],
       include: ['server/**/*.ts', 'cli/**/*.ts'],
       exclude: [
         '**/*.test.ts',


### PR DESCRIPTION
## Summary
- Install Headroom with an isolated uv-managed Python runtime so Python 3.9 hosts do not break package resolution.
- Keep Headroom/tool/test home paths hermetic via SPECRAILS_REGISTRY_HOME.
- Stabilize coverage by running Vitest coverage serially, reducing noisy coverage output, adding CLI request timeouts, and closing refine child streams on timeout.

## Validation
- npm run typecheck
- npx vitest run server/profiles-router.test.ts --reporter=verbose
- npm run test:coverage (ran twice; 227 files, 5592 tests)