### PR TITLE
Fix Headroom managed Python install

### DIFF
--- a/client/src/components/agent-chat/__tests__/agent-mission-selector.test.tsx
+++ b/client/src/components/agent-chat/__tests__/agent-mission-selector.test.tsx
@@ -140,7 +140,7 @@ describe('AgentMissionSelector', () => {
     expect(agentApi.getAgentConversation).toHaveBeenCalledWith('c2')
     await waitFor(() => expect(screen.getByTestId('active-id').textContent).toBe('c2'))
     // Dropdown closed after selection.
-    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument())
   })
 
   it('marks the active mission with aria-selected', async () => {

--- a/server/headroom-manager.test.ts
+++ b/server/headroom-manager.test.ts
@@ -95,7 +95,6 @@ describe('HeadroomManager', () => {
       UV_PYTHON: '3.12',
       UV_MANAGED_PYTHON: 'true',
       UV_PYTHON_DOWNLOADS: 'automatic',
-      UV_PYTHON_PREFERENCE: 'only-managed',
       UV_PYTHON_INSTALL_DIR: path.join(tempDir, '.specrails', 'tools', 'uv', 'python'),
       UV_PYTHON_CACHE_DIR: path.join(tempDir, '.specrails', 'tools', 'uv', 'python-cache'),
       UV_PYTHON_BIN_DIR: path.join(tempDir, '.specrails', 'tools', 'uv', 'python-bin'),
@@ -103,6 +102,7 @@ describe('HeadroomManager', () => {
       UV_PYTHON_INSTALL_REGISTRY: 'false',
       UV_NO_PROGRESS: '1',
     })
+    expect(plan.env).not.toHaveProperty('UV_PYTHON_PREFERENCE')
   })
 
   it('prepares managed Python before installing the Headroom tool', async () => {
@@ -149,11 +149,12 @@ describe('HeadroomManager', () => {
         command: uvExe,
         args: ['tool', 'install', '--python', '3.12', '--managed-python', '--force', 'headroom-ai[all]'],
       })
+      expect(calls[0].env).not.toHaveProperty('UV_PYTHON_PREFERENCE')
       expect(calls[1].env).toMatchObject({
         UV_PYTHON: '3.12',
-        UV_PYTHON_PREFERENCE: 'only-managed',
         UV_PYTHON_INSTALL_DIR: path.join(tempDir, '.specrails', 'tools', 'uv', 'python'),
       })
+      expect(calls[1].env).not.toHaveProperty('UV_PYTHON_PREFERENCE')
     } finally {
       if (previousRuntimePath === undefined) delete process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH
       else process.env.SPECRAILS_BUNDLED_RUNTIMES_PATH = previousRuntimePath

--- a/server/headroom-manager.ts
+++ b/server/headroom-manager.ts
@@ -321,7 +321,6 @@ export function getHeadroomManagedInstallPlan(): {
       UV_PYTHON: HEADROOM_MANAGED_PYTHON_VERSION,
       UV_MANAGED_PYTHON: 'true',
       UV_PYTHON_DOWNLOADS: 'automatic',
-      UV_PYTHON_PREFERENCE: 'only-managed',
       UV_PYTHON_INSTALL_DIR: uvPythonInstallDir(),
       UV_PYTHON_CACHE_DIR: uvPythonCacheDir(),
       UV_PYTHON_BIN_DIR: uvPythonBinDir(),


### PR DESCRIPTION
## Summary
- remove UV_PYTHON_PREFERENCE from the Headroom managed install environment
- keep explicit --managed-python args for uv python/tool install
- add regression assertions so the incompatible env var is not reintroduced

## Testing
- rtk npm run typecheck
- rtk npm exec -- vitest run server/headroom-manager.test.ts
- rtk git diff --check