### PR TITLE
fix(core-update): guard zero-provider materialize + surface swap-current failure detail

### DIFF
--- a/server/core-update-manager.test.ts
+++ b/server/core-update-manager.test.ts
@@ -199,6 +199,45 @@ describe('CoreUpdateManager', () => {
       expect(events.some((e) => e.type === 'core_update.progress' && e.phase === 'error')).toBe(true)
     })
 
+    it('surfaces the swap-current subprocess stderr in the error', async () => {
+      bundle('4.8.0')
+      // install-framework succeeds; swap-current fails loudly.
+      const cliSwapFail = FAKE_CLI.replace(
+        `if(sub==='swap-current'){const fw=arg('framework-dir');const v=arg('version');if(!fs.existsSync(path.join(fw,v)))process.exit(41);swap(fw,v);process.exit(0)}`,
+        `if(sub==='swap-current'){process.stderr.write('symlink EPERM: operation not permitted');process.exit(41)}`,
+      )
+      const m = new CoreUpdateManager({
+        home,
+        npmInstall: stagingInstaller('4.9.0', cliSwapFail),
+      })
+      const res = await m.update('4.9.0')
+      expect(res.ok).toBe(false)
+      expect(res.error).toMatch(/swap-current failed: .*EPERM/)
+      expect(readCurrentFrameworkVersion(home)).toBeNull()
+    })
+
+    it('fails BEFORE the swap when materialize reports no errors but zero providers', async () => {
+      bundle('4.8.0')
+      let swapAttempted = false
+      const m = new CoreUpdateManager({
+        home,
+        npmInstall: stagingInstaller('4.9.0'),
+        makeFramework: () =>
+          ({
+            bundledVersion: () => '4.9.0',
+            materialize: () => ({ ran: true, version: '4.9.0', providers: [], errors: [] }),
+            swapCurrentDetailed: () => {
+              swapAttempted = true
+              return { ok: false, detail: null }
+            },
+          }) as unknown as import('./framework-manager').FrameworkManager,
+      })
+      const res = await m.update('4.9.0')
+      expect(res.ok).toBe(false)
+      expect(res.error).toMatch(/without materializing any provider/)
+      expect(swapAttempted).toBe(false)
+    })
+
     it('fails when the staged core has no cli.js', async () => {
       bundle('4.8.0')
       const m = new CoreUpdateManager({

--- a/server/core-update-manager.ts
+++ b/server/core-update-manager.ts
@@ -184,9 +184,18 @@ export class CoreUpdateManager {
           `framework materialize failed: ${mat.errors.map((e) => `${e.provider}: ${e.message}`).join('; ')}`,
         )
       }
-      const swapped = fm.swapCurrent(installed)
-      if (!swapped) {
-        throw new Error('framework swap-current failed')
+      // A materialize that reports no errors but ALSO no materialized providers
+      // wrote nothing — swapping `current` at a nonexistent version dir would
+      // fail downstream with a misleading "swap-current failed". Surface the
+      // real condition instead (mirrors FrameworkManager.versionCheck's guard).
+      if (mat.providers.length === 0) {
+        throw new Error(
+          `framework materialize completed without materializing any provider (requested: ${providers.join(', ') || 'none'})`,
+        )
+      }
+      const swapped = fm.swapCurrentDetailed(installed)
+      if (!swapped.ok) {
+        throw new Error(`framework swap-current failed${swapped.detail ? `: ${swapped.detail}` : ''}`)
       }
 
       this.latestVersion = installed

--- a/server/framework-manager.test.ts
+++ b/server/framework-manager.test.ts
@@ -260,6 +260,27 @@ describe('FrameworkManager', () => {
       writeFileSync(path.join(coreDir, 'dist', 'installer', 'cli.js'), 'process.exit(5)')
       expect(fm.swapCurrent('9.9.9')).toBe(false)
     })
+
+    it('swapCurrentDetailed carries WHY: subprocess stderr, exit code, or missing CLI', () => {
+      installFakeCore('5.0.0')
+      const fm = new FrameworkManager({ home })
+      fm.materialize('5.0.0', ['claude'])
+      // stderr wins when the subprocess emits one.
+      writeFileSync(
+        path.join(coreDir, 'dist', 'installer', 'cli.js'),
+        `process.stderr.write('version dir 9.9.9 does not exist'); process.exit(41)`,
+      )
+      const failed = fm.swapCurrentDetailed('9.9.9')
+      expect(failed.ok).toBe(false)
+      expect(failed.detail).toContain('version dir 9.9.9 does not exist')
+      // Silent failure falls back to the exit code.
+      writeFileSync(path.join(coreDir, 'dist', 'installer', 'cli.js'), 'process.exit(5)')
+      expect(fm.swapCurrentDetailed('9.9.9')).toEqual({ ok: false, detail: 'exit 5' })
+      // No usable CLI at all.
+      delete process.env.SPECRAILS_BUNDLED_CORE_PATH
+      const noCli = new FrameworkManager({ home })
+      expect(noCli.swapCurrentDetailed('9.9.9').detail).toMatch(/no usable core CLI/)
+    })
   })
 
   describe('versionCheck when materialize fails', () => {

--- a/server/framework-manager.ts
+++ b/server/framework-manager.ts
@@ -253,17 +253,33 @@ export class FrameworkManager {
    * `swap-current` only moves the version pointer (provider-invariant).
    */
   swapCurrent(version: string, _provider = 'claude'): boolean {
+    return this.swapCurrentDetailed(version).ok
+  }
+
+  /**
+   * Like `swapCurrent`, but on failure carries WHY it failed (`detail`) — the
+   * subprocess stderr/exit or the missing-CLI/verify-mismatch case — so callers
+   * (the core update channel) can surface an actionable error instead of the
+   * bare "swap-current failed".
+   */
+  swapCurrentDetailed(version: string): { ok: boolean; detail: string | null } {
     const cli = this.resolveCli()
-    if (!cli) return false
-    if (readCurrentFrameworkVersion(this.home) === version) return true
+    if (!cli) return { ok: false, detail: 'no usable core CLI to run swap-current with' }
+    if (readCurrentFrameworkVersion(this.home) === version) return { ok: true, detail: null }
     const fwDir = frameworkRoot(this.home)
     const res = spawnSync(
       nodeInterpreter(),
       [cli, 'swap-current', '--framework-dir', fwDir, '--version', version],
       { env: this.childEnv(), encoding: 'utf-8', timeout: 120_000 },
     )
-    if (res.error || (res.status ?? 1) !== 0) return false
-    return readCurrentFrameworkVersion(this.home) === version
+    if (res.error || (res.status ?? 1) !== 0) {
+      const detail = (res.error?.message ?? `${res.stderr || res.stdout || ''}`.trim()) || `exit ${res.status ?? 'unknown'}`
+      return { ok: false, detail }
+    }
+    if (readCurrentFrameworkVersion(this.home) !== version) {
+      return { ok: false, detail: `swap-current exited 0 but current still resolves to ${readCurrentFrameworkVersion(this.home) ?? 'nothing'}` }
+    }
+    return { ok: true, detail: null }
   }
 
   /**
@@ -316,8 +332,8 @@ export class FrameworkManager {
       // No errors yet nothing materialized (empty/duplicate-only provider list).
       return { swapped: false, version: current }
     }
-    const ok = this.swapCurrent(bundled)
-    if (ok) {
+    const swap = this.swapCurrentDetailed(bundled)
+    if (swap.ok) {
       try {
         this.broadcast?.({ type: 'framework.updated', version: bundled })
       } catch {
@@ -330,7 +346,7 @@ export class FrameworkManager {
       this.broadcast?.({
         type: 'framework.update_failed',
         version: bundled,
-        errors: [{ provider: providers[0] ?? 'claude', message: 'swap-current failed' }],
+        errors: [{ provider: providers[0] ?? 'claude', message: `swap-current failed${swap.detail ? `: ${swap.detail}` : ''}` }],
       })
     } catch {
       /* broadcast is best-effort */


### PR DESCRIPTION
## Problem

A real-world core update to 4.11.2 failed with the bare message **"Core update failed: framework swap-current failed"** — `framework/<version>` was never created, yet materialize reported no errors, and the swap error carried zero diagnostic information (the same commands ran manually worked fine).

Two gaps:

1. `CoreUpdateManager.update()` checked `mat.errors` but not `mat.providers.length === 0` — a materialize that wrote nothing "successfully" proceeded to `swap-current` against a nonexistent version dir. `FrameworkManager.versionCheck()` already guards this case; `update()` did not.
2. `swapCurrent()` returned a bare boolean, discarding the subprocess stderr/exit code — the surfaced error could not say WHY.

## Fix

- `update()` fails before the swap when materialize reports zero materialized providers, with an explicit error naming the requested providers.
- New `FrameworkManager.swapCurrentDetailed(version)` returns `{ ok, detail }` (subprocess stderr → exit code → missing-CLI → post-swap verify mismatch); `swapCurrent()` delegates to it. The core update channel and `versionCheck`'s `framework.update_failed` broadcast now include the detail.

## Tests

- `swapCurrentDetailed`: stderr wins, exit-code fallback, missing-CLI case.
- `update()`: swap-current stderr surfaced in the result error; zero-provider materialize fails before any swap attempt.

`npm run typecheck` ✓ · `npm test` 6284 passed ✓ · `npm run test:coverage` thresholds ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ud2PVGVtgTDQFJVj1Ty7UK