### PR TITLE
fix(builder): anchor the sidebar blueprint panel to the trigger's top edge

### DIFF
--- a/client/src/components/__tests__/BuilderSidebarEntry.test.tsx
+++ b/client/src/components/__tests__/BuilderSidebarEntry.test.tsx
@@ -110,6 +110,12 @@ describe('BuilderSidebarEntry', () => {
     // M1 still has a todo ticket → launchable; M2 is the next planned milestone
     expect(screen.getByTestId('sidebar-launch-m1')).toBeInTheDocument()
     expect(screen.getByTestId('sidebar-generate-next')).toHaveTextContent('Generate M2')
+    // Regression: the entry is the FIRST nav item (top of the sidebar). A
+    // bottom-anchored panel grows UPWARD past the viewport top, so the tap
+    // looked like a no-op. The panel must anchor to the trigger's top edge.
+    const panel = screen.getByTestId('builder-sidebar-panel')
+    expect(panel.className).toContain('top-0')
+    expect(panel.className).not.toContain('bottom-0')
   })
 
   it('hides Launch M1 when no M1 todo tickets remain', async () => {

--- a/client/src/components/project-builder/BuilderSidebarEntry.tsx
+++ b/client/src/components/project-builder/BuilderSidebarEntry.tsx
@@ -147,7 +147,7 @@ export function BuilderSidebarEntry({ expanded }: BuilderSidebarEntryProps) {
 
       {panelOpen && (
         <div
-          className="absolute bottom-0 right-full z-[60] mr-2 w-64 rounded-lg border border-border/50 bg-background p-3 shadow-xl"
+          className="absolute top-0 right-full z-[60] mr-2 w-64 rounded-lg border border-border/50 bg-background p-3 shadow-xl"
           data-testid="builder-sidebar-panel"
         >
           <h4 className="text-xs font-semibold">{t('sidebar.title')}</h4>


### PR DESCRIPTION
## Problem

In board mode, tapping the Blueprint (Project Builder) entry — the FIRST item of the right sidebar — appeared to do nothing.

The tap actually toggled the flyout open, but the panel was positioned `absolute bottom-0 right-full`: bottom-anchored to a trigger that sits at the TOP of the sidebar, so the ~300px-tall panel grew upward past the viewport top and rendered fully off-screen.

## Fix

One-line anchor change: `bottom-0` → `top-0` (`BuilderSidebarEntry.tsx`), plus a regression assertion in the existing panel-open test.

## Tests

Client typecheck ✓ · `BuilderSidebarEntry.test.tsx` 5 passed ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ud2PVGVtgTDQFJVj1Ty7UK