### PR TITLE
fix(interactive): graceful stdin-EOF teardown on quiescent auto-settle

### DIFF
--- a/docs/internals/interactive-jobs.md
+++ b/docs/internals/interactive-jobs.md
@@ -61,7 +61,7 @@ spawnInteractive = isInteractiveJobsEnabled()            // SPECRAILS_INTERACTIV
 | | `'finalize'` | `'auto'` |
 |---|---|---|
 | Who gets it | freestyle/Freestyle QueueManager jobs (claude) | every other interactive job + ALL loop ai-steps |
-| End of session | explicit human **Finalize** only (SIGTERM → 2s → SIGKILL) | **quiescence**: a turn `result` arrived, nothing queued, no write in flight |
+| End of session | explicit human **Finalize** only (SIGTERM → 2s → SIGKILL) | **quiescence**: a turn `result` arrived, nothing queued, no write in flight — torn down GRACEFULLY: stdin EOF (the CLI exits itself, flushing its session transcript so the next loop step can `--resume`), SIGTERM only after a grace window (`quiescentEofGraceMs`, default 5s) or when stdin is already gone |
 | Idle between turns | by design (awaiting the human) | only transiently (microtask window) |
 | Wedge detector | never armed | the queue's zombie-timeout budget, reset on any raw child output; silence for the whole budget → fold in-flight turn, settle `crashed` |
 | Composer action | **Finalize Job** | **Wrap up now** (QueueManager) / **Settle this step** (loop step) |

--- a/server/interactive-job-session.test.ts
+++ b/server/interactive-job-session.test.ts
@@ -27,8 +27,16 @@ function makeFakeChild() {
     writes.push(s)
     return true
   }
+  // Mirrors the real CLI: stdin EOF ⇒ the child flushes and exits by itself
+  // (the graceful quiescent teardown relies on this). Escalation tests replace
+  // `end` with a no-op to simulate a child that ignores EOF.
+  stdin.end = () => {
+    child.stdinEnded = true
+    queueMicrotask(() => child.emit('close', 0))
+  }
   child.stdin = stdin
   child.stdinWrites = writes
+  child.stdinEnded = false
   child.stdinHadErrorListenerOnWrite = false
   child.treeKillSignals = [] as string[]
   child.pid = 4242
@@ -583,7 +591,11 @@ describe("InteractiveJobSession settleMode 'auto'", () => {
     h.child.stdout.push(resultFrame({ result: 'all done' }))
     await tick()
 
-    expect(h.child.killed).toBe(true)
+    // Graceful teardown: stdin EOF (the CLI exits itself, flushing its session
+    // transcript so the next step can --resume) — NOT an immediate SIGTERM.
+    expect(h.child.stdinEnded).toBe(true)
+    expect(h.child.killed).toBe(false)
+    expect(h.child.treeKillSignals).toEqual([])
     expect(h.settled.length).toBe(1)
     expect(h.settled[0].reason).toBe('finalized')
     expect(h.settled[0].totals.total_cost_usd).toBeCloseTo(0.05)
@@ -591,6 +603,31 @@ describe("InteractiveJobSession settleMode 'auto'", () => {
     expect(h.settled[0].estimated).toBe(false)
     // The turn's result payload rides SettleInfo for output chaining.
     expect(h.settled[0].resultText).toBe('all done')
+  })
+
+  it('escalates to SIGTERM when the child ignores the stdin EOF (grace elapsed)', async () => {
+    const h = setup('job-auto-eof', { settleMode: 'auto', quiescentEofGraceMs: 10 })
+    h.child.stdin.end = () => { h.child.stdinEnded = true } // child ignores EOF
+    h.session.start({ binary: 'claude', args: [] }, 'go')
+    h.child.stdout.push(resultFrame({ result: 'done' }))
+    await tick()
+    expect(h.child.stdinEnded).toBe(true)
+    expect(h.settled.length).toBe(0) // grace window — child still has time to exit
+    await new Promise((r) => setTimeout(r, 40))
+    expect(h.child.treeKillSignals).toEqual(['SIGTERM'])
+    expect(h.settled.length).toBe(1)
+    expect(h.settled[0].reason).toBe('finalized')
+  })
+
+  it('falls back to SIGTERM when stdin is already gone at quiescence', async () => {
+    const h = setup('job-auto-nostdin', { settleMode: 'auto' })
+    h.session.start({ binary: 'claude', args: [] }, 'go')
+    h.child.stdin.destroyed = true
+    h.child.stdout.push(resultFrame({ result: 'done' }))
+    await tick()
+    expect(h.child.treeKillSignals).toEqual(['SIGTERM'])
+    expect(h.settled.length).toBe(1)
+    expect(h.settled[0].reason).toBe('finalized')
   })
 
   it('a queued user turn EXTENDS the session instead of settling', async () => {

--- a/server/interactive-job-session.ts
+++ b/server/interactive-job-session.ts
@@ -195,6 +195,13 @@ export interface InteractiveJobSessionDeps {
    *  Never armed in 'finalize' mode — idling awaiting the human is by design.
    *  Unset / <= 0 disables the timer. */
   zombieTimeoutMs?: number
+  /** Grace window for the QUIESCENT auto-settle's graceful teardown: the child
+   *  gets its stdin EOF'd (the stream-json CLI exits by itself after flushing
+   *  its session transcript — an immediate SIGTERM races that flush and leaves
+   *  the session unresumable, so the NEXT loop step's `--resume` lands on a
+   *  missing conversation and settles zero-work) and only after this window is
+   *  it SIGTERM'd. Default 5000ms. */
+  quiescentEofGraceMs?: number
   /** Shared event-seq allocator. A session that shares its job row with OTHER
    *  writers (the loop engine persists its own step-boundary/log events on the
    *  same job id) must draw seq numbers from the owner's monotonic counter, or
@@ -244,6 +251,10 @@ export class InteractiveJobSession {
   private readonly _onSettle: (info: SettleInfo) => void
   private readonly _settleMode: 'finalize' | 'auto'
   private readonly _zombieTimeoutMs: number
+  private readonly _quiescentEofGraceMs: number
+  /** Armed by the quiescent graceful teardown: SIGTERM escalation if the child
+   *  ignores the stdin EOF. Cleared on close/settle/dispose. */
+  private _eofTimer: ReturnType<typeof setTimeout> | null = null
   private readonly _nextEventSeq: (() => number) | null
   private readonly _persistTurnUsage: ((
     turn: InteractiveTurnUsage,
@@ -329,6 +340,7 @@ export class InteractiveJobSession {
     this._onSettle = deps.onSettle
     this._settleMode = deps.settleMode ?? 'finalize'
     this._zombieTimeoutMs = deps.zombieTimeoutMs ?? 0
+    this._quiescentEofGraceMs = deps.quiescentEofGraceMs ?? 5000
     this._nextEventSeq = deps.nextEventSeq ?? null
     this._persistTurnUsage = deps.persistTurnUsage ?? null
     this._persistTurnActivity = deps.persistTurnActivity ?? null
@@ -367,6 +379,7 @@ export class InteractiveJobSession {
     child.on('close', (code) => {
       this._childClosed = true
       this._clearKillTimer()
+      this._clearEofTimer()
       this._handleClose(code)
     })
     // A buffered write can fail asynchronously (typically EPIPE after the child
@@ -463,6 +476,37 @@ export class InteractiveJobSession {
     this._terminateChildTree('finalized')
   }
 
+  /** Quiescent auto-settle teardown, GRACEFUL: EOF the child's stdin so the
+   *  stream-json CLI exits by itself — it flushes its session transcript on the
+   *  way out, keeping the session `--resume`-able by the NEXT loop step. The
+   *  previous immediate SIGTERM raced that flush: the next step's resume found
+   *  no conversation, got an instant empty synthetic result, and settled
+   *  zero-work in 0.0s. SIGTERM remains as escalation after the grace window,
+   *  and as the direct fallback when stdin is already gone. */
+  private _finalizeQuiescent(): void {
+    if (this._finalizing || this._settled) return
+    this._finalizing = true
+    this._clearZombieTimer()
+    const child = this._child
+    const stdin = child?.stdin
+    if (!child || this._childClosed || !stdin || stdin.destroyed || this._stdinFailed) {
+      this._terminateChildTree('finalized')
+      return
+    }
+    try {
+      stdin.end()
+    } catch {
+      this._terminateChildTree('finalized')
+      return
+    }
+    this._eofTimer = setTimeout(() => {
+      this._eofTimer = null
+      if (this._childClosed || this._settled || this._disposed) return
+      this._terminateChildTree('finalized')
+    }, this._quiescentEofGraceMs)
+    this._eofTimer.unref?.()
+  }
+
   /** Programmatic teardown that SETTLES 'crashed' after folding any in-flight
    *  turn (loop step timeout / run cancel). Unlike dispose(), the onSettle
    *  callback fires — an owner AWAITING the settle (the loop engine) is
@@ -484,6 +528,7 @@ export class InteractiveJobSession {
     if (this._disposed) return
     this._disposed = true
     this._clearZombieTimer()
+    this._clearEofTimer()
     this._closeReaders()
     this._terminateChildTree(null)
     this._child = null
@@ -735,7 +780,7 @@ export class InteractiveJobSession {
       queueMicrotask(() => {
         if (this._disposed || this._settled || this._finalizing) return
         if (this._streaming || this._pending.length > 0) return
-        this.finalize()
+        this._finalizeQuiescent()
       })
     }
   }
@@ -912,6 +957,7 @@ export class InteractiveJobSession {
     this._streaming = false
     this._awaitingResult = false
     this._clearKillTimer()
+    this._clearEofTimer()
     this._clearZombieTimer()
     this._closeReaders()
     // The child is gone — any prompts still queued (turn died without a `result`,
@@ -1008,6 +1054,13 @@ export class InteractiveJobSession {
     if (this._killTimer !== null) {
       clearTimeout(this._killTimer)
       this._killTimer = null
+    }
+  }
+
+  private _clearEofTimer(): void {
+    if (this._eofTimer !== null) {
+      clearTimeout(this._eofTimer)
+      this._eofTimer = null
     }
   }
 


### PR DESCRIPTION
## Problem

Every loop verification ai-step settled **zero-work in 0.0s** ("Zero work performed — the command never ran"), reproducible on both `factory:batch` runs of Milestone 1.

Chain: step N's interactive session auto-settles on quiescence → `finalize()` → **immediate SIGTERM** to the claude child, milliseconds after its final `result` frame — racing the CLI's session-transcript flush. Step N+1 spawns with `--resume <session>`, the CLI can't find the conversation, emits an instant empty synthetic result (0 turns, 0 tokens, no text) → the session goes quiescent with zero accumulated work → the step fails zero-work in 0.0s. The loop's verification never ran once.

## Fix

Quiescent auto-settle now tears down **gracefully**: new `_finalizeQuiescent()` EOFs the child's stdin — the stream-json CLI exits by itself after flushing its session transcript (verified empirically: `printf <frame> | claude -p --input-format stream-json …` processes the turn and exits cleanly on EOF). SIGTERM remains as escalation after a grace window (`quiescentEofGraceMs`, default 5s, injectable for tests) and as the direct fallback when stdin is already destroyed/failed.

Explicit `finalize()` (human Wrap-up / loop settle-step), `abort()` and `dispose()` keep their existing kill semantics — only the self-settle path changes.

## Tests

- Harness fake gains a realistic `stdin.end` (EOF ⇒ child exits), quiescent-settle test now asserts EOF-not-SIGTERM.
- New: SIGTERM escalation when the child ignores EOF (grace elapsed); direct SIGTERM fallback when stdin is already gone.
- `docs/internals/interactive-jobs.md` teardown matrix updated.

`npm run typecheck` ✓ · `npm test` 6283 passed ✓ · `npm run test:coverage` thresholds ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ud2PVGVtgTDQFJVj1Ty7UK