### PR TITLE
fix(core-update): symlinked-tmpdir silent no-op + toasts always above modals

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useLayoutEffect, useRef, useMemo, useCallback, lazy, Suspense }from 'react'
+import { createPortal } from 'react-dom'
 import { Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { Toaster } from 'sonner'
@@ -575,7 +576,14 @@ function ThemedToaster() {
   const danger = theme.status.failed
   const warning = theme.status.canceled
   const info = theme.status.running
-  return (
+  // Portal to <body>: sonner renders in place and #root establishes its own
+  // stacking context (position:relative + z-index:0 in globals.css, needed by
+  // the code-rain layer), so a toaster INSIDE #root can never paint above the
+  // body-portalled modal layers (Radix dialogs z-50, JobDetailModal z-[65],
+  // TicketDetailModal z-[68], browser-capture z-[80]) no matter its own
+  // z-index. At body level its max z-index wins over every modal — toasts are
+  // always on top.
+  return createPortal(
     <Toaster
       position="bottom-right"
       className="specrails-toaster"
@@ -613,7 +621,8 @@ function ThemedToaster() {
           loading: '',
         },
       }}
-    />
+    />,
+    document.body,
   )
 }
 

--- a/server/core-update-manager.test.ts
+++ b/server/core-update-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, symlinkSync, existsSync } from 'fs'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, symlinkSync, existsSync, realpathSync } from 'fs'
 import os from 'os'
 import path from 'path'
 
@@ -155,6 +155,31 @@ describe('CoreUpdateManager', () => {
       expect(phases).toContain('materializing')
       expect(phases).toContain('done')
       expect(events.some((e) => e.type === 'framework.updated' && e.version === '4.9.0')).toBe(true)
+    })
+
+    it('stages the download under a fully realpathed tmp dir (symlinked macOS /var/folders)', async () => {
+      // Core's cli.js auto-run guard compares import.meta.url (realpathed by
+      // Node) against the literal argv[1]; a symlinked staging path makes the
+      // child a silent exit-0 no-op. The staging dir must therefore already be
+      // symlink-free.
+      bundle('4.8.0')
+      let stagedCwd = ''
+      let stagedReal = ''
+      const m = new CoreUpdateManager({
+        home,
+        providers: () => ['claude'],
+        fetchLatest: async () => '4.9.0',
+        npmInstall: (spec, cwd) => {
+          stagedCwd = cwd
+          stagedReal = realpathSync(cwd) // while the dir still exists
+          stagingInstaller('4.9.0')(spec, cwd)
+        },
+      })
+      await m.checkForUpdate()
+      const res = await m.update()
+      expect(res.ok).toBe(true)
+      expect(stagedCwd).not.toBe('')
+      expect(stagedCwd).toBe(stagedReal)
     })
 
     it('rejects when unavailable (no bundled core)', async () => {

--- a/server/core-update-manager.ts
+++ b/server/core-update-manager.ts
@@ -161,7 +161,13 @@ export class CoreUpdateManager {
 
     this.updating = true
     this.emit('downloading', { version: requested })
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'core-update-'))
+    // realpath the tmp root: on macOS os.tmpdir() is a symlinked path
+    // (/var/folders → /private/var/folders). The staged core's cli.js has an
+    // auto-run guard comparing import.meta.url (realpathed by Node's ESM
+    // loader) against process.argv[1] (the literal spawn arg) — a symlinked
+    // staging path makes them differ, so main() never runs and every
+    // install-framework/swap-current child exits 0 as a silent no-op.
+    const tmp = fs.mkdtempSync(path.join(realTmpDir(), 'core-update-'))
     try {
       this.npmInstallFn(`${CORE_PACKAGE}@${requested}`, tmp)
       const coreRoot = path.join(tmp, 'node_modules', CORE_PACKAGE)
@@ -235,6 +241,16 @@ export class CoreUpdateManager {
 function uniqueProviders(values: string[]): string[] {
   const out = Array.from(new Set(values.filter((v) => typeof v === 'string' && v.length > 0)))
   return out.length > 0 ? out : ['claude']
+}
+
+/** os.tmpdir() with symlinks resolved (macOS /var/folders → /private/var/folders). */
+function realTmpDir(): string {
+  const dir = os.tmpdir()
+  try {
+    return fs.realpathSync(dir)
+  } catch {
+    return dir
+  }
 }
 
 /** GET the latest published version from the npm registry (no npm binary needed). */

--- a/server/framework-manager.test.ts
+++ b/server/framework-manager.test.ts
@@ -7,6 +7,8 @@ import {
   existsSync,
   lstatSync,
   readlinkSync,
+  readFileSync,
+  realpathSync,
   symlinkSync,
 } from 'fs'
 import os from 'os'
@@ -127,6 +129,30 @@ describe('FrameworkManager', () => {
       expect(existsSync(path.join(fw, '5.0.0', '.claude', 'agents', 'sr-architect.md'))).toBe(true)
       // materialize uses --no-swap: current is NOT moved by materialize alone.
       expect(readCurrentFrameworkVersion(home)).toBeNull()
+    })
+
+    it('passes a realpathed cli.js as argv[1] when the coreRoot path is symlinked', () => {
+      // Core's cli.js auto-run guard compares import.meta.url (realpathed by
+      // Node's ESM loader) against pathToFileURL(argv[1]) — a symlinked argv[1]
+      // (e.g. macOS /var/folders staging) makes main() silently never run.
+      installFakeCore('5.0.0')
+      // FAKE cli that dumps its own argv[1] into <framework-dir>/argv1.txt.
+      const dumpCli = `
+        const fs = require('fs')
+        function arg(n){const i=process.argv.indexOf('--'+n);return i>=0?process.argv[i+1]:undefined}
+        fs.mkdirSync(arg('framework-dir'), { recursive: true })
+        fs.writeFileSync(require('path').join(arg('framework-dir'), 'argv1.txt'), process.argv[1])
+        process.exit(0)
+      `
+      writeFileSync(path.join(coreDir, 'dist', 'installer', 'cli.js'), dumpCli)
+      const linkRoot = path.join(home, 'core-link')
+      symlinkSync(coreDir, linkRoot)
+      const fm = new FrameworkManager({ home, coreRoot: linkRoot })
+      const res = fm.materialize('5.0.0', ['claude'])
+      expect(res.errors).toEqual([])
+      const recorded = readFileSync(path.join(frameworkRoot(home), 'argv1.txt'), 'utf8')
+      expect(recorded).toBe(realpathSync(path.join(linkRoot, 'dist', 'installer', 'cli.js')))
+      expect(recorded).not.toContain('core-link')
     })
 
     it('materializes multiple providers', () => {

--- a/server/framework-manager.ts
+++ b/server/framework-manager.ts
@@ -65,6 +65,22 @@ export interface MaterializeResult {
   errors: Array<{ provider: string; message: string }>
 }
 
+/**
+ * Resolve symlinks in the CLI path we pass as the child's argv[1]. Core's
+ * cli.js auto-run guard compares import.meta.url (realpathed by Node's ESM
+ * loader) against pathToFileURL(process.argv[1]) — a symlinked argv[1] (e.g.
+ * a staging dir under macOS /var/folders) makes them differ, so main() never
+ * runs and the child exits 0 as a silent no-op. Realpathing here keeps the
+ * guard true regardless of where the core package lives.
+ */
+function realpathOrSelf(p: string): string {
+  try {
+    return fs.realpathSync(p)
+  } catch {
+    return p
+  }
+}
+
 /** `~/.specrails/framework` — same home as the registry. */
 export function frameworkRoot(home?: string): string {
   return path.join(resolveHome(home), '.specrails', 'framework')
@@ -160,9 +176,10 @@ export class FrameworkManager {
   private resolveCli(): string | null {
     if (this.coreRoot) {
       const cli = path.join(this.coreRoot, 'dist', 'installer', 'cli.js')
-      return fs.existsSync(cli) ? cli : null
+      return fs.existsSync(cli) ? realpathOrSelf(cli) : null
     }
-    return getBundledCoreCli()
+    const bundled = getBundledCoreCli()
+    return bundled ? realpathOrSelf(bundled) : null
   }
 
   /** True when a usable core (override or bundled) is present (else methods no-op). */


### PR DESCRIPTION
## Root cause (real-world failure, 4.11.2 → 4.11.3 update)

specrails-core's `dist/installer/cli.js` auto-run guard compares `import.meta.url` (realpathed by Node's ESM loader) against the **literal** `process.argv[1]`. The core update channel stages the npm download under `os.tmpdir()` = `/var/folders/...`, a symlink to `/private/var/folders` on macOS — so the comparison fails, `main()` never runs, and **every `install-framework` / `swap-current` child exits 0 having done nothing**. The user sees `framework swap-current failed: swap-current exited 0 but current still resolves to <old>` (the detailed message added in #556, which improved reporting but not the cause).

Reproduced deterministically: the exact same binary + args works when invoked via the real path and is a silent exit-0 no-op when invoked via the symlinked `/var/folders` path.

## Fixes

- **core-update-manager**: `mkdtempSync` under the realpathed tmp root (`realTmpDir()`), so the staged cli's argv[1] is symlink-free. This repairs updates against **every already-published core version** — no core release needed.
- **framework-manager**: `resolveCli()` returns the realpathed cli path (`realpathOrSelf()`), defence-in-depth for any symlinked coreRoot.
- **Toasts above modals**: `#root` establishes its own stacking context (`position:relative; z-index:0`, needed by the code-rain layer), so the sonner `Toaster` mounted inside `#root` could never paint above body-portalled modal layers (Radix dialogs z-50, JobDetailModal z-[65], TicketDetailModal z-[68], browser-capture z-[80]) regardless of its own z-index. `ThemedToaster` now portals to `document.body`, where its max z-index always wins.

A companion specrails-core PR hardens the guard itself (compare against `realpathSync(argv[1])` too).

## Tests

- New: staging dir handed to `npmInstall` is fully realpathed.
- New: symlinked `coreRoot` → child receives realpathed cli.js as argv[1].
- typecheck ✓ · full suite 6288 passed ✓ · server coverage 84.5/76.0/89.0/86.9 (thresholds 80/70) ✓ · client coverage ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKqZfeaxv4EzNZUcUfa36G