### PR TITLE
fix(release): bundle Kimi-compatible Core 4.12.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,11 @@ jobs:
   # junction/copy-fallback lifecycle before a tag can reach Desktop Release.
   # This is intentionally independent of the heavy Rust/Tauri build.
   bundled-core-windows:
-    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, windows-11-arm]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,21 @@ jobs:
       - name: Scan for secrets
         run: gitleaks detect --source . --redact --exit-code 1
 
+  # Exercise the release's exact vendored Core lock and Windows
+  # junction/copy-fallback lifecycle before a tag can reach Desktop Release.
+  # This is intentionally independent of the heavy Rust/Tauri build.
+  bundled-core-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+        with:
+          node-version: 20.19.0
+      - name: Assemble integrity-locked bundled Core
+        run: node scripts/assemble-bundled-core.mjs
+      - name: Smoke bundled Core relocation for every provider
+        run: pwsh scripts/smoke-bundled-core-windows.ps1 -CorePath src-tauri\core -Node node
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -35,7 +35,7 @@ env:
   # reproducibility — BUG-CI-02). This MUST equal the version the vendored
   # scripts/assemble-bundled-core.lock.json pins (assemble-bundled-core.mjs fails
   # fast on mismatch). Bump both together via PR. See server/bundled-core.ts.
-  CORE_BUNDLE_VERSION: "4.11.0"
+  CORE_BUNDLE_VERSION: "4.12.0"
   # Bundle @fission-ai/openspec into the app so the LAST network step of
   # project-add (openspec init) runs OFFLINE from the bundle instead of
   # `npx @fission-ai/openspec`. Pinned to match specrails-core's

--- a/scripts/assemble-bundled-core.lock.json
+++ b/scripts/assemble-bundled-core.lock.json
@@ -8,7 +8,7 @@
       "name": "bundled-core-stage",
       "version": "0.0.0",
       "dependencies": {
-        "specrails-core": "4.11.0"
+        "specrails-core": "4.12.0"
       }
     },
     "node_modules/@inquirer/ansi": {
@@ -548,9 +548,9 @@
       }
     },
     "node_modules/specrails-core": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/specrails-core/-/specrails-core-4.11.0.tgz",
-      "integrity": "sha512-YpR8U8pmQluBR1nfcROXsj0pXrMYdRUcpORSkXsjTmbL7o+JCy2vHxcvn2tY56eEvDR8EhCM6B5Oqzf12e8gew==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/specrails-core/-/specrails-core-4.12.0.tgz",
+      "integrity": "sha512-Srb0XI2WkUFATtG6vfXOVBW59qsOX4gDeWI27JfksftpCqzrTIAMDl4dAk6QfXNdjtcdJ89xxdIThUNFBE68BQ==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
@@ -562,7 +562,7 @@
         "specrails-core": "bin/specrails-core.mjs"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/string-width": {

--- a/scripts/smoke-bundled-core-windows.ps1
+++ b/scripts/smoke-bundled-core-windows.ps1
@@ -101,7 +101,10 @@ foreach ($p in $providers) {
   if ($p -eq "kimi") {
     $skills = Join-Path $pd "skills"
     if (-not (Test-Path $skills)) { Write-Error "kimi assemble: missing real skills root at $skills"; exit 1 }
-    $skillCount = (Get-ChildItem -Path $skills -Recurse -Filter "SKILL.md" -File -ErrorAction SilentlyContinue | Measure-Object).Count
+    # Framework-owned direct children are directory junctions on Windows.
+    # PowerShell does not recurse through reparse points unless explicitly told
+    # to follow them, which would report a false zero despite valid skills.
+    $skillCount = (Get-ChildItem -Path $skills -Recurse -FollowSymlink -Filter "SKILL.md" -File -ErrorAction SilentlyContinue | Measure-Object).Count
     if ($skillCount -lt 1) { Write-Error "kimi assemble: skills has no SKILL.md content"; exit 1 }
     $directRole = Join-Path $skills "sr-architect\SKILL.md"
     if (-not (Test-Path $directRole)) {

--- a/scripts/smoke-bundled-core-windows.ps1
+++ b/scripts/smoke-bundled-core-windows.ps1
@@ -10,8 +10,8 @@
 #      rules land as dir JUNCTIONS, agents land via the COPY-FALLBACK (file
 #      symlinks need admin on Windows; core falls back to copying). Each must
 #      have content.
-#   4. REAL provider discovery: three providers (claude + gemini + kimi)
-#      materialize +
+#   4. REAL provider discovery: all four providers (claude + codex + gemini +
+#      kimi) materialize +
 #      assemble independently into the same framework/workspace.
 #
 # Run with the BUNDLED node (no system node/git on PATH) to prove the tree is
@@ -51,7 +51,7 @@ function Invoke-Core {
   if ($LASTEXITCODE -ne 0) { Write-Error "core $($CoreArgs -join ' ') failed ($LASTEXITCODE)"; exit 1 }
 }
 
-$providers = @("claude", "gemini", "kimi")
+$providers = @("claude", "codex", "gemini", "kimi")
 
 # 1. Materialize every provider WITHOUT swapping current.
 foreach ($p in $providers) {
@@ -70,9 +70,15 @@ if (-not (Test-Path $current)) { Write-Error "current not created after swap-cur
 Write-Host "current → $version OK"
 
 # 3 + 4. Assemble a workspace per provider + validate the linked subtrees.
-$providerDirs = @{ "claude" = ".claude"; "gemini" = ".gemini"; "kimi" = ".kimi-code" }
+$providerDirs = @{
+  "claude" = ".claude"
+  "codex" = ".codex"
+  "gemini" = ".gemini"
+  "kimi" = ".kimi-code"
+}
 $linkedByProvider = @{
   "claude" = @("agents", "commands", "skills", "rules")
+  "codex" = @("skills")
   "gemini" = @("agents", "commands")
   # Kimi keeps the skills root real so OpenSpec and custom roles can coexist;
   # Core links framework-owned children within it. Rules remains a whole-dir

--- a/server/core-package.test.ts
+++ b/server/core-package.test.ts
@@ -1,10 +1,93 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
 import { describe, it, expect } from 'vitest'
 import { CORE_PACKAGE_SPEC } from './core-package'
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+)
+
+interface BundleLock {
+  packages?: Record<
+    string,
+    {
+      dependencies?: Record<string, string>
+      version?: string
+    }
+  >
+}
+
+function parseVersion(value: string): [number, number, number] {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(value)
+  if (!match) throw new Error(`Expected an exact semantic version, got ${value}`)
+  return [Number(match[1]), Number(match[2]), Number(match[3])]
+}
+
+function isAtLeast(
+  actual: [number, number, number],
+  floor: [number, number, number],
+): boolean {
+  for (let index = 0; index < actual.length; index += 1) {
+    if (actual[index]! > floor[index]!) return true
+    if (actual[index]! < floor[index]!) return false
+  }
+  return true
+}
 
 describe('CORE_PACKAGE_SPEC (H5)', () => {
   it('pins specrails-core to a caret major range, never a floating tag', () => {
     // Guard against regressing to `specrails-core@latest`: a breaking core
     // major must never auto-land on users via npx.
     expect(CORE_PACKAGE_SPEC).toMatch(/^specrails-core@\^\d+\.\d+\.\d+$/)
+  })
+
+  it('keeps the online Core floor, release pin, and vendored lock compatible', () => {
+    const lock = JSON.parse(
+      readFileSync(
+        path.join(repoRoot, 'scripts', 'assemble-bundled-core.lock.json'),
+        'utf8',
+      ),
+    ) as BundleLock
+    const declared =
+      lock.packages?.['']?.dependencies?.['specrails-core']
+    const resolved =
+      lock.packages?.['node_modules/specrails-core']?.version
+    const releaseWorkflow = readFileSync(
+      path.join(repoRoot, '.github', 'workflows', 'desktop-release.yml'),
+      'utf8',
+    )
+    const workflowVersion =
+      /^\s*CORE_BUNDLE_VERSION:\s*"(\d+\.\d+\.\d+)"\s*$/m.exec(
+        releaseWorkflow,
+      )?.[1]
+    const packageFloor =
+      /^specrails-core@\^(\d+\.\d+\.\d+)$/.exec(CORE_PACKAGE_SPEC)?.[1]
+
+    expect(declared).toBeDefined()
+    expect(resolved).toBe(declared)
+    expect(workflowVersion).toBe(declared)
+    expect(packageFloor).toBeDefined()
+
+    const bundled = parseVersion(declared!)
+    const floor = parseVersion(packageFloor!)
+    expect(bundled[0]).toBe(floor[0])
+    expect(isAtLeast(bundled, floor)).toBe(true)
+  })
+
+  it('exercises every bundled provider in the Windows release smoke', () => {
+    const smoke = readFileSync(
+      path.join(repoRoot, 'scripts', 'smoke-bundled-core-windows.ps1'),
+      'utf8',
+    )
+    const source =
+      /\$providers\s*=\s*@\(([^)]+)\)/.exec(smoke)?.[1] ?? ''
+    const providers = [...source.matchAll(/"([^"]+)"/g)].map(
+      (match) => match[1],
+    )
+
+    expect(providers).toEqual(['claude', 'codex', 'gemini', 'kimi'])
   })
 })


### PR DESCRIPTION
## Summary

Repairs the Windows x64 and ARM64 release failure from:

https://github.com/fjpulidop/specrails-desktop/actions/runs/29725297635

Desktop 2.31.0 included the Kimi provider surface and its Windows bundled-Core
smoke, but the release workflow and vendored npm lock still pinned
`specrails-core@4.11.0`. That Core version rejects `--provider kimi` with exit
code 40, so both Windows jobs stopped before the Tauri build.

## Changes

- pins `CORE_BUNDLE_VERSION` to the now-published `specrails-core@4.12.0`
- regenerates `assemble-bundled-core.lock.json` from the published 4.12.0
  package while preserving the existing transitive closure
- records the exact npm tarball URL and integrity:
  `sha512-Srb0XI2WkUFATtG6vfXOVBW59qsOX4gDeWI27JfksftpCqzrTIAMDl4dAk6QfXNdjtcdJ89xxdIThUNFBE68BQ==`
- extends the Windows release smoke to materialize and assemble all four
  framework providers: Claude, Codex, Gemini, and Kimi
- adds CI regressions that fail when:
  - the online Core floor, release workflow pin, and vendored lock disagree
  - the exact bundled Core falls below Desktop's supported Core floor
  - a provider is omitted from the Windows bundled-framework smoke
- adds lightweight Windows x64 and ARM64 CI jobs that assemble the
  integrity-locked Core and execute the same relocation smoke before any
  release tag is created

Codex must be included even though the original failure happened on Kimi:
Core 4.12 refuses to move `framework/current` until the provider-invariant
framework version contains all four provider targets.

## Validation

- `npm run typecheck`: passed
- `npm test`: **252 files, 6,579 tests passed**
- exact bundled compatibility:
  `specrails-core@4.12.0` vs `specrails-desktop@2.31.0`: compatible
- vendored-lock assembly:
  - `npm ci` integrity verification passed
  - 27 runtime dependency entries staged
  - bundled CLI smoke passed
- framework lifecycle smoke passed for Claude, Codex, Gemini, and Kimi:
  - materialize all providers with `--no-swap`
  - atomic `swap-current`
  - assemble all providers into one workspace
  - direct-child Kimi roles and managed runner verified
  - legacy nested Kimi role layout absent
- GitHub CI passed on the final commit:
  - full server coverage and client coverage suites
  - secret scan
  - integrity-locked bundled-Core smoke on Windows x64
  - integrity-locked bundled-Core smoke on Windows ARM64
- `git diff --check`: passed

## Release recovery

The failed `v2.31.0` workflow must not simply be rerun: the tag is reproducible
and still points to the commit that pins Core 4.11.0.

Merge this PR, merge the resulting Release Please patch release, and publish a
new Desktop tag (expected `v2.31.1`). The new tag will execute both Windows
release jobs with the reviewed Core 4.12.0 lock.
