### PR TITLE
fix(ui): enlarge existing project modal

### DIFF
--- a/client/src/components/AddProjectDialog.tsx
+++ b/client/src/components/AddProjectDialog.tsx
@@ -220,7 +220,11 @@ export function AddProjectDialog({ open, onClose, onOpenBuilder }: AddProjectDia
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent movableResizable className="max-w-md">
+      <DialogContent
+        movableResizable
+        className="max-h-[calc(100vh-2rem)] w-[calc(100vw-2rem)] max-w-2xl overflow-x-hidden"
+        data-testid="existing-project-dialog"
+      >
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <FolderOpen className="w-4 h-4" />
@@ -308,7 +312,10 @@ export function AddProjectDialog({ open, onClose, onOpenBuilder }: AddProjectDia
           {/* Provider selector — multi-select. Pick one or more. */}
           <div className="space-y-1.5">
             <label className="text-xs font-medium text-muted-foreground">{t('addProject.providersLabel')}</label>
-            <div className="flex gap-2">
+            <div
+              className="grid grid-cols-2 gap-2 sm:grid-cols-4"
+              data-testid="existing-project-provider-grid"
+            >
               {providerRenderOrder(availableProviders).map((id) => {
                 const { icon, label } = PROVIDER_META[id] ?? { icon: '•', label: id }
                 const avail = availableProviders[id]
@@ -323,7 +330,7 @@ export function AddProjectDialog({ open, onClose, onOpenBuilder }: AddProjectDia
                     onClick={() => toggleProvider(id)}
                     data-testid={`provider-toggle-${id}`}
                     className={cn(
-                      'flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-left transition-colors text-xs',
+                      'flex min-w-0 items-center justify-center gap-1.5 rounded-md border px-3 py-1.5 text-left text-xs transition-colors',
                       'focus:outline-none focus-visible:ring-1 focus-visible:ring-ring',
                       checked
                         ? 'border-accent-primary/60 bg-accent-primary/10 text-foreground'
@@ -341,7 +348,7 @@ export function AddProjectDialog({ open, onClose, onOpenBuilder }: AddProjectDia
                     <span>{icon}</span>
                     <span className="font-medium">{label}</span>
                     {!avail && (
-                      <span className="text-[9px] text-muted-foreground/60">
+                      <span className="min-w-0 text-[9px] leading-tight text-muted-foreground/60">
                         {providerIssues[id]?.code === 'core_provider_unsupported'
                           ? t('addProject.coreUpdateRequired')
                           : t('addProject.notFound')}

--- a/client/src/components/__tests__/AddProjectDialog.test.tsx
+++ b/client/src/components/__tests__/AddProjectDialog.test.tsx
@@ -277,6 +277,48 @@ describe('AddProjectDialog', () => {
     })
   })
 
+  it('gives all four providers a roomy responsive layout without horizontal overflow', async () => {
+    global.fetch = vi.fn().mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.includes('/api/available-providers')) {
+        return {
+          ok: true,
+          json: async () => ({
+            claude: true,
+            codex: true,
+            gemini: true,
+            kimi: true,
+          }),
+        }
+      }
+      if (url.includes('/api/setup-prerequisites')) {
+        return { ok: true, json: async () => goodPrereqsStatus }
+      }
+      return { ok: true, json: async () => ({}) }
+    })
+
+    render(<AddProjectDialog open={true} onClose={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('checkbox', { name: /Kimi/i })).toHaveAttribute('aria-checked', 'true')
+    })
+
+    expect(screen.getByTestId('existing-project-dialog')).toHaveClass(
+      'max-h-[calc(100vh-2rem)]',
+      'w-[calc(100vw-2rem)]',
+      'max-w-2xl',
+      'overflow-x-hidden',
+    )
+    expect(screen.getByTestId('existing-project-provider-grid')).toHaveClass(
+      'grid',
+      'grid-cols-2',
+      'sm:grid-cols-4',
+    )
+    for (const provider of ['Claude', 'Codex', 'Gemini', 'Kimi']) {
+      expect(screen.getByRole('checkbox', { name: new RegExp(provider, 'i') })).toBeEnabled()
+    }
+  })
+
   it('selects both providers by default when both are available and submits both', async () => {
     const user = userEvent.setup()
     global.fetch = vi.fn().mockImplementation(async (input: RequestInfo | URL) => {


### PR DESCRIPTION
## Summary

Makes the **Existing project** modal large enough to select all four AI
providers — including Kimi — without introducing horizontal or secondary
vertical scrollbars at the normal desktop window size.

## Root cause

The existing-project form was capped at `max-w-md` (448 px), while Claude,
Codex, Gemini, and Kimi were forced into a single non-wrapping flex row.
Provider availability messages could make that row wider than the dialog's
roughly 400 px content area. Because the shared dialog is vertically
scrollable, the horizontal overflow also consumed height and could trigger a
second scrollbar.

## Changes

- enlarges only the existing-project form to `max-w-2xl` (672 px)
- keeps a 16 px viewport margin through
  `w-[calc(100vw-2rem)]` / `max-h-[calc(100vh-2rem)]`
- renders provider choices as a responsive grid:
  - four equal columns on desktop
  - two columns on narrow windows
- lets long unavailable-provider messages shrink and wrap safely
- keeps the initial Existing/New project chooser at its current compact size
- adds a regression test covering Claude, Codex, Gemini, and Kimi together

## Validation

- focused AddProjectDialog suite: **19 tests passed**
- complete client suite: **333 files, 4,017 tests passed**
- `npm run typecheck`: passed
- client production build: passed
- `git diff --check`: passed
- GitHub Actions: **all checks passed**, including client/server coverage,
  Windows x64, Windows ARM64, and secret scanning

Automated in-app browser capture was unavailable in the current environment;
the responsive width, viewport bounds, four-provider grid, and Kimi state are
asserted directly in the component regression test.
