### PR TITLE
feat(loops): run built-in loops untimed (0 = no timeout)

### DIFF
--- a/client/src/components/loops/LoopPreviewModal.tsx
+++ b/client/src/components/loops/LoopPreviewModal.tsx
@@ -84,10 +84,14 @@ export function LoopPreviewModal({
         </div>
 
         <p className="text-[11px] text-muted-foreground">
-          {t('preview.limits', {
-            iterations: loop.graph.config.maxIterations,
-            timeout: loop.graph.config.timeoutMinutes,
-          })}
+          {loop.graph.config.timeoutMinutes > 0
+            ? t('preview.limits', {
+                iterations: loop.graph.config.maxIterations,
+                timeout: loop.graph.config.timeoutMinutes,
+              })
+            : t('preview.limitsNoTimeout', {
+                iterations: loop.graph.config.maxIterations,
+              })}
         </p>
 
         <div className="min-h-0 space-y-1.5 overflow-y-auto pr-1">

--- a/client/src/components/loops/TemplatePreviewModal.tsx
+++ b/client/src/components/loops/TemplatePreviewModal.tsx
@@ -80,10 +80,14 @@ export function TemplatePreviewModal({
             </div>
 
             <p className="text-[11px] text-muted-foreground">
-              {t('preview.limits', {
-                iterations: template.graph.config.maxIterations,
-                timeout: template.graph.config.timeoutMinutes,
-              })}
+              {template.graph.config.timeoutMinutes > 0
+                ? t('preview.limits', {
+                    iterations: template.graph.config.maxIterations,
+                    timeout: template.graph.config.timeoutMinutes,
+                  })
+                : t('preview.limitsNoTimeout', {
+                    iterations: template.graph.config.maxIterations,
+                  })}
             </p>
 
             <div className="max-h-[50vh] overflow-y-auto space-y-1.5 pr-1">

--- a/client/src/locales/de/loops.json
+++ b/client/src/locales/de/loops.json
@@ -165,6 +165,7 @@
   "preview": {
     "steps": "Schritte",
     "limits": "max. {{iterations}} Iterationen · {{timeout}} Min. Timeout",
+    "limitsNoTimeout": "max. {{iterations}} Iterationen · kein Timeout",
     "openInBuilder": "Im Builder öffnen",
     "builtin": "Integriert"
   },

--- a/client/src/locales/en/loops.json
+++ b/client/src/locales/en/loops.json
@@ -165,6 +165,7 @@
   "preview": {
     "steps": "Steps",
     "limits": "{{iterations}} iterations max · {{timeout}} min timeout",
+    "limitsNoTimeout": "{{iterations}} iterations max · no timeout",
     "openInBuilder": "Open in builder",
     "builtin": "Built-in"
   },

--- a/client/src/locales/es/loops.json
+++ b/client/src/locales/es/loops.json
@@ -165,6 +165,7 @@
   "preview": {
     "steps": "Pasos",
     "limits": "máx. {{iterations}} iteraciones · {{timeout}} min de timeout",
+    "limitsNoTimeout": "máx. {{iterations}} iteraciones · sin timeout",
     "openInBuilder": "Abrir en el builder",
     "builtin": "Integrado"
   },

--- a/client/src/locales/fr/loops.json
+++ b/client/src/locales/fr/loops.json
@@ -165,6 +165,7 @@
   "preview": {
     "steps": "Étapes",
     "limits": "{{iterations}} itérations max · {{timeout}} min de délai",
+    "limitsNoTimeout": "{{iterations}} itérations max · aucun délai",
     "openInBuilder": "Ouvrir dans le builder",
     "builtin": "Intégré"
   },

--- a/client/src/locales/it/loops.json
+++ b/client/src/locales/it/loops.json
@@ -165,6 +165,7 @@
   "preview": {
     "steps": "Passi",
     "limits": "max {{iterations}} iterazioni · {{timeout}} min di timeout",
+    "limitsNoTimeout": "max {{iterations}} iterazioni · nessun timeout",
     "openInBuilder": "Apri nel builder",
     "builtin": "Integrato"
   },

--- a/client/src/locales/ja/loops.json
+++ b/client/src/locales/ja/loops.json
@@ -165,6 +165,7 @@
   "preview": {
     "steps": "ステップ",
     "limits": "最大 {{iterations}} 回 · {{timeout}} 分タイムアウト",
+    "limitsNoTimeout": "最大 {{iterations}} 回 · タイムアウトなし",
     "openInBuilder": "ビルダーで開く",
     "builtin": "ビルトイン"
   },

--- a/client/src/locales/pt/loops.json
+++ b/client/src/locales/pt/loops.json
@@ -165,6 +165,7 @@
   "preview": {
     "steps": "Passos",
     "limits": "máx. {{iterations}} iterações · {{timeout}} min de timeout",
+    "limitsNoTimeout": "máx. {{iterations}} iterações · sem timeout",
     "openInBuilder": "Abrir no builder",
     "builtin": "Integrado"
   },

--- a/client/src/locales/zh/loops.json
+++ b/client/src/locales/zh/loops.json
@@ -165,6 +165,7 @@
   "preview": {
     "steps": "步骤",
     "limits": "最多 {{iterations}} 次迭代 · {{timeout}} 分钟超时",
+    "limitsNoTimeout": "最多 {{iterations}} 次迭代 · 无超时",
     "openInBuilder": "在构建器中打开",
     "builtin": "内置"
   },

--- a/server/loop-executors.ts
+++ b/server/loop-executors.ts
@@ -193,7 +193,9 @@ export function createLoopExecutors(
         buildOpts,
         cwd,
         env: buildProviderEnv(adapter, buildOpts, stepEnv),
-        timeoutMs: aiStepTimeoutMs ?? AI_STEP_TIMEOUT_MS,
+        // 0 ⇒ watchdog disabled (factory loops run untimed; the loop's
+        // maxIterations / cost cap remain the runaway guards).
+        timeoutMs: (aiStepTimeoutMs ?? AI_STEP_TIMEOUT_MS) > 0 ? (aiStepTimeoutMs ?? AI_STEP_TIMEOUT_MS) : undefined,
         onSpawn,
         // Two complementary streams, mirroring QueueManager's contract:
         //  • RAW JSONL via onStdoutLine → engine emits parsed `event`s that drive
@@ -313,7 +315,8 @@ export function createLoopExecutors(
       return {
         adapter,
         spec: { binary: adapter.binary, args, cwd, env: buildProviderEnv(adapter, buildOpts, stepEnv) },
-        // The loop's ai-step timeout bounds the WHOLE step, interactive included.
+        // The loop's ai-step timeout bounds the WHOLE step, interactive
+        // included. 0 ⇒ unbounded (the engine skips arming the step timer).
         stepTimeoutMs: aiStepTimeoutMs ?? AI_STEP_TIMEOUT_MS,
       }
     },

--- a/server/loop-factory.test.ts
+++ b/server/loop-factory.test.ts
@@ -63,13 +63,12 @@ describe('factory loops', () => {
     expect(prompts.some((p) => p.includes('{{cmd:fix}}'))).toBe(true) // refinement on failure
   })
 
-  it('every rail-mode factory loop gets generous timeouts (pipeline-in-one-step needs headroom)', () => {
+  it('every factory loop runs UNTIMED (0 = no timeout; a legit implement must never be killed by wall clock)', () => {
     for (const f of FACTORY_LOOPS) {
-      if (f.mode === 'loop') continue // graph-native loops carry their own authored bounds
-      expect(f.graph.config.timeoutMinutes, f.id).toBe(360)
-      expect(f.graph.config.aiStepTimeoutMinutes, f.id).toBe(60)
+      expect(f.graph.config.timeoutMinutes, f.id).toBe(0)
+      expect(f.graph.config.aiStepTimeoutMinutes, f.id).toBe(0)
     }
-    // The openspec lifecycle keeps its own conservative bounds (3 passes max).
+    // The openspec lifecycle keeps its own conservative iteration bound (3 passes max).
     expect(getFactoryLoop('factory:sdd-quick-openspec')?.graph.config.maxIterations).toBe(3)
     expect(getFactoryLoop('factory:openspec')?.graph.config.maxIterations).toBe(3)
   })

--- a/server/loop-factory.ts
+++ b/server/loop-factory.ts
@@ -33,12 +33,14 @@ export interface FactoryLoop {
 const GREEN_GOAL = 'Stop only when the latest verification step reports {{const:VERIFICATION_PASS}} and the history proves the spec is implemented with all required tests/build checks passing.'
 
 // Factory loops run the WHOLE architect→developer→reviewer pipeline inside a
-// single AI step (`/specrails:implement` etc.), so they need far more headroom
-// than the engine defaults (loop 30 min / step 15 min): a real implement can run
-// for a long time. 360 min loop deadline, 60 min per AI step.
+// single AI step (`/specrails:implement` etc.), so no fixed wall-clock budget is
+// honest — a legit implement outran the old 60-min step cap and got killed
+// mid-run. Built-in loops therefore run UNTIMED (0 = no timeout, both the run
+// deadline and the per-step watchdog); maxIterations and the optional cost cap
+// remain the runaway guards.
 const FACTORY_MAX_ITERATIONS = 12
-const FACTORY_LOOP_TIMEOUT_MIN = 360
-const FACTORY_AI_STEP_TIMEOUT_MIN = 60
+const FACTORY_LOOP_TIMEOUT_MIN = 0
+const FACTORY_AI_STEP_TIMEOUT_MIN = 0
 
 const SDD_QUICK_OPENSPEC_FACTORY: FactoryLoop = {
   id: 'factory:sdd-quick-openspec',

--- a/server/loop-graph.test.ts
+++ b/server/loop-graph.test.ts
@@ -163,13 +163,22 @@ describe('validateLoopGraph', () => {
     expect(validateLoopGraph(g).errors.map((e) => e.code)).toContain('INVALID_CONFIG')
   })
 
-  it('flags INVALID_CONFIG for non-positive timeout', () => {
+  it('flags INVALID_CONFIG for a negative timeout', () => {
+    const g = graph(
+      [node('s', 'start'), node('e', 'end')],
+      [edge('e1', 's', 'e')],
+      { timeoutMinutes: -1 }
+    )
+    expect(validateLoopGraph(g).errors.map((e) => e.code)).toContain('INVALID_CONFIG')
+  })
+
+  it('accepts timeoutMinutes 0 (no timeout — the factory-loop untimed sentinel)', () => {
     const g = graph(
       [node('s', 'start'), node('e', 'end')],
       [edge('e1', 's', 'e')],
       { timeoutMinutes: 0 }
     )
-    expect(validateLoopGraph(g).errors.map((e) => e.code)).toContain('INVALID_CONFIG')
+    expect(validateLoopGraph(g).valid).toBe(true)
   })
 
   it('reports multiple distinct problems at once (empty graph)', () => {

--- a/server/loop-graph.ts
+++ b/server/loop-graph.ts
@@ -42,11 +42,14 @@ export interface LoopEdge {
 export interface LoopGraphConfig {
   /** Hard upper bound on iterations regardless of the Decider's verdict. */
   maxIterations: number
-  /** Wall-clock timeout for the whole run, in minutes. */
+  /** Wall-clock timeout for the whole run, in minutes. 0 ⇒ no run deadline
+   *  (the iteration cap / cost cap remain the runaway guards). */
   timeoutMinutes: number
   /** Per-AI-step wall-clock timeout, in minutes. Undefined ⇒ the engine default
-   *  (15 min). Factory pipeline loops (implement/batch/freestyle) raise this
-   *  because a single step runs the whole architect→developer→reviewer pipeline. */
+   *  (15 min); 0 ⇒ no per-step timeout. Factory pipeline loops
+   *  (implement/batch/freestyle) disable both because a single step runs the
+   *  whole architect→developer→reviewer pipeline and a legit implement can
+   *  outlast any fixed budget. */
   aiStepTimeoutMinutes?: number
   /** Optional cost cap (USD) for the whole run. Enforced BETWEEN steps (per-step
    *  cost is only known when a step's process exits), so the loop stops before
@@ -99,7 +102,7 @@ export function emptyLoopGraph(): LoopGraph {
  *  - at least one `end` node (the explicit exit),
  *  - every edge references existing nodes (no dangling edges),
  *  - every node is reachable from `start` (no orphan / disconnected nodes),
- *  - a sane config (maxIterations ≥ 1, timeoutMinutes ≥ 1).
+ *  - a sane config (maxIterations ≥ 1, timeoutMinutes ≥ 0 — 0 = no timeout).
  *
  * Returns all errors found (not just the first) so the builder can highlight
  * every problem at once.
@@ -136,11 +139,12 @@ export function validateLoopGraph(graph: LoopGraph): GraphValidationResult {
     !Number.isInteger(cfg.maxIterations) ||
     cfg.maxIterations < 1 ||
     typeof cfg.timeoutMinutes !== 'number' ||
-    cfg.timeoutMinutes < 1
+    !Number.isFinite(cfg.timeoutMinutes) ||
+    cfg.timeoutMinutes < 0
   ) {
     errors.push({
       code: 'INVALID_CONFIG',
-      message: 'maxIterations and timeoutMinutes must both be ≥ 1.',
+      message: 'maxIterations must be ≥ 1 and timeoutMinutes ≥ 0 (0 = no timeout).',
     })
   }
 

--- a/server/loop-run-manager.ts
+++ b/server/loop-run-manager.ts
@@ -142,7 +142,8 @@ export interface InteractivePlanInput {
   /** Resume a prior step's session (mid-pass continuity — the interactive
    *  equivalent of the one-shot path's chat-resume). Absent on a fresh pass. */
   sessionId?: string
-  /** Per-step wall-clock timeout (ms). Undefined ⇒ executor default (15 min). */
+  /** Per-step wall-clock timeout (ms). Undefined ⇒ executor default (15 min);
+   *  0 ⇒ no per-step timeout. */
   aiStepTimeoutMs?: number
 }
 
@@ -175,7 +176,8 @@ export interface LoopExecutors {
     onLine?: LoopLogSink
     onRawLine?: (line: string) => void
     onSpawn?: LoopSpawnSink
-    /** Per-step wall-clock timeout (ms). Undefined ⇒ executor default (15 min). */
+    /** Per-step wall-clock timeout (ms). Undefined ⇒ executor default (15 min);
+     *  0 ⇒ no per-step timeout. */
     aiStepTimeoutMs?: number
   }): Promise<AiStepResult>
   /** OPTIONAL interactive upgrade for ai-steps: return a resident-session spawn
@@ -852,9 +854,13 @@ export class LoopRunManager {
     const neverAfterDispose = (): Promise<LoopRunResult> => new Promise(() => { /* startup recovery owns settlement */ })
     const runId = req.runId ?? newId()
     const maxIterations = req.graph.config.maxIterations
-    const timeoutMs = req.graph.config.timeoutMinutes * 60_000
-    const deadline = this.now() + timeoutMs
-    // Per-step AI timeout (ms) — undefined falls back to the executor default.
+    // 0 ⇒ no whole-run deadline (built-in pipeline loops opt out of the wall
+    // clock; maxIterations / maxCostUsd remain the runaway guards).
+    const deadline = req.graph.config.timeoutMinutes > 0
+      ? this.now() + req.graph.config.timeoutMinutes * 60_000
+      : Infinity
+    // Per-step AI timeout (ms) — undefined falls back to the executor default,
+    // 0 disables the per-step watchdog entirely.
     const aiStepTimeoutMs = req.graph.config.aiStepTimeoutMinutes != null
       ? req.graph.config.aiStepTimeoutMinutes * 60_000
       : undefined

--- a/server/loop-templates.ts
+++ b/server/loop-templates.ts
@@ -240,9 +240,10 @@ export function opsxLifecycleGraph(): LoopGraph {
       { id: 'e-stop', source: 'decide', target: 'archive', branch: 'stop' },
       { id: 'e-archive', source: 'archive', target: 'done' },
     ],
-    // Conservative bounds so a never-satisfied verify can't spin: at most 3 full
-    // lifecycle passes; per-step cap raised (apply can implement a whole change).
-    config: { maxIterations: 3, timeoutMinutes: 180, aiStepTimeoutMinutes: 45 },
+    // At most 3 full lifecycle passes guard a never-satisfied verify. Like the
+    // other built-in loops the run is UNTIMED (0 = no timeout) — apply can
+    // implement a whole change and must never be killed mid-flight.
+    config: { maxIterations: 3, timeoutMinutes: 0, aiStepTimeoutMinutes: 0 },
   }
 }
 

--- a/server/spawn-lifecycle.ts
+++ b/server/spawn-lifecycle.ts
@@ -61,7 +61,7 @@ export interface RunInvocationHooks {
   onSpawnError?: (err: Error) => void
 
   /** Optional wall-clock watchdog. On fire the child is killed and the run
-   *  settles with `timedOut: true`. */
+   *  settles with `timedOut: true`. Undefined or ≤ 0 ⇒ no watchdog. */
   timeoutMs?: number
   onTimeout?: () => void
 }
@@ -131,7 +131,7 @@ export function runAiCliInvocation(hooks: RunInvocationHooks): Promise<Invocatio
     }
     hooks.onSpawn?.(child)
 
-    if (hooks.timeoutMs != null) {
+    if (hooks.timeoutMs != null && hooks.timeoutMs > 0) {
       timer = setTimeout(() => {
         hooks.onTimeout?.()
         // treeKill the whole subtree (a bare child.kill leaves grandchildren),


### PR DESCRIPTION
## Why

A legitimate `/specrails:implement` run outlasted the fixed 60-minute per-AI-step watchdog (`FACTORY_AI_STEP_TIMEOUT_MIN = 60`) and was killed mid-implementation. No fixed wall-clock budget is honest for a step that runs the whole architect→developer→reviewer pipeline.

## What

- New sentinel **`0` = no timeout**, supported end-to-end:
  - `loop-graph.ts` — validation accepts `timeoutMinutes: 0` (negative still invalid).
  - `loop-run-manager.ts` — `timeoutMinutes: 0` ⇒ run deadline `Infinity`; `aiStepTimeoutMinutes: 0` flows to the executors.
  - `loop-executors.ts` — one-shot: `timeoutMs ≤ 0` ⇒ no watchdog; interactive path already skips arming the timer at `stepTimeoutMs ≤ 0`.
  - `spawn-lifecycle.ts` — watchdog guard hardened to `timeoutMs > 0`.
- **Factory loops run untimed**: Implement, Batch, Freestyle (`loop-factory.ts`) and SDD Quick OpenSpec (`opsxLifecycleGraph`). `maxIterations` and the optional cost cap remain the runaway guards.
- The **decider keeps its 3-min cap** (one-turn read-only judgment — hanging there for hours would be worse).
- Preview modals (`LoopPreviewModal`/`TemplatePreviewModal`) render “no timeout” for 0 — new `preview.limitsNoTimeout` key in all 8 locales.
- Custom/forked loops keep their authored bounds byte-identical.

## Tests

- `npm run typecheck` ✓
- Full suite: 6580 tests ✓ (loop-graph validation gains 0-accepted + negative-rejected cases; factory test asserts untimed config)
- Locale-parity ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)